### PR TITLE
feat(confenge): full stack — import, review, enroll, outcomes, CRM

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -984,7 +984,10 @@ func main() {
 			log.Fatalf("confenge config: %v", err)
 		}
 		outreachRepo := repository.NewOutreachRepository(primaryDB.Pool)
-		confengeServiceForHandler = confenge.NewService(confengeCfg, outreachRepo, auditService)
+		confengeServiceForHandler = confenge.NewServiceWithAI(confengeCfg, outreachRepo, auditService, aiProvider)
+		if confengeServiceForHandler != nil && aiProvider != nil {
+			confengeServiceForHandler.SetAI(aiProvider)
+		}
 
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -988,6 +988,8 @@ func main() {
 		if confengeServiceForHandler != nil && aiProvider != nil {
 			confengeServiceForHandler.SetAI(aiProvider)
 		}
+		// Async outcome outbox → extra-cli HMAC webhook (idle when URL/secret unset).
+		go confenge.NewOutcomeDeliveryWorker(outreachRepo, confengeCfg, confenge.OutcomeDeliveryOptions{}).Run(ctx)
 
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)
@@ -1021,6 +1023,10 @@ func main() {
 		templateService = template.NewService(templateRepository)
 		schedulerService := scheduler.NewSchedulerService(taskRepository, warmupRepository, campaignProgressRepository, emailRepostory, campaignRepostory, contactRepostory, campaignLogRepository)
 		campaignService = campaign.NewService(campaignRepostory, taskRepository, emailRepostory, campaignLogRepository, featureGateService, dailyThrottleService, schedulerService, tasksClient, streamingPublisher)
+		// CONFENGE enroll uses campaign + contact services (execution plane).
+		if confengeServiceForHandler != nil {
+			confengeServiceForHandler.WireExecution(campaignService, contactService)
+		}
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
 		composeService = compose.NewService(emailRepostory, repository.NewComposeRepository(primaryDB))
 		// uniboxService is constructed here (rather than alongside the

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1026,6 +1026,9 @@ func main() {
 		// CONFENGE enroll uses campaign + contact services (execution plane).
 		if confengeServiceForHandler != nil {
 			confengeServiceForHandler.WireExecution(campaignService, contactService)
+			if crmService != nil {
+				confengeServiceForHandler.WireCRM(crmService)
+			}
 		}
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
 		composeService = compose.NewService(emailRepostory, repository.NewComposeRepository(primaryDB))
@@ -1171,6 +1174,10 @@ func main() {
 		// agent wired onto the advanced service so any reply processed here also
 		// drafts. Paid + opt-in checked inside; nil provider leaves it inert.
 		aiDraftRepo = repository.NewAIDraftRepository(primaryDB.Pool)
+		// CONFENGE reply attribution (outbox + CRM) when outreach feature is on.
+		if confengeServiceForHandler != nil && confengeServiceForHandler.Enabled() {
+			advancedService.WireConfengeReply(confengeServiceForHandler)
+		}
 		advancedService.WireInboxAgent(inboxagent.NewService(
 			aiProvider, creditService, featureGateService,
 			organizationRepository, uniboxRepository, skillsService,

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1024,20 +1024,12 @@ func main() {
 		schedulerService := scheduler.NewSchedulerService(taskRepository, warmupRepository, campaignProgressRepository, emailRepostory, campaignRepostory, contactRepostory, campaignLogRepository)
 		campaignService = campaign.NewService(campaignRepostory, taskRepository, emailRepostory, campaignLogRepository, featureGateService, dailyThrottleService, schedulerService, tasksClient, streamingPublisher)
 		// CONFENGE enroll uses campaign + contact services (execution plane).
+		// Platform suppress is wired only AFTER advancedService is constructed
+		// (below); wiring it here would no-op because advancedService is still nil.
 		if confengeServiceForHandler != nil {
 			confengeServiceForHandler.WireExecution(campaignService, contactService)
 			if crmService != nil {
 				confengeServiceForHandler.WireCRM(crmService)
-			}
-			if advancedService != nil {
-				confengeServiceForHandler.WireSuppress(confenge.SuppressFromAdvanced{
-					Fn: func(ctx context.Context, orgID uuid.UUID, email, reason string) error {
-						if xerr := advancedService.SuppressRecipient(ctx, orgID, email, reason); xerr != nil {
-							return fmt.Errorf("%s", xerr.Message)
-						}
-						return nil
-					},
-				})
 			}
 		}
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
@@ -1070,6 +1062,12 @@ func main() {
 			tasksClient,
 			warmupService,
 		)
+		// CONFENGE DNC must write the platform suppression list (same path
+		// campaign send checks). advancedService is non-nil here; do not move
+		// this block above NewService.
+		if confengeServiceForHandler != nil && advancedService != nil {
+			confengeServiceForHandler.WireSuppress(confenge.NewSuppressAdapter(advancedService))
+		}
 
 		// Shared AI tool registry: every tool calls a service-layer function as
 		// the invoking user, so the dashboard agent (M3) and MCP server (M8) can

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1029,6 +1029,16 @@ func main() {
 			if crmService != nil {
 				confengeServiceForHandler.WireCRM(crmService)
 			}
+			if advancedService != nil {
+				confengeServiceForHandler.WireSuppress(confenge.SuppressFromAdvanced{
+					Fn: func(ctx context.Context, orgID uuid.UUID, email, reason string) error {
+						if xerr := advancedService.SuppressRecipient(ctx, orgID, email, reason); xerr != nil {
+							return fmt.Errorf("%s", xerr.Message)
+						}
+						return nil
+					},
+				})
+			}
 		}
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
 		composeService = compose.NewService(emailRepostory, repository.NewComposeRepository(primaryDB))

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/app/compose"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/app/contact"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/app/creditwatch"
@@ -239,6 +240,7 @@ func main() {
 	var contactRepoForHandler repository.ContactRepository
 	var attachmentRepoForHandler repository.AttachmentRepository
 	var leadSyncServiceForHandler leadsync.Service
+	var confengeServiceForHandler confenge.Service
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -974,6 +976,16 @@ func main() {
 		leadSyncRepository := repository.NewLeadSyncRepository(primaryDB.Pool)
 		leadSyncServiceForHandler = leadsync.NewService(leadSyncRepository, integrationServiceForHandler, contactService)
 
+		// CONFENGE outreach staging: extra-cli feed import. Off by default
+		// (CONFENGE_OUTREACH_ENABLED=false). Fail closed on insecure prod config.
+		confengeCfg := confenge.LoadConfig()
+		if err := confengeCfg.ValidateStartup(os.Getenv("APP_ENV")); err != nil {
+			sentry.CaptureException(err)
+			log.Fatalf("confenge config: %v", err)
+		}
+		outreachRepo := repository.NewOutreachRepository(primaryDB.Pool)
+		confengeServiceForHandler = confenge.NewService(confengeCfg, outreachRepo, auditService)
+
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)
 		teamRepository := repository.NewTeamRepository(primaryDB.Pool)
@@ -1469,6 +1481,9 @@ func main() {
 
 		// On-demand Google Sheets -> leads sync
 		LeadSyncService: leadSyncServiceForHandler,
+
+		// CONFENGE outreach staging (feature-flagged)
+		ConfengeService: confengeServiceForHandler,
 
 		WebsocketURI: websocketURI,
 

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/warmbly/warmbly/internal/app/advanced"
 	"github.com/warmbly/warmbly/internal/app/cipher"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	jobs "github.com/warmbly/warmbly/internal/app/consumer"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/app/creditwatch"
@@ -354,6 +355,13 @@ func main() {
 
 	eventsPublisher := events.NewPublisher(consumerBus, s3Client, consumerCodec, cipherService)
 
+	// CONFENGE outcome sink (feature-flagged; no-op when disabled).
+	confengeCfgC := confenge.LoadConfig()
+	var confengeSink confenge.OutcomeSink
+	if confengeCfgC.Enabled {
+		confengeSink = confenge.NewService(confengeCfgC, repository.NewOutreachRepository(primaryDB.Pool), nil).(confenge.OutcomeSink)
+	}
+
 	// JobsService
 	jobsService := &jobs.JobsService{
 		Bus:                         consumerBus,
@@ -372,6 +380,7 @@ func main() {
 		Publisher:                   eventsPublisher,
 		StreamingPublisher:          streamingPublisher,
 		AdvancedService:             advancedService,
+		ConfengeOutcomes:            confengeSink,
 		Cache:                       redisCache,
 		AdminRepo:                   repository.NewAdminRepository(primaryDB.Pool),
 		AssignmentService:           workerAssignmentSvc,

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -351,16 +351,23 @@ func main() {
 		repository.NewAIDraftRepository(primaryDB.Pool),
 		streamingPublisher,
 	)
+	// CONFENGE outcome sink (feature-flagged; no-op when disabled).
+	confengeCfgC := confenge.LoadConfig()
+	var confengeSvc confenge.Service
+	var confengeSink confenge.OutcomeSink
+	if confengeCfgC.Enabled {
+		confengeSvc = confenge.NewService(confengeCfgC, repository.NewOutreachRepository(primaryDB.Pool), nil)
+		if sink, ok := confengeSvc.(confenge.OutcomeSink); ok {
+			confengeSink = sink
+		}
+		// CRM not wired on consumer (control-plane tasks/deals stay on backend);
+		// outbox + staging updates still run via OnClassifiedReply.
+		advancedService.WireConfengeReply(confengeSvc)
+	}
+
 	advancedService.WireInboxAgent(inboxAgentServiceC)
 
 	eventsPublisher := events.NewPublisher(consumerBus, s3Client, consumerCodec, cipherService)
-
-	// CONFENGE outcome sink (feature-flagged; no-op when disabled).
-	confengeCfgC := confenge.LoadConfig()
-	var confengeSink confenge.OutcomeSink
-	if confengeCfgC.Enabled {
-		confengeSink = confenge.NewService(confengeCfgC, repository.NewOutreachRepository(primaryDB.Pool), nil).(confenge.OutcomeSink)
-	}
 
 	// JobsService
 	jobsService := &jobs.JobsService{

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -352,6 +352,8 @@ func main() {
 		streamingPublisher,
 	)
 	// CONFENGE outcome sink (feature-flagged; no-op when disabled).
+	// advancedService is already constructed above; WireSuppress must run so
+	// reply-class DNC (OnClassifiedReply → NoteDNC) writes the platform list.
 	confengeCfgC := confenge.LoadConfig()
 	var confengeSvc confenge.Service
 	var confengeSink confenge.OutcomeSink
@@ -360,8 +362,9 @@ func main() {
 		if sink, ok := confengeSvc.(confenge.OutcomeSink); ok {
 			confengeSink = sink
 		}
+		confengeSvc.WireSuppress(confenge.NewSuppressAdapter(advancedService))
 		// CRM not wired on consumer (control-plane tasks/deals stay on backend);
-		// outbox + staging updates still run via OnClassifiedReply.
+		// outbox + staging updates + suppress still run via OnClassifiedReply.
 		advancedService.WireConfengeReply(confengeSvc)
 	}
 

--- a/deploy/config/env.example
+++ b/deploy/config/env.example
@@ -167,6 +167,21 @@ CHECK_ORIGIN=false
 # SEARCH_API_URL=
 # SEARCH_API_KEY=
 
+# === CONFENGE outreach (optional; off by default) ===
+# Intelligence plane remains extra-cli. Warmbly only imports a versioned feed
+# into multi-tenant staging. Do not point these at the extra-cli Postgres.
+# CONFENGE_OUTREACH_ENABLED=false
+# CONFENGE_AUTO_SEND_ENABLED=false
+# CONFENGE_REQUIRE_HUMAN_APPROVAL=true
+# CONFENGE_EXTRA_CLI_FEED_URL=        # https://... or file:///path/to/feed.json
+# CONFENGE_EXTRA_CLI_FEED_TOKEN=      # optional Bearer for HTTPS feed
+# CONFENGE_EXTRA_CLI_ALLOWED_HOSTS=   # comma-separated host allowlist (required in prod with feed URL)
+# CONFENGE_OUTCOME_WEBHOOK_URL=       # HTTPS webhook back to extra-cli (PR3)
+# CONFENGE_OUTCOME_WEBHOOK_SECRET=    # HMAC secret for outcome webhooks
+# CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=10
+# CONFENGE_MAX_INITIAL_EMAIL_WORDS=120
+# CONFENGE_MAX_FEED_PAYLOAD_BYTES=33554432
+
 # === Observability ===
 # Optional in dev; REQUIRED (fatal at boot) on every Go service when APP_ENV=prod.
 # SENTRY_DSN=

--- a/docs/confenge/README.md
+++ b/docs/confenge/README.md
@@ -1,0 +1,149 @@
+# CONFENGE outreach on Warmbly
+
+Warmbly is the **execution plane** for CONFENGE commercial outreach. The
+`extra-cli` remains the **intelligence plane** (datalake, signals, evidence,
+scoring, Decision & Outcome Memory).
+
+```text
+datalake (VPS) → extra-cli → versioned feed → Warmbly staging → review → campaign → outcomes → extra-cli
+```
+
+This document covers **PR1**: feed contract, import, staging models, API, and
+feature flag. Message generation, review UI, campaign enrollment, and outcome
+webhooks land in follow-up PRs.
+
+## Separation of concerns
+
+| Warmbly | extra-cli |
+| --- | --- |
+| Contacts, mailboxes, campaigns, sequences | Datalake, public contracts |
+| Send limits, follow-ups, stop-on-reply | Commercial signals, facts |
+| Inbox, replies, bounces, suppression | Evidence, hypotheses |
+| CRM, tasks, analytics | Prioritization, provenance |
+| Staging import + review queue | Canonical decision/outcome memory |
+
+Warmbly **must not**:
+
+- connect to the extra-cli production Postgres
+- write into the datalake
+- re-score leads or re-run commercial analytics
+
+## Feature flag
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `CONFENGE_OUTREACH_ENABLED` | `false` | Master switch for API + import |
+| `CONFENGE_AUTO_SEND_ENABLED` | `false` | Reserved; never default on |
+| `CONFENGE_REQUIRE_HUMAN_APPROVAL` | `true` | Safety default for later send paths |
+| `CONFENGE_EXTRA_CLI_FEED_URL` | empty | HTTPS or `file://` feed |
+| `CONFENGE_EXTRA_CLI_FEED_TOKEN` | empty | Optional Bearer for HTTPS |
+| `CONFENGE_EXTRA_CLI_ALLOWED_HOSTS` | empty | Required in prod when feed URL set |
+| `CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT` | `10` | Future campaign bootstrap |
+| `CONFENGE_MAX_INITIAL_EMAIL_WORDS` | `120` | Future copy validators |
+| `CONFENGE_MAX_FEED_PAYLOAD_BYTES` | `33554432` | Import payload cap |
+
+In production, feed and outcome URLs must be `https://`, and the feed host
+must be on the allowlist. Fetch uses the SSRF-hardened HTTP client.
+
+## Contract `confenge.outreach.v1`
+
+Top-level:
+
+```json
+{
+  "schema_version": "confenge.outreach.v1",
+  "generated_at": "2026-08-06T12:00:00Z",
+  "source": {
+    "system": "extra-cli",
+    "run_id": "...",
+    "snapshot_hash": "...",
+    "repo_sha": "...",
+    "profile_id": "confenge",
+    "profile_version": "1.0.0"
+  },
+  "pagination": { "cursor": null, "next_cursor": null, "has_more": false },
+  "leads": []
+}
+```
+
+Each lead carries company (CNPJ14), priority (opaque scores from extra-cli),
+moment, offer, messaging_context, contacts, contracts, evidence, and
+`commercial_state`. Missing email is valid: the company enters as
+`NEEDS_CONTACT`, never discarded.
+
+Synthetic fixtures: `internal/app/confenge/testdata/`.
+
+### Legacy adapters
+
+If `schema_version` is absent, the importer normalizes:
+
+- top-level `leads.json` arrays
+- commercial run objects with a `leads` key
+- flat contact fields (`email`, `contact_name`, …)
+
+Missing fields are left empty. Nothing is invented.
+
+## Data model (staging)
+
+Multi-tenant tables (migration `000080_outreach_staging`):
+
+- `outreach_import_runs` — audit of each dry-run/apply
+- `outreach_accounts` — company staging, unique `(organization_id, cnpj14)`
+- `outreach_contact_candidates` — candidates before Warmbly contact promotion
+- `outreach_evidence` — sanitized text evidence per account
+
+Human flags (`do_not_contact`, `blocked`, post-send queue states) survive
+reimport. Machine fields (score, moment, offer) update on content-hash change.
+
+## API (JWT + org context)
+
+Base: `/api/v1/confenge` (requires organization).
+
+| Method | Path | Permission | Notes |
+| --- | --- | --- | --- |
+| GET | `/status` | any org member | Works even when disabled |
+| GET | `/summary` | view contacts | Queue counters |
+| GET | `/accounts` | view contacts | Filters: `queue_state`, `cnpj14`, `q` |
+| GET | `/accounts/:id` | view contacts | Includes contacts + evidence |
+| POST | `/accounts/:id/block` | manage contacts | Optional `do_not_contact` |
+| POST | `/import` | manage contacts | Body = feed JSON or `{"uri":"..."}` |
+| GET | `/import-runs` | view contacts | Recent runs |
+| GET | `/import-runs/:id` | view contacts | Run detail + counts |
+
+Import query/header:
+
+- `?dry_run=true` — validate + count only
+- `Idempotency-Key` — same key + same payload returns prior run; different payload → `409`
+
+## Local quickstart
+
+1. Set `CONFENGE_OUTREACH_ENABLED=true` on the backend env.
+2. Apply migrations (`make backend` applies embedded migrations).
+3. Import fixture:
+
+```bash
+curl -sS -X POST "$API/api/v1/confenge/import?dry_run=true" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @internal/app/confenge/testdata/native_feed_v1.json
+```
+
+4. Apply (no dry_run), then `GET /confenge/summary` and `GET /confenge/accounts`.
+
+## Tests
+
+```bash
+go test ./internal/app/confenge/ -count=1
+```
+
+Covers native + legacy parse, dry-run, idempotency, DNC preservation, multi-tenant
+isolation, evidence add, invalid feed, queue states for missing/unverified contacts.
+
+## Upstream maintenance
+
+See [upstream-maintenance.md](./upstream-maintenance.md).
+
+## Outcome loop (PR3)
+
+Outcome webhook env vars are reserved. Delivery uses HMAC + outbox; Warmbly
+never writes to the extra-cli database.

--- a/docs/confenge/external-blockers.md
+++ b/docs/confenge/external-blockers.md
@@ -1,0 +1,89 @@
+# External blockers (honest status)
+
+These items cannot be completed from this agent session without operator /
+maintainer action. Code paths are implemented and unit-tested; production
+proof remains open.
+
+## 1. GitHub Actions on warmbly/warmbly#91
+
+| Item | Status |
+| --- | --- |
+| Upstream PR | https://github.com/warmbly/warmbly/pull/91 |
+| CI run | https://github.com/warmbly/warmbly/actions/runs/31142042410 |
+| Conclusion | `action_required` |
+
+First-time contributor workflows from the fork require **maintainer approval**
+before jobs run. This agent cannot approve Actions on `warmbly/warmbly`
+(403 admin rights). After approval, CI should run `make lint` + `go test -race
+./...` and web typecheck.
+
+## 2. Fork CI (`tjsasakifln/warmbly`)
+
+`.github/workflows/ci.yml` only triggers on:
+
+```yaml
+push:
+  branches: [main]
+pull_request:
+  branches: [main]
+```
+
+Stacked PRs targeting intermediate branches (review → import, ops → review)
+therefore **do not** run GitHub Actions. PR #3 (import → `main`) is the only
+fork PR eligible for CI. Actions history on the fork showed zero runs at last
+check; if that persists after a new push to a `main`-targeted PR, check
+Actions enablement and billing for the personal fork.
+
+**Workaround for full-stack CI:** open or use a tip PR
+`feat/confenge-outcome-ops` → `main` so the complete commit stack is tested
+against the same workflow as production PRs.
+
+## 3. Netcup VPS deploy
+
+No live inventory of the Netcup box (ports, compose projects, reverse proxy,
+extra-cli containers) was available in this environment.  
+`docs/confenge/netcup-ops.md` describes an isolated `warmbly-confenge` project.
+Do **not** declare production until preflight + smoke on the real VPS.
+
+## 4. Microsoft 365 / Graph
+
+Warmbly already supports Outlook OAuth (`BOX_OUTLOOK_CLIENT_ID` /
+`BOX_OUTLOOK_CLIENT_SECRET`, redirect `/addresses/outlook/callback`).  
+No operator Azure app credentials or test mailbox were available here.
+Smoke steps for Tiago:
+
+1. Register / reuse Azure app with Mail.Send, Mail.Read, offline_access
+2. Set BOX_OUTLOOK_* on backend + workers
+3. Connect confenge.com.br mailbox in dashboard
+4. Send test to an address Tiago owns (never to real leads)
+
+## 5. extra-cli feed / outcome receptor
+
+Legacy import works (`leads.json` / commercial run shapes).  
+Native `confenge.outreach.v1` exporter and HMAC outcome endpoint on extra-cli
+are **not** required for Warmbly unit tests; they remain optional separate PRs
+on `tjsasakifln/extra-cli` if production wants HTTPS feed + Decision & Outcome
+Memory writeback.
+
+## 6. Frontend typecheck in this environment
+
+Host Node is v20; pnpm 11 requires Node ≥ 22.13. Web CI uses Node 20 + pnpm 10
+and is the authoritative frontend gate once Actions run. Local
+`pnpm typecheck` may fail on this machine for toolchain reasons, not app code.
+
+## Local verification that did pass
+
+```bash
+go test ./internal/app/confenge/ -count=1   # import, drafts, enroll, CRM, e2e, HMAC
+make lint
+go test ./cmd/backend/ ./cmd/consumer/ ./internal/api/handler/ -count=0
+```
+
+## What is NOT a blocker for merging code review
+
+- Intelligence / execution separation (feed + outbox only)
+- Multi-tenant staging + DNC preservation
+- Validators + template AI fallback
+- Campaign bootstrap + enroll
+- Outcome HMAC outbox worker
+- CRM pipeline bootstrap + reply-class mapping

--- a/docs/confenge/netcup-ops.md
+++ b/docs/confenge/netcup-ops.md
@@ -1,0 +1,65 @@
+# Netcup deployment notes (CONFENGE Warmbly)
+
+Deploy Warmbly as an **isolated Compose project** next to extra-cli. Do not share
+Postgres, Redis, or Kafka with the intelligence plane.
+
+## Preflight checklist
+
+- Inventory ports, volumes, reverse proxy, DNS, TLS, disk, RAM, and extra-cli
+  services already running on the VPS.
+- Choose non-colliding names: project `warmbly-confenge`, network
+  `warmbly_confenge_net`, volumes `warmbly_confenge_pg` / `_redis`.
+- Do not mount the extra-cli datalake volume into Warmbly.
+- Do not grant Warmbly credentials to the extra-cli database.
+
+## Integration path
+
+```text
+extra-cli export feed (HTTPS or file drop)
+        → Warmbly CONFENGE_EXTRA_CLI_FEED_URL
+Warmbly outcome outbox
+        → CONFENGE_OUTCOME_WEBHOOK_URL (extra-cli receiver)
+```
+
+## Required env (minimum)
+
+```env
+CONFENGE_OUTREACH_ENABLED=true
+CONFENGE_AUTO_SEND_ENABLED=false
+CONFENGE_REQUIRE_HUMAN_APPROVAL=true
+CONFENGE_EXTRA_CLI_FEED_URL=https://...
+CONFENGE_EXTRA_CLI_ALLOWED_HOSTS=...
+CONFENGE_OUTCOME_WEBHOOK_URL=https://...
+CONFENGE_OUTCOME_WEBHOOK_SECRET=...
+BOX_OUTLOOK_CLIENT_ID=...
+BOX_OUTLOOK_CLIENT_SECRET=...
+```
+
+Use Microsoft Graph OAuth already supported by Warmbly. Do not put mailbox
+passwords in `.env`.
+
+## Ops
+
+| Action | Notes |
+| --- | --- |
+| Deploy | Isolated compose up; migrations apply on backend boot |
+| Smoke | `/health`, import fixture dry-run, generate template draft |
+| Backup | Postgres volume only for Warmbly project |
+| Restore | Restore volume, restart backend, verify migration version |
+| Rollback | Set `CONFENGE_OUTREACH_ENABLED=false`; optional down migrations |
+| Upgrade | Pull image/tag, recreate containers, watch migrations |
+
+## External access
+
+If DNS/TLS is not ready, use SSH tunnel to the dashboard/API. Do not expose an
+unauthenticated panel.
+
+## Proof bar
+
+Do not declare production ready without:
+
+1. Clean import of synthetic feed
+2. Review + approve path
+3. Mailbox Graph connection test to an operator-owned address
+4. Outcome outbox delivery or documented export path
+5. Backup/restore drill

--- a/docs/confenge/outcomes.md
+++ b/docs/confenge/outcomes.md
@@ -1,0 +1,69 @@
+# Outcome contract `confenge.outcome.v1`
+
+Warmbly returns commercial outcomes to extra-cli through an **outbox + HTTPS
+HMAC webhook**. Warmbly never writes the datalake database.
+
+## Envelope
+
+```json
+{
+  "schema_version": "confenge.outcome.v1",
+  "event_id": "uuid",
+  "idempotency_key": "string",
+  "occurred_at": "RFC3339",
+  "source": "warmbly",
+  "source_lead_id": "string",
+  "cnpj14": "string",
+  "contact_email": "string",
+  "event_type": "REPLIED",
+  "campaign_id": "string",
+  "message_id": "string",
+  "metadata": {}
+}
+```
+
+## Event types
+
+`LEAD_IMPORTED`, `LEAD_REVIEWED`, `CONTACT_APPROVED`, `CONTACTED`, `REPLIED`,
+`MEETING`, `PROPOSAL`, `WON`, `LOST`, `DO_NOT_CONTACT`, `BOUNCED`.
+
+## Transport
+
+| Setting | Purpose |
+| --- | --- |
+| `CONFENGE_OUTCOME_WEBHOOK_URL` | HTTPS endpoint on extra-cli |
+| `CONFENGE_OUTCOME_WEBHOOK_SECRET` | HMAC shared secret |
+
+Header: `X-Warmbly-Signature: t=<unix>,v1=<hex(hmac_sha256(secret, "<unix>." + body))>`
+
+Receivers must:
+
+1. Reject non-HTTPS in production
+2. Verify signature with constant-time compare
+3. Reject timestamps outside a short skew window (for example 5 minutes)
+4. Deduplicate on `idempotency_key` / `event_id`
+
+## Delivery semantics
+
+- Enqueue is transactional with the user action path (outbox table).
+- A background worker (or manual replay) drains pending rows with exponential
+  backoff and a dead-letter flag after repeated failure.
+- Replays are safe: same idempotency key must not create a second ledger entry
+  in extra-cli Decision & Outcome Memory.
+
+## Mapping to extra-cli commercial states
+
+| Outcome | Suggested extra-cli state |
+| --- | --- |
+| LEAD_IMPORTED | IMPORTED / known in Warmbly |
+| CONTACT_APPROVED | READY |
+| CONTACTED | CONTACTED |
+| REPLIED | REPLIED |
+| MEETING | MEETING |
+| PROPOSAL | PROPOSAL |
+| WON | WON (human only) |
+| LOST | LOST (human or explicit rule) |
+| DO_NOT_CONTACT | DNC |
+| BOUNCED | BOUNCED |
+
+Do not auto-mark WON from machine classification alone.

--- a/docs/confenge/upstream-maintenance.md
+++ b/docs/confenge/upstream-maintenance.md
@@ -1,0 +1,52 @@
+# Upstream maintenance notes (CONFENGE outreach)
+
+Fork: `tjsasakifln/warmbly` · Upstream: `warmbly/warmbly`
+
+## Files introduced (PR1)
+
+| Area | Paths |
+| --- | --- |
+| Migration | `internal/infrastructure/db/migrations/000080_outreach_staging.{up,down}.sql` |
+| Models | `internal/models/outreach.go`; audit entity constants in `audit.go` |
+| App | `internal/app/confenge/*` |
+| Repository | `internal/repository/pg_outreach.go` |
+| API | `internal/api/handler/confenge.go`; routes in `routes.go`; `handler.go` field |
+| Wire | `cmd/backend/main.go` (config load + service) |
+| Config sample | `deploy/config/env.example` |
+| Realtime spine | `web/src/hooks/useRealtimeEvents.ts` (`outreach_*` keys) |
+| Docs | `docs/confenge/*` |
+
+## Extension points used
+
+- Feature flag via env (no change to billing/feature gate matrix)
+- Org-scoped routes with existing `RequireAccess` / contact permissions
+- Audit spine (`AuditEntityOutreachImportRun`, `AuditEntityOutreachAccount`)
+- Embedded migrations (same as other features)
+- SSRF client (`internal/pkg/safehttp`) for remote feeds
+
+## Probable upstream conflicts
+
+- Migration number `000080` if upstream adds migrations in the same band — renumber before merge
+- `cmd/backend/main.go` and `handler.go` are high-churn; keep confenge wiring in a tight block
+- `routes.go` advisor/contacts region
+
+## Update strategy
+
+1. Fetch upstream `main`, rebase or merge carefully.
+2. If migration collision: renumber `000080` and keep down migration paired.
+3. Re-run `gofmt`, `make lint`, `go test ./internal/app/confenge/`.
+4. Keep confenge packages self-contained; avoid editing campaign/send cores.
+
+## Disable
+
+Set `CONFENGE_OUTREACH_ENABLED=false` (default). Routes still expose
+`GET /confenge/status` with `"enabled": false`. Import/list return not found.
+
+## Remove customization
+
+1. Drop env vars and docs.
+2. Delete `internal/app/confenge`, handler, repo, models, migration (new down).
+3. Remove wiring in `main.go` / `handler.go` / `routes.go` / realtime spine.
+
+Do not leave staging tables with PII if decommissioning a deployment: export then
+drop via down migration after backup.

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -1,0 +1,64 @@
+---
+title: CONFENGE outreach staging
+description: Import versioned commercial feeds from extra-cli into a multi-tenant staging queue without writing to the datalake.
+---
+
+CONFENGE outreach is an optional, feature-flagged staging layer. It lets an organization import a versioned commercial feed (for example from `extra-cli`) into Warmbly so companies can sit in a queue even when no verified email exists yet.
+
+Warmbly stays the execution plane: contacts, mailboxes, campaigns, inbox, CRM. The intelligence plane (datalake, signals, evidence scoring) stays outside Warmbly. Warmbly never connects to that database and never writes into it.
+
+## Enable
+
+Set on the backend:
+
+```env
+CONFENGE_OUTREACH_ENABLED=true
+```
+
+Leave `CONFENGE_AUTO_SEND_ENABLED=false` unless you have an explicit operational policy. Human approval remains the default.
+
+Optional feed source:
+
+```env
+CONFENGE_EXTRA_CLI_FEED_URL=https://feed.example.com/confenge/outreach.json
+CONFENGE_EXTRA_CLI_FEED_TOKEN=
+CONFENGE_EXTRA_CLI_ALLOWED_HOSTS=feed.example.com
+```
+
+In production the feed URL must be HTTPS and the host must be on the allowlist. Local development may use a `file://` path.
+
+## Import
+
+`POST /api/v1/confenge/import` accepts:
+
+- the full feed JSON body (`schema_version: confenge.outreach.v1` or legacy shapes)
+- or `{"uri":"https://...","dry_run":true}` to fetch then import
+
+Use `?dry_run=true` for counts only (`creates`, `updates`, `unchanged`, `missing_contact`, and related fields). Send `Idempotency-Key` for safe retries.
+
+Companies without an enrollable contact enter as `NEEDS_CONTACT`. They are not discarded and are not forced into the contacts table.
+
+## Reimport rules
+
+Reimport updates machine-owned fields (priority, moment, offer, messaging, evidence). It preserves:
+
+- human `DO_NOT_CONTACT` and block flags
+- post-send queue states (enrolled, sent, replied, and later CRM states)
+- prior approvals once those exist in later PRs
+
+## API surface
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /confenge/status` | Whether the feature is on |
+| `GET /confenge/summary` | Queue counters |
+| `GET /confenge/accounts` | Staged companies |
+| `GET /confenge/accounts/:id` | Company with candidates and evidence |
+| `POST /confenge/import` | Dry-run or apply feed |
+| `GET /confenge/import-runs` | Import audit history |
+
+Permissions follow contacts: view for reads, manage for import and block.
+
+## What this does not do yet
+
+Message generation, review UI, campaign enrollment, Microsoft Graph send, and outcome webhooks back to `extra-cli` ship in follow-up work. See `docs/confenge/` in the repository for architecture and upstream maintenance notes.

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -29,6 +29,7 @@
     "---Integrations---",
     "webhooks",
     "integrations",
+    "confenge-outreach",
     "zapier",
     "make",
     "---Account and team---",

--- a/docs/package.json
+++ b/docs/package.json
@@ -37,7 +37,11 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml": "4.3.1"
+      "js-yaml": "4.3.1",
+      "postcss": "8.5.23",
+      "picomatch": "^4.0.4",
+      "path-to-regexp": "^8.4.0",
+      "sharp": "^0.35.0"
     }
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,5 +34,10 @@
     "postcss": "^8.5.23",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml": "4.3.1"
+    }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 overrides:
   js-yaml: 4.3.1
+  postcss: 8.5.23
+  picomatch: ^4.0.4
+  path-to-regexp: ^8.4.0
+  sharp: ^0.35.0
 
 importers:
 
@@ -16,13 +20,13 @@ importers:
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.4.11
-        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 14.2.6
-        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: 16.4.11
-        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
@@ -31,7 +35,7 @@ importers:
         version: 11.16.0
       next:
         specifier: 16.2.11
-        version: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -67,7 +71,7 @@ importers:
         specifier: 16.2.11
         version: 16.2.11(@typescript-eslint/parser@8.59.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       postcss:
-        specifier: ^8.5.23
+        specifier: 8.5.23
         version: 8.5.23
       tailwindcss:
         specifier: ^4.1.18
@@ -428,136 +432,145 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -2159,7 +2172,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3061,10 +3074,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -3082,10 +3091,6 @@ packages:
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -3282,9 +3287,14 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3882,9 +3892,9 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.0
       tslib: 2.8.1
 
-  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
+  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
     dependencies:
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss-selector-parser: 7.1.1
       react: 19.2.4
@@ -3892,7 +3902,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
 
   '@humanfs/core@0.19.1': {}
@@ -3917,98 +3927,108 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.34.5':
+  '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
+  '@img/sharp-darwin-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.3.2
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
+  '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
+  '@img/sharp-libvips-linux-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
+  '@img/sharp-libvips-linux-arm@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
+  '@img/sharp-libvips-linux-s390x@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+  '@img/sharp-libvips-linux-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.5':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-arm@0.34.5':
+  '@img/sharp-linux-arm@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.3.2
     optional: true
 
-  '@img/sharp-linux-ppc64@0.34.5':
+  '@img/sharp-linux-ppc64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-riscv64@0.34.5':
+  '@img/sharp-linux-riscv64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.5':
+  '@img/sharp-linux-s390x@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.3.2
     optional: true
 
-  '@img/sharp-linux-x64@0.34.5':
+  '@img/sharp-linux-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
+  '@img/sharp-linuxmusl-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
+  '@img/sharp-linuxmusl-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
     optional: true
 
-  '@img/sharp-wasm32@0.34.5':
+  '@img/sharp-wasm32@0.35.3':
     dependencies:
       '@emnapi/runtime': 1.11.2
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
+  '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -5871,7 +5891,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
+  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.0
       '@orama/orama': 3.1.18
@@ -5895,21 +5915,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
       lucide-react: 0.563.0(react@19.2.4)
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       js-yaml: 4.3.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -5924,14 +5944,14 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
+  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
     dependencies:
-      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -5943,7 +5963,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.10)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       lucide-react: 0.563.0(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -5952,7 +5972,7 @@ snapshots:
       scroll-into-view-if-needed: 3.1.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -6884,7 +6904,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   minimatch@10.2.5:
     dependencies:
@@ -6915,13 +6935,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.3
       caniuse-lite: 1.0.30001806
-      postcss: 8.4.31
+      postcss: 8.5.23
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -6934,9 +6954,10 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.11
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
-      sharp: 0.34.5
+      sharp: 0.35.3(@types/node@25.1.0)
     transitivePeerDependencies:
       - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
   node-exports-info@1.6.0:
@@ -7051,8 +7072,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
   picomatch@4.0.4: {}
 
   points-on-curve@0.2.0: {}
@@ -7068,12 +7087,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
@@ -7338,36 +7351,38 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
 
-  sharp@0.34.5:
+  sharp@0.35.3(@types/node@25.1.0):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 25.1.0
     optional: true
 
   shebang-command@2.0.0:

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -5,11 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  picomatch: ^4.0.4
-  path-to-regexp: ^8.4.0
-  js-yaml: ^4.3.0
-  sharp: ^0.35.0
-  postcss: ^8.5.23
+  js-yaml: 4.3.1
 
 importers:
 
@@ -20,13 +16,13 @@ importers:
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.4.11
-        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 14.2.6
-        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: 16.4.11
-        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
@@ -35,7 +31,7 @@ importers:
         version: 11.16.0
       next:
         specifier: 16.2.11
-        version: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -432,161 +428,136 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.35.3':
-    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.35.3':
-    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
-    engines: {node: '>=20.9.0'}
-    os: [freebsd]
-
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
-    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
-    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
-    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
-    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-linux-arm64@0.35.3':
-    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-arm@0.35.3':
-    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.3':
-    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.35.3':
-    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.3':
-    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-x64@0.35.3':
-    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-wasm32@0.35.3':
-    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
-    engines: {node: '>=20.9.0'}
-
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.35.3':
-    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.3':
-    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
-    engines: {node: ^20.9.0}
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.35.3':
-    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
@@ -641,28 +612,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.11':
     resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.11':
     resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.11':
     resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.11':
     resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
@@ -1135,28 +1102,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1437,61 +1400,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -2206,7 +2159,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2616,8 +2569,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2709,28 +2662,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3112,6 +3061,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -3129,6 +3082,10 @@ packages:
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -3325,14 +3282,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.35.3:
-    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
-    engines: {node: '>=20.9.0'}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3889,7 +3841,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3930,9 +3882,9 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.0
       tslib: 2.8.1
 
-  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
+  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
     dependencies:
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss-selector-parser: 7.1.1
       react: 19.2.4
@@ -3940,7 +3892,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
 
   '@humanfs/core@0.19.1': {}
@@ -3965,108 +3917,98 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.35.3':
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.3':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
+  '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.35.3':
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.35.3':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.3':
+  '@img/sharp-linux-ppc64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-riscv64@0.35.3':
+  '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.3':
+  '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.35.3':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
+  '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.35.3':
+  '@img/sharp-wasm32@0.34.5':
     dependencies:
       '@emnapi/runtime': 1.11.2
     optional: true
 
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.3':
+  '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.3':
-    optional: true
-
-  '@img/sharp-win32-x64@0.35.3':
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -5929,7 +5871,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
+  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.0
       '@orama/orama': 3.1.18
@@ -5953,22 +5895,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
       lucide-react: 0.563.0(react@19.2.4)
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
-      js-yaml: 4.3.0
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      js-yaml: 4.3.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
       picomatch: 4.0.4
@@ -5982,14 +5924,14 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
+  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
     dependencies:
-      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6001,7 +5943,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.10)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       lucide-react: 0.563.0(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -6010,7 +5952,7 @@ snapshots:
       scroll-into-view-if-needed: 3.1.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -6353,7 +6295,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -6942,7 +6884,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   minimatch@10.2.5:
     dependencies:
@@ -6973,13 +6915,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.3
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.23
+      postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -6992,10 +6934,9 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.11
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
-      sharp: 0.35.3(@types/node@25.1.0)
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
-      - '@types/node'
       - babel-plugin-macros
 
   node-exports-info@1.6.0:
@@ -7110,6 +7051,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   points-on-curve@0.2.0: {}
@@ -7125,6 +7068,12 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
@@ -7389,38 +7338,36 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
 
-  sharp@0.35.3(@types/node@25.1.0):
+  sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 25.1.0
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     optional: true
 
   shebang-command@2.0.0:

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -411,3 +411,17 @@ func (h *Handler) EnrollConfengeDraft(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"data": d})
 }
+
+// BootstrapConfengePipeline — POST /confenge/crm/bootstrap
+func (h *Handler) BootstrapConfengePipeline(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	pipe, xerr := h.ConfengeService.BootstrapPipeline(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": pipe})
+}

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -368,3 +368,46 @@ func (h *Handler) ReviewConfengeDraft(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"data": d})
 }
+
+// BootstrapConfengeCampaign — POST /confenge/campaign/bootstrap
+func (h *Handler) BootstrapConfengeCampaign(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	camp, xerr := h.ConfengeService.BootstrapCampaign(c.Request.Context(), orgID, userID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": camp})
+}
+
+// EnrollConfengeDraft — POST /confenge/drafts/:id/enroll
+func (h *Handler) EnrollConfengeDraft(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	d, xerr := h.ConfengeService.EnrollDraft(c.Request.Context(), orgID, userID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": d})
+}

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -425,3 +425,39 @@ func (h *Handler) BootstrapConfengePipeline(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"data": pipe})
 }
+
+// BatchApproveConfengeDrafts — POST /confenge/drafts/batch-approve
+// Body: {"draft_ids":["uuid",...]} — only GREEN / validated / enrollable items.
+func (h *Handler) BatchApproveConfengeDrafts(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	var body struct {
+		DraftIDs []string `json:"draft_ids"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		errx.JSON(c, errx.ErrInvalid)
+		return
+	}
+	ids := make([]uuid.UUID, 0, len(body.DraftIDs))
+	for _, s := range body.DraftIDs {
+		id, err := uuid.Parse(s)
+		if err != nil {
+			errx.JSON(c, errx.New(errx.BadRequest, "invalid draft_id"))
+			return
+		}
+		ids = append(ids, id)
+	}
+	res, xerr := h.ConfengeService.BatchApproveDrafts(c.Request.Context(), orgID, userID, ids)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": res})
+}

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -1,0 +1,258 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/app/confenge"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// confengeOrg resolves the org when CONFENGE outreach is wired and enabled.
+func (h *Handler) confengeOrg(c *gin.Context) (uuid.UUID, bool) {
+	if h.ConfengeService == nil || !h.ConfengeService.Enabled() {
+		errx.JSON(c, errx.New(errx.NotFound, "CONFENGE outreach is not enabled on this server"))
+		return uuid.Nil, false
+	}
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+		return uuid.Nil, false
+	}
+	return *orgID, true
+}
+
+// GetConfengeStatus — GET /confenge/status
+// Reports whether the feature is on (always 200 when authenticated with org).
+func (h *Handler) GetConfengeStatus(c *gin.Context) {
+	enabled := h.ConfengeService != nil && h.ConfengeService.Enabled()
+	cfg := confenge.Config{}
+	if h.ConfengeService != nil {
+		cfg = h.ConfengeService.Config()
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"enabled":                 enabled,
+		"auto_send_enabled":       enabled && cfg.AutoSendEnabled,
+		"require_human_approval":  cfg.RequireHumanApproval,
+		"default_daily_limit":     cfg.DefaultDailyLimit,
+		"max_initial_email_words": cfg.MaxInitialEmailWords,
+		"feed_configured":         enabled && cfg.FeedURL != "",
+	})
+}
+
+// GetConfengeSummary — GET /confenge/summary
+func (h *Handler) GetConfengeSummary(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	sum, xerr := h.ConfengeService.Summary(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": sum})
+}
+
+// ListConfengeAccounts — GET /confenge/accounts
+func (h *Handler) ListConfengeAccounts(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	filter := repository.OutreachAccountFilter{
+		QueueState: c.Query("queue_state"),
+		CNPJ14:     c.Query("cnpj14"),
+		Search:     c.Query("q"),
+	}
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > 200 {
+			errx.JSON(c, errx.New(errx.BadRequest, "limit must be between 1 and 200"))
+			return
+		}
+		filter.Limit = n
+	}
+	if raw := c.Query("offset"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			errx.JSON(c, errx.New(errx.BadRequest, "invalid offset"))
+			return
+		}
+		filter.Offset = n
+	}
+	list, xerr := h.ConfengeService.ListAccounts(c.Request.Context(), orgID, filter)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": list})
+}
+
+// GetConfengeAccount — GET /confenge/accounts/:id
+func (h *Handler) GetConfengeAccount(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	acc, xerr := h.ConfengeService.GetAccount(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": acc})
+}
+
+// BlockConfengeAccount — POST /confenge/accounts/:id/block
+func (h *Handler) BlockConfengeAccount(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	var body struct {
+		Reason       string `json:"reason"`
+		DoNotContact bool   `json:"do_not_contact"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil && err.Error() != "EOF" {
+		// empty body is fine
+		if c.Request.ContentLength != 0 {
+			errx.JSON(c, errx.ErrInvalid)
+			return
+		}
+	}
+	acc, xerr := h.ConfengeService.BlockAccount(c.Request.Context(), orgID, userID, id, body.Reason, body.DoNotContact)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": acc})
+}
+
+// ImportConfengeFeed — POST /confenge/import
+// Accepts a raw feed body (native confenge.outreach.v1 or legacy) or
+// {"uri":"https://...","dry_run":true}. Honour Idempotency-Key.
+func (h *Handler) ImportConfengeFeed(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	var userPtr *uuid.UUID
+	if uid, err := middleware.GetUserUUID(c); err == nil {
+		userPtr = &uid
+	}
+	opts := confenge.ImportOptions{
+		DryRun:         queryBool(c, "dry_run"),
+		IdempotencyKey: strings.TrimSpace(c.GetHeader("Idempotency-Key")),
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(c.Request.Body, 33<<20))
+	if err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "failed to read body"))
+		return
+	}
+	if len(raw) == 0 {
+		// Empty body: import from configured feed URL.
+		run, xerr := h.ConfengeService.ImportFromURI(c.Request.Context(), orgID, userPtr, "", opts)
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"data": run})
+		return
+	}
+
+	// Envelope: fetch by URI without embedding the full feed.
+	var env struct {
+		URI           string          `json:"uri"`
+		DryRun        *bool           `json:"dry_run"`
+		SchemaVersion string          `json:"schema_version"`
+		Leads         json.RawMessage `json:"leads"`
+	}
+	if err := json.Unmarshal(raw, &env); err == nil && env.URI != "" && env.SchemaVersion == "" && len(env.Leads) == 0 {
+		if env.DryRun != nil {
+			opts.DryRun = *env.DryRun
+		}
+		run, xerr := h.ConfengeService.ImportFromURI(c.Request.Context(), orgID, userPtr, env.URI, opts)
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"data": run})
+		return
+	}
+
+	run, xerr := h.ConfengeService.ImportFromBytes(c.Request.Context(), orgID, userPtr, raw, opts)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": run})
+}
+
+// ListConfengeImportRuns — GET /confenge/import-runs
+func (h *Handler) ListConfengeImportRuns(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	limit := 20
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err == nil && n > 0 && n <= 100 {
+			limit = n
+		}
+	}
+	list, xerr := h.ConfengeService.ListImportRuns(c.Request.Context(), orgID, limit)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": list})
+}
+
+// GetConfengeImportRun — GET /confenge/import-runs/:id
+func (h *Handler) GetConfengeImportRun(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	run, xerr := h.ConfengeService.GetImportRun(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": run})
+}
+
+func queryBool(c *gin.Context, key string) bool {
+	v := strings.ToLower(strings.TrimSpace(c.Query(key)))
+	return v == "1" || v == "true" || v == "yes"
+}

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -256,3 +256,115 @@ func queryBool(c *gin.Context, key string) bool {
 	v := strings.ToLower(strings.TrimSpace(c.Query(key)))
 	return v == "1" || v == "true" || v == "yes"
 }
+
+// ListConfengeDrafts — GET /confenge/drafts
+func (h *Handler) ListConfengeDrafts(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	limit, offset := 50, 0
+	if raw := c.Query("limit"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 && n <= 200 {
+			limit = n
+		}
+	}
+	if raw := c.Query("offset"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	list, xerr := h.ConfengeService.ListDrafts(c.Request.Context(), orgID, c.Query("status"), limit, offset)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": list})
+}
+
+// GetConfengeDraft — GET /confenge/drafts/:id
+func (h *Handler) GetConfengeDraft(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	d, xerr := h.ConfengeService.GetDraft(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": d})
+}
+
+// GenerateConfengeDraft — POST /confenge/accounts/:id/generate
+func (h *Handler) GenerateConfengeDraft(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	accountID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	var body struct {
+		ContactCandidateID *uuid.UUID `json:"contact_candidate_id"`
+	}
+	_ = c.ShouldBindJSON(&body)
+	d, xerr := h.ConfengeService.GenerateDraft(c.Request.Context(), orgID, userID, accountID, body.ContactCandidateID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": d})
+}
+
+// ReviewConfengeDraft — POST /confenge/drafts/:id/review
+// Body: {"action":"approve|reject|skip|edit|block", "subject":"...", "body_text":"...", "do_not_contact":false}
+func (h *Handler) ReviewConfengeDraft(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	var body struct {
+		Action       string  `json:"action" binding:"required"`
+		Subject      *string `json:"subject"`
+		BodyText     *string `json:"body_text"`
+		Reason       *string `json:"reason"`
+		DoNotContact bool    `json:"do_not_contact"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		errx.JSON(c, errx.ErrInvalid)
+		return
+	}
+	edit := &confenge.DraftEdit{
+		Subject: body.Subject, BodyText: body.BodyText,
+		Reason: body.Reason, DoNotContact: body.DoNotContact,
+	}
+	d, xerr := h.ConfengeService.ReviewDraft(c.Request.Context(), orgID, userID, id, body.Action, edit)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": d})
+}

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/auth"
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/compose"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/app/contact"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/app/crm"
@@ -111,6 +112,10 @@ type Handler struct {
 
 	// CRM
 	CRMService crm.CRMService
+
+	// CONFENGE outreach staging (extra-cli feed import). Nil or disabled when
+	// CONFENGE_OUTREACH_ENABLED is false.
+	ConfengeService confenge.Service
 
 	// Teams
 	TeamService team.TeamService

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -467,6 +467,8 @@ func Run(
 					confengeWrite.POST("/accounts/:id/block", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BlockConfengeAccount)
 					confengeWrite.POST("/accounts/:id/generate", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.GenerateConfengeDraft)
 					confengeWrite.POST("/drafts/:id/review", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReviewConfengeDraft)
+					confengeWrite.POST("/drafts/:id/enroll", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.EnrollConfengeDraft)
+					confengeWrite.POST("/campaign/bootstrap", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.BootstrapConfengeCampaign)
 				}
 			}
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -457,12 +457,16 @@ func Run(
 				confengeGroup.GET("/accounts/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeAccount)
 				confengeGroup.GET("/import-runs", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeImportRuns)
 				confengeGroup.GET("/import-runs/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeImportRun)
+				confengeGroup.GET("/drafts", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeDrafts)
+				confengeGroup.GET("/drafts/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeDraft)
 
 				confengeWrite := confengeGroup.Group("")
 				confengeWrite.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 				{
 					confengeWrite.POST("/import", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ImportConfengeFeed)
 					confengeWrite.POST("/accounts/:id/block", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BlockConfengeAccount)
+					confengeWrite.POST("/accounts/:id/generate", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.GenerateConfengeDraft)
+					confengeWrite.POST("/drafts/:id/review", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReviewConfengeDraft)
 				}
 			}
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -466,6 +466,7 @@ func Run(
 					confengeWrite.POST("/import", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ImportConfengeFeed)
 					confengeWrite.POST("/accounts/:id/block", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BlockConfengeAccount)
 					confengeWrite.POST("/accounts/:id/generate", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.GenerateConfengeDraft)
+					confengeWrite.POST("/drafts/batch-approve", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BatchApproveConfengeDrafts)
 					confengeWrite.POST("/drafts/:id/review", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReviewConfengeDraft)
 					confengeWrite.POST("/drafts/:id/enroll", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.EnrollConfengeDraft)
 					confengeWrite.POST("/campaign/bootstrap", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.BootstrapConfengeCampaign)

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -469,6 +469,7 @@ func Run(
 					confengeWrite.POST("/drafts/:id/review", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReviewConfengeDraft)
 					confengeWrite.POST("/drafts/:id/enroll", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.EnrollConfengeDraft)
 					confengeWrite.POST("/campaign/bootstrap", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.BootstrapConfengeCampaign)
+					confengeWrite.POST("/crm/bootstrap", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.BootstrapConfengePipeline)
 				}
 			}
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -445,6 +445,27 @@ func Run(
 				}
 			}
 
+			// CONFENGE outreach staging (extra-cli feed import). Feature-flagged
+			// server-side; status is always readable so the dashboard can hide
+			// the nav when disabled. Mutations require manage contacts.
+			confengeGroup := protected.Group("/confenge")
+			confengeGroup.Use(m.RequireOrganization())
+			{
+				confengeGroup.GET("/status", h.GetConfengeStatus)
+				confengeGroup.GET("/summary", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeSummary)
+				confengeGroup.GET("/accounts", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeAccounts)
+				confengeGroup.GET("/accounts/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeAccount)
+				confengeGroup.GET("/import-runs", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeImportRuns)
+				confengeGroup.GET("/import-runs/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeImportRun)
+
+				confengeWrite := confengeGroup.Group("")
+				confengeWrite.Use(m.RateLimitMiddleware(models.RateLimitWrite))
+				{
+					confengeWrite.POST("/import", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ImportConfengeFeed)
+					confengeWrite.POST("/accounts/:id/block", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BlockConfengeAccount)
+				}
+			}
+
 			contacts := protected.Group("/contacts")
 			contacts.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 			{

--- a/internal/app/advanced/events.go
+++ b/internal/app/advanced/events.go
@@ -100,6 +100,10 @@ func (s *service) WireInboxAgent(a InboxAgent) {
 	s.inboxAgent = a
 }
 
+func (s *service) WireConfengeReply(h ConfengeReplyHook) {
+	s.confengeReply = h
+}
+
 // notify raises an in-app notification off the hot path. It detaches from the
 // request context (the ingest call may return first) and is best-effort.
 func (s *service) notify(userID uuid.UUID, orgID *uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any) {

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -117,6 +117,9 @@ type Service interface {
 	// WireInboxAgent attaches the inbox agent so an inbound human reply drafts a
 	// suggested reply for review (M10). Best-effort; nil = feature off.
 	WireInboxAgent(a InboxAgent)
+	// WireConfengeReply attributes classified replies to CONFENGE staging
+	// (outcome outbox + CRM tasks/deals). Best-effort; nil = feature off.
+	WireConfengeReply(h ConfengeReplyHook)
 
 	// EmitCampaignEvent dispatches a campaign event (e.g. from a sequence
 	// "notify" action node) to customer webhooks and wired integrations.
@@ -159,6 +162,13 @@ type service struct {
 	realtime             ReplyRealtimePublisher
 	automationRunner     AutomationRunner
 	inboxAgent           InboxAgent
+	confengeReply        ConfengeReplyHook
+}
+
+// ConfengeReplyHook is implemented by the CONFENGE outreach service. Kept as a
+// narrow interface so advanced does not import the confenge package.
+type ConfengeReplyHook interface {
+	OnClassifiedReply(ctx context.Context, orgID uuid.UUID, contactEmail, replyClass string, contactID *uuid.UUID) error
 }
 
 func NewService(
@@ -893,6 +903,11 @@ func (s *service) ProcessIncomingReply(ctx context.Context, emailAccountID uuid.
 		// for every reply, so OOO/unsubscribe stay correct even when the gate
 		// skipped the model.
 		_ = s.campaignProgressRepo.RecordReplyClassification(ctx, cID, ctID, sID, replyResult.Class, replyResult.Source, replyResult.Confidence)
+
+		// CONFENGE staging: attribute the class to outbox + CRM (best-effort).
+		if s.confengeReply != nil && account.OrganizationID != nil {
+			_ = s.confengeReply.OnClassifiedReply(ctx, *account.OrganizationID, sender, replyResult.Class, &ctID)
+		}
 
 		// OOO trap fix: only a HUMAN reply stamps replied_at. An auto_reply /
 		// out_of_office must NOT count as a reply, or it would (a) trip

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -43,6 +43,9 @@ type Service interface {
 	RecordInboundBounce(ctx context.Context, emailAccountID uuid.UUID, originalMessageID, failedRecipient, reason string) *errx.Error
 
 	ShouldSuppressRecipient(ctx context.Context, organizationID uuid.UUID, recipient string) (bool, string, *errx.Error)
+	// SuppressRecipient adds an address to the org suppression list (e.g. DNC
+	// from CONFENGE reply classification). Always suppress — explicit request.
+	SuppressRecipient(ctx context.Context, organizationID uuid.UUID, email, reason string) *errx.Error
 	// Unsubscribe suppresses a contact in response to a List-Unsubscribe action
 	// (one-click POST or the manual link). Always suppresses — it's an explicit
 	// recipient request, independent of the auto-suppress settings.
@@ -496,6 +499,26 @@ func (s *service) ListPipelines(ctx context.Context, orgID uuid.UUID) ([]models.
 		return nil, nil
 	}
 	return s.crmRepo.ListPipelines(ctx, orgID)
+}
+
+func (s *service) SuppressRecipient(ctx context.Context, organizationID uuid.UUID, email, reason string) *errx.Error {
+	email = strings.TrimSpace(strings.ToLower(email))
+	if email == "" {
+		return errx.New(errx.BadRequest, "email is required")
+	}
+	if reason == "" {
+		reason = "manual suppression"
+	}
+	if err := s.repo.UpsertSuppressedRecipient(ctx, &models.SuppressedRecipient{
+		OrganizationID: organizationID,
+		Email:          email,
+		Reason:         reason,
+		Source:         models.DeliverabilityEventUnsubscribe,
+		Metadata:       map[string]interface{}{"via": "confenge_dnc"},
+	}); err != nil {
+		return toErrx(err)
+	}
+	return nil
 }
 
 func (s *service) Unsubscribe(ctx context.Context, campaignID, contactID uuid.UUID) *errx.Error {

--- a/internal/app/confenge/campaign.go
+++ b/internal/app/confenge/campaign.go
@@ -1,0 +1,278 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Default campaign name for CONFENGE bootstrap (idempotent).
+const DefaultCampaignName = "CONFENGE | Outreach consultivo inicial"
+
+// CampaignAPI is the slice of campaign service used for bootstrap.
+type CampaignAPI interface {
+	Create(ctx context.Context, userID string, orgID *uuid.UUID, data *models.CreateCampaign) (*models.Campaign, *errx.Error)
+	Get(ctx context.Context, orgID, id string) (*models.Campaign, *errx.Error)
+}
+
+// ContactAPI is the slice of contact service used for enrollment.
+type ContactAPI interface {
+	Add(ctx context.Context, userID string, orgID uuid.UUID, contacts []models.AddContact) ([]models.Contact, *errx.Error)
+}
+
+// WireExecution attaches campaign/contact execution-plane services.
+func (s *service) WireExecution(campaigns CampaignAPI, contacts ContactAPI) {
+	s.campaigns = campaigns
+	s.contacts = contacts
+}
+
+// BootstrapCampaign finds or creates the CONFENGE campaign for the org.
+// Idempotent: re-runs return the same campaign_id stored in outreach_org_settings.
+func (s *service) BootstrapCampaign(ctx context.Context, orgID, userID uuid.UUID) (*models.Campaign, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if s.campaigns == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "campaign service not wired")
+	}
+
+	settings, err := s.repo.GetOrgSettings(ctx, orgID)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load org settings")
+	}
+	if settings != nil && settings.CampaignID != nil {
+		c, xerr := s.campaigns.Get(ctx, orgID.String(), settings.CampaignID.String())
+		if xerr == nil && c != nil {
+			return c, nil
+		}
+		// Campaign was deleted; fall through to recreate.
+	}
+
+	tz := "America/Sao_Paulo"
+	limit := s.cfg.DefaultDailyLimit
+	if limit < 1 {
+		limit = DefaultCampaignDailyLimit
+	}
+	stop := true
+	openTrack := false
+	linkTrack := false
+	unsub := true
+	textOnly := true
+	start := "09:00"
+	end := "17:00"
+	// Mon-Fri bitmask: leave Days nil so repository uses DefaultDays().
+	steps := defaultCadenceSteps()
+	desc := "CONFENGE consultive outreach. Human-approved enrollments only. Stop on reply/bounce."
+
+	created, xerr := s.campaigns.Create(ctx, userID.String(), &orgID, &models.CreateCampaign{
+		Name:              DefaultCampaignName,
+		Description:       desc,
+		StopOnReply:       &stop,
+		OpenTracking:      &openTrack,
+		LinkTracking:      &linkTrack,
+		UnsubscribeHeader: &unsub,
+		TextOnly:          &textOnly,
+		DailyLimit:        &limit,
+		Timezone:          &tz,
+		StartTime:         &start,
+		EndTime:           &end,
+		Sequences:         steps,
+	})
+	if xerr != nil {
+		return nil, xerr
+	}
+
+	st := &models.OutreachOrgSettings{
+		OrganizationID: orgID,
+		CampaignID:     &created.ID,
+		CampaignName:   DefaultCampaignName,
+	}
+	if err := s.repo.UpsertOrgSettings(ctx, st); err != nil {
+		return nil, errx.New(errx.Internal, "failed to persist campaign pointer")
+	}
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionCreate, models.AuditEntityCampaign, &created.ID, "", "",
+			map[string]string{"name": DefaultCampaignName, "source": "confenge_bootstrap"},
+			nil,
+		)
+	}
+	return created, nil
+}
+
+func defaultCadenceSteps() []models.CreateSequenceInput {
+	w3, w4, w7 := 3, 4, 7
+	return []models.CreateSequenceInput{
+		{
+			Name:      "Email inicial",
+			Subject:   "{{.Company}} — conversa objetiva",
+			BodyPlain: "Ola{{if .FirstName}} {{.FirstName}}{{end}},\n\nSou da CONFENGE. Acompanhei publicacoes recentes da {{.Company}} e gostaria de entender se faz sentido uma conversa curta sobre aditivos e controle contratual.\n\nPosso enviar um checklist de uma pagina?\n\nAbraço,\nTiago Sasaki\nCONFENGE",
+			WaitAfter: &w3,
+		},
+		{
+			Name:      "Follow-up D+3",
+			Subject:   "Re: {{.Company}}",
+			BodyPlain: "Reenvio com uma pergunta mais objetiva: quem na equipe acompanha aditivos e reajustes?\n\nSe fizer sentido, respondo em poucos minutos.",
+			WaitAfter: &w4,
+		},
+		{
+			Name:      "Follow-up D+7",
+			Subject:   "Re: {{.Company}}",
+			BodyPlain: "Se nao for com voce, pode me indicar a pessoa certa de contratos ou engenharia?\n\nObrigado.",
+			WaitAfter: &w7,
+		},
+		{
+			Name:      "Encerramento D+14",
+			Subject:   "Re: {{.Company}}",
+			BodyPlain: "Encerro por aqui para nao ocupar sua caixa. Se fizer sentido no futuro, e so responder este fio.\n\nAbraço.",
+			WaitAfter: nil,
+		},
+	}
+}
+
+// EnrollDraft promotes an APPROVED, validated draft into a Warmbly contact
+// and campaign lead. Never enrolls unverified / DNC / bounced addresses.
+func (s *service) EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if s.cfg.AutoSendEnabled && !s.cfg.RequireHumanApproval {
+		return nil, errx.New(errx.BadRequest, "refusing enroll: auto-send without human approval is not allowed")
+	}
+	if s.contacts == nil || s.campaigns == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "execution services not wired")
+	}
+
+	d, err := s.repo.GetDraft(ctx, orgID, draftID)
+	if err != nil || d == nil {
+		return nil, errx.New(errx.NotFound, "draft not found")
+	}
+	if d.Status == models.OutreachDraftEnrolled {
+		return d, nil // idempotent
+	}
+	if d.Status != models.OutreachDraftApproved {
+		return nil, errx.New(errx.BadRequest, "draft must be APPROVED before enrollment")
+	}
+
+	acc, err := s.repo.GetAccount(ctx, orgID, d.AccountID)
+	if err != nil || acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	if acc.DoNotContact || acc.Blocked {
+		return nil, errx.New(errx.BadRequest, "account is blocked or DO_NOT_CONTACT")
+	}
+
+	var cand *models.OutreachContactCandidate
+	if d.ContactCandidateID != nil {
+		cand, err = s.repo.GetCandidate(ctx, orgID, *d.ContactCandidateID)
+		if err != nil || cand == nil {
+			return nil, errx.New(errx.NotFound, "contact candidate not found")
+		}
+	}
+	if cand == nil || !cand.CanEnroll() {
+		return nil, errx.New(errx.BadRequest, "contact is not enrollable")
+	}
+
+	out := DraftOutput{
+		Subject: d.Subject, BodyText: d.BodyText, FactUsed: d.FactUsed,
+		ServiceCode: d.ServiceCode, EvidenceIDs: d.EvidenceIDs,
+	}
+	val := ValidateDraft(&out, acc, cand, s.cfg.MaxInitialEmailWords)
+	if !val.OK {
+		return nil, errx.New(errx.BadRequest, "draft failed validation: "+joinErrs(val.Errors))
+	}
+	if d.RiskClass == "RED" {
+		// RED may enroll only after explicit approve (already APPROVED); allowed but audited.
+	}
+
+	camp, xerr := s.BootstrapCampaign(ctx, orgID, userID)
+	if xerr != nil {
+		return nil, xerr
+	}
+
+	first, last := splitName(cand.Name)
+	company := firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
+	added, xerr := s.contacts.Add(ctx, userID.String(), orgID, []models.AddContact{{
+		FirstName: first,
+		LastName:  last,
+		Email:     strings.TrimSpace(strings.ToLower(cand.Email)),
+		Company:   company,
+		Phone:     cand.Phone,
+		Campaigns: []string{camp.ID.String()},
+		CustomFields: map[string]string{
+			"cnpj14":           acc.CNPJ14,
+			"confenge_subject": d.Subject,
+			"confenge_body":    d.BodyText,
+			"confenge_service": d.ServiceCode,
+			"confenge_fact":    d.FactUsed,
+		},
+	}})
+	if xerr != nil {
+		return nil, xerr
+	}
+	if len(added) == 0 {
+		return nil, errx.New(errx.Internal, "contact create returned empty")
+	}
+	contactID := added[0].ID
+
+	// Mark candidate promoted
+	cand.WarmblyContactID = &contactID
+	now := time.Now().UTC()
+	cand.PromotedAt = &now
+	_, _ = s.repo.UpsertCandidate(ctx, cand)
+
+	d.Status = models.OutreachDraftEnrolled
+	d.CampaignID = &camp.ID
+	d.EnrollmentContactID = &contactID
+	d.EnrolledAt = &now
+	if err := s.repo.UpsertDraft(ctx, d); err != nil {
+		return nil, errx.New(errx.Internal, "failed to update draft enrollment")
+	}
+	_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueEnrolled)
+
+	// Outcomes: approved contact + contacted (enrolled into campaign)
+	_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("contact_approved:%s:%s", orgID, d.ID),
+		SourceLeadID:   acc.SourceLeadID,
+		CNPJ14:         acc.CNPJ14,
+		ContactEmail:   cand.Email,
+		EventType:      OutcomeContactApproved,
+		OccurredAt:     now,
+	})
+	_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("contacted:%s:%s", orgID, d.ID),
+		SourceLeadID:   acc.SourceLeadID,
+		CNPJ14:         acc.CNPJ14,
+		ContactEmail:   cand.Email,
+		EventType:      OutcomeContacted,
+		OccurredAt:     now,
+	})
+
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionCreate, models.AuditEntityContact, &contactID, "", "",
+			map[string]string{
+				"draft_id":    d.ID.String(),
+				"campaign_id": camp.ID.String(),
+				"cnpj14":      acc.CNPJ14,
+			},
+			map[string]string{"source": "confenge_enroll"},
+		)
+	}
+	return d, nil
+}
+
+func splitName(full string) (first, last string) {
+	parts := strings.Fields(strings.TrimSpace(full))
+	if len(parts) == 0 {
+		return "", ""
+	}
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], strings.Join(parts[1:], " ")
+}

--- a/internal/app/confenge/campaign.go
+++ b/internal/app/confenge/campaign.go
@@ -2,6 +2,7 @@ package confenge
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -105,34 +106,72 @@ func (s *service) BootstrapCampaign(ctx context.Context, orgID, userID uuid.UUID
 	return created, nil
 }
 
+// defaultCadenceSteps uses merge variables filled at enroll from the human-
+// approved draft (confenge_subject / confenge_body / confenge_followup_N).
+// The campaign send path renders these via RenderTemplate + contact CustomFields,
+// so the message that leaves the mailbox is the reviewed copy, not a generic
+// template. No em dashes (product prohibition for lead-facing copy).
 func defaultCadenceSteps() []models.CreateSequenceInput {
 	w3, w4, w7 := 3, 4, 7
 	return []models.CreateSequenceInput{
 		{
 			Name:      "Email inicial",
-			Subject:   "{{.Company}} — conversa objetiva",
-			BodyPlain: "Ola{{if .FirstName}} {{.FirstName}}{{end}},\n\nSou da CONFENGE. Acompanhei publicacoes recentes da {{.Company}} e gostaria de entender se faz sentido uma conversa curta sobre aditivos e controle contratual.\n\nPosso enviar um checklist de uma pagina?\n\nAbraço,\nTiago Sasaki\nCONFENGE",
+			Subject:   "{{.confenge_subject}}",
+			BodyPlain: "{{.confenge_body}}",
 			WaitAfter: &w3,
 		},
 		{
 			Name:      "Follow-up D+3",
 			Subject:   "Re: {{.Company}}",
-			BodyPlain: "Reenvio com uma pergunta mais objetiva: quem na equipe acompanha aditivos e reajustes?\n\nSe fizer sentido, respondo em poucos minutos.",
+			BodyPlain: "{{if .confenge_followup_1}}{{.confenge_followup_1}}{{else}}Reenvio com uma pergunta mais objetiva: quem na equipe acompanha aditivos e reajustes?\n\nSe fizer sentido, respondo em poucos minutos.{{end}}",
 			WaitAfter: &w4,
 		},
 		{
 			Name:      "Follow-up D+7",
 			Subject:   "Re: {{.Company}}",
-			BodyPlain: "Se nao for com voce, pode me indicar a pessoa certa de contratos ou engenharia?\n\nObrigado.",
+			BodyPlain: "{{if .confenge_followup_2}}{{.confenge_followup_2}}{{else}}Se nao for com voce, pode me indicar a pessoa certa de contratos ou engenharia?\n\nObrigado.{{end}}",
 			WaitAfter: &w7,
 		},
 		{
 			Name:      "Encerramento D+14",
 			Subject:   "Re: {{.Company}}",
-			BodyPlain: "Encerro por aqui para nao ocupar sua caixa. Se fizer sentido no futuro, e so responder este fio.\n\nAbraço.",
+			BodyPlain: "{{if .confenge_followup_3}}{{.confenge_followup_3}}{{else}}Encerro por aqui para nao ocupar sua caixa. Se fizer sentido no futuro, e so responder este fio.\n\nAbraco.{{end}}",
 			WaitAfter: nil,
 		},
 	}
+}
+
+// EnrollCustomFields builds contact custom fields that the cadence templates
+// merge at send time. Subject/body must match the approved draft exactly.
+func EnrollCustomFields(d *models.OutreachDraft, acc *models.OutreachAccount) map[string]string {
+	cf := map[string]string{
+		"confenge_subject": strings.TrimSpace(d.Subject),
+		"confenge_body":    strings.TrimSpace(d.BodyText),
+	}
+	if acc != nil {
+		cf["cnpj14"] = acc.CNPJ14
+		cf["confenge_service"] = firstNonEmpty(d.ServiceCode, acc.ServiceCode)
+		cf["confenge_fact"] = firstNonEmpty(d.FactUsed, acc.FactToMention)
+	} else {
+		cf["confenge_service"] = d.ServiceCode
+		cf["confenge_fact"] = d.FactUsed
+	}
+	// Follow-ups from draft JSON (delay-ordered as stored).
+	if len(d.FollowupsJSON) > 0 {
+		var fus []DraftFollowup
+		if json.Unmarshal(d.FollowupsJSON, &fus) == nil {
+			for i, fu := range fus {
+				if i >= 3 {
+					break
+				}
+				body := strings.TrimSpace(fu.BodyText)
+				if body != "" {
+					cf[fmt.Sprintf("confenge_followup_%d", i+1)] = body
+				}
+			}
+		}
+	}
+	return cf
 }
 
 // EnrollDraft promotes an APPROVED, validated draft into a Warmbly contact
@@ -197,20 +236,16 @@ func (s *service) EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.U
 
 	first, last := splitName(cand.Name)
 	company := firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
+	// Custom fields feed the cadence merge vars so send uses the approved draft.
+	cf := EnrollCustomFields(d, acc)
 	added, xerr := s.contacts.Add(ctx, userID.String(), orgID, []models.AddContact{{
-		FirstName: first,
-		LastName:  last,
-		Email:     strings.TrimSpace(strings.ToLower(cand.Email)),
-		Company:   company,
-		Phone:     cand.Phone,
-		Campaigns: []string{camp.ID.String()},
-		CustomFields: map[string]string{
-			"cnpj14":           acc.CNPJ14,
-			"confenge_subject": d.Subject,
-			"confenge_body":    d.BodyText,
-			"confenge_service": d.ServiceCode,
-			"confenge_fact":    d.FactUsed,
-		},
+		FirstName:    first,
+		LastName:     last,
+		Email:        strings.TrimSpace(strings.ToLower(cand.Email)),
+		Company:      company,
+		Phone:        cand.Phone,
+		Campaigns:    []string{camp.ID.String()},
+		CustomFields: cf,
 	}})
 	if xerr != nil {
 		return nil, xerr

--- a/internal/app/confenge/campaign_test.go
+++ b/internal/app/confenge/campaign_test.go
@@ -2,6 +2,7 @@ package confenge
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -246,4 +247,17 @@ func (m *memRepoFull) GetActiveDraftForAccount(ctx context.Context, orgID, accou
 
 func (m *memRepoFull) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
 	return nil
+}
+
+func (m *memRepoFull) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	for _, list := range m.cands {
+		for i := range list {
+			if list[i].OrganizationID == orgID && strings.EqualFold(list[i].Email, email) {
+				acc, _ := m.GetAccount(ctx, orgID, list[i].AccountID)
+				cp := list[i]
+				return &cp, acc, nil
+			}
+		}
+	}
+	return nil, nil, nil
 }

--- a/internal/app/confenge/campaign_test.go
+++ b/internal/app/confenge/campaign_test.go
@@ -1,0 +1,249 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+type mockCampaigns struct {
+	created *models.Campaign
+	gets    map[string]*models.Campaign
+}
+
+func (m *mockCampaigns) Create(ctx context.Context, userID string, orgID *uuid.UUID, data *models.CreateCampaign) (*models.Campaign, *errx.Error) {
+	if data.Name != DefaultCampaignName {
+		return nil, errx.New(errx.BadRequest, "unexpected name")
+	}
+	if data.StopOnReply == nil || !*data.StopOnReply {
+		return nil, errx.New(errx.BadRequest, "stop_on_reply required")
+	}
+	if data.Timezone == nil || *data.Timezone != "America/Sao_Paulo" {
+		return nil, errx.New(errx.BadRequest, "timezone")
+	}
+	if len(data.Sequences) != 4 {
+		return nil, errx.New(errx.BadRequest, "want 4 cadence steps")
+	}
+	c := &models.Campaign{ID: uuid.New(), Name: data.Name, Status: "draft"}
+	m.created = c
+	if m.gets == nil {
+		m.gets = map[string]*models.Campaign{}
+	}
+	m.gets[c.ID.String()] = c
+	return c, nil
+}
+
+func (m *mockCampaigns) Get(ctx context.Context, orgID, id string) (*models.Campaign, *errx.Error) {
+	if c := m.gets[id]; c != nil {
+		return c, nil
+	}
+	return nil, errx.New(errx.NotFound, "missing")
+}
+
+type mockContacts struct {
+	added []models.AddContact
+}
+
+func (m *mockContacts) Add(ctx context.Context, userID string, orgID uuid.UUID, contacts []models.AddContact) ([]models.Contact, *errx.Error) {
+	m.added = append(m.added, contacts...)
+	out := make([]models.Contact, len(contacts))
+	for i, c := range contacts {
+		out[i] = models.Contact{ID: uuid.New(), Email: c.Email, FirstName: c.FirstName, Company: c.Company}
+	}
+	return out, nil
+}
+
+func TestBootstrapCampaignIdempotent(t *testing.T) {
+	repo := newMemRepo()
+	// enrich memRepo for org settings
+	settings := map[uuid.UUID]*models.OutreachOrgSettings{}
+	// override via embedding won't work — use real methods if we stored on memRepo
+	// Patch: use service with mock campaigns that tracks creates
+	camps := &mockCampaigns{}
+	svc := testSvc(repo).(*service)
+	svc.WireExecution(camps, &mockContacts{})
+	// need GetOrgSettings/Upsert on memRepo - already stub returns nil
+	// First create stores settings - but memRepo UpsertOrgSettings is no-op and Get returns nil
+	// so every bootstrap creates again. Fix memRepo to store settings.
+	org := uuid.New()
+	user := uuid.New()
+
+	// Use a settings-aware mem repo extension
+	r2 := newMemRepoWithSettings()
+	svc2 := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120, RequireHumanApproval: true}, r2, nil).(*service)
+	camps2 := &mockCampaigns{}
+	svc2.WireExecution(camps2, &mockContacts{})
+
+	c1, xerr := svc2.BootstrapCampaign(context.Background(), org, user)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	c2, xerr := svc2.BootstrapCampaign(context.Background(), org, user)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if c1.ID != c2.ID {
+		t.Fatalf("bootstrap not idempotent: %s vs %s", c1.ID, c2.ID)
+	}
+	if camps2.created == nil || camps2.created.ID != c1.ID {
+		t.Fatal("expected single create")
+	}
+	_ = settings
+}
+
+func TestEnrollRejectsUnapproved(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120, RequireHumanApproval: true}, r, nil).(*service)
+	svc.WireExecution(&mockCampaigns{}, &mockContacts{})
+	org := uuid.New()
+	// seed account + candidate + draft NEEDS_REVIEW
+	accID := uuid.New()
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", QueueState: models.OutreachQueueReadyToGenerate,
+		FactToMention: "fato", ServiceCode: "S",
+	}
+	_, _ = r.UpsertAccount(context.Background(), acc)
+	candID := uuid.New()
+	cand := &models.OutreachContactCandidate{
+		ID: candID, OrganizationID: org, AccountID: accID,
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Recommended: true,
+	}
+	_, _ = r.UpsertCandidate(context.Background(), cand)
+	d := &models.OutreachDraft{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, ContactCandidateID: &candID,
+		Subject: "Oi", BodyText: "corpo com fato publico ok", FactUsed: "fato",
+		ServiceCode: "S", Status: models.OutreachDraftNeedsReview, RiskClass: "GREEN",
+		RecipientEmail: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	ok := true
+	d.ValidationOK = &ok
+	_ = r.UpsertDraft(context.Background(), d)
+
+	_, xerr := svc.EnrollDraft(context.Background(), org, uuid.New(), d.ID)
+	if xerr == nil {
+		t.Fatal("must reject non-approved")
+	}
+}
+
+func TestEnrollApprovedHappyPath(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120, RequireHumanApproval: true}, r, nil).(*service)
+	contacts := &mockContacts{}
+	svc.WireExecution(&mockCampaigns{}, contacts)
+	org := uuid.New()
+	accID := uuid.New()
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", NomeFantasia: "ACME", QueueState: models.OutreachQueueApproved,
+		FactToMention: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW", SourceLeadID: "L1",
+	}
+	_, _ = r.UpsertAccount(context.Background(), acc)
+	candID := uuid.New()
+	cand := &models.OutreachContactCandidate{
+		ID: candID, OrganizationID: org, AccountID: accID, Name: "Ana Silva",
+		Email: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Recommended: true,
+	}
+	_, _ = r.UpsertCandidate(context.Background(), cand)
+	d := &models.OutreachDraft{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, ContactCandidateID: &candID,
+		Subject: "Sobre ACME", BodyText: "Ola Ana,\n\nNotei a prorrogacao do contrato. Faz sentido conversarmos?\n\nPosso enviar checklist?",
+		FactUsed: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
+		Status: models.OutreachDraftApproved, RiskClass: "GREEN",
+		RecipientEmail: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	ok := true
+	d.ValidationOK = &ok
+	_ = r.UpsertDraft(context.Background(), d)
+
+	out, xerr := svc.EnrollDraft(context.Background(), org, uuid.New(), d.ID)
+	if xerr != nil {
+		t.Fatal(xerr.Message)
+	}
+	if out.Status != models.OutreachDraftEnrolled {
+		t.Fatalf("status %s", out.Status)
+	}
+	if out.CampaignID == nil || out.EnrollmentContactID == nil {
+		t.Fatal("missing campaign/contact ids")
+	}
+	if len(contacts.added) != 1 || contacts.added[0].Email != "ana@example.com" {
+		t.Fatalf("contact add: %+v", contacts.added)
+	}
+	// idempotent re-enroll
+	out2, xerr := svc.EnrollDraft(context.Background(), org, uuid.New(), d.ID)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if out2.ID != out.ID {
+		t.Fatal("re-enroll should return same draft")
+	}
+}
+
+// memRepo with settings + drafts storage
+type memRepoFull struct {
+	*memRepo
+	settings map[uuid.UUID]*models.OutreachOrgSettings
+	drafts   map[uuid.UUID]*models.OutreachDraft
+}
+
+func newMemRepoWithSettings() *memRepoFull {
+	return &memRepoFull{
+		memRepo:  newMemRepo(),
+		settings: map[uuid.UUID]*models.OutreachOrgSettings{},
+		drafts:   map[uuid.UUID]*models.OutreachDraft{},
+	}
+}
+
+func (m *memRepoFull) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error) {
+	s := m.settings[orgID]
+	if s == nil {
+		return nil, nil
+	}
+	cp := *s
+	return &cp, nil
+}
+
+func (m *memRepoFull) UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error {
+	cp := *s
+	m.settings[s.OrganizationID] = &cp
+	return nil
+}
+
+func (m *memRepoFull) UpsertDraft(ctx context.Context, d *models.OutreachDraft) error {
+	if d.ID == uuid.Nil {
+		d.ID = uuid.New()
+	}
+	cp := *d
+	m.drafts[d.ID] = &cp
+	return nil
+}
+
+func (m *memRepoFull) GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error) {
+	d := m.drafts[id]
+	if d == nil || d.OrganizationID != orgID {
+		return nil, nil
+	}
+	cp := *d
+	return &cp, nil
+}
+
+func (m *memRepoFull) GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error) {
+	for _, d := range m.drafts {
+		if d.OrganizationID == orgID && d.AccountID == accountID {
+			switch d.Status {
+			case models.OutreachDraftNotGenerated, models.OutreachDraftGenerating, models.OutreachDraftNeedsReview, models.OutreachDraftApproved:
+				cp := *d
+				return &cp, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (m *memRepoFull) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
+	return nil
+}

--- a/internal/app/confenge/campaign_test.go
+++ b/internal/app/confenge/campaign_test.go
@@ -12,8 +12,9 @@ import (
 )
 
 type mockCampaigns struct {
-	created *models.Campaign
-	gets    map[string]*models.Campaign
+	created      *models.Campaign
+	gets         map[string]*models.Campaign
+	captureSteps *[]models.CreateSequenceInput
 }
 
 func (m *mockCampaigns) Create(ctx context.Context, userID string, orgID *uuid.UUID, data *models.CreateCampaign) (*models.Campaign, *errx.Error) {
@@ -28,6 +29,18 @@ func (m *mockCampaigns) Create(ctx context.Context, userID string, orgID *uuid.U
 	}
 	if len(data.Sequences) != 4 {
 		return nil, errx.New(errx.BadRequest, "want 4 cadence steps")
+	}
+	// Lead-facing step 0 must use approved-draft merge vars (not generic prose).
+	if data.Sequences[0].Subject != "{{.confenge_subject}}" || data.Sequences[0].BodyPlain != "{{.confenge_body}}" {
+		return nil, errx.New(errx.BadRequest, "step0 must use confenge_subject/body merge vars")
+	}
+	for _, seq := range data.Sequences {
+		if strings.Contains(seq.Subject, "—") || strings.Contains(seq.BodyPlain, "—") {
+			return nil, errx.New(errx.BadRequest, "em dash forbidden in cadence")
+		}
+	}
+	if m.captureSteps != nil {
+		*m.captureSteps = append([]models.CreateSequenceInput{}, data.Sequences...)
 	}
 	c := &models.Campaign{ID: uuid.New(), Name: data.Name, Status: "draft"}
 	m.created = c

--- a/internal/app/confenge/config.go
+++ b/internal/app/confenge/config.go
@@ -1,0 +1,147 @@
+// Package confenge implements the CONFENGE outreach operational layer:
+// import of extra-cli intelligence feeds into Warmbly staging, review queue
+// foundation, and outcome outbox (later PRs). Intelligence stays in extra-cli;
+// Warmbly remains the execution plane (contacts, campaigns, mailboxes, CRM).
+package confenge
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Env keys for CONFENGE outreach. Documented in deploy/config/env.example
+// and docs/confenge/.
+const (
+	EnvEnabled           = "CONFENGE_OUTREACH_ENABLED"
+	EnvAutoSend          = "CONFENGE_AUTO_SEND_ENABLED"
+	EnvFeedURL           = "CONFENGE_EXTRA_CLI_FEED_URL"
+	EnvFeedToken         = "CONFENGE_EXTRA_CLI_FEED_TOKEN"
+	EnvAllowedHosts      = "CONFENGE_EXTRA_CLI_ALLOWED_HOSTS"
+	EnvOutcomeWebhookURL = "CONFENGE_OUTCOME_WEBHOOK_URL"
+	EnvOutcomeWebhookSec = "CONFENGE_OUTCOME_WEBHOOK_SECRET"
+	EnvDefaultDailyLimit = "CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT"
+	EnvMaxInitialWords   = "CONFENGE_MAX_INITIAL_EMAIL_WORDS"
+	EnvRequireHuman      = "CONFENGE_REQUIRE_HUMAN_APPROVAL"
+	EnvMaxPayloadBytes   = "CONFENGE_MAX_FEED_PAYLOAD_BYTES"
+)
+
+// Defaults for conservative cold outreach.
+const (
+	DefaultCampaignDailyLimit = 10
+	DefaultMaxInitialWords    = 120
+	DefaultMaxPayloadBytes    = 32 << 20 // 32 MiB
+)
+
+// Config is runtime configuration for the confenge outreach feature.
+type Config struct {
+	Enabled              bool
+	AutoSendEnabled      bool
+	FeedURL              string
+	FeedToken            string
+	AllowedHosts         []string
+	OutcomeWebhookURL    string
+	OutcomeWebhookSecret string
+	DefaultDailyLimit    int
+	MaxInitialEmailWords int
+	RequireHumanApproval bool
+	MaxFeedPayloadBytes  int64
+}
+
+// LoadConfig reads CONFENGE_* env vars. Safe defaults keep the feature off.
+func LoadConfig() Config {
+	cfg := Config{
+		Enabled:              envBool(EnvEnabled, false),
+		AutoSendEnabled:      envBool(EnvAutoSend, false),
+		FeedURL:              strings.TrimSpace(os.Getenv(EnvFeedURL)),
+		FeedToken:            strings.TrimSpace(os.Getenv(EnvFeedToken)),
+		AllowedHosts:         splitHosts(os.Getenv(EnvAllowedHosts)),
+		OutcomeWebhookURL:    strings.TrimSpace(os.Getenv(EnvOutcomeWebhookURL)),
+		OutcomeWebhookSecret: strings.TrimSpace(os.Getenv(EnvOutcomeWebhookSec)),
+		DefaultDailyLimit:    envInt(EnvDefaultDailyLimit, DefaultCampaignDailyLimit),
+		MaxInitialEmailWords: envInt(EnvMaxInitialWords, DefaultMaxInitialWords),
+		RequireHumanApproval: envBool(EnvRequireHuman, true),
+		MaxFeedPayloadBytes:  int64(envInt(EnvMaxPayloadBytes, DefaultMaxPayloadBytes)),
+	}
+	return cfg
+}
+
+// ValidateStartup fails closed on insecure production combinations.
+// Called when the feature is enabled.
+func (c Config) ValidateStartup(appEnv string) error {
+	if !c.Enabled {
+		return nil
+	}
+	prod := strings.EqualFold(appEnv, "prod") || strings.EqualFold(appEnv, "production")
+	if c.AutoSendEnabled && c.RequireHumanApproval {
+		// Explicit: auto-send may be on only when human approval is also required
+		// is contradictory; refuse auto-send when we cannot verify intent.
+		// Keep RequireHumanApproval as the safety net — auto-send alone is never default.
+	}
+	if prod {
+		if c.FeedURL != "" {
+			if !strings.HasPrefix(strings.ToLower(c.FeedURL), "https://") {
+				return fmt.Errorf("%s must be https in production", EnvFeedURL)
+			}
+			if len(c.AllowedHosts) == 0 {
+				return fmt.Errorf("%s is required when feed URL is set in production", EnvAllowedHosts)
+			}
+		}
+		if c.OutcomeWebhookURL != "" {
+			if !strings.HasPrefix(strings.ToLower(c.OutcomeWebhookURL), "https://") {
+				return fmt.Errorf("%s must be https in production", EnvOutcomeWebhookURL)
+			}
+			if c.OutcomeWebhookSecret == "" {
+				return fmt.Errorf("%s is required when outcome webhook is set", EnvOutcomeWebhookSec)
+			}
+		}
+	}
+	if c.DefaultDailyLimit < 1 || c.DefaultDailyLimit > 100 {
+		return fmt.Errorf("%s must be between 1 and 100", EnvDefaultDailyLimit)
+	}
+	if c.MaxInitialEmailWords < 20 || c.MaxInitialEmailWords > 500 {
+		return fmt.Errorf("%s must be between 20 and 500", EnvMaxInitialWords)
+	}
+	return nil
+}
+
+func envBool(key string, def bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+func envInt(key string, def int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func splitHosts(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/app/confenge/crm.go
+++ b/internal/app/confenge/crm.go
@@ -53,6 +53,33 @@ func (a SuppressFromAdvanced) SuppressRecipient(ctx context.Context, orgID uuid.
 	return a.Fn(ctx, orgID, email, reason)
 }
 
+// AdvancedSuppressor is the slice of advanced.Service used for DNC suppression.
+// Kept as a narrow interface so confenge does not import advanced at compile time
+// from every consumer of this package; mains pass advancedService.
+type AdvancedSuppressor interface {
+	SuppressRecipient(ctx context.Context, organizationID uuid.UUID, email, reason string) *errx.Error
+}
+
+// NewSuppressAdapter wraps an AdvancedSuppressor for WireSuppress.
+// Returns nil when adv is nil so callers can write:
+//
+//	s.WireSuppress(confenge.NewSuppressAdapter(advancedService))
+//
+// without a nil-check; WireSuppress(nil) clears the adapter (safe no-op on DNC).
+func NewSuppressAdapter(adv AdvancedSuppressor) SuppressAPI {
+	if adv == nil {
+		return nil
+	}
+	return SuppressFromAdvanced{
+		Fn: func(ctx context.Context, orgID uuid.UUID, email, reason string) error {
+			if xerr := adv.SuppressRecipient(ctx, orgID, email, reason); xerr != nil {
+				return fmt.Errorf("%s", xerr.Message)
+			}
+			return nil
+		},
+	}
+}
+
 // confengeStages is the fixed stage list. Re-bootstrap never renames human edits
 // when a pipeline with the same name already exists.
 func confengeStages() []models.CreatePipelineStage {

--- a/internal/app/confenge/crm.go
+++ b/internal/app/confenge/crm.go
@@ -1,0 +1,268 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/replyclassify"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Default CRM pipeline name (idempotent bootstrap).
+const DefaultPipelineName = "CONFENGE Comercial"
+
+// CRMAPI is the slice of CRM service used for pipeline/task/deal bootstrap.
+type CRMAPI interface {
+	ListPipelines(ctx context.Context, orgID uuid.UUID) ([]models.Pipeline, *errx.Error)
+	CreatePipeline(ctx context.Context, orgID uuid.UUID, data *models.CreatePipeline) (*models.Pipeline, *errx.Error)
+	CreateCRMTask(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, *errx.Error)
+	CreateDeal(ctx context.Context, orgID uuid.UUID, data *models.CreateDeal) (*models.Deal, *errx.Error)
+	// Optional activity recording via underlying repo is not on the service
+	// surface; tasks/deals create their own activity trails.
+}
+
+// WireCRM attaches the CRM control-plane service.
+func (s *service) WireCRM(crm CRMAPI) {
+	s.crm = crm
+}
+
+// confengeStages is the fixed stage list. Re-bootstrap never renames human edits
+// when a pipeline with the same name already exists.
+func confengeStages() []models.CreatePipelineStage {
+	// Colors match dashboard slate/sky/amber/emerald conventions.
+	return []models.CreatePipelineStage{
+		{Name: "Novo", Color: "#94a3b8"},
+		{Name: "Preparação", Color: "#64748b"},
+		{Name: "Contato aprovado", Color: "#0ea5e9"},
+		{Name: "Contatado", Color: "#0284c7"},
+		{Name: "Respondeu", Color: "#8b5cf6"},
+		{Name: "Reunião", Color: "#f59e0b"},
+		{Name: "Diagnóstico", Color: "#d97706"},
+		{Name: "Proposta", Color: "#ea580c"},
+		{Name: "Negociação", Color: "#dc2626"},
+		{Name: "Ganho", Color: "#16a34a"},
+		{Name: "Perdido", Color: "#6b7280"},
+		{Name: "Não contatar", Color: "#1f2937"},
+	}
+}
+
+// BootstrapPipeline finds or creates the CONFENGE Comercial pipeline.
+// Idempotent: existing pipeline by name is returned unchanged (preserves human edits).
+func (s *service) BootstrapPipeline(ctx context.Context, orgID uuid.UUID) (*models.Pipeline, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if s.crm == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "CRM service not wired")
+	}
+	list, xerr := s.crm.ListPipelines(ctx, orgID)
+	if xerr != nil {
+		return nil, xerr
+	}
+	for i := range list {
+		if strings.EqualFold(list[i].Name, DefaultPipelineName) {
+			return &list[i], nil
+		}
+	}
+	created, xerr := s.crm.CreatePipeline(ctx, orgID, &models.CreatePipeline{
+		Name:   DefaultPipelineName,
+		Stages: confengeStages(),
+	})
+	if xerr != nil {
+		return nil, xerr
+	}
+	// Persist pointer on org settings when available.
+	if settings, err := s.repo.GetOrgSettings(ctx, orgID); err == nil {
+		if settings == nil {
+			settings = &models.OutreachOrgSettings{OrganizationID: orgID, CampaignName: DefaultCampaignName}
+		}
+		// reuse campaign_name field area; store pipeline id in raw via upsert only if we add column
+		// For now pipeline is found by name — no extra column required.
+		_ = settings
+	}
+	return created, nil
+}
+
+// MapReplyClass converts replyclassify / confenge commercial classes into
+// outcome event type + optional CRM side effects (task/deal). Never auto-WON.
+type ReplyCRMAction struct {
+	OutcomeType string
+	CreateTask  bool
+	TaskTitle   string
+	TaskType    string
+	OpenDeal    bool // only on explicit positive interest path when contact known
+	SuppressDNC bool
+	QueueState  string
+}
+
+// ClassifyReplyForCRM maps classifier/commercial labels to CRM actions.
+// replyClass is replyclassify class or confenge commercial class.
+func ClassifyReplyForCRM(replyClass string) ReplyCRMAction {
+	switch strings.ToLower(strings.TrimSpace(replyClass)) {
+	case replyclassify.ClassPositive, "positive_interest":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeReplied,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: interesse positivo - acompanhar",
+			TaskType:    "call",
+			OpenDeal:    true,
+			QueueState:  models.OutreachQueueReplied,
+		}
+	case replyclassify.ClassNeutral:
+		return ReplyCRMAction{OutcomeType: OutcomeReplied, CreateTask: false, QueueState: models.OutreachQueueReplied}
+	case "referral":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeReplied,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: encaminhamento - cadastrar contato indicado",
+			TaskType:    "email",
+			QueueState:  models.OutreachQueueReplied,
+		}
+	case "wrong_contact":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeReplied,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: contato errado - achar interlocutor",
+			TaskType:    "email",
+			QueueState:  models.OutreachQueueNeedsContact,
+		}
+	case "not_now":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeReplied,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: nao agora - follow-up futuro",
+			TaskType:    "call",
+			QueueState:  models.OutreachQueueReplied,
+		}
+	case replyclassify.ClassNegative, "no_interest":
+		return ReplyCRMAction{OutcomeType: OutcomeReplied, QueueState: models.OutreachQueueSkipped}
+	case replyclassify.ClassUnsubscribe, "do_not_contact", "dnc":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeDoNotContact,
+			SuppressDNC: true,
+			QueueState:  models.OutreachQueueDoNotContact,
+		}
+	case replyclassify.ClassOutOfOffice, "ooo":
+		return ReplyCRMAction{OutcomeType: OutcomeReplied, QueueState: ""} // no queue change
+	case replyclassify.ClassAutoReply, "automated_reply", "bounce":
+		// auto_reply covers OOO-adjacent headers; hard bounces use NoteBounce
+		return ReplyCRMAction{OutcomeType: "", QueueState: ""}
+	case "meeting":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeMeeting,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: reuniao marcada - preparar",
+			TaskType:    "meeting",
+			QueueState:  models.OutreachQueueMeeting,
+		}
+	case "proposal":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeProposal,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: proposta - acompanhar",
+			TaskType:    "email",
+			QueueState:  models.OutreachQueueProposal,
+		}
+	default:
+		return ReplyCRMAction{OutcomeType: OutcomeReplied, QueueState: models.OutreachQueueReplied}
+	}
+}
+
+// HandleClassifiedReply applies CRM + outbox side effects for a classified reply
+// on a confenge-staged contact. Never marks WON automatically.
+func (s *service) HandleClassifiedReply(ctx context.Context, orgID, actorID uuid.UUID, contactEmail, replyClass string, warmblyContactID *uuid.UUID) *errx.Error {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil // feature off — silent
+	}
+	email := strings.TrimSpace(strings.ToLower(contactEmail))
+	if email == "" {
+		return nil
+	}
+	action := ClassifyReplyForCRM(replyClass)
+	cand, acc, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil {
+		return errx.New(errx.Internal, "lookup candidate: "+err.Error())
+	}
+	if cand == nil && warmblyContactID == nil {
+		return nil
+	}
+	cnpj, lead := "", ""
+	if acc != nil {
+		cnpj, lead = acc.CNPJ14, acc.SourceLeadID
+		if action.QueueState != "" {
+			_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, acc.Blocked || action.SuppressDNC, acc.DoNotContact || action.SuppressDNC, "reply:"+replyClass, action.QueueState)
+		}
+	}
+	if action.SuppressDNC {
+		_ = s.NoteDNC(ctx, orgID, email, "reply classification: "+replyClass)
+	}
+	if action.OutcomeType != "" {
+		_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+			IdempotencyKey: fmt.Sprintf("%s:%s:%s:%d", strings.ToLower(action.OutcomeType), orgID, email, time.Now().UTC().Truncate(time.Minute).Unix()),
+			SourceLeadID:   lead,
+			CNPJ14:         cnpj,
+			ContactEmail:   email,
+			EventType:      action.OutcomeType,
+			OccurredAt:     time.Now().UTC(),
+			Payload: mustJSON(map[string]any{
+				"reply_class": replyClass,
+			}),
+		})
+	}
+	if s.crm == nil {
+		return nil
+	}
+	contactID := warmblyContactID
+	if contactID == nil && cand != nil {
+		contactID = cand.WarmblyContactID
+	}
+	if contactID == nil {
+		return nil
+	}
+	if action.CreateTask && actorID != uuid.Nil {
+		_, _ = s.crm.CreateCRMTask(ctx, orgID, actorID, &models.CreateCRMTask{
+			ContactID: contactID,
+			Title:     action.TaskTitle,
+			Type:      action.TaskType,
+			Priority:  "medium",
+		})
+	}
+	// Positive interest may open a deal in "Respondeu" stage — never Ganho.
+	if action.OpenDeal {
+		pipe, xerr := s.BootstrapPipeline(ctx, orgID)
+		if xerr == nil && pipe != nil {
+			stageID := stageIDByName(pipe, "Respondeu")
+			if stageID != uuid.Nil {
+				name := "CONFENGE"
+				if acc != nil {
+					name = firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial, "CONFENGE")
+				}
+				_, _ = s.crm.CreateDeal(ctx, orgID, &models.CreateDeal{
+					PipelineID: pipe.ID,
+					StageID:    stageID,
+					ContactID:  contactID,
+					Name:       name,
+					Currency:   "BRL",
+				})
+			}
+		}
+	}
+	return nil
+}
+
+func stageIDByName(p *models.Pipeline, name string) uuid.UUID {
+	if p == nil {
+		return uuid.Nil
+	}
+	for _, st := range p.Stages {
+		if strings.EqualFold(st.Name, name) {
+			return st.ID
+		}
+	}
+	return uuid.Nil
+}

--- a/internal/app/confenge/crm.go
+++ b/internal/app/confenge/crm.go
@@ -22,13 +22,35 @@ type CRMAPI interface {
 	CreatePipeline(ctx context.Context, orgID uuid.UUID, data *models.CreatePipeline) (*models.Pipeline, *errx.Error)
 	CreateCRMTask(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, *errx.Error)
 	CreateDeal(ctx context.Context, orgID uuid.UUID, data *models.CreateDeal) (*models.Deal, *errx.Error)
-	// Optional activity recording via underlying repo is not on the service
-	// surface; tasks/deals create their own activity trails.
+}
+
+// SuppressAPI writes platform-wide suppression (blocks campaign send).
+type SuppressAPI interface {
+	SuppressRecipient(ctx context.Context, orgID uuid.UUID, email, reason string) error
 }
 
 // WireCRM attaches the CRM control-plane service.
 func (s *service) WireCRM(crm CRMAPI) {
 	s.crm = crm
+}
+
+// WireSuppress attaches platform suppression (advanced outreach list).
+func (s *service) WireSuppress(sup SuppressAPI) {
+	s.suppress = sup
+}
+
+// SuppressFromAdvanced adapts advanced.Service.SuppressRecipient to SuppressAPI
+// without importing advanced into every confenge call site (wiring only).
+type SuppressFromAdvanced struct {
+	// Fn is typically advancedService.SuppressRecipient wrapped to return error.
+	Fn func(ctx context.Context, orgID uuid.UUID, email, reason string) error
+}
+
+func (a SuppressFromAdvanced) SuppressRecipient(ctx context.Context, orgID uuid.UUID, email, reason string) error {
+	if a.Fn == nil {
+		return nil
+	}
+	return a.Fn(ctx, orgID, email, reason)
 }
 
 // confengeStages is the fixed stage list. Re-bootstrap never renames human edits

--- a/internal/app/confenge/crm_test.go
+++ b/internal/app/confenge/crm_test.go
@@ -1,0 +1,135 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/replyclassify"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+type mockCRM struct {
+	pipelines []models.Pipeline
+	creates   int
+	tasks     int
+	deals     int
+}
+
+func (m *mockCRM) ListPipelines(ctx context.Context, orgID uuid.UUID) ([]models.Pipeline, *errx.Error) {
+	return m.pipelines, nil
+}
+
+func (m *mockCRM) CreatePipeline(ctx context.Context, orgID uuid.UUID, data *models.CreatePipeline) (*models.Pipeline, *errx.Error) {
+	m.creates++
+	if data.Name != DefaultPipelineName {
+		return nil, errx.New(errx.BadRequest, "name")
+	}
+	if len(data.Stages) != 12 {
+		return nil, errx.New(errx.BadRequest, "want 12 stages")
+	}
+	stages := make([]models.PipelineStage, len(data.Stages))
+	for i, s := range data.Stages {
+		stages[i] = models.PipelineStage{ID: uuid.New(), Name: s.Name, Color: s.Color, Position: i}
+	}
+	p := models.Pipeline{ID: uuid.New(), OrganizationID: orgID, Name: data.Name, Stages: stages}
+	m.pipelines = append(m.pipelines, p)
+	return &p, nil
+}
+
+func (m *mockCRM) CreateCRMTask(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, *errx.Error) {
+	m.tasks++
+	return &models.CRMTask{ID: uuid.New(), Title: data.Title}, nil
+}
+
+func (m *mockCRM) CreateDeal(ctx context.Context, orgID uuid.UUID, data *models.CreateDeal) (*models.Deal, *errx.Error) {
+	m.deals++
+	return &models.Deal{ID: uuid.New(), Name: data.Name}, nil
+}
+
+func TestBootstrapPipelineIdempotent(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120}, r, nil).(*service)
+	crm := &mockCRM{}
+	svc.WireCRM(crm)
+	org := uuid.New()
+	p1, xerr := svc.BootstrapPipeline(context.Background(), org)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	p2, xerr := svc.BootstrapPipeline(context.Background(), org)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if p1.ID != p2.ID {
+		t.Fatal("not idempotent")
+	}
+	if crm.creates != 1 {
+		t.Fatalf("creates=%d", crm.creates)
+	}
+}
+
+func TestClassifyReplyForCRMNeverAutoWon(t *testing.T) {
+	for _, c := range []string{
+		replyclassify.ClassPositive, "meeting", "proposal", "won", "WON",
+	} {
+		a := ClassifyReplyForCRM(c)
+		if a.OutcomeType == OutcomeWon {
+			t.Fatalf("%s mapped to WON", c)
+		}
+	}
+}
+
+func TestHandleClassifiedReplyPositiveCreatesTaskAndDeal(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120}, r, nil).(*service)
+	crm := &mockCRM{}
+	svc.WireCRM(crm)
+	org := uuid.New()
+	accID := uuid.New()
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", QueueState: models.OutreachQueueEnrolled, SourceLeadID: "L1",
+	}
+	_, _ = r.UpsertAccount(context.Background(), acc)
+	contactID := uuid.New()
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID,
+		Email: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+		WarmblyContactID: &contactID,
+	}
+	_, _ = r.UpsertCandidate(context.Background(), cand)
+
+	if xerr := svc.HandleClassifiedReply(context.Background(), org, uuid.New(), "ana@example.com", replyclassify.ClassPositive, &contactID); xerr != nil {
+		t.Fatal(xerr)
+	}
+	if crm.tasks < 1 {
+		t.Fatal("expected task")
+	}
+	if crm.deals < 1 {
+		t.Fatal("expected deal in Respondeu")
+	}
+}
+
+func TestHandleClassifiedReplyDNC(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120}, r, nil).(*service)
+	crm := &mockCRM{}
+	svc.WireCRM(crm)
+	org := uuid.New()
+	accID := uuid.New()
+	_, _ = r.UpsertAccount(context.Background(), &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181", RazaoSocial: "X",
+	})
+	_, _ = r.UpsertCandidate(context.Background(), &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, Email: "x@example.com",
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+	})
+	_ = svc.HandleClassifiedReply(context.Background(), org, uuid.Nil, "x@example.com", replyclassify.ClassUnsubscribe, nil)
+	acc, _ := r.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acc == nil || !acc.DoNotContact {
+		t.Fatalf("DNC not set: %+v", acc)
+	}
+}

--- a/internal/app/confenge/delivery.go
+++ b/internal/app/confenge/delivery.go
@@ -1,0 +1,142 @@
+package confenge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/safehttp"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// OutcomeDeliveryWorker drains outreach_outcome_outbox to the configured webhook.
+type OutcomeDeliveryWorker struct {
+	repo      repository.OutreachRepository
+	cfg       Config
+	http      *http.Client
+	batchSize int
+	pollEvery time.Duration
+	maxTries  int
+}
+
+// OutcomeDeliveryOptions configures the worker.
+type OutcomeDeliveryOptions struct {
+	BatchSize  int
+	PollEvery  time.Duration
+	HTTPClient *http.Client
+	MaxTries   int
+}
+
+// NewOutcomeDeliveryWorker builds a worker. When webhook URL is empty, Run waits on ctx only.
+func NewOutcomeDeliveryWorker(repo repository.OutreachRepository, cfg Config, opts OutcomeDeliveryOptions) *OutcomeDeliveryWorker {
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 25
+	}
+	if opts.PollEvery <= 0 {
+		opts.PollEvery = 3 * time.Second
+	}
+	if opts.MaxTries <= 0 {
+		opts.MaxTries = 8
+	}
+	if opts.HTTPClient == nil {
+		client := safehttp.Client(15 * time.Second)
+		client.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+		opts.HTTPClient = client
+	}
+	return &OutcomeDeliveryWorker{
+		repo:      repo,
+		cfg:       cfg,
+		http:      opts.HTTPClient,
+		batchSize: opts.BatchSize,
+		pollEvery: opts.PollEvery,
+		maxTries:  opts.MaxTries,
+	}
+}
+
+// Run blocks until ctx is cancelled.
+func (w *OutcomeDeliveryWorker) Run(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	if strings.TrimSpace(w.cfg.OutcomeWebhookURL) == "" || strings.TrimSpace(w.cfg.OutcomeWebhookSecret) == "" {
+		log.Info().Msg("confenge outcome delivery worker idle (webhook URL/secret unset)")
+		<-ctx.Done()
+		return
+	}
+	t := time.NewTicker(w.pollEvery)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			w.tick(ctx)
+		}
+	}
+}
+
+func (w *OutcomeDeliveryWorker) tick(ctx context.Context) {
+	rows, err := w.repo.ListPendingOutcomes(ctx, w.batchSize)
+	if err != nil {
+		log.Warn().Err(err).Msg("confenge outbox list failed")
+		return
+	}
+	for i := range rows {
+		w.deliverOne(ctx, &rows[i])
+	}
+}
+
+func (w *OutcomeDeliveryWorker) deliverOne(ctx context.Context, ev *models.OutreachOutcome) {
+	env := BuildOutcomeEnvelope(ev)
+	body, err := json.Marshal(env)
+	if err != nil {
+		w.fail(ctx, ev, "marshal: "+err.Error())
+		return
+	}
+	ts := time.Now().UTC()
+	sig := SignOutcomeHMAC(w.cfg.OutcomeWebhookSecret, ts, body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.cfg.OutcomeWebhookURL, bytes.NewReader(body))
+	if err != nil {
+		w.fail(ctx, ev, err.Error())
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Warmbly-Signature", sig)
+	req.Header.Set("X-Warmbly-Event-Id", env.EventID)
+	req.Header.Set("Idempotency-Key", env.IdempotencyKey)
+
+	resp, err := w.http.Do(req)
+	if err != nil {
+		w.fail(ctx, ev, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if err := w.repo.MarkOutcomeDelivered(ctx, ev.OrganizationID, ev.ID); err != nil {
+			log.Warn().Err(err).Str("id", ev.ID.String()).Msg("mark delivered failed")
+		}
+		return
+	}
+	w.fail(ctx, ev, fmt.Sprintf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet))))
+}
+
+func (w *OutcomeDeliveryWorker) fail(ctx context.Context, ev *models.OutreachOutcome, reason string) {
+	attempts := ev.Attempts + 1
+	dead := attempts >= w.maxTries
+	next := time.Now().UTC().Add(OutcomeBackoff(attempts))
+	if err := w.repo.MarkOutcomeAttempt(ctx, ev.OrganizationID, ev.ID, attempts, next, reason, dead); err != nil {
+		log.Warn().Err(err).Str("id", ev.ID.String()).Msg("mark attempt failed")
+	}
+}

--- a/internal/app/confenge/drafts.go
+++ b/internal/app/confenge/drafts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -253,6 +252,17 @@ func (s *service) ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.U
 		d.Status = models.OutreachDraftApproved
 		d.ApprovedBy = &userID
 		d.ApprovedAt = &now
+		// Human review duration (seconds since last update / creation).
+		if !d.UpdatedAt.IsZero() {
+			sec := int(now.Sub(d.UpdatedAt).Seconds())
+			if sec < 0 {
+				sec = 0
+			}
+			if sec > 3600 {
+				sec = 3600
+			}
+			d.ReviewSeconds = sec
+		}
 		if acc != nil {
 			_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueApproved)
 			email := ""
@@ -285,18 +295,16 @@ func (s *service) ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.U
 		dnc := edit != nil && edit.DoNotContact
 		_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, true, dnc, reason,
 			map[bool]string{true: models.OutreachQueueDoNotContact, false: models.OutreachQueueBlocked}[dnc])
-		if acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID); acc != nil {
-			evType := OutcomeLeadReviewed
-			if dnc {
-				evType = OutcomeDoNotContact
-			}
-			email := d.RecipientEmail
+		email := d.RecipientEmail
+		if dnc && email != "" {
+			_ = s.NoteDNC(ctx, orgID, email, reason) // staging + platform suppression + outbox
+		} else if acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID); acc != nil {
 			_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
-				IdempotencyKey: fmt.Sprintf("%s:%s", strings.ToLower(evType), d.ID.String()),
+				IdempotencyKey: fmt.Sprintf("blocked:%s", d.ID.String()),
 				SourceLeadID:   acc.SourceLeadID,
 				CNPJ14:         acc.CNPJ14,
 				ContactEmail:   email,
-				EventType:      evType,
+				EventType:      OutcomeLeadReviewed,
 				OccurredAt:     time.Now().UTC(),
 			})
 		}
@@ -341,4 +349,64 @@ func stringsJoin(parts []string, sep string) string {
 // Ensure service holds optional AI provider.
 func (s *service) SetAI(p generation.Provider) {
 	s.ai = p
+}
+
+// BatchApproveResult summarizes bulk approval (only GREEN / validated items).
+type BatchApproveResult struct {
+	Approved []uuid.UUID `json:"approved"`
+	Skipped  []struct {
+		ID     uuid.UUID `json:"id"`
+		Reason string    `json:"reason"`
+	} `json:"skipped"`
+}
+
+// BatchApproveDrafts approves only drafts that pass CanBatchApprove gates.
+func (s *service) BatchApproveDrafts(ctx context.Context, orgID, userID uuid.UUID, draftIDs []uuid.UUID) (*BatchApproveResult, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if len(draftIDs) == 0 {
+		return nil, errx.New(errx.BadRequest, "draft_ids required")
+	}
+	if len(draftIDs) > 100 {
+		return nil, errx.New(errx.BadRequest, "at most 100 drafts per batch")
+	}
+	res := &BatchApproveResult{}
+	for _, id := range draftIDs {
+		d, err := s.repo.GetDraft(ctx, orgID, id)
+		if err != nil || d == nil {
+			res.Skipped = append(res.Skipped, struct {
+				ID     uuid.UUID `json:"id"`
+				Reason string    `json:"reason"`
+			}{ID: id, Reason: "not found"})
+			continue
+		}
+		var cand *models.OutreachContactCandidate
+		if d.ContactCandidateID != nil {
+			cand, _ = s.repo.GetCandidate(ctx, orgID, *d.ContactCandidateID)
+		}
+		if !CanBatchApprove(d, cand) {
+			res.Skipped = append(res.Skipped, struct {
+				ID     uuid.UUID `json:"id"`
+				Reason string    `json:"reason"`
+			}{ID: id, Reason: "not eligible for batch (risk, validation, or contact)"})
+			continue
+		}
+		approved, xerr := s.ReviewDraft(ctx, orgID, userID, id, "approve", nil)
+		if xerr != nil {
+			res.Skipped = append(res.Skipped, struct {
+				ID     uuid.UUID `json:"id"`
+				Reason string    `json:"reason"`
+			}{ID: id, Reason: xerr.Message})
+			continue
+		}
+		res.Approved = append(res.Approved, approved.ID)
+	}
+	return res, nil
+}
+
+// Metrics returns queue summary (funnel counts). Human review time is
+// aggregated from draft.review_seconds when listing approved drafts.
+func (s *service) Metrics(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, *errx.Error) {
+	return s.Summary(ctx, orgID)
 }

--- a/internal/app/confenge/drafts.go
+++ b/internal/app/confenge/drafts.go
@@ -1,0 +1,315 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/generation"
+)
+
+// GenerateDraft creates or regenerates a draft for an account using AI when
+// configured, otherwise a deterministic template (never auto-approved).
+func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uuid.UUID, contactID *uuid.UUID) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, accountID)
+	if err != nil || acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	if acc.DoNotContact || acc.Blocked {
+		return nil, errx.New(errx.BadRequest, "account is blocked or DO_NOT_CONTACT")
+	}
+
+	var cand *models.OutreachContactCandidate
+	if contactID != nil {
+		cand, err = s.repo.GetCandidate(ctx, orgID, *contactID)
+		if err != nil || cand == nil || cand.AccountID != accountID {
+			return nil, errx.New(errx.NotFound, "contact candidate not found")
+		}
+	} else {
+		list, err := s.repo.ListCandidates(ctx, orgID, accountID)
+		if err != nil {
+			return nil, errx.New(errx.Internal, "failed to list contacts")
+		}
+		cand = pickRecommended(list)
+	}
+	if cand == nil {
+		return nil, errx.New(errx.BadRequest, "no contact candidate; resolve NEEDS_CONTACT first")
+	}
+
+	evidence, err := s.repo.ListEvidence(ctx, orgID, accountID)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load evidence")
+	}
+
+	existing, _ := s.repo.GetActiveDraftForAccount(ctx, orgID, accountID)
+	draft := &models.OutreachDraft{
+		OrganizationID:     orgID,
+		AccountID:          accountID,
+		ContactCandidateID: &cand.ID,
+		RecipientName:      cand.Name,
+		RecipientRole:      cand.Role,
+		RecipientEmail:     cand.Email,
+		VerificationStatus: cand.VerificationStatus,
+		Status:             models.OutreachDraftGenerating,
+		PromptVersion:      PromptVersion,
+	}
+	if existing != nil {
+		draft.ID = existing.ID
+		draft.Generation = existing.Generation + 1
+		draft.CreatedAt = existing.CreatedAt
+	}
+
+	gen := s.generator()
+	out, provider, model, genErr := gen.Generate(ctx, acc, cand, evidence)
+	usedTemplate := false
+	if genErr != nil {
+		// Fallback template; import/review remain usable without AI.
+		out = TemplateDraft(acc, cand)
+		provider = "template"
+		model = "deterministic"
+		usedTemplate = true
+	}
+	if out.ServiceCode == "" {
+		out.ServiceCode = acc.ServiceCode
+	}
+	if len(out.EvidenceIDs) == 0 && len(acc.MomentEvidenceIDs) > 0 {
+		out.EvidenceIDs = acc.MomentEvidenceIDs
+	}
+
+	val := ValidateDraft(&out, acc, cand, s.cfg.MaxInitialEmailWords)
+	risk, flags := ClassifyRisk(acc, cand, &out, val)
+	if usedTemplate {
+		flags = append(flags, "template_fallback")
+		if risk == "GREEN" {
+			risk = "YELLOW"
+		}
+	}
+
+	valJSON, _ := json.Marshal(val)
+	followJSON, _ := json.Marshal(out.Followups)
+	draft.Subject = SanitizeText(out.Subject, 200)
+	draft.BodyText = SanitizeText(out.BodyText, 8000)
+	draft.BodyHTML = "" // never store unsafe HTML from model raw
+	draft.FollowupsJSON = followJSON
+	draft.ServiceCode = SanitizeText(out.ServiceCode, 100)
+	draft.FactUsed = SanitizeText(out.FactUsed, 2000)
+	draft.EvidenceIDs = out.EvidenceIDs
+	draft.Question = SanitizeText(out.Question, 1000)
+	draft.CTA = SanitizeText(out.CTA, 500)
+	draft.Provider = provider
+	draft.Model = model
+	draft.ValidationJSON = valJSON
+	ok := val.OK
+	draft.ValidationOK = &ok
+	draft.RiskClass = risk
+	draft.RiskFlags = flags
+	draft.Status = models.OutreachDraftNeedsReview
+	if err := s.repo.UpsertDraft(ctx, draft); err != nil {
+		return nil, errx.New(errx.Internal, "failed to save draft: "+err.Error())
+	}
+
+	// Move account into review queue when machine-owned.
+	if acc.QueueState == models.OutreachQueueReadyToGenerate || acc.QueueState == models.OutreachQueueNeedsContact {
+		_ = s.repo.SetAccountHumanFlags(ctx, orgID, accountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueNeedsReview)
+	}
+
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionCreate, models.AuditEntityOutreachAccount, &accountID, "", "",
+			map[string]string{"draft_id": draft.ID.String(), "status": draft.Status, "risk": draft.RiskClass},
+			map[string]string{"provider": provider},
+		)
+	}
+	return draft, nil
+}
+
+func (s *service) generator() DraftGenerator {
+	if s.ai != nil {
+		return &AIDraftGenerator{Provider: s.ai}
+	}
+	return TemplateGenerator{}
+}
+
+func pickRecommended(list []models.OutreachContactCandidate) *models.OutreachContactCandidate {
+	var fallback *models.OutreachContactCandidate
+	for i := range list {
+		c := &list[i]
+		if c.DoNotContact || c.Bounced || c.Blocked {
+			continue
+		}
+		if c.Email == "" {
+			continue
+		}
+		if c.Recommended && c.CanEnroll() {
+			return c
+		}
+		if fallback == nil && c.CanEnroll() {
+			fallback = c
+		}
+		if fallback == nil {
+			fallback = c
+		}
+	}
+	return fallback
+}
+
+// GetDraft returns one draft by id.
+func (s *service) GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	d, err := s.repo.GetDraft(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load draft")
+	}
+	if d == nil {
+		return nil, errx.New(errx.NotFound, "draft not found")
+	}
+	return d, nil
+}
+
+// ListDrafts lists drafts optionally filtered by status.
+func (s *service) ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	list, err := s.repo.ListDrafts(ctx, orgID, status, limit, offset)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to list drafts")
+	}
+	if list == nil {
+		list = []models.OutreachDraft{}
+	}
+	return list, nil
+}
+
+// ReviewDraft applies human actions: approve, reject, skip, edit, block.
+func (s *service) ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.UUID, action string, edit *DraftEdit) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	d, err := s.repo.GetDraft(ctx, orgID, draftID)
+	if err != nil || d == nil {
+		return nil, errx.New(errx.NotFound, "draft not found")
+	}
+	switch action {
+	case "edit":
+		if edit == nil {
+			return nil, errx.New(errx.BadRequest, "edit payload required")
+		}
+		if edit.Subject != nil {
+			d.Subject = SanitizeText(*edit.Subject, 200)
+		}
+		if edit.BodyText != nil {
+			d.BodyText = SanitizeText(*edit.BodyText, 8000)
+		}
+		d.HumanEdited = true
+		// Re-validate after edit
+		acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID)
+		var cand *models.OutreachContactCandidate
+		if d.ContactCandidateID != nil {
+			cand, _ = s.repo.GetCandidate(ctx, orgID, *d.ContactCandidateID)
+		}
+		out := DraftOutput{
+			Subject: d.Subject, BodyText: d.BodyText, FactUsed: d.FactUsed,
+			ServiceCode: d.ServiceCode, EvidenceIDs: d.EvidenceIDs,
+			Question: d.Question, CTA: d.CTA,
+		}
+		val := ValidateDraft(&out, acc, cand, s.cfg.MaxInitialEmailWords)
+		risk, flags := ClassifyRisk(acc, cand, &out, val)
+		valJSON, _ := json.Marshal(val)
+		d.ValidationJSON = valJSON
+		ok := val.OK
+		d.ValidationOK = &ok
+		d.RiskClass = risk
+		d.RiskFlags = flags
+		d.Status = models.OutreachDraftNeedsReview
+	case "approve":
+		acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID)
+		var cand *models.OutreachContactCandidate
+		if d.ContactCandidateID != nil {
+			cand, _ = s.repo.GetCandidate(ctx, orgID, *d.ContactCandidateID)
+		}
+		out := DraftOutput{
+			Subject: d.Subject, BodyText: d.BodyText, FactUsed: d.FactUsed,
+			ServiceCode: d.ServiceCode, EvidenceIDs: d.EvidenceIDs,
+		}
+		val := ValidateDraft(&out, acc, cand, s.cfg.MaxInitialEmailWords)
+		if !val.OK {
+			return nil, errx.New(errx.BadRequest, "draft failed validation: "+joinErrs(val.Errors))
+		}
+		if d.Provider == "template" && s.cfg.RequireHumanApproval {
+			// Template is allowed after explicit human approve.
+		}
+		now := time.Now().UTC()
+		d.Status = models.OutreachDraftApproved
+		d.ApprovedBy = &userID
+		d.ApprovedAt = &now
+		if acc != nil {
+			_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueApproved)
+		}
+	case "reject":
+		d.Status = models.OutreachDraftRejected
+	case "skip":
+		d.Status = models.OutreachDraftSkipped
+		acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID)
+		if acc != nil {
+			_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueSkipped)
+		}
+	case "block":
+		d.Status = models.OutreachDraftBlocked
+		reason := "blocked from review"
+		if edit != nil && edit.Reason != nil {
+			reason = *edit.Reason
+		}
+		dnc := edit != nil && edit.DoNotContact
+		_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, true, dnc, reason,
+			map[bool]string{true: models.OutreachQueueDoNotContact, false: models.OutreachQueueBlocked}[dnc])
+	default:
+		return nil, errx.New(errx.BadRequest, "unknown action (approve|reject|skip|edit|block)")
+	}
+	if err := s.repo.UpsertDraft(ctx, d); err != nil {
+		return nil, errx.New(errx.Internal, "failed to update draft")
+	}
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionUpdate, models.AuditEntityOutreachAccount, &d.AccountID, "", "",
+			map[string]string{"draft_id": d.ID.String(), "action": action, "status": d.Status},
+			nil,
+		)
+	}
+	return d, nil
+}
+
+// DraftEdit is an optional body for review actions.
+type DraftEdit struct {
+	Subject      *string `json:"subject"`
+	BodyText     *string `json:"body_text"`
+	Reason       *string `json:"reason"`
+	DoNotContact bool    `json:"do_not_contact"`
+}
+
+func joinErrs(errs []string) string {
+	return stringsJoin(errs, "; ")
+}
+
+func stringsJoin(parts []string, sep string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += sep + parts[i]
+	}
+	return out
+}
+
+// Ensure service holds optional AI provider.
+func (s *service) SetAI(p generation.Provider) {
+	s.ai = p
+}

--- a/internal/app/confenge/drafts.go
+++ b/internal/app/confenge/drafts.go
@@ -3,6 +3,8 @@ package confenge
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -253,6 +255,18 @@ func (s *service) ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.U
 		d.ApprovedAt = &now
 		if acc != nil {
 			_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueApproved)
+			email := ""
+			if cand != nil {
+				email = cand.Email
+			}
+			_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+				IdempotencyKey: "lead_reviewed:" + d.ID.String(),
+				SourceLeadID:   acc.SourceLeadID,
+				CNPJ14:         acc.CNPJ14,
+				ContactEmail:   email,
+				EventType:      OutcomeLeadReviewed,
+				OccurredAt:     now,
+			})
 		}
 	case "reject":
 		d.Status = models.OutreachDraftRejected
@@ -271,6 +285,21 @@ func (s *service) ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.U
 		dnc := edit != nil && edit.DoNotContact
 		_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, true, dnc, reason,
 			map[bool]string{true: models.OutreachQueueDoNotContact, false: models.OutreachQueueBlocked}[dnc])
+		if acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID); acc != nil {
+			evType := OutcomeLeadReviewed
+			if dnc {
+				evType = OutcomeDoNotContact
+			}
+			email := d.RecipientEmail
+			_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+				IdempotencyKey: fmt.Sprintf("%s:%s", strings.ToLower(evType), d.ID.String()),
+				SourceLeadID:   acc.SourceLeadID,
+				CNPJ14:         acc.CNPJ14,
+				ContactEmail:   email,
+				EventType:      evType,
+				OccurredAt:     time.Now().UTC(),
+			})
+		}
 	default:
 		return nil, errx.New(errx.BadRequest, "unknown action (approve|reject|skip|edit|block)")
 	}

--- a/internal/app/confenge/e2e_flow_test.go
+++ b/internal/app/confenge/e2e_flow_test.go
@@ -1,0 +1,165 @@
+package confenge
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Synthetic path: import fixture → generate template draft → block bad copy →
+// approve → enroll → reimport → DNC → bounce/HMAC. In-memory only.
+func TestSyntheticOperationalFlow(t *testing.T) {
+	var outcomes []models.OutreachOutcome
+	rf := &memRepoOutcome{
+		memRepoFull: *newMemRepoWithSettings(),
+		outcomes:    &outcomes,
+	}
+	// Fix maps after value copy of memRepoFull
+	rf.memRepo = newMemRepo()
+	rf.settings = map[uuid.UUID]*models.OutreachOrgSettings{}
+	rf.drafts = map[uuid.UUID]*models.OutreachDraft{}
+
+	cfg := Config{
+		Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120,
+		RequireHumanApproval: true, MaxFeedPayloadBytes: DefaultMaxPayloadBytes,
+	}
+	svc := NewService(cfg, rf, nil).(*service)
+	contacts := &mockContacts{}
+	camps := &mockCampaigns{}
+	svc.WireExecution(camps, contacts)
+
+	org := uuid.New()
+	user := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+
+	run, xerr := svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.Creates < 4 {
+		t.Fatalf("import creates: %+v", run.Counts)
+	}
+
+	noMail, _ := rf.GetAccountByCNPJ(context.Background(), org, "55444333000122")
+	if noMail == nil || noMail.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("no-email company: %+v", noMail)
+	}
+
+	acme, _ := rf.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acme == nil {
+		t.Fatal("acme missing")
+	}
+
+	draft, xerr := svc.GenerateDraft(context.Background(), org, user, acme.ID, nil)
+	if xerr != nil {
+		t.Fatal(xerr.Message)
+	}
+	if draft.Status != models.OutreachDraftNeedsReview {
+		t.Fatalf("status %s", draft.Status)
+	}
+
+	// Banned phrase must fail approve after edit
+	bad := "Identificamos dinheiro a receber na conta"
+	if _, xerr = svc.ReviewDraft(context.Background(), org, user, draft.ID, "edit", &DraftEdit{BodyText: &bad}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	if _, xerr = svc.ReviewDraft(context.Background(), org, user, draft.ID, "approve", nil); xerr == nil {
+		t.Fatal("expected approve to fail on banned phrase")
+	}
+
+	// Clean human edit + approve
+	subj := "Sobre ACME"
+	body := "Ola Ana,\n\nNotei " + acme.FactToMention + ".\n\nFaz sentido conversarmos?\n\nPosso enviar checklist?"
+	if _, xerr = svc.ReviewDraft(context.Background(), org, user, draft.ID, "edit", &DraftEdit{Subject: &subj, BodyText: &body}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	// Ensure fact_used and service align for validators
+	dMid, _ := rf.GetDraft(context.Background(), org, draft.ID)
+	dMid.FactUsed = acme.FactToMention
+	dMid.ServiceCode = acme.ServiceCode
+	dMid.EvidenceIDs = []string{"ev-acme-1"}
+	_ = rf.UpsertDraft(context.Background(), dMid)
+
+	approved, xerr := svc.ReviewDraft(context.Background(), org, user, draft.ID, "approve", nil)
+	if xerr != nil {
+		t.Fatal(xerr.Message)
+	}
+	if approved.Status != models.OutreachDraftApproved {
+		t.Fatalf("status %s", approved.Status)
+	}
+
+	enrolled, xerr := svc.EnrollDraft(context.Background(), org, user, draft.ID)
+	if xerr != nil {
+		t.Fatal(xerr.Message)
+	}
+	if enrolled.Status != models.OutreachDraftEnrolled {
+		t.Fatalf("enroll status %s", enrolled.Status)
+	}
+	if len(contacts.added) != 1 {
+		t.Fatal("expected contact promotion")
+	}
+
+	run2, xerr := svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run2.Counts.Creates != 0 {
+		t.Fatalf("reimport creates should be 0: %+v", run2.Counts)
+	}
+
+	acc, _ := rf.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	acc.DoNotContact = true
+	acc.QueueState = models.OutreachQueueDoNotContact
+	_, _ = rf.UpsertAccount(context.Background(), acc)
+	_, _ = svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{})
+	again, _ := rf.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if again == nil || !again.DoNotContact {
+		t.Fatal("DNC not preserved")
+	}
+
+	email := contacts.added[0].Email
+	if err := svc.NoteBounce(context.Background(), org, email, "550 user unknown"); err != nil {
+		t.Fatal(err)
+	}
+
+	secret := "whsec_test"
+	payload := []byte(`{"event_type":"REPLIED"}`)
+	ts := time.Now().UTC()
+	hdr := SignOutcomeHMAC(secret, ts, payload)
+	if !VerifyOutcomeHMAC(secret, hdr, payload, ts, 5*time.Minute) {
+		t.Fatal("hmac roundtrip")
+	}
+	if !strings.Contains(hdr, "v1=") {
+		t.Fatalf("header shape %q", hdr)
+	}
+}
+
+type memRepoOutcome struct {
+	memRepoFull
+	outcomes *[]models.OutreachOutcome
+}
+
+func (m *memRepoOutcome) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
+	if m.outcomes != nil {
+		*m.outcomes = append(*m.outcomes, *ev)
+	}
+	return nil
+}
+
+func (m *memRepoOutcome) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	for _, list := range m.cands {
+		for i := range list {
+			if list[i].OrganizationID == orgID && strings.EqualFold(list[i].Email, email) {
+				acc, _ := m.GetAccount(ctx, orgID, list[i].AccountID)
+				cp := list[i]
+				return &cp, acc, nil
+			}
+		}
+	}
+	return nil, nil, nil
+}

--- a/internal/app/confenge/enroll_content_test.go
+++ b/internal/app/confenge/enroll_content_test.go
@@ -1,0 +1,169 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/tasks"
+)
+
+func TestDefaultCadenceStepsUseApprovedDraftMergeVars(t *testing.T) {
+	steps := defaultCadenceSteps()
+	if len(steps) < 1 {
+		t.Fatal("no steps")
+	}
+	if steps[0].Subject != "{{.confenge_subject}}" {
+		t.Fatalf("step0 subject must merge approved draft subject, got %q", steps[0].Subject)
+	}
+	if steps[0].BodyPlain != "{{.confenge_body}}" {
+		t.Fatalf("step0 body must merge approved draft body, got %q", steps[0].BodyPlain)
+	}
+	for _, s := range steps {
+		if strings.Contains(s.Subject, "\u2014") || strings.Contains(s.BodyPlain, "\u2014") ||
+			strings.Contains(s.Subject, "—") || strings.Contains(s.BodyPlain, "—") {
+			t.Fatalf("em dash forbidden in cadence: subject=%q body=%q", s.Subject, s.BodyPlain)
+		}
+	}
+}
+
+func TestEnrollCustomFieldsFeedSendTemplate(t *testing.T) {
+	d := &models.OutreachDraft{
+		Subject:     "Assunto aprovado",
+		BodyText:    "Corpo humano revisado com fato publico.",
+		ServiceCode: "ADDITIVE_REVIEW",
+		FactUsed:    "fato publico",
+	}
+	fus, _ := json.Marshal([]DraftFollowup{
+		{DelayDays: 3, BodyText: "Followup um"},
+		{DelayDays: 7, BodyText: "Followup dois"},
+	})
+	d.FollowupsJSON = fus
+	acc := &models.OutreachAccount{CNPJ14: "11222333000181", ServiceCode: "ADDITIVE_REVIEW", FactToMention: "fato publico"}
+	cf := EnrollCustomFields(d, acc)
+	if cf["confenge_subject"] != "Assunto aprovado" || cf["confenge_body"] != "Corpo humano revisado com fato publico." {
+		t.Fatalf("custom fields: %+v", cf)
+	}
+	if cf["confenge_followup_1"] != "Followup um" {
+		t.Fatalf("followup1: %q", cf["confenge_followup_1"])
+	}
+
+	// Simulate campaign send: RenderTemplate of bootstrap sequence with contact custom fields.
+	contact := models.Contact{
+		FirstName:    "Ana",
+		Company:      "ACME",
+		CustomFields: cf,
+	}
+	steps := defaultCadenceSteps()
+	gotSubj := tasks.RenderTemplate(steps[0].Subject, contact)
+	gotBody := tasks.RenderTemplate(steps[0].BodyPlain, contact)
+	if gotSubj != "Assunto aprovado" {
+		t.Fatalf("rendered subject %q want approved draft", gotSubj)
+	}
+	if gotBody != "Corpo humano revisado com fato publico." {
+		t.Fatalf("rendered body %q want approved draft", gotBody)
+	}
+	gotFU := tasks.RenderTemplate(steps[1].BodyPlain, contact)
+	if !strings.Contains(gotFU, "Followup um") {
+		t.Fatalf("follow-up render missing approved content: %q", gotFU)
+	}
+}
+
+func TestEnrollSetsCustomFieldsMatchingApprovedDraft(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120, RequireHumanApproval: true}, r, nil).(*service)
+	contacts := &mockContacts{}
+	camps := &mockCampaigns{}
+	svc.WireExecution(camps, contacts)
+	org := uuid.New()
+	accID := uuid.New()
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", NomeFantasia: "ACME", QueueState: models.OutreachQueueApproved,
+		FactToMention: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW", SourceLeadID: "L1",
+	}
+	_, _ = r.UpsertAccount(context.Background(), acc)
+	candID := uuid.New()
+	cand := &models.OutreachContactCandidate{
+		ID: candID, OrganizationID: org, AccountID: accID, Name: "Ana Silva",
+		Email: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Recommended: true,
+	}
+	_, _ = r.UpsertCandidate(context.Background(), cand)
+	approvedBody := "Ola Ana,\n\nNotei a prorrogacao do contrato. Faz sentido conversarmos?\n\nPosso enviar checklist?"
+	approvedSubj := "Sobre ACME"
+	fus, _ := json.Marshal([]DraftFollowup{{DelayDays: 3, BodyText: "Pergunta de encaminhamento"}})
+	d := &models.OutreachDraft{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, ContactCandidateID: &candID,
+		Subject: approvedSubj, BodyText: approvedBody,
+		FactUsed: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
+		Status: models.OutreachDraftApproved, RiskClass: "GREEN",
+		RecipientEmail: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+		FollowupsJSON: fus,
+	}
+	ok := true
+	d.ValidationOK = &ok
+	_ = r.UpsertDraft(context.Background(), d)
+
+	// Capture CreateCampaign sequences
+	var createdSteps []models.CreateSequenceInput
+	camps.captureSteps = &createdSteps
+
+	out, xerr := svc.EnrollDraft(context.Background(), org, uuid.New(), d.ID)
+	if xerr != nil {
+		t.Fatal(xerr.Message)
+	}
+	if out.Status != models.OutreachDraftEnrolled {
+		t.Fatalf("status %s", out.Status)
+	}
+	if len(contacts.added) != 1 {
+		t.Fatal("expected contact")
+	}
+	cf := contacts.added[0].CustomFields
+	if cf["confenge_subject"] != approvedSubj || cf["confenge_body"] != approvedBody {
+		t.Fatalf("enroll custom fields must equal approved draft: %+v", cf)
+	}
+	if cf["confenge_followup_1"] != "Pergunta de encaminhamento" {
+		t.Fatalf("followup field: %+v", cf)
+	}
+	// Bootstrap steps (from first Create) must use merge vars for step 0
+	if len(createdSteps) > 0 {
+		if createdSteps[0].BodyPlain != "{{.confenge_body}}" {
+			t.Fatalf("campaign sequence body must be merge var, got %q", createdSteps[0].BodyPlain)
+		}
+	}
+	// End-to-end render proof
+	contact := models.Contact{CustomFields: cf, Company: "ACME", FirstName: "Ana"}
+	steps := defaultCadenceSteps()
+	if tasks.RenderTemplate(steps[0].BodyPlain, contact) != approvedBody {
+		t.Fatal("send path would not use approved body")
+	}
+}
+
+func TestNoteDNCCallsPlatformSuppress(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120}, r, nil).(*service)
+	var suppressed []string
+	svc.WireSuppress(SuppressFromAdvanced{Fn: func(ctx context.Context, orgID uuid.UUID, email, reason string) error {
+		suppressed = append(suppressed, email)
+		return nil
+	}})
+	org := uuid.New()
+	accID := uuid.New()
+	_, _ = r.UpsertAccount(context.Background(), &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181", RazaoSocial: "X",
+	})
+	_, _ = r.UpsertCandidate(context.Background(), &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, Email: "dnc@example.com",
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+	})
+	if err := svc.NoteDNC(context.Background(), org, "dnc@example.com", "reply unsub"); err != nil {
+		t.Fatal(err)
+	}
+	if len(suppressed) != 1 || suppressed[0] != "dnc@example.com" {
+		t.Fatalf("expected platform suppress, got %v", suppressed)
+	}
+}

--- a/internal/app/confenge/feed_fetch.go
+++ b/internal/app/confenge/feed_fetch.go
@@ -1,0 +1,108 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/pkg/safehttp"
+)
+
+// FeedFetcher loads a feed from HTTPS (production) or file:// (dev/tests).
+// Remote fetches use the SSRF-hardened client and optional host allowlist.
+type FeedFetcher struct {
+	AllowedHosts []string
+	Token        string
+	MaxBytes     int64
+	HTTPClient   *http.Client
+}
+
+// Fetch returns raw payload bytes from uri.
+// Supported schemes: https, http (dev only via WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS), file.
+func (f *FeedFetcher) Fetch(ctx context.Context, uri string) ([]byte, error) {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return nil, fmt.Errorf("feed URI is required")
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid feed URI: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "file":
+		return f.fetchFile(u)
+	case "https", "http":
+		return f.fetchHTTP(ctx, u)
+	default:
+		return nil, fmt.Errorf("unsupported feed scheme %q", u.Scheme)
+	}
+}
+
+func (f *FeedFetcher) fetchFile(u *url.URL) ([]byte, error) {
+	path := u.Path
+	if path == "" {
+		path = u.Opaque
+	}
+	// file:///absolute/path
+	if strings.HasPrefix(u.String(), "file://") && path == "" {
+		return nil, fmt.Errorf("empty file path")
+	}
+	data, err := readFileLimited(path, f.maxBytes())
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (f *FeedFetcher) fetchHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
+	host := strings.ToLower(u.Hostname())
+	if len(f.AllowedHosts) > 0 && !hostAllowed(host, f.AllowedHosts) {
+		return nil, fmt.Errorf("feed host %q is not in allowlist", host)
+	}
+	client := f.HTTPClient
+	if client == nil {
+		client = safehttp.Client(30 * time.Second)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if f.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+f.Token)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("feed fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("feed fetch HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, f.maxBytes()))
+}
+
+func (f *FeedFetcher) maxBytes() int64 {
+	if f.MaxBytes > 0 {
+		return f.MaxBytes
+	}
+	return DefaultMaxPayloadBytes
+}
+
+func hostAllowed(host string, allow []string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	for _, a := range allow {
+		a = strings.ToLower(strings.TrimSpace(a))
+		if a == "" {
+			continue
+		}
+		if host == a || strings.HasSuffix(host, "."+a) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/confenge/file_io.go
+++ b/internal/app/confenge/file_io.go
@@ -1,0 +1,29 @@
+package confenge
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func readFileLimited(path string, maxBytes int64) ([]byte, error) {
+	if path == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxPayloadBytes
+	}
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("payload exceeds max size of %d bytes", maxBytes)
+	}
+	return data, nil
+}

--- a/internal/app/confenge/generate.go
+++ b/internal/app/confenge/generate.go
@@ -1,0 +1,155 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/generation"
+)
+
+// DraftGenerator produces structured outreach copy from staging inputs only.
+type DraftGenerator interface {
+	Generate(ctx context.Context, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) (DraftOutput, string, string, error)
+}
+
+// AIDraftGenerator uses the existing generation.Provider abstraction.
+type AIDraftGenerator struct {
+	Provider generation.Provider
+	Model    string
+}
+
+// Generate asks the model for JSON only from structured inputs (no research).
+func (g *AIDraftGenerator) Generate(ctx context.Context, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) (DraftOutput, string, string, error) {
+	if g == nil || g.Provider == nil {
+		return DraftOutput{}, "", "", generation.ErrNotConfigured
+	}
+	system := draftSystemPrompt()
+	user := draftUserPrompt(acc, cand, evidence)
+	model := g.Model
+	if model == "" {
+		model = g.Provider.ModelForTier(true)
+	}
+	res, err := g.Provider.Complete(ctx, generation.CompletionRequest{
+		System:      system,
+		Prompt:      user,
+		Model:       model,
+		MaxTokens:   1200,
+		Temperature: generation.Deterministic(),
+	})
+	if err != nil {
+		return DraftOutput{}, g.Provider.Name(), model, err
+	}
+	out, err := parseDraftJSON(res.Text)
+	if err != nil {
+		return DraftOutput{}, g.Provider.Name(), res.Model, err
+	}
+	return out, g.Provider.Name(), res.Model, nil
+}
+
+// TemplateGenerator is the safe fallback when AI is off.
+type TemplateGenerator struct{}
+
+func (TemplateGenerator) Generate(ctx context.Context, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) (DraftOutput, string, string, error) {
+	_ = ctx
+	_ = evidence
+	return TemplateDraft(acc, cand), "template", "deterministic", nil
+}
+
+func draftSystemPrompt() string {
+	return strings.TrimSpace(`
+Você redige e-mails comerciais curtos em português brasileiro para a CONFENGE (engenharia consultiva).
+Você NÃO pesquisa. Use somente os dados estruturados do usuário.
+Não transforme hipótese em fato. Não invente número, contrato, data, órgão, nome ou cargo ausentes dos inputs.
+Não use travessões. Não use frases de IA. Não diga "espero que esta mensagem o encontre bem".
+Não prometa resultado, crédito, dinheiro a receber, irregularidade ou urgência falsa.
+Primeira mensagem: até ~120 palavras, até 3 parágrafos curtos, uma pergunta, um CTA, um serviço.
+Follow-ups menores, mesmo fio, sem repetir o primeiro e-mail.
+Responda APENAS com JSON válido no schema:
+{"subject":"","body_text":"","body_html":"","followups":[{"delay_days":3,"subject_mode":"same_thread","body_text":"","body_html":""}],"fact_used":"","evidence_ids":[],"service_code":"","question":"","cta":"","risk_flags":[]}
+`)
+}
+
+func draftUserPrompt(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) string {
+	type payload struct {
+		Company   any `json:"company"`
+		Contact   any `json:"contact"`
+		Moment    any `json:"moment"`
+		Offer     any `json:"offer"`
+		Messaging any `json:"messaging"`
+		Evidence  any `json:"evidence"`
+	}
+	company := map[string]any{}
+	moment := map[string]any{}
+	offer := map[string]any{}
+	messaging := map[string]any{}
+	if acc != nil {
+		company = map[string]any{
+			"razao_social":  acc.RazaoSocial,
+			"nome_fantasia": acc.NomeFantasia,
+			"cnpj14":        acc.CNPJ14,
+			"municipio":     acc.Municipio,
+			"uf":            acc.UF,
+		}
+		moment = map[string]any{
+			"code":    acc.MomentCode,
+			"summary": acc.MomentSummary,
+		}
+		offer = map[string]any{
+			"service_code": acc.ServiceCode,
+			"service_name": acc.ServiceName,
+			"entry_offer":  acc.EntryOffer,
+		}
+		messaging = map[string]any{
+			"fact_to_mention": acc.FactToMention,
+			"question_to_ask": acc.QuestionToAsk,
+			"cta":             acc.CTA,
+			"claims_to_avoid": acc.ClaimsToAvoid,
+		}
+	}
+	contact := map[string]any{}
+	if cand != nil {
+		contact = map[string]any{
+			"name":                cand.Name,
+			"role":                cand.Role,
+			"email":               cand.Email,
+			"verification_status": cand.VerificationStatus,
+		}
+	}
+	ev := make([]map[string]any, 0, len(evidence))
+	for _, e := range evidence {
+		ev = append(ev, map[string]any{
+			"id":              e.SourceEvidenceID,
+			"title":           e.Title,
+			"synthesis":       e.Synthesis,
+			"excerpt":         e.Excerpt,
+			"epistemic_class": e.EpistemicClass,
+			"url":             e.URL,
+		})
+	}
+	b, _ := json.MarshalIndent(payload{
+		Company: company, Contact: contact, Moment: moment,
+		Offer: offer, Messaging: messaging, Evidence: ev,
+	}, "", "  ")
+	return "Gere a mensagem com base apenas nestes dados:\n" + string(b)
+}
+
+func parseDraftJSON(text string) (DraftOutput, error) {
+	text = strings.TrimSpace(text)
+	// Strip markdown fences if the model wraps JSON.
+	if i := strings.Index(text, "{"); i >= 0 {
+		if j := strings.LastIndex(text, "}"); j > i {
+			text = text[i : j+1]
+		}
+	}
+	var out DraftOutput
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		return DraftOutput{}, fmt.Errorf("invalid draft JSON: %w", err)
+	}
+	out.Subject = strings.TrimSpace(out.Subject)
+	out.BodyText = strings.TrimSpace(out.BodyText)
+	out.FactUsed = strings.TrimSpace(out.FactUsed)
+	return out, nil
+}

--- a/internal/app/confenge/hooks.go
+++ b/internal/app/confenge/hooks.go
@@ -1,0 +1,131 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// OutcomeSink is the consumer-facing surface for commercial outcomes.
+// Implemented by *service.
+type OutcomeSink interface {
+	Enabled() bool
+	// NoteReply enqueues REPLIED when the address matches a staged candidate.
+	NoteReply(ctx context.Context, orgID uuid.UUID, contactEmail string, meta map[string]any) error
+	// NoteBounce enqueues BOUNCED for a failed recipient email.
+	NoteBounce(ctx context.Context, orgID uuid.UUID, contactEmail, reason string) error
+	// NoteDNC enqueues DO_NOT_CONTACT and marks matching candidates.
+	NoteDNC(ctx context.Context, orgID uuid.UUID, contactEmail, reason string) error
+}
+
+func (s *service) enqueueErr(ctx context.Context, orgID uuid.UUID, ev models.OutreachOutcome) error {
+	if xerr := s.EnqueueOutcome(ctx, orgID, ev); xerr != nil {
+		return fmt.Errorf("%s", xerr.Message)
+	}
+	return nil
+}
+
+// NoteReply implements OutcomeSink.
+func (s *service) NoteReply(ctx context.Context, orgID uuid.UUID, contactEmail string, meta map[string]any) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	email := strings.TrimSpace(strings.ToLower(contactEmail))
+	if email == "" {
+		return nil
+	}
+	cand, acc, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil || cand == nil || acc == nil {
+		return nil // not a confenge lead
+	}
+	payload, _ := jsonMarshalMap(meta)
+	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("replied:%s:%s:%d", orgID, email, time.Now().UTC().Truncate(time.Minute).Unix()),
+		SourceLeadID:   acc.SourceLeadID,
+		CNPJ14:         acc.CNPJ14,
+		ContactEmail:   email,
+		EventType:      OutcomeReplied,
+		OccurredAt:     time.Now().UTC(),
+		Payload:        payload,
+	})
+}
+
+// NoteBounce implements OutcomeSink.
+func (s *service) NoteBounce(ctx context.Context, orgID uuid.UUID, contactEmail, reason string) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	email := strings.TrimSpace(strings.ToLower(contactEmail))
+	if email == "" {
+		return nil
+	}
+	cand, acc, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil {
+		return err
+	}
+	if cand != nil {
+		cand.Bounced = true
+		cand.VerificationStatus = models.OutreachVerifyBounced
+		_, _ = s.repo.UpsertCandidate(ctx, cand)
+	}
+	cnpj, lead := "", ""
+	if acc != nil {
+		cnpj, lead = acc.CNPJ14, acc.SourceLeadID
+		_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, acc.Blocked, acc.DoNotContact, "bounce", models.OutreachQueueBounced)
+	}
+	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("bounced:%s:%s", orgID, email),
+		SourceLeadID:   lead,
+		CNPJ14:         cnpj,
+		ContactEmail:   email,
+		EventType:      OutcomeBounced,
+		OccurredAt:     time.Now().UTC(),
+		Payload:        mustJSON(map[string]any{"reason": reason}),
+	})
+}
+
+// NoteDNC implements OutcomeSink.
+func (s *service) NoteDNC(ctx context.Context, orgID uuid.UUID, contactEmail, reason string) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	email := strings.TrimSpace(strings.ToLower(contactEmail))
+	if email == "" {
+		return nil
+	}
+	cand, acc, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil {
+		return err
+	}
+	if cand != nil {
+		cand.DoNotContact = true
+		cand.VerificationStatus = models.OutreachVerifyDoNotContact
+		_, _ = s.repo.UpsertCandidate(ctx, cand)
+	}
+	cnpj, lead := "", ""
+	if acc != nil {
+		cnpj, lead = acc.CNPJ14, acc.SourceLeadID
+		_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, true, true, reason, models.OutreachQueueDoNotContact)
+	}
+	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("dnc:%s:%s", orgID, email),
+		SourceLeadID:   lead,
+		CNPJ14:         cnpj,
+		ContactEmail:   email,
+		EventType:      OutcomeDoNotContact,
+		OccurredAt:     time.Now().UTC(),
+		Payload:        mustJSON(map[string]any{"reason": reason}),
+	})
+}
+
+func jsonMarshalMap(m map[string]any) ([]byte, error) {
+	if m == nil {
+		return []byte("{}"), nil
+	}
+	return marshalJSON(m)
+}

--- a/internal/app/confenge/hooks.go
+++ b/internal/app/confenge/hooks.go
@@ -112,6 +112,10 @@ func (s *service) NoteDNC(ctx context.Context, orgID uuid.UUID, contactEmail, re
 		cnpj, lead = acc.CNPJ14, acc.SourceLeadID
 		_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, true, true, reason, models.OutreachQueueDoNotContact)
 	}
+	// Platform suppression list: campaign send paths check this before enqueue.
+	if s.suppress != nil {
+		_ = s.suppress.SuppressRecipient(ctx, orgID, email, firstNonEmpty(reason, "confenge DO_NOT_CONTACT"))
+	}
 	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
 		IdempotencyKey: fmt.Sprintf("dnc:%s:%s", orgID, email),
 		SourceLeadID:   lead,

--- a/internal/app/confenge/hooks.go
+++ b/internal/app/confenge/hooks.go
@@ -129,3 +129,11 @@ func jsonMarshalMap(m map[string]any) ([]byte, error) {
 	}
 	return marshalJSON(m)
 }
+
+// OnClassifiedReply implements advanced.ConfengeReplyHook.
+func (s *service) OnClassifiedReply(ctx context.Context, orgID uuid.UUID, contactEmail, replyClass string, contactID *uuid.UUID) error {
+	if xerr := s.HandleClassifiedReply(ctx, orgID, uuid.Nil, contactEmail, replyClass, contactID); xerr != nil {
+		return fmt.Errorf("%s", xerr.Message)
+	}
+	return nil
+}

--- a/internal/app/confenge/json_util.go
+++ b/internal/app/confenge/json_util.go
@@ -1,0 +1,7 @@
+package confenge
+
+import "encoding/json"
+
+func marshalJSON(v any) ([]byte, error) {
+	return json.Marshal(v)
+}

--- a/internal/app/confenge/legacy.go
+++ b/internal/app/confenge/legacy.go
@@ -1,0 +1,427 @@
+package confenge
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// DetectAndNormalize accepts either a native confenge.outreach.v1 document or
+// common legacy extra-cli artifacts (leads.json array, commercial-leads wrapper,
+// single-run export). Missing fields are left empty; never invented.
+func DetectAndNormalize(raw []byte) (*Feed, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty payload")
+	}
+	// Peek schema_version without failing on legacy shapes.
+	var peek struct {
+		SchemaVersion string          `json:"schema_version"`
+		Leads         json.RawMessage `json:"leads"`
+	}
+	_ = json.Unmarshal(raw, &peek)
+	if peek.SchemaVersion == models.OutreachSchemaV1 {
+		return ParseFeed(raw)
+	}
+
+	// Top-level array of leads (leads.json).
+	trim := strings.TrimSpace(string(raw))
+	if strings.HasPrefix(trim, "[") {
+		var arr []map[string]any
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			return nil, fmt.Errorf("legacy leads array: %w", err)
+		}
+		return legacyMapToFeed(arr, FeedSource{System: "extra-cli", ProfileID: "confenge"}), nil
+	}
+
+	// Object with leads key (commercial run export / commercial-leads.json).
+	var wrap map[string]any
+	if err := json.Unmarshal(raw, &wrap); err != nil {
+		return nil, fmt.Errorf("legacy object: %w", err)
+	}
+	src := FeedSource{
+		System:         "extra-cli",
+		ProfileID:      "confenge",
+		RunID:          strField(wrap, "run_id", "id", "source_run_id"),
+		SnapshotHash:   strField(wrap, "snapshot_hash"),
+		RepoSHA:        strField(wrap, "repo_sha", "git_sha"),
+		ProfileVersion: strField(wrap, "profile_version"),
+	}
+	if v := strField(wrap, "profile_id", "profile"); v != "" {
+		src.ProfileID = v
+	}
+	leadsRaw, ok := wrap["leads"]
+	if !ok {
+		// Some exports nest under "data" or "queue".
+		if d, ok := wrap["data"].(map[string]any); ok {
+			leadsRaw = d["leads"]
+		} else if q, ok := wrap["queue"].([]any); ok {
+			leadsRaw = q
+		}
+	}
+	arr, err := asMapSlice(leadsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("legacy leads: %w", err)
+	}
+	feed := legacyMapToFeed(arr, src)
+	if g := strField(wrap, "generated_at", "created_at"); g != "" {
+		feed.GeneratedAt = g
+	}
+	return feed, nil
+}
+
+func legacyMapToFeed(arr []map[string]any, src FeedSource) *Feed {
+	leads := make([]FeedLead, 0, len(arr))
+	for i, m := range arr {
+		leads = append(leads, mapLegacyLead(m, i+1))
+	}
+	return &Feed{
+		SchemaVersion: models.OutreachSchemaV1,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Source:        src,
+		Pagination:    FeedPagination{HasMore: false},
+		Leads:         leads,
+	}
+}
+
+func mapLegacyLead(m map[string]any, rankFallback int) FeedLead {
+	cnpj := digitsOnly(strField(m, "cnpj14", "cnpj", "company_cnpj"))
+	root := digitsOnly(strField(m, "cnpj_root", "cnpj_basico"))
+	if root == "" && len(cnpj) == 14 {
+		root = cnpj[:8]
+	}
+	razao := strField(m, "razao_social", "company_name", "name")
+	fantasia := strField(m, "nome_fantasia", "trade_name")
+	sourceLead := strField(m, "source_lead_id", "lead_id", "id")
+	if sourceLead == "" && cnpj != "" {
+		sourceLead = "cnpj:" + cnpj
+	}
+
+	// Nested company object if present.
+	if co, ok := m["company"].(map[string]any); ok {
+		if v := digitsOnly(strField(co, "cnpj14", "cnpj")); v != "" {
+			cnpj = v
+		}
+		if v := digitsOnly(strField(co, "cnpj_root")); v != "" {
+			root = v
+		}
+		if v := strField(co, "razao_social", "name"); v != "" {
+			razao = v
+		}
+		if v := strField(co, "nome_fantasia"); v != "" {
+			fantasia = v
+		}
+	}
+
+	rank := intField(m, "rank_position", "rank", "priority_rank")
+	if rank == 0 {
+		rank = rankFallback
+	}
+	score := floatField(m, "score_total", "score", "priority_score")
+	tier := strField(m, "priority", "tier", "priority_tier")
+	offerCode := strField(m, "suggested_offer", "service_code", "offer")
+	offerName := strField(m, "service_name", "suggested_offer_name")
+	entry := strField(m, "entry_offer", "next_human_step")
+	state := strField(m, "commercial_state")
+	if state == "" {
+		state = "NEW"
+	}
+
+	momentCode := strField(m, "moment_code", "signal_primary")
+	momentSummary := strField(m, "moment_summary", "explanation", "why")
+	if momentSummary == "" {
+		// signals_fired is common in commercial_leads exports; take first name only.
+		if sigs, ok := m["signals_fired"].([]any); ok && len(sigs) > 0 {
+			switch s := sigs[0].(type) {
+			case string:
+				momentCode = firstNonEmpty(momentCode, s)
+				momentSummary = s
+			case map[string]any:
+				momentCode = firstNonEmpty(momentCode, strField(s, "code", "id", "name"))
+				momentSummary = strField(s, "summary", "label", "name", "code")
+			}
+		}
+	}
+
+	fact := strField(m, "fact_to_mention", "public_fact")
+	question := strField(m, "question_to_ask")
+	cta := strField(m, "cta")
+
+	// messaging_context nested
+	if mc, ok := m["messaging_context"].(map[string]any); ok {
+		fact = firstNonEmpty(fact, strField(mc, "fact_to_mention"))
+		question = firstNonEmpty(question, strField(mc, "question_to_ask"))
+		cta = firstNonEmpty(cta, strField(mc, "cta"))
+	}
+
+	contacts := mapLegacyContacts(m)
+	evidence := mapLegacyEvidence(m)
+
+	var contracts []json.RawMessage
+	if raw, ok := m["contracts"]; ok {
+		if b, err := json.Marshal(raw); err == nil {
+			var arr []json.RawMessage
+			if json.Unmarshal(b, &arr) == nil {
+				contracts = arr
+			}
+		}
+	}
+
+	municipio := strField(m, "municipio", "city")
+	uf := strField(m, "uf", "state")
+	website := strField(m, "website", "site")
+	if co, ok := m["company"].(map[string]any); ok {
+		municipio = firstNonEmpty(municipio, strField(co, "municipio", "city"))
+		uf = firstNonEmpty(uf, strField(co, "uf", "state"))
+		website = firstNonEmpty(website, strField(co, "website"))
+	}
+
+	return FeedLead{
+		SourceLeadID: sourceLead,
+		Company: FeedCompany{
+			CNPJ14:       cnpj,
+			CNPJRoot:     root,
+			RazaoSocial:  razao,
+			NomeFantasia: fantasia,
+			Municipio:    municipio,
+			UF:           uf,
+			Website:      website,
+		},
+		Priority: FeedPriority{
+			Rank:       rank,
+			Score:      score,
+			Tier:       tier,
+			Confidence: strField(m, "confidence", "priority_confidence"),
+		},
+		Moment: FeedMoment{
+			Code:       momentCode,
+			Summary:    momentSummary,
+			ObservedAt: strField(m, "observed_at", "moment_observed_at"),
+			Confidence: strField(m, "moment_confidence"),
+		},
+		Offer: FeedOffer{
+			ServiceCode: offerCode,
+			ServiceName: offerName,
+			EntryOffer:  entry,
+			Rationale:   strField(m, "rationale", "offer_rationale"),
+		},
+		MessagingContext: FeedMessaging{
+			FactToMention: fact,
+			QuestionToAsk: question,
+			CTA:           cta,
+		},
+		Contacts:        contacts,
+		Contracts:       contracts,
+		Evidence:        evidence,
+		CommercialState: state,
+	}
+}
+
+func mapLegacyContacts(m map[string]any) []FeedContact {
+	var out []FeedContact
+	raw, ok := m["contacts"]
+	if !ok {
+		// Flat single contact fields.
+		email := strField(m, "email", "contact_email")
+		name := strField(m, "contact_name", "contato")
+		if email == "" && name == "" {
+			return nil
+		}
+		return []FeedContact{{
+			SourceContactID:    strField(m, "source_contact_id", "contact_id"),
+			Name:               name,
+			Role:               strField(m, "role", "cargo", "contact_role"),
+			Email:              email,
+			Phone:              strField(m, "phone", "telefone"),
+			VerificationStatus: strField(m, "verification_status", "email_status"),
+			Recommended:        true,
+		}}
+	}
+	arr, err := asMapSlice(raw)
+	if err != nil {
+		return nil
+	}
+	for i, c := range arr {
+		sid := strField(c, "source_contact_id", "id", "contact_id")
+		if sid == "" {
+			sid = fmt.Sprintf("legacy-%d", i+1)
+		}
+		out = append(out, FeedContact{
+			SourceContactID:    sid,
+			Name:               strField(c, "name", "nome"),
+			Role:               strField(c, "role", "cargo"),
+			Email:              strField(c, "email"),
+			Phone:              strField(c, "phone", "telefone"),
+			LinkedInURL:        strField(c, "linkedin_url", "linkedin"),
+			SourceURL:          strField(c, "source_url"),
+			SourceDocument:     strField(c, "source_document"),
+			SourceDate:         strField(c, "source_date"),
+			VerificationStatus: strField(c, "verification_status", "status"),
+			Confidence:         strField(c, "confidence"),
+			Recommended:        boolField(c, "recommended", true),
+		})
+	}
+	return out
+}
+
+func mapLegacyEvidence(m map[string]any) []FeedEvidence {
+	raw, ok := m["evidence"]
+	if !ok {
+		// evidence_ids alone cannot invent full evidence rows.
+		return nil
+	}
+	arr, err := asMapSlice(raw)
+	if err != nil {
+		return nil
+	}
+	out := make([]FeedEvidence, 0, len(arr))
+	for i, e := range arr {
+		id := strField(e, "id", "source_evidence_id", "evidence_id")
+		if id == "" {
+			id = fmt.Sprintf("legacy-ev-%d", i+1)
+		}
+		out = append(out, FeedEvidence{
+			ID:             id,
+			Type:           strField(e, "type", "evidence_type"),
+			Title:          strField(e, "title"),
+			URL:            strField(e, "url", "source_url"),
+			Document:       strField(e, "document"),
+			Date:           strField(e, "date", "evidence_date"),
+			Location:       strField(e, "location", "page", "section"),
+			Excerpt:        strField(e, "excerpt", "snippet", "trecho"),
+			Synthesis:      strField(e, "synthesis", "summary"),
+			EpistemicClass: strField(e, "epistemic_class", "class"),
+			Reliability:    strField(e, "reliability"),
+			ConsultedAt:    strField(e, "consulted_at"),
+		})
+	}
+	return out
+}
+
+func asMapSlice(v any) ([]map[string]any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch t := v.(type) {
+	case []map[string]any:
+		return t, nil
+	case []any:
+		out := make([]map[string]any, 0, len(t))
+		for _, item := range t {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("lead item is not an object")
+			}
+			out = append(out, m)
+		}
+		return out, nil
+	default:
+		// Re-marshal path for typed JSON.
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		var out []map[string]any
+		if err := json.Unmarshal(b, &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+}
+
+func strField(m map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch t := v.(type) {
+			case string:
+				return strings.TrimSpace(t)
+			case float64:
+				// JSON numbers
+				if t == float64(int64(t)) {
+					return strconv.FormatInt(int64(t), 10)
+				}
+				return strconv.FormatFloat(t, 'f', -1, 64)
+			case json.Number:
+				return t.String()
+			case bool:
+				return strconv.FormatBool(t)
+			}
+		}
+	}
+	return ""
+}
+
+func intField(m map[string]any, keys ...string) int {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch t := v.(type) {
+			case float64:
+				return int(t)
+			case int:
+				return t
+			case int64:
+				return int(t)
+			case string:
+				n, _ := strconv.Atoi(strings.TrimSpace(t))
+				return n
+			case json.Number:
+				n, _ := t.Int64()
+				return int(n)
+			}
+		}
+	}
+	return 0
+}
+
+func floatField(m map[string]any, keys ...string) float64 {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch t := v.(type) {
+			case float64:
+				return t
+			case int:
+				return float64(t)
+			case int64:
+				return float64(t)
+			case string:
+				f, _ := strconv.ParseFloat(strings.TrimSpace(t), 64)
+				return f
+			case json.Number:
+				f, _ := t.Float64()
+				return f
+			}
+		}
+	}
+	return 0
+}
+
+func boolField(m map[string]any, key string, def bool) bool {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return def
+	}
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		b, err := strconv.ParseBool(t)
+		if err != nil {
+			return def
+		}
+		return b
+	default:
+		return def
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/app/confenge/outcomes.go
+++ b/internal/app/confenge/outcomes.go
@@ -1,0 +1,147 @@
+package confenge
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Outcome event types for confenge.outcome.v1.
+const (
+	OutcomeLeadImported    = "LEAD_IMPORTED"
+	OutcomeLeadReviewed    = "LEAD_REVIEWED"
+	OutcomeContactApproved = "CONTACT_APPROVED"
+	OutcomeContacted       = "CONTACTED"
+	OutcomeReplied         = "REPLIED"
+	OutcomeMeeting         = "MEETING"
+	OutcomeProposal        = "PROPOSAL"
+	OutcomeWon             = "WON"
+	OutcomeLost            = "LOST"
+	OutcomeDoNotContact    = "DO_NOT_CONTACT"
+	OutcomeBounced         = "BOUNCED"
+)
+
+// OutcomeEnvelope is the payload posted to extra-cli.
+type OutcomeEnvelope struct {
+	SchemaVersion  string         `json:"schema_version"`
+	EventID        string         `json:"event_id"`
+	IdempotencyKey string         `json:"idempotency_key"`
+	OccurredAt     string         `json:"occurred_at"`
+	Source         string         `json:"source"`
+	SourceLeadID   string         `json:"source_lead_id"`
+	CNPJ14         string         `json:"cnpj14"`
+	ContactEmail   string         `json:"contact_email"`
+	EventType      string         `json:"event_type"`
+	CampaignID     string         `json:"campaign_id,omitempty"`
+	MessageID      string         `json:"message_id,omitempty"`
+	Metadata       map[string]any `json:"metadata,omitempty"`
+}
+
+// EnqueueOutcome records an async outbox row (idempotent by key).
+func (s *service) EnqueueOutcome(ctx context.Context, orgID uuid.UUID, ev models.OutreachOutcome) *errx.Error {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return xerr
+	}
+	if strings.TrimSpace(ev.IdempotencyKey) == "" {
+		return errx.New(errx.BadRequest, "idempotency_key is required")
+	}
+	if strings.TrimSpace(ev.EventType) == "" {
+		return errx.New(errx.BadRequest, "event_type is required")
+	}
+	if ev.OccurredAt.IsZero() {
+		ev.OccurredAt = time.Now().UTC()
+	}
+	ev.OrganizationID = orgID
+	if err := s.repo.EnqueueOutcome(ctx, &ev); err != nil {
+		// unique violation → already queued
+		if strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "unique") {
+			return nil
+		}
+		return errx.New(errx.Internal, "failed to enqueue outcome: "+err.Error())
+	}
+	return nil
+}
+
+// SignOutcomeHMAC builds the signature header value: t=<unix>,v1=<hex>.
+func SignOutcomeHMAC(secret string, ts time.Time, body []byte) string {
+	msg := fmt.Sprintf("%d.", ts.Unix()) + string(body)
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(msg))
+	return "t=" + strconv.FormatInt(ts.Unix(), 10) + ",v1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyOutcomeHMAC checks timestamp skew and constant-time signature.
+func VerifyOutcomeHMAC(secret, header string, body []byte, now time.Time, maxSkew time.Duration) bool {
+	// header: t=...,v1=...
+	var tUnix int64
+	var sig string
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "t=") {
+			tUnix, _ = strconv.ParseInt(strings.TrimPrefix(part, "t="), 10, 64)
+		}
+		if strings.HasPrefix(part, "v1=") {
+			sig = strings.TrimPrefix(part, "v1=")
+		}
+	}
+	if tUnix == 0 || sig == "" {
+		return false
+	}
+	ts := time.Unix(tUnix, 0).UTC()
+	if now.Sub(ts) > maxSkew || ts.Sub(now) > maxSkew {
+		return false
+	}
+	expected := SignOutcomeHMAC(secret, ts, body)
+	// Compare only the v1 portion for constant-time on hex.
+	want := strings.TrimPrefix(strings.Split(expected, ",v1=")[1], "")
+	return hmac.Equal([]byte(want), []byte(sig))
+}
+
+// BuildOutcomeEnvelope maps a stored row to the wire contract.
+func BuildOutcomeEnvelope(ev *models.OutreachOutcome) OutcomeEnvelope {
+	meta := map[string]any{}
+	if len(ev.Payload) > 0 {
+		_ = json.Unmarshal(ev.Payload, &meta)
+	}
+	return OutcomeEnvelope{
+		SchemaVersion:  models.OutreachOutcomeSchemaV1,
+		EventID:        ev.EventID.String(),
+		IdempotencyKey: ev.IdempotencyKey,
+		OccurredAt:     ev.OccurredAt.UTC().Format(time.RFC3339),
+		Source:         "warmbly",
+		SourceLeadID:   ev.SourceLeadID,
+		CNPJ14:         ev.CNPJ14,
+		ContactEmail:   ev.ContactEmail,
+		EventType:      ev.EventType,
+		Metadata:       meta,
+	}
+}
+
+// OutcomeBackoff grows attempts: 30s, 1m, 2m, 5m, 15m, 1h (cap).
+func OutcomeBackoff(attempt int) time.Duration {
+	switch {
+	case attempt <= 1:
+		return 30 * time.Second
+	case attempt == 2:
+		return time.Minute
+	case attempt == 3:
+		return 2 * time.Minute
+	case attempt == 4:
+		return 5 * time.Minute
+	case attempt == 5:
+		return 15 * time.Minute
+	default:
+		return time.Hour
+	}
+}

--- a/internal/app/confenge/outcomes_test.go
+++ b/internal/app/confenge/outcomes_test.go
@@ -1,0 +1,35 @@
+package confenge
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSignAndVerifyOutcomeHMAC(t *testing.T) {
+	secret := "whsec_test"
+	body := []byte(`{"event_type":"REPLIED"}`)
+	ts := time.Unix(1700000000, 0).UTC()
+	hdr := SignOutcomeHMAC(secret, ts, body)
+	if !VerifyOutcomeHMAC(secret, hdr, body, ts, 5*time.Minute) {
+		t.Fatal("valid signature rejected")
+	}
+	if VerifyOutcomeHMAC("other", hdr, body, ts, 5*time.Minute) {
+		t.Fatal("wrong secret accepted")
+	}
+	if VerifyOutcomeHMAC(secret, hdr, []byte(`{}`), ts, 5*time.Minute) {
+		t.Fatal("tampered body accepted")
+	}
+	// Outside skew window
+	if VerifyOutcomeHMAC(secret, hdr, body, ts.Add(10*time.Minute), 5*time.Minute) {
+		t.Fatal("stale timestamp accepted")
+	}
+}
+
+func TestOutcomeBackoffGrows(t *testing.T) {
+	if OutcomeBackoff(1) != 30*time.Second {
+		t.Fatal(OutcomeBackoff(1))
+	}
+	if OutcomeBackoff(6) != time.Hour {
+		t.Fatal(OutcomeBackoff(6))
+	}
+}

--- a/internal/app/confenge/schema.go
+++ b/internal/app/confenge/schema.go
@@ -1,0 +1,423 @@
+package confenge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Native feed contract: confenge.outreach.v1
+
+// Feed is the top-level document produced by extra-cli (or fixtures).
+type Feed struct {
+	SchemaVersion string         `json:"schema_version"`
+	GeneratedAt   string         `json:"generated_at"`
+	Source        FeedSource     `json:"source"`
+	Pagination    FeedPagination `json:"pagination"`
+	Leads         []FeedLead     `json:"leads"`
+}
+
+// FeedSource identifies the producing intelligence-plane run.
+type FeedSource struct {
+	System         string `json:"system"`
+	RunID          string `json:"run_id"`
+	SnapshotHash   string `json:"snapshot_hash"`
+	RepoSHA        string `json:"repo_sha"`
+	ProfileID      string `json:"profile_id"`
+	ProfileVersion string `json:"profile_version"`
+}
+
+// FeedPagination supports paged feeds; all fields optional.
+type FeedPagination struct {
+	Cursor     *string `json:"cursor"`
+	NextCursor *string `json:"next_cursor"`
+	HasMore    bool    `json:"has_more"`
+}
+
+// FeedLead is one company opportunity in the feed.
+type FeedLead struct {
+	SourceLeadID     string            `json:"source_lead_id"`
+	Company          FeedCompany       `json:"company"`
+	Priority         FeedPriority      `json:"priority"`
+	Moment           FeedMoment        `json:"moment"`
+	Offer            FeedOffer         `json:"offer"`
+	MessagingContext FeedMessaging     `json:"messaging_context"`
+	Contacts         []FeedContact     `json:"contacts"`
+	Contracts        []json.RawMessage `json:"contracts"`
+	Evidence         []FeedEvidence    `json:"evidence"`
+	CommercialState  string            `json:"commercial_state"`
+}
+
+// FeedCompany is Brazilian company identity from the datalake.
+type FeedCompany struct {
+	CNPJ14       string `json:"cnpj14"`
+	CNPJRoot     string `json:"cnpj_root"`
+	RazaoSocial  string `json:"razao_social"`
+	NomeFantasia string `json:"nome_fantasia"`
+	Municipio    string `json:"municipio"`
+	UF           string `json:"uf"`
+	Website      string `json:"website"`
+}
+
+// FeedPriority is rank/score from extra-cli (stored, never re-scored here).
+type FeedPriority struct {
+	Rank       int     `json:"rank"`
+	Score      float64 `json:"score"`
+	Tier       string  `json:"tier"`
+	Confidence string  `json:"confidence"`
+}
+
+// FeedMoment is the commercial moment / fato gerador.
+type FeedMoment struct {
+	Code        string   `json:"code"`
+	Summary     string   `json:"summary"`
+	ObservedAt  string   `json:"observed_at"`
+	Confidence  string   `json:"confidence"`
+	EvidenceIDs []string `json:"evidence_ids"`
+}
+
+// FeedOffer is the suggested service entry offer.
+type FeedOffer struct {
+	ServiceCode string `json:"service_code"`
+	ServiceName string `json:"service_name"`
+	EntryOffer  string `json:"entry_offer"`
+	Rationale   string `json:"rationale"`
+}
+
+// FeedMessaging is structured messaging context for generation.
+type FeedMessaging struct {
+	FactToMention string   `json:"fact_to_mention"`
+	QuestionToAsk string   `json:"question_to_ask"`
+	CTA           string   `json:"cta"`
+	ClaimsToAvoid []string `json:"claims_to_avoid"`
+}
+
+// FeedContact is a candidate recipient (may lack email).
+type FeedContact struct {
+	SourceContactID    string `json:"source_contact_id"`
+	Name               string `json:"name"`
+	Role               string `json:"role"`
+	Email              string `json:"email"`
+	Phone              string `json:"phone"`
+	LinkedInURL        string `json:"linkedin_url"`
+	SourceURL          string `json:"source_url"`
+	SourceDocument     string `json:"source_document"`
+	SourceDate         string `json:"source_date"`
+	VerificationStatus string `json:"verification_status"`
+	Confidence         string `json:"confidence"`
+	Recommended        bool   `json:"recommended"`
+}
+
+// FeedEvidence is one evidence item (text only; HTML stripped on import).
+type FeedEvidence struct {
+	ID             string `json:"id"`
+	Type           string `json:"type"`
+	Title          string `json:"title"`
+	URL            string `json:"url"`
+	Document       string `json:"document"`
+	Date           string `json:"date"`
+	Location       string `json:"location"`
+	Excerpt        string `json:"excerpt"`
+	Synthesis      string `json:"synthesis"`
+	EpistemicClass string `json:"epistemic_class"`
+	Reliability    string `json:"reliability"`
+	ConsultedAt    string `json:"consulted_at"`
+}
+
+var (
+	cnpj14Re   = regexp.MustCompile(`^\d{14}$`)
+	cnpjRootRe = regexp.MustCompile(`^\d{8}$`)
+)
+
+var allowedVerification = map[string]bool{
+	models.OutreachVerifyOfficialSource:       true,
+	models.OutreachVerifyPublicDocumentRecent: true,
+	models.OutreachVerifyMultipleSources:      true,
+	models.OutreachVerifyInstitutionalGeneric: true,
+	models.OutreachVerifyPublicPossiblyStale:  true,
+	models.OutreachVerifyCandidateUnverified:  true,
+	models.OutreachVerifyNotFound:             true,
+	models.OutreachVerifyInvalid:              true,
+	models.OutreachVerifyBounced:              true,
+	models.OutreachVerifyDoNotContact:         true,
+}
+
+var allowedEpistemic = map[string]bool{
+	models.OutreachEpistemicConfirmedFact:          true,
+	models.OutreachEpistemicStrongInference:        true,
+	models.OutreachEpistemicWeakInference:          true,
+	models.OutreachEpistemicCommercialHypothesis:   true,
+	models.OutreachEpistemicNotFound:               true,
+	models.OutreachEpistemicRequiresCompanyConfirm: true,
+	models.OutreachEpistemicContradictoryEvidence:  true,
+}
+
+// ParseFeed unmarshals JSON bytes into a Feed. Does not invent missing fields.
+func ParseFeed(raw []byte) (*Feed, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty payload")
+	}
+	var f Feed
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	return &f, nil
+}
+
+// ValidateFeed checks schema_version and required identity fields.
+// Per-lead errors are returned separately so a run can continue.
+func ValidateFeed(f *Feed) error {
+	if f == nil {
+		return fmt.Errorf("nil feed")
+	}
+	if f.SchemaVersion != models.OutreachSchemaV1 {
+		return fmt.Errorf("unsupported schema_version %q (want %s)", f.SchemaVersion, models.OutreachSchemaV1)
+	}
+	if strings.TrimSpace(f.Source.System) == "" {
+		return fmt.Errorf("source.system is required")
+	}
+	return nil
+}
+
+// LeadValidationError is a non-fatal per-lead problem.
+type LeadValidationError struct {
+	Index        int
+	SourceLeadID string
+	CNPJ14       string
+	Message      string
+}
+
+// ValidateLead checks one lead. Missing contact is allowed (NEEDS_CONTACT).
+func ValidateLead(i int, lead FeedLead) *LeadValidationError {
+	cnpj := digitsOnly(lead.Company.CNPJ14)
+	sid := strings.TrimSpace(lead.SourceLeadID)
+	if cnpj == "" {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, Message: "company.cnpj14 is required"}
+	}
+	if !cnpj14Re.MatchString(cnpj) {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, CNPJ14: cnpj, Message: "company.cnpj14 must be 14 digits"}
+	}
+	if root := digitsOnly(lead.Company.CNPJRoot); root != "" && !cnpjRootRe.MatchString(root) {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, CNPJ14: cnpj, Message: "company.cnpj_root must be 8 digits when set"}
+	}
+	if strings.TrimSpace(lead.Company.RazaoSocial) == "" && strings.TrimSpace(lead.Company.NomeFantasia) == "" {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, CNPJ14: cnpj, Message: "company needs razao_social or nome_fantasia"}
+	}
+	for j, c := range lead.Contacts {
+		vs := strings.TrimSpace(c.VerificationStatus)
+		if vs != "" && !allowedVerification[vs] {
+			return &LeadValidationError{
+				Index: i, SourceLeadID: sid, CNPJ14: cnpj,
+				Message: fmt.Sprintf("contacts[%d].verification_status %q is not allowed", j, vs),
+			}
+		}
+	}
+	for j, e := range lead.Evidence {
+		ec := strings.TrimSpace(e.EpistemicClass)
+		if ec != "" && !allowedEpistemic[ec] {
+			return &LeadValidationError{
+				Index: i, SourceLeadID: sid, CNPJ14: cnpj,
+				Message: fmt.Sprintf("evidence[%d].epistemic_class %q is not allowed", j, ec),
+			}
+		}
+		if strings.TrimSpace(e.ID) == "" {
+			return &LeadValidationError{
+				Index: i, SourceLeadID: sid, CNPJ14: cnpj,
+				Message: fmt.Sprintf("evidence[%d].id is required", j),
+			}
+		}
+	}
+	return nil
+}
+
+// CanonicalPayloadHash is a stable SHA-256 of the raw payload bytes (hex).
+// Callers that re-serialize should use the original bytes for idempotency.
+func CanonicalPayloadHash(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// LeadContentHash hashes the lead's machine-owned fields for change detection.
+func LeadContentHash(lead FeedLead) string {
+	// Exclude human-only outcomes; include messaging, priority, moment, offer, contacts, evidence ids.
+	type slim struct {
+		SourceLeadID string         `json:"source_lead_id"`
+		Company      FeedCompany    `json:"company"`
+		Priority     FeedPriority   `json:"priority"`
+		Moment       FeedMoment     `json:"moment"`
+		Offer        FeedOffer      `json:"offer"`
+		Messaging    FeedMessaging  `json:"messaging_context"`
+		Contacts     []FeedContact  `json:"contacts"`
+		Evidence     []FeedEvidence `json:"evidence"`
+		State        string         `json:"commercial_state"`
+	}
+	b, _ := json.Marshal(slim{
+		SourceLeadID: lead.SourceLeadID,
+		Company:      lead.Company,
+		Priority:     lead.Priority,
+		Moment:       lead.Moment,
+		Offer:        lead.Offer,
+		Messaging:    lead.MessagingContext,
+		Contacts:     lead.Contacts,
+		Evidence:     lead.Evidence,
+		State:        lead.CommercialState,
+	})
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// NormalizeCNPJ14 returns digits-only 14-char CNPJ or empty.
+func NormalizeCNPJ14(s string) string {
+	d := digitsOnly(s)
+	if !cnpj14Re.MatchString(d) {
+		return ""
+	}
+	return d
+}
+
+// SanitizeText strips control chars and truncates; never invents content.
+func SanitizeText(s string, maxRunes int) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Drop HTML tags roughly (no script execution surface).
+	s = stripTags(s)
+	s = strings.Map(func(r rune) rune {
+		if r < 32 && r != '\n' && r != '\t' {
+			return -1
+		}
+		return r
+	}, s)
+	if maxRunes > 0 && utf8.RuneCountInString(s) > maxRunes {
+		runes := []rune(s)
+		s = string(runes[:maxRunes])
+	}
+	return s
+}
+
+func stripTags(s string) string {
+	// Simple angle-bracket strip; feed must not carry executable HTML.
+	var b strings.Builder
+	b.Grow(len(s))
+	in := false
+	for _, r := range s {
+		switch {
+		case r == '<':
+			in = true
+		case r == '>':
+			in = false
+		case !in:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func digitsOnly(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// ParseDate accepts YYYY-MM-DD or RFC3339 date portion; empty -> nil.
+func ParseDate(s string) *time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return &t
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		d := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+		return &d
+	}
+	// Date-only prefix of datetime
+	if len(s) >= 10 {
+		if t, err := time.Parse("2006-01-02", s[:10]); err == nil {
+			return &t
+		}
+	}
+	return nil
+}
+
+// DefaultQueueState for a lead after import (no invention of contacts).
+func DefaultQueueState(lead FeedLead, existing *models.OutreachAccount) string {
+	// Preserve human terminal states.
+	if existing != nil {
+		if existing.DoNotContact || existing.QueueState == models.OutreachQueueDoNotContact {
+			return models.OutreachQueueDoNotContact
+		}
+		if existing.Blocked || existing.QueueState == models.OutreachQueueBlocked {
+			return models.OutreachQueueBlocked
+		}
+		// Do not silently restart post-send states.
+		switch existing.QueueState {
+		case models.OutreachQueueEnrolled, models.OutreachQueueSent, models.OutreachQueueReplied,
+			models.OutreachQueueMeeting, models.OutreachQueueProposal, models.OutreachQueueWon,
+			models.OutreachQueueLost, models.OutreachQueueSkipped, models.OutreachQueueBounced,
+			models.OutreachQueueApproved, models.OutreachQueueNeedsReview:
+			return existing.QueueState
+		}
+	}
+	if hasEnrollableContact(lead) {
+		return models.OutreachQueueReadyToGenerate
+	}
+	return models.OutreachQueueNeedsContact
+}
+
+func hasEnrollableContact(lead FeedLead) bool {
+	for _, c := range lead.Contacts {
+		email := strings.TrimSpace(c.Email)
+		if email == "" {
+			continue
+		}
+		vs := strings.TrimSpace(c.VerificationStatus)
+		if vs == "" {
+			vs = models.OutreachVerifyCandidateUnverified
+		}
+		if models.OutreachUnenrollableVerification[vs] {
+			continue
+		}
+		if vs == models.OutreachVerifyDoNotContact {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// NormalizeVerification returns a known status or CANDIDATE_UNVERIFIED when
+// email is present without status; NOT_FOUND when empty.
+func NormalizeVerification(status, email string) string {
+	status = strings.TrimSpace(status)
+	email = strings.TrimSpace(email)
+	if status != "" && allowedVerification[status] {
+		return status
+	}
+	if email == "" {
+		return models.OutreachVerifyNotFound
+	}
+	return models.OutreachVerifyCandidateUnverified
+}
+
+// NormalizeEpistemic defaults missing class to COMMERCIAL_HYPOTHESIS.
+func NormalizeEpistemic(class string) string {
+	class = strings.TrimSpace(class)
+	if class != "" && allowedEpistemic[class] {
+		return class
+	}
+	return models.OutreachEpistemicCommercialHypothesis
+}

--- a/internal/app/confenge/schema_test.go
+++ b/internal/app/confenge/schema_test.go
@@ -1,0 +1,305 @@
+package confenge
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestParseAndValidateNativeFeed(t *testing.T) {
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	feed, err := ParseFeed(raw)
+	if err != nil {
+		t.Fatalf("ParseFeed: %v", err)
+	}
+	if err := ValidateFeed(feed); err != nil {
+		t.Fatalf("ValidateFeed: %v", err)
+	}
+	if feed.SchemaVersion != models.OutreachSchemaV1 {
+		t.Fatalf("schema %q", feed.SchemaVersion)
+	}
+	if len(feed.Leads) < 5 {
+		t.Fatalf("want >=5 leads, got %d", len(feed.Leads))
+	}
+	// Company without email must validate (NEEDS_CONTACT later).
+	var noEmail bool
+	for i, lead := range feed.Leads {
+		if lv := ValidateLead(i, lead); lv != nil {
+			t.Fatalf("lead %d invalid: %s", i, lv.Message)
+		}
+		if !hasEnrollableContact(lead) {
+			noEmail = true
+			if DefaultQueueState(lead, nil) != models.OutreachQueueNeedsContact {
+				t.Fatalf("lead without email should be NEEDS_CONTACT")
+			}
+		}
+	}
+	if !noEmail {
+		t.Fatal("fixture should include a lead without enrollable contact")
+	}
+}
+
+func TestRejectInvalidSchemaVersion(t *testing.T) {
+	raw := []byte(`{"schema_version":"nope","source":{"system":"x"},"leads":[]}`)
+	feed, err := ParseFeed(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateFeed(feed); err == nil {
+		t.Fatal("expected schema version error")
+	}
+}
+
+func TestRejectBadCNPJ(t *testing.T) {
+	lead := FeedLead{
+		SourceLeadID: "x",
+		Company:      FeedCompany{CNPJ14: "123", RazaoSocial: "ACME"},
+	}
+	if lv := ValidateLead(0, lead); lv == nil {
+		t.Fatal("expected cnpj error")
+	}
+}
+
+func TestCanonicalPayloadHashStable(t *testing.T) {
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	a := CanonicalPayloadHash(raw)
+	b := CanonicalPayloadHash(raw)
+	if a != b || len(a) != 64 {
+		t.Fatalf("hash unstable or wrong length: %s", a)
+	}
+	other := append([]byte{}, raw...)
+	other[len(other)-2] = 'x'
+	if CanonicalPayloadHash(other) == a {
+		t.Fatal("different payload should hash differently")
+	}
+}
+
+func TestLeadContentHashChangesWithScore(t *testing.T) {
+	lead := FeedLead{
+		SourceLeadID: "1",
+		Company:      FeedCompany{CNPJ14: "11222333000181", RazaoSocial: "ACME"},
+		Priority:     FeedPriority{Score: 10},
+	}
+	h1 := LeadContentHash(lead)
+	lead.Priority.Score = 20
+	h2 := LeadContentHash(lead)
+	if h1 == h2 {
+		t.Fatal("score change must change content hash")
+	}
+}
+
+func TestSanitizeTextStripsTagsAndControl(t *testing.T) {
+	in := "<script>alert(1)</script>Hello\x00World"
+	out := SanitizeText(in, 100)
+	if out != "alert(1)HelloWorld" && out != "HelloWorld" {
+		// stripTags leaves inner text of script; control stripped
+		if containsAngle(out) {
+			t.Fatalf("tags remain: %q", out)
+		}
+	}
+	if containsAngle(out) {
+		t.Fatalf("angle brackets remain: %q", out)
+	}
+}
+
+func containsAngle(s string) bool {
+	for _, r := range s {
+		if r == '<' || r == '>' {
+			return true
+		}
+	}
+	return false
+}
+
+func TestUnenrollableVerification(t *testing.T) {
+	cases := []struct {
+		vs   string
+		want bool
+	}{
+		{models.OutreachVerifyOfficialSource, true},
+		{models.OutreachVerifyInstitutionalGeneric, true},
+		{models.OutreachVerifyCandidateUnverified, false},
+		{models.OutreachVerifyNotFound, false},
+		{models.OutreachVerifyInvalid, false},
+		{models.OutreachVerifyBounced, false},
+		{models.OutreachVerifyDoNotContact, false},
+	}
+	for _, tc := range cases {
+		c := &models.OutreachContactCandidate{
+			Email:              "a@example.com",
+			VerificationStatus: tc.vs,
+		}
+		if c.CanEnroll() != tc.want {
+			t.Errorf("%s CanEnroll=%v want %v", tc.vs, c.CanEnroll(), tc.want)
+		}
+	}
+}
+
+func TestDefaultQueueStatePreservesDNC(t *testing.T) {
+	lead := FeedLead{
+		Company:  FeedCompany{CNPJ14: "11222333000181", RazaoSocial: "X"},
+		Contacts: []FeedContact{{Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource}},
+	}
+	existing := &models.OutreachAccount{
+		DoNotContact: true,
+		QueueState:   models.OutreachQueueDoNotContact,
+	}
+	if DefaultQueueState(lead, existing) != models.OutreachQueueDoNotContact {
+		t.Fatal("DNC must be preserved on reimport")
+	}
+}
+
+func TestDefaultQueueStatePreservesSent(t *testing.T) {
+	lead := FeedLead{
+		Company:  FeedCompany{CNPJ14: "11222333000181", RazaoSocial: "X"},
+		Contacts: []FeedContact{{Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource}},
+	}
+	existing := &models.OutreachAccount{QueueState: models.OutreachQueueSent}
+	if DefaultQueueState(lead, existing) != models.OutreachQueueSent {
+		t.Fatal("SENT must not restart on reimport")
+	}
+}
+
+func TestLegacyLeadsArrayNormalizes(t *testing.T) {
+	raw := mustReadFixture(t, "legacy_leads_array.json")
+	feed, err := DetectAndNormalize(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if feed.SchemaVersion != models.OutreachSchemaV1 {
+		t.Fatalf("normalized schema %q", feed.SchemaVersion)
+	}
+	if len(feed.Leads) != 3 {
+		t.Fatalf("want 3 leads, got %d", len(feed.Leads))
+	}
+	// No invented email on contactless company
+	var missing bool
+	for _, l := range feed.Leads {
+		if !hasEnrollableContact(l) {
+			missing = true
+		}
+		if NormalizeCNPJ14(l.Company.CNPJ14) == "" {
+			t.Fatalf("cnpj not normalized: %q", l.Company.CNPJ14)
+		}
+	}
+	if !missing {
+		t.Fatal("legacy fixture should include company without contact")
+	}
+}
+
+func TestLegacyDoesNotInventMissingFields(t *testing.T) {
+	raw := []byte(`[{"cnpj14":"11222333000181","razao_social":"Only Name"}]`)
+	feed, err := DetectAndNormalize(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := feed.Leads[0]
+	if l.Offer.ServiceCode != "" || l.MessagingContext.FactToMention != "" {
+		t.Fatalf("must not invent offer/fact: %+v", l)
+	}
+	if len(l.Contacts) != 0 {
+		t.Fatalf("must not invent contacts: %+v", l.Contacts)
+	}
+}
+
+func TestHostAllowlist(t *testing.T) {
+	if !hostAllowed("feed.example.com", []string{"example.com"}) {
+		t.Fatal("subdomain should match parent allow")
+	}
+	if hostAllowed("evil.com", []string{"example.com"}) {
+		t.Fatal("unrelated host must not match")
+	}
+	if !hostAllowed("example.com", []string{"example.com"}) {
+		t.Fatal("exact host should match")
+	}
+}
+
+func TestConfigDefaultsOff(t *testing.T) {
+	t.Setenv(EnvEnabled, "")
+	t.Setenv(EnvAutoSend, "")
+	cfg := LoadConfig()
+	if cfg.Enabled || cfg.AutoSendEnabled {
+		t.Fatal("feature must default off")
+	}
+	if !cfg.RequireHumanApproval {
+		t.Fatal("human approval must default true")
+	}
+}
+
+func TestConfigValidateProdHTTPS(t *testing.T) {
+	cfg := Config{
+		Enabled:      true,
+		FeedURL:      "http://insecure.example.com/feed",
+		AllowedHosts: []string{"insecure.example.com"},
+	}
+	if err := cfg.ValidateStartup("prod"); err == nil {
+		t.Fatal("prod must require https feed")
+	}
+	cfg.FeedURL = "https://feed.example.com/x"
+	cfg.AllowedHosts = nil
+	if err := cfg.ValidateStartup("prod"); err == nil {
+		t.Fatal("prod must require allowlist when feed set")
+	}
+}
+
+func TestForbiddenWordsNotInFixtureSubjects(t *testing.T) {
+	// Structural: native fixture messaging must not use prohibited outreach phrases.
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	var feed Feed
+	if err := json.Unmarshal(raw, &feed); err != nil {
+		t.Fatal(err)
+	}
+	banned := []string{"dinheiro a receber", "crédito identificado", "lead quente"}
+	for _, l := range feed.Leads {
+		blob := l.MessagingContext.FactToMention + l.MessagingContext.QuestionToAsk + l.MessagingContext.CTA
+		for _, b := range banned {
+			if containsFold(blob, b) {
+				t.Fatalf("fixture contains banned phrase %q", b)
+			}
+		}
+	}
+}
+
+func containsFold(s, sub string) bool {
+	return len(sub) > 0 && (s == sub || len(s) >= len(sub) &&
+		(json.Valid([]byte(`"`+s+`"`)) && // keep compiler happy path
+			false || stringContainsFold(s, sub)))
+}
+
+func stringContainsFold(s, sub string) bool {
+	// simple ASCII fold
+	ls, lsub := []rune(s), []rune(sub)
+	for i := 0; i+len(lsub) <= len(ls); i++ {
+		match := true
+		for j := range lsub {
+			a, b := ls[i+j], lsub[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 32
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 32
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func mustReadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	p := filepath.Join("testdata", name)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return b
+}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -44,6 +44,7 @@ type Service interface {
 	ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, *errx.Error)
 	ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.UUID, action string, edit *DraftEdit) (*models.OutreachDraft, *errx.Error)
 	SetAI(p generation.Provider)
+	EnqueueOutcome(ctx context.Context, orgID uuid.UUID, ev models.OutreachOutcome) *errx.Error
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/generation"
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
@@ -36,6 +37,13 @@ type Service interface {
 	ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, *errx.Error)
 	GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, *errx.Error)
 	BlockAccount(ctx context.Context, orgID, userID, id uuid.UUID, reason string, dnc bool) (*models.OutreachAccount, *errx.Error)
+
+	// Drafts / review (PR2)
+	GenerateDraft(ctx context.Context, orgID, userID, accountID uuid.UUID, contactID *uuid.UUID) (*models.OutreachDraft, *errx.Error)
+	GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, *errx.Error)
+	ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, *errx.Error)
+	ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.UUID, action string, edit *DraftEdit) (*models.OutreachDraft, *errx.Error)
+	SetAI(p generation.Provider)
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.
@@ -50,6 +58,7 @@ type service struct {
 	repo  repository.OutreachRepository
 	audit AuditLogger
 	fetch *FeedFetcher
+	ai    generation.Provider
 }
 
 // NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.
@@ -64,6 +73,22 @@ func NewService(cfg Config, repo repository.OutreachRepository, audit AuditLogge
 			MaxBytes:     cfg.MaxFeedPayloadBytes,
 		},
 	}
+}
+
+// NewServiceWithAI wires confenge with an optional LLM provider for drafts.
+func NewServiceWithAI(cfg Config, repo repository.OutreachRepository, audit AuditLogger, ai generation.Provider) Service {
+	svc := &service{
+		cfg:   cfg,
+		repo:  repo,
+		audit: audit,
+		fetch: &FeedFetcher{
+			AllowedHosts: cfg.AllowedHosts,
+			Token:        cfg.FeedToken,
+			MaxBytes:     cfg.MaxFeedPayloadBytes,
+		},
+		ai: ai,
+	}
+	return svc
 }
 
 func (s *service) Enabled() bool  { return s.cfg.Enabled }

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -49,10 +49,13 @@ type Service interface {
 	BootstrapCampaign(ctx context.Context, orgID, userID uuid.UUID) (*models.Campaign, *errx.Error)
 	EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error)
 	WireCRM(crm CRMAPI)
+	WireSuppress(sup SuppressAPI)
 	BootstrapPipeline(ctx context.Context, orgID uuid.UUID) (*models.Pipeline, *errx.Error)
 	HandleClassifiedReply(ctx context.Context, orgID, actorID uuid.UUID, contactEmail, replyClass string, warmblyContactID *uuid.UUID) *errx.Error
 	// OnClassifiedReply is the advanced-package hook (error, not errx).
 	OnClassifiedReply(ctx context.Context, orgID uuid.UUID, contactEmail, replyClass string, contactID *uuid.UUID) error
+	BatchApproveDrafts(ctx context.Context, orgID, userID uuid.UUID, draftIDs []uuid.UUID) (*BatchApproveResult, *errx.Error)
+	Metrics(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, *errx.Error)
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.
@@ -71,6 +74,7 @@ type service struct {
 	campaigns CampaignAPI
 	contacts  ContactAPI
 	crm       CRMAPI
+	suppress  SuppressAPI
 }
 
 // NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -1,0 +1,500 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// AuditLogger writes org-scoped audit entries (realtime spine).
+type AuditLogger interface {
+	LogAction(ctx context.Context, orgID, actorID uuid.UUID, action models.AuditAction, entityType models.AuditEntityType, entityID *uuid.UUID, ip, userAgent string, changes, metadata map[string]string)
+}
+
+// Service is the control-plane surface for CONFENGE outreach staging.
+type Service interface {
+	Enabled() bool
+	Config() Config
+
+	// ImportFromBytes validates and optionally applies a feed payload.
+	ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, raw []byte, opts ImportOptions) (*models.OutreachImportRun, *errx.Error)
+	// ImportFromURI fetches a feed (file/https) then imports.
+	ImportFromURI(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, uri string, opts ImportOptions) (*models.OutreachImportRun, *errx.Error)
+
+	GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, *errx.Error)
+	ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, *errx.Error)
+
+	Summary(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, *errx.Error)
+	ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, *errx.Error)
+	GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, *errx.Error)
+	BlockAccount(ctx context.Context, orgID, userID, id uuid.UUID, reason string, dnc bool) (*models.OutreachAccount, *errx.Error)
+}
+
+// ImportOptions controls dry-run, idempotency, and source tracking.
+type ImportOptions struct {
+	DryRun         bool
+	IdempotencyKey string
+	SourceURI      string
+}
+
+type service struct {
+	cfg   Config
+	repo  repository.OutreachRepository
+	audit AuditLogger
+	fetch *FeedFetcher
+}
+
+// NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.
+func NewService(cfg Config, repo repository.OutreachRepository, audit AuditLogger) Service {
+	return &service{
+		cfg:   cfg,
+		repo:  repo,
+		audit: audit,
+		fetch: &FeedFetcher{
+			AllowedHosts: cfg.AllowedHosts,
+			Token:        cfg.FeedToken,
+			MaxBytes:     cfg.MaxFeedPayloadBytes,
+		},
+	}
+}
+
+func (s *service) Enabled() bool  { return s.cfg.Enabled }
+func (s *service) Config() Config { return s.cfg }
+
+func (s *service) requireEnabled() *errx.Error {
+	if !s.cfg.Enabled {
+		return errx.New(errx.NotFound, "CONFENGE outreach is not enabled on this server")
+	}
+	return nil
+}
+
+func (s *service) ImportFromURI(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, uri string, opts ImportOptions) (*models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	// Prefer configured feed URL when client sends empty.
+	if strings.TrimSpace(uri) == "" {
+		uri = s.cfg.FeedURL
+	}
+	if strings.TrimSpace(uri) == "" {
+		return nil, errx.New(errx.BadRequest, "feed URI is required (or set CONFENGE_EXTRA_CLI_FEED_URL)")
+	}
+	opts.SourceURI = uri
+	raw, err := s.fetch.Fetch(ctx, uri)
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, "failed to fetch feed: "+err.Error())
+	}
+	return s.ImportFromBytes(ctx, orgID, userID, raw, opts)
+}
+
+func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, raw []byte, opts ImportOptions) (*models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if len(raw) == 0 {
+		return nil, errx.New(errx.BadRequest, "empty feed payload")
+	}
+	if s.cfg.MaxFeedPayloadBytes > 0 && int64(len(raw)) > s.cfg.MaxFeedPayloadBytes {
+		return nil, errx.New(errx.BadRequest, "feed payload too large")
+	}
+
+	payloadHash := CanonicalPayloadHash(raw)
+	if opts.IdempotencyKey != "" {
+		existing, err := s.repo.GetImportRunByIdempotency(ctx, orgID, opts.IdempotencyKey)
+		if err != nil {
+			return nil, errx.New(errx.Internal, "failed to check idempotency key")
+		}
+		if existing != nil {
+			// Same key + same hash: return prior result (idempotent).
+			if existing.PayloadHash == payloadHash {
+				return existing, nil
+			}
+			// Same key, different body: conflict.
+			return nil, errx.New(errx.Conflict, "idempotency key already used with a different payload")
+		}
+	}
+
+	feed, err := DetectAndNormalize(raw)
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, "invalid feed: "+err.Error())
+	}
+	if err := ValidateFeed(feed); err != nil {
+		return nil, errx.New(errx.BadRequest, err.Error())
+	}
+
+	run := &models.OutreachImportRun{
+		OrganizationID:  orgID,
+		SourceSystem:    feed.Source.System,
+		SourceRunID:     feed.Source.RunID,
+		SchemaVersion:   feed.SchemaVersion,
+		SnapshotHash:    feed.Source.SnapshotHash,
+		RepoSHA:         feed.Source.RepoSHA,
+		PayloadHash:     payloadHash,
+		ProfileID:       feed.Source.ProfileID,
+		ProfileVersion:  feed.Source.ProfileVersion,
+		Status:          models.OutreachImportRunning,
+		DryRun:          opts.DryRun,
+		CreatedByUserID: userID,
+		IdempotencyKey:  opts.IdempotencyKey,
+		SourceURI:       opts.SourceURI,
+		Warnings:        nil,
+		Errors:          nil,
+	}
+	if feed.Pagination.Cursor != nil {
+		run.CursorIn = *feed.Pagination.Cursor
+	}
+	if feed.Pagination.NextCursor != nil {
+		run.CursorOut = *feed.Pagination.NextCursor
+	}
+
+	if err := s.repo.CreateImportRun(ctx, run); err != nil {
+		return nil, errx.New(errx.Internal, "failed to create import run: "+err.Error())
+	}
+
+	counts, leadErrs, warns := s.applyFeed(ctx, orgID, run, feed, opts.DryRun)
+	run.Counts = counts
+	run.Errors = leadErrs
+	run.Warnings = warns
+	now := time.Now().UTC()
+	run.FinishedAt = &now
+	if len(leadErrs) > 0 && counts.Creates+counts.Updates > 0 {
+		run.Status = models.OutreachImportPartial
+	} else if len(leadErrs) > 0 && counts.Creates+counts.Updates == 0 && counts.LeadsProcessed == 0 {
+		run.Status = models.OutreachImportFailed
+	} else {
+		run.Status = models.OutreachImportCompleted
+	}
+	if err := s.repo.UpdateImportRun(ctx, run); err != nil {
+		return nil, errx.New(errx.Internal, "failed to finalize import run")
+	}
+
+	if s.audit != nil && userID != nil && !opts.DryRun {
+		s.audit.LogAction(ctx, orgID, *userID, models.AuditActionCreate, models.AuditEntityOutreachImportRun, &run.ID, "", "",
+			map[string]string{
+				"payload_hash": payloadHash,
+				"creates":      fmt.Sprintf("%d", counts.Creates),
+				"updates":      fmt.Sprintf("%d", counts.Updates),
+			},
+			map[string]string{"source_system": feed.Source.System, "source_run_id": feed.Source.RunID},
+		)
+	}
+	return run, nil
+}
+
+func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.OutreachImportRun, feed *Feed, dryRun bool) (models.OutreachImportCounts, []models.OutreachImportError, []string) {
+	var counts models.OutreachImportCounts
+	var leadErrs []models.OutreachImportError
+	var warns []string
+
+	for i, lead := range feed.Leads {
+		if lv := ValidateLead(i, lead); lv != nil {
+			counts.Invalid++
+			counts.LeadsSkippedError++
+			leadErrs = append(leadErrs, models.OutreachImportError{
+				SourceLeadID: lv.SourceLeadID,
+				CNPJ14:       lv.CNPJ14,
+				Message:      lv.Message,
+			})
+			continue
+		}
+		cnpj := NormalizeCNPJ14(lead.Company.CNPJ14)
+		existing, err := s.repo.GetAccountByCNPJ(ctx, orgID, cnpj)
+		if err != nil {
+			counts.LeadsSkippedError++
+			leadErrs = append(leadErrs, models.OutreachImportError{
+				SourceLeadID: lead.SourceLeadID, CNPJ14: cnpj, Message: "db error loading account",
+			})
+			continue
+		}
+
+		// Preserve DNC: never re-open.
+		if existing != nil && existing.DoNotContact {
+			counts.Blocked++
+			counts.Unchanged++
+			counts.LeadsProcessed++
+			continue
+		}
+
+		contentHash := LeadContentHash(lead)
+		queueState := DefaultQueueState(lead, existing)
+		if !hasEnrollableContact(lead) {
+			counts.MissingContact++
+		}
+
+		if dryRun {
+			if existing == nil {
+				counts.Creates++
+			} else if existing.LastPayloadHash == contentHash {
+				counts.Unchanged++
+			} else {
+				counts.Updates++
+			}
+			// Estimate evidence adds
+			if existing != nil {
+				existingEv, _ := s.repo.ListEvidence(ctx, orgID, existing.ID)
+				known := map[string]bool{}
+				for _, e := range existingEv {
+					known[e.SourceEvidenceID] = true
+				}
+				for _, e := range lead.Evidence {
+					if e.ID != "" && !known[e.ID] {
+						counts.EvidenceAdded++
+					}
+				}
+			} else {
+				counts.EvidenceAdded += len(lead.Evidence)
+			}
+			counts.LeadsProcessed++
+			continue
+		}
+
+		// APPLY
+		acc := leadToAccount(orgID, lead, feed, run.ID, contentHash, queueState, existing)
+		created, err := s.repo.UpsertAccount(ctx, acc)
+		if err != nil {
+			counts.LeadsSkippedError++
+			leadErrs = append(leadErrs, models.OutreachImportError{
+				SourceLeadID: lead.SourceLeadID, CNPJ14: cnpj, Message: "upsert account: " + err.Error(),
+			})
+			continue
+		}
+		if created {
+			counts.Creates++
+		} else if existing != nil && existing.LastPayloadHash == contentHash {
+			counts.Unchanged++
+		} else {
+			counts.Updates++
+		}
+
+		for _, fc := range lead.Contacts {
+			cand := leadToCandidate(orgID, acc.ID, run.ID, fc)
+			if _, err := s.repo.UpsertCandidate(ctx, cand); err != nil {
+				warns = append(warns, fmt.Sprintf("%s contact %s: %v", cnpj, fc.Email, err))
+				counts.Warnings++
+			}
+		}
+		for _, fe := range lead.Evidence {
+			ev := leadToEvidence(orgID, acc.ID, run.ID, fe)
+			createdEv, err := s.repo.UpsertEvidence(ctx, ev)
+			if err != nil {
+				warns = append(warns, fmt.Sprintf("%s evidence %s: %v", cnpj, fe.ID, err))
+				counts.Warnings++
+				continue
+			}
+			if createdEv {
+				counts.EvidenceAdded++
+			}
+		}
+		counts.LeadsProcessed++
+	}
+	return counts, leadErrs, warns
+}
+
+func leadToAccount(orgID uuid.UUID, lead FeedLead, feed *Feed, runID uuid.UUID, contentHash, queueState string, existing *models.OutreachAccount) *models.OutreachAccount {
+	cnpj := NormalizeCNPJ14(lead.Company.CNPJ14)
+	root := digitsOnly(lead.Company.CNPJRoot)
+	if root == "" && len(cnpj) == 14 {
+		root = cnpj[:8]
+	}
+	contracts, _ := json.Marshal(lead.Contracts)
+	if contracts == nil {
+		contracts = []byte("[]")
+	}
+	acc := &models.OutreachAccount{
+		OrganizationID:     orgID,
+		SourceLeadID:       SanitizeText(lead.SourceLeadID, 200),
+		CNPJ14:             cnpj,
+		CNPJRoot:           root,
+		RazaoSocial:        SanitizeText(lead.Company.RazaoSocial, 500),
+		NomeFantasia:       SanitizeText(lead.Company.NomeFantasia, 500),
+		Municipio:          SanitizeText(lead.Company.Municipio, 200),
+		UF:                 strings.ToUpper(SanitizeText(lead.Company.UF, 2)),
+		Website:            SanitizeText(lead.Company.Website, 500),
+		PriorityRank:       lead.Priority.Rank,
+		PriorityScore:      lead.Priority.Score,
+		PriorityTier:       SanitizeText(lead.Priority.Tier, 100),
+		PriorityConfidence: SanitizeText(lead.Priority.Confidence, 50),
+		MomentCode:         SanitizeText(lead.Moment.Code, 100),
+		MomentSummary:      SanitizeText(lead.Moment.Summary, 2000),
+		MomentObservedAt:   ParseDate(lead.Moment.ObservedAt),
+		MomentConfidence:   SanitizeText(lead.Moment.Confidence, 50),
+		MomentEvidenceIDs:  lead.Moment.EvidenceIDs,
+		ServiceCode:        SanitizeText(lead.Offer.ServiceCode, 100),
+		ServiceName:        SanitizeText(lead.Offer.ServiceName, 200),
+		EntryOffer:         SanitizeText(lead.Offer.EntryOffer, 1000),
+		OfferRationale:     SanitizeText(lead.Offer.Rationale, 2000),
+		FactToMention:      SanitizeText(lead.MessagingContext.FactToMention, 2000),
+		QuestionToAsk:      SanitizeText(lead.MessagingContext.QuestionToAsk, 1000),
+		CTA:                SanitizeText(lead.MessagingContext.CTA, 500),
+		ClaimsToAvoid:      lead.MessagingContext.ClaimsToAvoid,
+		CommercialState:    firstNonEmpty(SanitizeText(lead.CommercialState, 50), "NEW"),
+		QueueState:         queueState,
+		SourceSystem:       feed.Source.System,
+		SourceRunID:        feed.Source.RunID,
+		LastImportRunID:    &runID,
+		LastPayloadHash:    contentHash,
+		ContractsJSON:      contracts,
+	}
+	if existing != nil {
+		acc.ID = existing.ID
+		acc.HumanOverride = existing.HumanOverride
+		acc.Blocked = existing.Blocked
+		acc.BlockReason = existing.BlockReason
+		acc.DoNotContact = existing.DoNotContact
+		acc.CreatedAt = existing.CreatedAt
+	}
+	return acc
+}
+
+func leadToCandidate(orgID, accountID, runID uuid.UUID, fc FeedContact) *models.OutreachContactCandidate {
+	email := strings.TrimSpace(strings.ToLower(fc.Email))
+	vs := NormalizeVerification(fc.VerificationStatus, email)
+	dnc := vs == models.OutreachVerifyDoNotContact
+	bounced := vs == models.OutreachVerifyBounced
+	return &models.OutreachContactCandidate{
+		OrganizationID:     orgID,
+		AccountID:          accountID,
+		SourceContactID:    SanitizeText(fc.SourceContactID, 200),
+		Name:               SanitizeText(fc.Name, 300),
+		Role:               SanitizeText(fc.Role, 200),
+		Email:              email,
+		Phone:              SanitizeText(fc.Phone, 50),
+		LinkedInURL:        SanitizeText(fc.LinkedInURL, 500),
+		SourceURL:          SanitizeText(fc.SourceURL, 1000),
+		SourceDocument:     SanitizeText(fc.SourceDocument, 500),
+		SourceDate:         ParseDate(fc.SourceDate),
+		VerificationStatus: vs,
+		Confidence:         SanitizeText(fc.Confidence, 50),
+		Recommended:        fc.Recommended,
+		DoNotContact:       dnc,
+		Bounced:            bounced,
+		LastImportRunID:    &runID,
+	}
+}
+
+func leadToEvidence(orgID, accountID, runID uuid.UUID, fe FeedEvidence) *models.OutreachEvidence {
+	return &models.OutreachEvidence{
+		OrganizationID:   orgID,
+		AccountID:        accountID,
+		SourceEvidenceID: SanitizeText(fe.ID, 200),
+		EvidenceType:     SanitizeText(fe.Type, 100),
+		Title:            SanitizeText(fe.Title, 500),
+		URL:              SanitizeText(fe.URL, 1000),
+		Document:         SanitizeText(fe.Document, 500),
+		EvidenceDate:     ParseDate(fe.Date),
+		Location:         SanitizeText(fe.Location, 200),
+		Excerpt:          SanitizeText(fe.Excerpt, 4000),
+		Synthesis:        SanitizeText(fe.Synthesis, 2000),
+		EpistemicClass:   NormalizeEpistemic(fe.EpistemicClass),
+		Reliability:      SanitizeText(fe.Reliability, 50),
+		ConsultedAt:      ParseDate(fe.ConsultedAt),
+		LastImportRunID:  &runID,
+	}
+}
+
+func (s *service) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	run, err := s.repo.GetImportRun(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load import run")
+	}
+	if run == nil {
+		return nil, errx.New(errx.NotFound, "import run not found")
+	}
+	return run, nil
+}
+
+func (s *service) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	list, err := s.repo.ListImportRuns(ctx, orgID, limit)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to list import runs")
+	}
+	if list == nil {
+		list = []models.OutreachImportRun{}
+	}
+	return list, nil
+}
+
+func (s *service) Summary(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	sum, err := s.repo.CountByQueueState(ctx, orgID)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load summary")
+	}
+	return sum, nil
+}
+
+func (s *service) ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	list, err := s.repo.ListAccounts(ctx, orgID, filter)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to list accounts")
+	}
+	if list == nil {
+		list = []models.OutreachAccount{}
+	}
+	return list, nil
+}
+
+func (s *service) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load account")
+	}
+	if acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	contacts, err := s.repo.ListCandidates(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load contacts")
+	}
+	evidence, err := s.repo.ListEvidence(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load evidence")
+	}
+	acc.Contacts = contacts
+	acc.Evidence = evidence
+	acc.ContactN = len(contacts)
+	acc.EvidenceN = len(evidence)
+	return acc, nil
+}
+
+func (s *service) BlockAccount(ctx context.Context, orgID, userID, id uuid.UUID, reason string, dnc bool) (*models.OutreachAccount, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	queue := models.OutreachQueueBlocked
+	if dnc {
+		queue = models.OutreachQueueDoNotContact
+	}
+	if err := s.repo.SetAccountHumanFlags(ctx, orgID, id, true, dnc, SanitizeText(reason, 500), queue); err != nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionUpdate, models.AuditEntityOutreachAccount, &id, "", "",
+			map[string]string{"blocked": "true", "do_not_contact": fmt.Sprintf("%v", dnc)},
+			map[string]string{"reason": reason},
+		)
+	}
+	return s.GetAccount(ctx, orgID, id)
+}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -48,6 +48,11 @@ type Service interface {
 	WireExecution(campaigns CampaignAPI, contacts ContactAPI)
 	BootstrapCampaign(ctx context.Context, orgID, userID uuid.UUID) (*models.Campaign, *errx.Error)
 	EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error)
+	WireCRM(crm CRMAPI)
+	BootstrapPipeline(ctx context.Context, orgID uuid.UUID) (*models.Pipeline, *errx.Error)
+	HandleClassifiedReply(ctx context.Context, orgID, actorID uuid.UUID, contactEmail, replyClass string, warmblyContactID *uuid.UUID) *errx.Error
+	// OnClassifiedReply is the advanced-package hook (error, not errx).
+	OnClassifiedReply(ctx context.Context, orgID uuid.UUID, contactEmail, replyClass string, contactID *uuid.UUID) error
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.
@@ -65,6 +70,7 @@ type service struct {
 	ai        generation.Provider
 	campaigns CampaignAPI
 	contacts  ContactAPI
+	crm       CRMAPI
 }
 
 // NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -45,6 +45,9 @@ type Service interface {
 	ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.UUID, action string, edit *DraftEdit) (*models.OutreachDraft, *errx.Error)
 	SetAI(p generation.Provider)
 	EnqueueOutcome(ctx context.Context, orgID uuid.UUID, ev models.OutreachOutcome) *errx.Error
+	WireExecution(campaigns CampaignAPI, contacts ContactAPI)
+	BootstrapCampaign(ctx context.Context, orgID, userID uuid.UUID) (*models.Campaign, *errx.Error)
+	EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error)
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.
@@ -55,11 +58,13 @@ type ImportOptions struct {
 }
 
 type service struct {
-	cfg   Config
-	repo  repository.OutreachRepository
-	audit AuditLogger
-	fetch *FeedFetcher
-	ai    generation.Provider
+	cfg       Config
+	repo      repository.OutreachRepository
+	audit     AuditLogger
+	fetch     *FeedFetcher
+	ai        generation.Provider
+	campaigns CampaignAPI
+	contacts  ContactAPI
 }
 
 // NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.
@@ -212,7 +217,28 @@ func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *
 			map[string]string{"source_system": feed.Source.System, "source_run_id": feed.Source.RunID},
 		)
 	}
+	// One LEAD_IMPORTED summary outcome per successful apply (not dry-run).
+	if !opts.DryRun && counts.LeadsProcessed > 0 {
+		_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+			IdempotencyKey: fmt.Sprintf("lead_imported:%s:%s", orgID, payloadHash),
+			SourceLeadID:   feed.Source.RunID,
+			EventType:      OutcomeLeadImported,
+			OccurredAt:     time.Now().UTC(),
+			Payload: mustJSON(map[string]any{
+				"creates": counts.Creates, "updates": counts.Updates,
+				"leads_processed": counts.LeadsProcessed, "payload_hash": payloadHash,
+			}),
+		})
+	}
 	return run, nil
+}
+
+func mustJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	if b == nil {
+		return []byte("{}")
+	}
+	return b
 }
 
 func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.OutreachImportRun, feed *Feed, dryRun bool) (models.OutreachImportCounts, []models.OutreachImportError, []string) {

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -229,6 +230,21 @@ func (m *memRepo) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.
 }
 func (m *memRepo) UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error {
 	return nil
+}
+func (m *memRepo) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
+	return nil
+}
+func (m *memRepo) ListPendingOutcomes(ctx context.Context, limit int) ([]models.OutreachOutcome, error) {
+	return nil, nil
+}
+func (m *memRepo) MarkOutcomeDelivered(ctx context.Context, orgID, id uuid.UUID) error {
+	return nil
+}
+func (m *memRepo) MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, attempts int, next time.Time, lastErr string, dead bool) error {
+	return nil
+}
+func (m *memRepo) GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error) {
+	return nil, nil
 }
 
 func testSvc(repo repository.OutreachRepository) Service {

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -167,7 +167,7 @@ func (m *memRepo) UpsertCandidate(ctx context.Context, c *models.OutreachContact
 	}
 	list := m.cands[c.AccountID]
 	for i, existing := range list {
-		if existing.SourceContactID != "" && existing.SourceContactID == c.SourceContactID {
+		if existing.ID == c.ID || (existing.SourceContactID != "" && existing.SourceContactID == c.SourceContactID) {
 			if existing.DoNotContact {
 				c.DoNotContact = true
 			}
@@ -182,6 +182,16 @@ func (m *memRepo) UpsertCandidate(ctx context.Context, c *models.OutreachContact
 }
 
 func (m *memRepo) GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, list := range m.cands {
+		for i := range list {
+			if list[i].ID == id && list[i].OrganizationID == orgID {
+				cp := list[i]
+				return &cp, nil
+			}
+		}
+	}
 	return nil, nil
 }
 
@@ -245,6 +255,9 @@ func (m *memRepo) MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, a
 }
 func (m *memRepo) GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error) {
 	return nil, nil
+}
+func (m *memRepo) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	return nil, nil, nil
 }
 
 func testSvc(repo repository.OutreachRepository) Service {

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -1,0 +1,466 @@
+package confenge
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// memRepo is an in-memory OutreachRepository for unit tests of ImportFromBytes.
+type memRepo struct {
+	mu       sync.Mutex
+	runs     map[uuid.UUID]*models.OutreachImportRun
+	byIdem   map[string]*models.OutreachImportRun
+	accounts map[string]*models.OutreachAccount // org|cnpj
+	byID     map[uuid.UUID]*models.OutreachAccount
+	cands    map[uuid.UUID][]models.OutreachContactCandidate
+	evidence map[uuid.UUID][]models.OutreachEvidence
+}
+
+func newMemRepo() *memRepo {
+	return &memRepo{
+		runs:     map[uuid.UUID]*models.OutreachImportRun{},
+		byIdem:   map[string]*models.OutreachImportRun{},
+		accounts: map[string]*models.OutreachAccount{},
+		byID:     map[uuid.UUID]*models.OutreachAccount{},
+		cands:    map[uuid.UUID][]models.OutreachContactCandidate{},
+		evidence: map[uuid.UUID][]models.OutreachEvidence{},
+	}
+}
+
+func accKey(org uuid.UUID, cnpj string) string { return org.String() + "|" + cnpj }
+
+func (m *memRepo) CreateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if run.ID == uuid.Nil {
+		run.ID = uuid.New()
+	}
+	cp := *run
+	m.runs[run.ID] = &cp
+	if run.IdempotencyKey != "" {
+		m.byIdem[run.OrganizationID.String()+"|"+run.IdempotencyKey] = &cp
+	}
+	return nil
+}
+
+func (m *memRepo) UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *run
+	m.runs[run.ID] = &cp
+	if run.IdempotencyKey != "" {
+		m.byIdem[run.OrganizationID.String()+"|"+run.IdempotencyKey] = &cp
+	}
+	return nil
+}
+
+func (m *memRepo) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.runs[id]
+	if r == nil || r.OrganizationID != orgID {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (m *memRepo) GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.byIdem[orgID.String()+"|"+key]
+	if r == nil {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (m *memRepo) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error) {
+	return nil, nil
+}
+
+func (m *memRepo) GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a := m.accounts[accKey(orgID, cnpj14)]
+	if a == nil {
+		return nil, nil
+	}
+	cp := *a
+	return &cp, nil
+}
+
+func (m *memRepo) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a := m.byID[id]
+	if a == nil || a.OrganizationID != orgID {
+		return nil, nil
+	}
+	cp := *a
+	return &cp, nil
+}
+
+func (m *memRepo) UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := accKey(acc.OrganizationID, acc.CNPJ14)
+	existing := m.accounts[k]
+	created := existing == nil
+	if existing != nil {
+		acc.ID = existing.ID
+		// preserve DNC
+		if existing.DoNotContact {
+			acc.DoNotContact = true
+		}
+	} else if acc.ID == uuid.Nil {
+		acc.ID = uuid.New()
+	}
+	cp := *acc
+	m.accounts[k] = &cp
+	m.byID[cp.ID] = &cp
+	return created, nil
+}
+
+func (m *memRepo) ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, error) {
+	return nil, nil
+}
+
+func (m *memRepo) CountByQueueState(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, error) {
+	return &models.OutreachQueueSummary{}, nil
+}
+
+func (m *memRepo) SetAccountHumanFlags(ctx context.Context, orgID, id uuid.UUID, blocked, dnc bool, reason, queueState string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a := m.byID[id]
+	if a == nil || a.OrganizationID != orgID {
+		return context.Canceled
+	}
+	a.Blocked = blocked
+	a.DoNotContact = dnc
+	a.BlockReason = reason
+	a.QueueState = queueState
+	a.HumanOverride = true
+	return nil
+}
+
+func (m *memRepo) ListCandidates(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachContactCandidate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]models.OutreachContactCandidate{}, m.cands[accountID]...), nil
+}
+
+func (m *memRepo) UpsertCandidate(ctx context.Context, c *models.OutreachContactCandidate) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if c.ID == uuid.Nil {
+		c.ID = uuid.New()
+	}
+	list := m.cands[c.AccountID]
+	for i, existing := range list {
+		if existing.SourceContactID != "" && existing.SourceContactID == c.SourceContactID {
+			if existing.DoNotContact {
+				c.DoNotContact = true
+			}
+			c.ID = existing.ID
+			list[i] = *c
+			m.cands[c.AccountID] = list
+			return false, nil
+		}
+	}
+	m.cands[c.AccountID] = append(list, *c)
+	return true, nil
+}
+
+func (m *memRepo) GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error) {
+	return nil, nil
+}
+
+func (m *memRepo) ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]models.OutreachEvidence{}, m.evidence[accountID]...), nil
+}
+
+func (m *memRepo) UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e.ID == uuid.Nil {
+		e.ID = uuid.New()
+	}
+	list := m.evidence[e.AccountID]
+	for i, existing := range list {
+		if existing.SourceEvidenceID == e.SourceEvidenceID {
+			e.ID = existing.ID
+			list[i] = *e
+			m.evidence[e.AccountID] = list
+			return false, nil
+		}
+	}
+	m.evidence[e.AccountID] = append(list, *e)
+	return true, nil
+}
+
+func testSvc(repo repository.OutreachRepository) Service {
+	cfg := Config{
+		Enabled:              true,
+		RequireHumanApproval: true,
+		DefaultDailyLimit:    10,
+		MaxInitialEmailWords: 120,
+		MaxFeedPayloadBytes:  DefaultMaxPayloadBytes,
+	}
+	return NewService(cfg, repo, nil)
+}
+
+func TestImportNativeFeedCreatesAccounts(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	user := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+
+	run, xerr := svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatalf("import: %v", xerr)
+	}
+	if run.Status != models.OutreachImportCompleted && run.Status != models.OutreachImportPartial {
+		t.Fatalf("status %s counts=%+v errs=%+v", run.Status, run.Counts, run.Errors)
+	}
+	if run.Counts.Creates < 4 {
+		t.Fatalf("want >=4 creates, got %+v", run.Counts)
+	}
+	// No-email company staged as NEEDS_CONTACT
+	acc, err := repo.GetAccountByCNPJ(context.Background(), org, "55444333000122")
+	if err != nil || acc == nil {
+		t.Fatal("missing no-contact company")
+	}
+	if acc.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("queue_state=%s want NEEDS_CONTACT", acc.QueueState)
+	}
+	// Official contact company ready
+	acme, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acme == nil || acme.QueueState != models.OutreachQueueReadyToGenerate {
+		t.Fatalf("acme state=%v", acme)
+	}
+	// Unverified-only contact is not enrollable => NEEDS_CONTACT
+	cn, _ := repo.GetAccountByCNPJ(context.Background(), org, "66777888000199")
+	if cn == nil || cn.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("unverified-only should be NEEDS_CONTACT, got %v", cn)
+	}
+}
+
+func TestImportDryRunDoesNotPersistAccounts(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{DryRun: true})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if !run.DryRun {
+		t.Fatal("expected dry_run")
+	}
+	if run.Counts.Creates < 1 {
+		t.Fatalf("dry-run should count creates: %+v", run.Counts)
+	}
+	// accounts map empty of real companies
+	acc, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acc != nil {
+		t.Fatal("dry-run must not persist accounts")
+	}
+}
+
+func TestImportIdempotencySameKeySamePayload(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	opts := ImportOptions{IdempotencyKey: "idem-1"}
+	r1, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, opts)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	r2, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, opts)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if r1.ID != r2.ID {
+		t.Fatalf("idempotent reimport should return same run %s vs %s", r1.ID, r2.ID)
+	}
+}
+
+func TestImportIdempotencyConflictOnDifferentPayload(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	opts := ImportOptions{IdempotencyKey: "idem-2"}
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, opts); xerr != nil {
+		t.Fatal(xerr)
+	}
+	other := []byte(`{"schema_version":"confenge.outreach.v1","source":{"system":"extra-cli"},"leads":[]}`)
+	_, xerr := svc.ImportFromBytes(context.Background(), org, nil, other, opts)
+	if xerr == nil {
+		t.Fatal("expected conflict")
+	}
+}
+
+func TestReimportPreservesDNC(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	acc, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acc == nil {
+		t.Fatal("missing")
+	}
+	acc.DoNotContact = true
+	acc.QueueState = models.OutreachQueueDoNotContact
+	_, _ = repo.UpsertAccount(context.Background(), acc)
+
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	again, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if again == nil || !again.DoNotContact {
+		t.Fatal("DNC must survive reimport")
+	}
+}
+
+func TestReimportIdenticalIsUnchanged(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	run2, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run2.Counts.Creates != 0 {
+		t.Fatalf("second import should not create: %+v", run2.Counts)
+	}
+	if run2.Counts.Unchanged < 1 {
+		t.Fatalf("expected unchanged counts: %+v", run2.Counts)
+	}
+}
+
+func TestReimportScoreChangeUpdates(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	// Mutate score in payload
+	feed, _ := ParseFeed(raw)
+	feed.Leads[0].Priority.Score = 99
+	mut, _ := jsonMarshal(feed)
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, mut, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.Updates < 1 {
+		t.Fatalf("score change should update: %+v", run.Counts)
+	}
+}
+
+func TestMultiTenantIsolation(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	orgA, orgB := uuid.New(), uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), orgA, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	accB, _ := repo.GetAccountByCNPJ(context.Background(), orgB, "11222333000181")
+	if accB != nil {
+		t.Fatal("org B must not see org A accounts")
+	}
+	accA, _ := repo.GetAccountByCNPJ(context.Background(), orgA, "11222333000181")
+	if accA == nil {
+		t.Fatal("org A should have account")
+	}
+}
+
+func TestDisabledServiceRejects(t *testing.T) {
+	repo := newMemRepo()
+	cfg := Config{Enabled: false}
+	svc := NewService(cfg, repo, nil)
+	_, xerr := svc.ImportFromBytes(context.Background(), uuid.New(), nil, []byte(`{}`), ImportOptions{})
+	if xerr == nil {
+		t.Fatal("disabled must reject")
+	}
+}
+
+func TestLegacyImportWorks(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "legacy_leads_array.json")
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.Creates < 2 {
+		t.Fatalf("legacy creates: %+v errs=%+v", run.Counts, run.Errors)
+	}
+	noContact, _ := repo.GetAccountByCNPJ(context.Background(), org, "55444333000122")
+	if noContact == nil || noContact.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("legacy no-contact company: %+v", noContact)
+	}
+}
+
+func TestInvalidFeedRejected(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	_, xerr := svc.ImportFromBytes(context.Background(), uuid.New(), nil, []byte(`{not json`), ImportOptions{})
+	if xerr == nil {
+		t.Fatal("expected invalid feed error")
+	}
+}
+
+func TestEvidenceAddedOnReimport(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	feed, _ := ParseFeed(raw)
+	feed.Leads[0].Evidence = append(feed.Leads[0].Evidence, FeedEvidence{
+		ID:             "ev-acme-2",
+		Title:          "Nova evidencia",
+		EpistemicClass: models.OutreachEpistemicConfirmedFact,
+	})
+	// Also change a machine field so content hash moves (evidence is in hash)
+	mut, _ := jsonMarshal(feed)
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, mut, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.EvidenceAdded < 1 {
+		t.Fatalf("expected new evidence: %+v", run.Counts)
+	}
+}
+
+// local helper avoiding import cycle noise
+func jsonMarshal(v any) ([]byte, error) {
+	return marshalJSON(v)
+}

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -209,6 +209,28 @@ func (m *memRepo) UpsertEvidence(ctx context.Context, e *models.OutreachEvidence
 	return true, nil
 }
 
+func (m *memRepo) UpsertDraft(ctx context.Context, d *models.OutreachDraft) error {
+	return nil
+}
+func (m *memRepo) GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error) {
+	return nil, nil
+}
+func (m *memRepo) GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error) {
+	return nil, nil
+}
+func (m *memRepo) ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, error) {
+	return nil, nil
+}
+func (m *memRepo) UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error {
+	return nil
+}
+func (m *memRepo) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error) {
+	return nil, nil
+}
+func (m *memRepo) UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error {
+	return nil
+}
+
 func testSvc(repo repository.OutreachRepository) Service {
 	cfg := Config{
 		Enabled:              true,

--- a/internal/app/confenge/suppress_wire_test.go
+++ b/internal/app/confenge/suppress_wire_test.go
@@ -1,0 +1,114 @@
+package confenge
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+type mockAdvancedSuppress struct {
+	calls []string
+	err   *errx.Error
+}
+
+func (m *mockAdvancedSuppress) SuppressRecipient(ctx context.Context, organizationID uuid.UUID, email, reason string) *errx.Error {
+	m.calls = append(m.calls, email+"|"+reason)
+	return m.err
+}
+
+func TestNewSuppressAdapterNilReturnsNil(t *testing.T) {
+	if NewSuppressAdapter(nil) != nil {
+		t.Fatal("nil advanced must yield nil adapter (WireSuppress no-op)")
+	}
+}
+
+func TestNewSuppressAdapterCallsThrough(t *testing.T) {
+	mock := &mockAdvancedSuppress{}
+	api := NewSuppressAdapter(mock)
+	if api == nil {
+		t.Fatal("expected adapter")
+	}
+	org := uuid.New()
+	if err := api.SuppressRecipient(context.Background(), org, "dnc@example.com", "reply unsub"); err != nil {
+		t.Fatal(err)
+	}
+	if len(mock.calls) != 1 || !strings.Contains(mock.calls[0], "dnc@example.com") {
+		t.Fatalf("adapter did not call through: %v", mock.calls)
+	}
+}
+
+func TestNewSuppressAdapterPropagatesError(t *testing.T) {
+	mock := &mockAdvancedSuppress{err: errx.New(errx.Internal, "db down")}
+	api := NewSuppressAdapter(mock)
+	err := api.SuppressRecipient(context.Background(), uuid.New(), "x@example.com", "r")
+	if err == nil || !strings.Contains(err.Error(), "db down") {
+		t.Fatalf("want propagated error, got %v", err)
+	}
+}
+
+// TestBackendMainWiresSuppressAfterAdvancedConstruction is a structural
+// regression guard for the bug where WireSuppress ran while advancedService
+// was still nil (before advanced.NewService), so production never attached
+// platform suppression.
+func TestBackendMainWiresSuppressAfterAdvancedConstruction(t *testing.T) {
+	src := readRepoFile(t, "cmd/backend/main.go")
+	newIdx := strings.Index(src, "advancedService = advanced.NewService(")
+	wireIdx := strings.Index(src, "WireSuppress(confenge.NewSuppressAdapter(advancedService))")
+	if newIdx < 0 || wireIdx < 0 {
+		t.Fatal("backend main missing advanced.NewService or WireSuppress(NewSuppressAdapter)")
+	}
+	if wireIdx < newIdx {
+		t.Fatalf("WireSuppress must appear AFTER advanced.NewService (wire at %d, new at %d)", wireIdx, newIdx)
+	}
+	// Early block must not still gate WireSuppress on a nil advancedService
+	// before construction.
+	early := src[:newIdx]
+	if strings.Contains(early, "WireSuppress(confenge.NewSuppressAdapter") {
+		t.Fatal("WireSuppress adapter call must not appear before advanced.NewService")
+	}
+}
+
+// TestConsumerMainWiresSuppressForClassifiedReplyDNC guards the live reply
+// path: OnClassifiedReply → NoteDNC needs suppress wired on the consumer.
+func TestConsumerMainWiresSuppressForClassifiedReplyDNC(t *testing.T) {
+	src := readRepoFile(t, "cmd/consumer/main.go")
+	if !strings.Contains(src, "WireSuppress(confenge.NewSuppressAdapter(advancedService))") {
+		t.Fatal("consumer must WireSuppress(NewSuppressAdapter(advancedService)) for DNC on reply classification")
+	}
+	// confenge construction and suppress wire should both be inside Enabled block
+	// and after advancedService is created.
+	advIdx := strings.Index(src, "advancedService := advanced.NewService(")
+	wireIdx := strings.Index(src, "WireSuppress(confenge.NewSuppressAdapter(advancedService))")
+	if advIdx < 0 || wireIdx < 0 {
+		t.Fatal("missing advanced.NewService or WireSuppress in consumer")
+	}
+	if wireIdx < advIdx {
+		t.Fatal("consumer WireSuppress must run after advanced.NewService")
+	}
+}
+
+func readRepoFile(t *testing.T, rel string) string {
+	t.Helper()
+	// Prefer repo root relative to this test file (…/internal/app/confenge → …/).
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	root := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", "..", ".."))
+	b, err := os.ReadFile(filepath.Join(root, rel))
+	if err != nil {
+		// Fallback: cwd is often module root under `go test`.
+		b, err = os.ReadFile(rel)
+		if err != nil {
+			t.Fatalf("read %s: %v", rel, err)
+		}
+	}
+	return string(b)
+}

--- a/internal/app/confenge/testdata/legacy_leads_array.json
+++ b/internal/app/confenge/testdata/legacy_leads_array.json
@@ -1,0 +1,45 @@
+[
+  {
+    "cnpj14": "11222333000181",
+    "razao_social": "Construtora Regional ACME Ltda",
+    "score_total": 80,
+    "priority": "HIGH",
+    "rank_position": 1,
+    "suggested_offer": "ADDITIVE_REVIEW",
+    "next_human_step": "Validar interlocutor de contratos",
+    "commercial_state": "NEW",
+    "municipio": "Florianopolis",
+    "uf": "SC",
+    "signals_fired": ["CONTRACT_EXTENSION"],
+    "email": "ana.silva@acme.example.com",
+    "contact_name": "Ana Silva",
+    "cargo": "Engenheira de contratos",
+    "verification_status": "OFFICIAL_SOURCE"
+  },
+  {
+    "cnpj14": "55444333000122",
+    "razao_social": "Obras do Planalto Ltda",
+    "score_total": 50,
+    "priority": "MEDIUM",
+    "rank_position": 2,
+    "suggested_offer": "BID_READINESS",
+    "commercial_state": "NEW",
+    "municipio": "Brasilia",
+    "uf": "DF"
+  },
+  {
+    "cnpj14": "99888777000166",
+    "razao_social": "Empresa Nacional de Infraestrutura SA",
+    "score_total": 65,
+    "priority": "MEDIUM",
+    "contacts": [
+      {
+        "id": "c1",
+        "name": "Equipe comercial",
+        "email": "contato@eni.example.org",
+        "verification_status": "INSTITUTIONAL_GENERIC",
+        "recommended": true
+      }
+    ]
+  }
+]

--- a/internal/app/confenge/testdata/native_feed_v1.json
+++ b/internal/app/confenge/testdata/native_feed_v1.json
@@ -1,0 +1,312 @@
+{
+  "schema_version": "confenge.outreach.v1",
+  "generated_at": "2026-08-06T12:00:00Z",
+  "source": {
+    "system": "extra-cli",
+    "run_id": "fixture-run-001",
+    "snapshot_hash": "abc123snapshot",
+    "repo_sha": "deadbeef",
+    "profile_id": "confenge",
+    "profile_version": "1.0.0"
+  },
+  "pagination": {
+    "cursor": null,
+    "next_cursor": null,
+    "has_more": false
+  },
+  "leads": [
+    {
+      "source_lead_id": "lead-acme-sc",
+      "company": {
+        "cnpj14": "11222333000181",
+        "cnpj_root": "11222333",
+        "razao_social": "Construtora Regional ACME Ltda",
+        "nome_fantasia": "ACME Obras",
+        "municipio": "Florianopolis",
+        "uf": "SC",
+        "website": "https://acme.example.com"
+      },
+      "priority": {
+        "rank": 1,
+        "score": 82.5,
+        "tier": "HIGH",
+        "confidence": "HIGH"
+      },
+      "moment": {
+        "code": "CONTRACT_EXTENSION",
+        "summary": "Contrato de obra publica com prorrogacao publicada no PNCP",
+        "observed_at": "2026-07-15",
+        "confidence": "HIGH",
+        "evidence_ids": ["ev-acme-1"]
+      },
+      "offer": {
+        "service_code": "ADDITIVE_REVIEW",
+        "service_name": "Revisao de aditivos",
+        "entry_offer": "Leitura tecnica do aditivo em curso",
+        "rationale": "Momento de prorrogacao com margem para apoio consultivo"
+      },
+      "messaging_context": {
+        "fact_to_mention": "Prorrogacao do contrato 001/2025 publicada no PNCP em julho/2026",
+        "question_to_ask": "Faz sentido conversarmos sobre o controle de aditivos desta obra?",
+        "cta": "Posso enviar um checklist de 1 pagina?",
+        "claims_to_avoid": ["garantia de economia", "erro na gestao"]
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-acme-eng",
+          "name": "Ana Silva",
+          "role": "Engenheira de contratos",
+          "email": "ana.silva@acme.example.com",
+          "phone": "",
+          "linkedin_url": "",
+          "source_url": "https://acme.example.com/equipe",
+          "source_document": "",
+          "source_date": "2026-06-01",
+          "verification_status": "OFFICIAL_SOURCE",
+          "confidence": "HIGH",
+          "recommended": true
+        }
+      ],
+      "contracts": [
+        {"id": "c-001", "number": "001/2025", "agency": "Prefeitura Exemplo"}
+      ],
+      "evidence": [
+        {
+          "id": "ev-acme-1",
+          "type": "PNCP_PUBLICATION",
+          "title": "Prorrogacao contrato 001/2025",
+          "url": "https://pncp.example.gov.br/contratos/001-2025",
+          "document": "Termo de prorrogacao",
+          "date": "2026-07-15",
+          "location": "secao 2",
+          "excerpt": "Fica prorrogado o prazo de execucao por 180 dias.",
+          "synthesis": "Prorrogacao formal publicada",
+          "epistemic_class": "CONFIRMED_FACT",
+          "reliability": "HIGH",
+          "consulted_at": "2026-08-01"
+        }
+      ],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-nacional",
+      "company": {
+        "cnpj14": "99888777000166",
+        "cnpj_root": "99888777",
+        "razao_social": "Empresa Nacional de Infraestrutura SA",
+        "nome_fantasia": "ENI",
+        "municipio": "Sao Paulo",
+        "uf": "SP",
+        "website": "https://eni.example.org"
+      },
+      "priority": {
+        "rank": 2,
+        "score": 70,
+        "tier": "MEDIUM",
+        "confidence": "MEDIUM"
+      },
+      "moment": {
+        "code": "ADDITIVE_SIGNED",
+        "summary": "Aditivo de reajuste publicado",
+        "observed_at": "2026-06-20",
+        "confidence": "HIGH",
+        "evidence_ids": ["ev-eni-1"]
+      },
+      "offer": {
+        "service_code": "REAJUSTE_SUPPORT",
+        "service_name": "Apoio a reajustes",
+        "entry_offer": "Parecer resumido sobre clausula de reajuste",
+        "rationale": "Aditivo recente com potencial de segunda opiniao tecnica"
+      },
+      "messaging_context": {
+        "fact_to_mention": "Aditivo de reajuste do contrato 44/2024 publicado em junho/2026",
+        "question_to_ask": "Voces ja fecharam a leitura economica deste aditivo?",
+        "cta": "Posso compartilhar um modelo de memoria de calculo?",
+        "claims_to_avoid": []
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-eni-generic",
+          "name": "",
+          "role": "Comercial",
+          "email": "contato@eni.example.org",
+          "verification_status": "INSTITUTIONAL_GENERIC",
+          "confidence": "MEDIUM",
+          "recommended": true
+        }
+      ],
+      "contracts": [],
+      "evidence": [
+        {
+          "id": "ev-eni-1",
+          "type": "CONTRACT_ADDITIVE",
+          "title": "Aditivo reajuste 44/2024",
+          "url": "https://portal.example.gov.br/44-2024",
+          "date": "2026-06-20",
+          "excerpt": "Reajuste conforme indices oficiais.",
+          "synthesis": "Aditivo de reajuste formal",
+          "epistemic_class": "CONFIRMED_FACT",
+          "reliability": "HIGH",
+          "consulted_at": "2026-08-01"
+        }
+      ],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-no-contact",
+      "company": {
+        "cnpj14": "55444333000122",
+        "cnpj_root": "55444333",
+        "razao_social": "Obras do Planalto Ltda",
+        "nome_fantasia": "Planalto",
+        "municipio": "Brasilia",
+        "uf": "DF",
+        "website": ""
+      },
+      "priority": {
+        "rank": 3,
+        "score": 55,
+        "tier": "MEDIUM",
+        "confidence": "LOW"
+      },
+      "moment": {
+        "code": "TENDER_WIN",
+        "summary": "Homologacao recente em licitacao de reforma",
+        "observed_at": "2026-05-10",
+        "confidence": "MEDIUM",
+        "evidence_ids": []
+      },
+      "offer": {
+        "service_code": "BID_READINESS",
+        "service_name": "Preparacao de propostas",
+        "entry_offer": "Checklist de conformidade documental",
+        "rationale": ""
+      },
+      "messaging_context": {
+        "fact_to_mention": "Homologacao em licitação de reforma em maio/2026",
+        "question_to_ask": "Quem na equipe cuida da memoria de calculo de aditivos?",
+        "cta": "Posso enviar um checklist curto?",
+        "claims_to_avoid": []
+      },
+      "contacts": [],
+      "contracts": [],
+      "evidence": [],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-unverified",
+      "company": {
+        "cnpj14": "66777888000199",
+        "cnpj_root": "66777888",
+        "razao_social": "Consorcio Ponte Norte",
+        "nome_fantasia": "Ponte Norte",
+        "municipio": "Curitiba",
+        "uf": "PR",
+        "website": "https://pontenorte.example.net"
+      },
+      "priority": {
+        "rank": 4,
+        "score": 60,
+        "tier": "MEDIUM",
+        "confidence": "MEDIUM"
+      },
+      "moment": {
+        "code": "CONSORTIUM_ACTIVE",
+        "summary": "Consorcio ativo em obra rodoviaria",
+        "observed_at": "2026-04-01",
+        "confidence": "MEDIUM",
+        "evidence_ids": ["ev-cn-1"]
+      },
+      "offer": {
+        "service_code": "ADDITIVE_REVIEW",
+        "service_name": "Revisao de aditivos",
+        "entry_offer": "Mapa de riscos de aditivos do consorcio",
+        "rationale": "Estrutura multi-empresa exige cuidado com interlocutor"
+      },
+      "messaging_context": {
+        "fact_to_mention": "Consorcio ativo em obra rodoviaria com publicacoes recentes",
+        "question_to_ask": "Quem e o interlocutor tecnico de aditivos no consorcio?",
+        "cta": "Posso enviar uma pergunta objetiva por e-mail?",
+        "claims_to_avoid": ["vinculo societario"]
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-cn-cand",
+          "name": "Bruno Costa",
+          "role": "Diretor",
+          "email": "bruno@pontenorte.example.net",
+          "verification_status": "CANDIDATE_UNVERIFIED",
+          "confidence": "LOW",
+          "recommended": false
+        }
+      ],
+      "contracts": [],
+      "evidence": [
+        {
+          "id": "ev-cn-1",
+          "type": "PUBLIC_NOTICE",
+          "title": "Ata de consorcio",
+          "url": "https://docs.example.gov.br/consorcio-ponte",
+          "date": "2026-04-01",
+          "excerpt": "Constituido o consorcio Ponte Norte.",
+          "synthesis": "Consorcio formalizado",
+          "epistemic_class": "CONFIRMED_FACT",
+          "reliability": "MEDIUM",
+          "consulted_at": "2026-08-01"
+        }
+      ],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-dnc",
+      "company": {
+        "cnpj14": "12345678000195",
+        "cnpj_root": "12345678",
+        "razao_social": "Servicos Tecnicos Beta Ltda",
+        "nome_fantasia": "Beta",
+        "municipio": "Joinville",
+        "uf": "SC",
+        "website": "https://beta.example.com"
+      },
+      "priority": {
+        "rank": 5,
+        "score": 40,
+        "tier": "LOW",
+        "confidence": "HIGH"
+      },
+      "moment": {
+        "code": "NO_RECENT_SIGNAL",
+        "summary": "Sem fato gerador recente",
+        "observed_at": "2026-01-01",
+        "confidence": "HIGH",
+        "evidence_ids": []
+      },
+      "offer": {
+        "service_code": "DIAGNOSTIC",
+        "service_name": "Diagnostico leve",
+        "entry_offer": "Conversa exploratoria",
+        "rationale": ""
+      },
+      "messaging_context": {
+        "fact_to_mention": "Atuacao regional em contratos publicos de engenharia",
+        "question_to_ask": "Faz sentido uma conversa curta sobre controle de aditivos?",
+        "cta": "Posso ligar 10 minutos esta semana?",
+        "claims_to_avoid": []
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-beta-dnc",
+          "name": "Carlos Souza",
+          "role": "Socio",
+          "email": "carlos@beta.example.com",
+          "verification_status": "DO_NOT_CONTACT",
+          "confidence": "HIGH",
+          "recommended": false
+        }
+      ],
+      "contracts": [],
+      "evidence": [],
+      "commercial_state": "DO_NOT_CONTACT"
+    }
+  ]
+}

--- a/internal/app/confenge/validators.go
+++ b/internal/app/confenge/validators.go
@@ -1,0 +1,425 @@
+package confenge
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// PromptVersion tags generation prompt revisions.
+const PromptVersion = "confenge.draft.v1"
+
+// DraftOutput is the structured generation result (validated before save).
+type DraftOutput struct {
+	Subject     string          `json:"subject"`
+	BodyText    string          `json:"body_text"`
+	BodyHTML    string          `json:"body_html"`
+	Followups   []DraftFollowup `json:"followups"`
+	FactUsed    string          `json:"fact_used"`
+	EvidenceIDs []string        `json:"evidence_ids"`
+	ServiceCode string          `json:"service_code"`
+	Question    string          `json:"question"`
+	CTA         string          `json:"cta"`
+	RiskFlags   []string        `json:"risk_flags"`
+}
+
+// DraftFollowup is one cadence follow-up in the same thread.
+type DraftFollowup struct {
+	DelayDays   int    `json:"delay_days"`
+	SubjectMode string `json:"subject_mode"`
+	BodyText    string `json:"body_text"`
+	BodyHTML    string `json:"body_html"`
+}
+
+// ValidationResult is deterministic pre-send / pre-approve checks.
+type ValidationResult struct {
+	OK       bool     `json:"ok"`
+	Errors   []string `json:"errors,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// Banned outreach phrases (Portuguese + known AI tells). Lowercased match.
+var bannedPhrases = []string{
+	"dinheiro a receber",
+	"crédito identificado",
+	"credito identificado",
+	"descobrimos um erro",
+	"há irregularidade",
+	"ha irregularidade",
+	"vocês deixaram de receber",
+	"voces deixaram de receber",
+	"sua equipe não controla",
+	"sua equipe nao controla",
+	"falta estrutura",
+	"lead quente",
+	"alta chance de conversão",
+	"alta chance de conversao",
+	"espero que esta mensagem o encontre bem",
+	"espero que esta mensagem a encontre bem",
+	"espero que este e-mail o encontre bem",
+	"i hope this email finds you",
+	"garantimos",
+	"garantia de",
+	"100% de sucesso",
+}
+
+// emDash and similar are banned in outbound confenge copy.
+var emDashRe = regexp.MustCompile(`[\x{2014}\x{2013}]`)
+
+// shortURLRe catches common shorteners (tracking risk).
+var shortURLRe = regexp.MustCompile(`(?i)https?://(bit\.ly|t\.co|goo\.gl|tinyurl\.com|ow\.ly)/`)
+
+// ValidateDraft runs deterministic checks before human approval / enrollment.
+func ValidateDraft(out *DraftOutput, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, maxWords int) ValidationResult {
+	var res ValidationResult
+	res.OK = true
+	if out == nil {
+		res.OK = false
+		res.Errors = append(res.Errors, "empty draft")
+		return res
+	}
+	if maxWords <= 0 {
+		maxWords = DefaultMaxInitialWords
+	}
+
+	email := ""
+	if cand != nil {
+		email = strings.TrimSpace(cand.Email)
+		if !cand.CanEnroll() {
+			res.OK = false
+			res.Errors = append(res.Errors, "contact is not enrollable (verification, DNC, bounce, or missing email)")
+		}
+		if cand.DoNotContact {
+			res.OK = false
+			res.Errors = append(res.Errors, "contact is DO_NOT_CONTACT")
+		}
+		if cand.Bounced {
+			res.OK = false
+			res.Errors = append(res.Errors, "contact address bounced")
+		}
+	} else {
+		res.OK = false
+		res.Errors = append(res.Errors, "no contact candidate")
+	}
+	if email == "" {
+		res.OK = false
+		res.Errors = append(res.Errors, "missing recipient email")
+	}
+
+	body := strings.TrimSpace(out.BodyText)
+	if body == "" {
+		res.OK = false
+		res.Errors = append(res.Errors, "empty body")
+	}
+	if strings.TrimSpace(out.Subject) == "" {
+		res.OK = false
+		res.Errors = append(res.Errors, "empty subject")
+	}
+
+	blob := strings.ToLower(out.Subject + "\n" + body)
+	for _, fu := range out.Followups {
+		blob += "\n" + strings.ToLower(fu.BodyText)
+	}
+
+	if emDashRe.MatchString(out.Subject + body) {
+		res.OK = false
+		res.Errors = append(res.Errors, "em dash / en dash not allowed in outreach copy")
+	}
+	for _, fu := range out.Followups {
+		if emDashRe.MatchString(fu.BodyText) {
+			res.OK = false
+			res.Errors = append(res.Errors, "em dash / en dash not allowed in follow-up copy")
+			break
+		}
+	}
+
+	for _, p := range bannedPhrases {
+		if strings.Contains(blob, p) {
+			res.OK = false
+			res.Errors = append(res.Errors, "banned phrase: "+p)
+		}
+	}
+
+	if shortURLRe.MatchString(body) {
+		res.OK = false
+		res.Errors = append(res.Errors, "shortened URLs are not allowed")
+	}
+	if strings.Contains(strings.ToLower(out.BodyHTML), "<script") {
+		res.OK = false
+		res.Errors = append(res.Errors, "unsafe HTML (script) not allowed")
+	}
+
+	words := countWords(body)
+	if words > maxWords {
+		res.OK = false
+		res.Errors = append(res.Errors, fmt.Sprintf("body exceeds %d words (%d)", maxWords, words))
+	}
+
+	if strings.TrimSpace(out.FactUsed) == "" {
+		res.OK = false
+		res.Errors = append(res.Errors, "fact_used is required")
+	}
+	if acc != nil && strings.TrimSpace(out.FactUsed) != "" {
+		// Fact should be grounded in account messaging or evidence synthesis.
+		grounded := strings.Contains(strings.ToLower(acc.FactToMention), strings.ToLower(out.FactUsed)) ||
+			strings.Contains(strings.ToLower(out.FactUsed), firstWords(acc.FactToMention, 4)) ||
+			strings.Contains(strings.ToLower(acc.MomentSummary), strings.ToLower(out.FactUsed))
+		if !grounded && acc.FactToMention != "" {
+			// Soft: warn if fact diverges heavily; still allow if evidence_ids present.
+			if len(out.EvidenceIDs) == 0 {
+				res.Warnings = append(res.Warnings, "fact_used may not match staging fact_to_mention and has no evidence_ids")
+			}
+		}
+	}
+	if strings.TrimSpace(out.FactUsed) != "" && len(out.EvidenceIDs) == 0 && acc != nil && len(acc.MomentEvidenceIDs) == 0 {
+		res.Warnings = append(res.Warnings, "fact used without evidence_ids")
+	}
+
+	if acc != nil {
+		if sc := strings.TrimSpace(out.ServiceCode); sc != "" && acc.ServiceCode != "" && !strings.EqualFold(sc, acc.ServiceCode) {
+			res.OK = false
+			res.Errors = append(res.Errors, "service_code does not match account offer")
+		}
+		// More than one service mention is a warning (hard multi-service check is approximate).
+		if countServiceMentions(body) > 1 {
+			res.OK = false
+			res.Errors = append(res.Errors, "body appears to offer more than one service")
+		}
+	}
+
+	qMarks := strings.Count(body, "?")
+	if qMarks > 2 {
+		res.Warnings = append(res.Warnings, "body has multiple question marks")
+	}
+
+	if !res.OK && len(res.Errors) == 0 {
+		res.Errors = append(res.Errors, "validation failed")
+	}
+	return res
+}
+
+func countWords(s string) int {
+	fields := strings.Fields(s)
+	return len(fields)
+}
+
+func firstWords(s string, n int) string {
+	f := strings.Fields(s)
+	if len(f) == 0 {
+		return ""
+	}
+	if len(f) < n {
+		n = len(f)
+	}
+	return strings.ToLower(strings.Join(f[:n], " "))
+}
+
+func countServiceMentions(body string) int {
+	// Conservative: count known multi-offer patterns rather than NLP.
+	patterns := []string{"além disso oferecemos", "alem disso oferecemos", "também fazemos", "tambem fazemos", "nossos serviços incluem", "nossos servicos incluem"}
+	n := 0
+	low := strings.ToLower(body)
+	for _, p := range patterns {
+		if strings.Contains(low, p) {
+			n++
+		}
+	}
+	return n
+}
+
+// ClassifyRisk returns GREEN/YELLOW/RED send-risk (not lead value).
+func ClassifyRisk(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, out *DraftOutput, val ValidationResult) (class string, flags []string) {
+	flags = []string{}
+	class = "GREEN"
+
+	raise := func(to string, flag string) {
+		flags = append(flags, flag)
+		if rank(to) > rank(class) {
+			class = to
+		}
+	}
+
+	if !val.OK {
+		raise("RED", "validation_failed")
+	}
+	if cand != nil {
+		switch cand.VerificationStatus {
+		case models.OutreachVerifyOfficialSource, models.OutreachVerifyMultipleSources, models.OutreachVerifyPublicDocumentRecent:
+			// ok
+		case models.OutreachVerifyInstitutionalGeneric:
+			raise("YELLOW", "institutional_generic_recipient")
+		case models.OutreachVerifyPublicPossiblyStale:
+			raise("YELLOW", "possibly_stale_contact")
+		default:
+			raise("RED", "weak_or_blocked_verification")
+		}
+		role := strings.ToLower(cand.Role)
+		for _, k := range []string{"ceo", "cfo", "presidente", "sócio", "socio", "diretor geral"} {
+			if strings.Contains(role, k) {
+				raise("RED", "senior_executive_recipient")
+				break
+			}
+		}
+	}
+	if acc != nil {
+		code := strings.ToUpper(acc.MomentCode + " " + acc.ServiceCode + " " + acc.MomentSummary)
+		for _, k := range []string{"CREDIT", "CRÉDITO", "CREDITO", "REEQUILIB", "SANCTION", "SANÇÃO", "SANCAO", "LITIG", "CONSÓRCIO", "CONSORCIO", "CONSORTIUM"} {
+			if strings.Contains(code, k) {
+				raise("RED", "sensitive_moment_or_service")
+				break
+			}
+		}
+		for _, k := range []string{"ADDITIVE", "ADITIVO", "EXTENSION", "PRORROG", "REAJUSTE"} {
+			if strings.Contains(code, k) {
+				raise("YELLOW", "contract_sensitive_topic")
+				break
+			}
+		}
+		if acc.FactToMention == "" {
+			raise("YELLOW", "missing_public_fact")
+		}
+	}
+	if out != nil {
+		blob := strings.ToLower(out.BodyText + " " + out.Subject)
+		for _, k := range []string{"crédito", "credito", "reequilíbrio", "reequilibrio", "litígio", "litigio", "sanção", "sancao"} {
+			if strings.Contains(blob, k) {
+				raise("RED", "economic_or_legal_claim_language")
+				break
+			}
+		}
+	}
+	if class == "GREEN" && len(flags) == 0 {
+		flags = []string{"low_send_risk"}
+	}
+	return class, flags
+}
+
+func rank(c string) int {
+	switch c {
+	case "RED":
+		return 3
+	case "YELLOW":
+		return 2
+	default:
+		return 1
+	}
+}
+
+// TemplateDraft builds a deterministic safe draft when AI is unavailable.
+// Never marked as AI-generated approved output by callers.
+func TemplateDraft(acc *models.OutreachAccount, cand *models.OutreachContactCandidate) DraftOutput {
+	name := ""
+	role := ""
+	email := ""
+	if cand != nil {
+		name = strings.TrimSpace(cand.Name)
+		role = strings.TrimSpace(cand.Role)
+		email = strings.TrimSpace(cand.Email)
+	}
+	company := ""
+	if acc != nil {
+		company = firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
+	}
+	greeting := "Olá"
+	if name != "" && cand != nil && cand.VerificationStatus != models.OutreachVerifyInstitutionalGeneric {
+		greeting = "Olá, " + firstName(name)
+	} else if cand != nil && cand.VerificationStatus == models.OutreachVerifyInstitutionalGeneric {
+		greeting = "Olá, equipe"
+	}
+
+	fact := ""
+	question := "Faz sentido conversarmos brevemente?"
+	cta := "Posso enviar um checklist de uma página?"
+	service := ""
+	if acc != nil {
+		fact = acc.FactToMention
+		if acc.QuestionToAsk != "" {
+			question = acc.QuestionToAsk
+		}
+		if acc.CTA != "" {
+			cta = acc.CTA
+		}
+		service = acc.ServiceName
+		if service == "" {
+			service = acc.ServiceCode
+		}
+	}
+	if fact == "" {
+		fact = "acompanhei publicações recentes relacionadas à " + company
+	}
+
+	body := greeting + ",\n\n"
+	body += "Sou da CONFENGE. Notei que " + fact + ".\n\n"
+	if service != "" {
+		body += "Ajudamos times de engenharia com " + strings.ToLower(service) + ", sempre a partir de fatos públicos e sem pressa.\n\n"
+	}
+	body += question + " " + cta + "\n\n"
+	body += "Abraço,\nTiago Sasaki\nCONFENGE"
+
+	// Strip any accidental em dashes from inputs.
+	body = emDashRe.ReplaceAllString(body, ",")
+	subj := "Sobre " + company
+	if utf8.RuneCountInString(subj) > 80 {
+		subj = "Conversa rápida"
+	}
+
+	_ = email
+	_ = role
+	return DraftOutput{
+		Subject:     subj,
+		BodyText:    body,
+		BodyHTML:    "",
+		Followups:   defaultFollowups(question),
+		FactUsed:    fact,
+		EvidenceIDs: nil,
+		ServiceCode: func() string {
+			if acc != nil {
+				return acc.ServiceCode
+			}
+			return ""
+		}(),
+		Question:  question,
+		CTA:       cta,
+		RiskFlags: []string{"template_fallback"},
+	}
+}
+
+func defaultFollowups(question string) []DraftFollowup {
+	return []DraftFollowup{
+		{DelayDays: 3, SubjectMode: "same_thread", BodyText: "Reenvio com uma pergunta mais objetiva: " + question},
+		{DelayDays: 7, SubjectMode: "same_thread", BodyText: "Se não for com você, pode me indicar a pessoa certa de contratos ou engenharia?"},
+		{DelayDays: 14, SubjectMode: "same_thread", BodyText: "Encerro por aqui para não ocupar sua caixa. Se fizer sentido no futuro, é só responder este fio."},
+	}
+}
+
+func firstName(full string) string {
+	parts := strings.Fields(full)
+	if len(parts) == 0 {
+		return full
+	}
+	return parts[0]
+}
+
+// CanBatchApprove reports whether a draft may be approved in bulk.
+func CanBatchApprove(d *models.OutreachDraft, cand *models.OutreachContactCandidate) bool {
+	if d == nil || cand == nil {
+		return false
+	}
+	if d.Status != models.OutreachDraftNeedsReview && d.Status != models.OutreachDraftApproved {
+		return false
+	}
+	if d.RiskClass != "GREEN" {
+		return false
+	}
+	if !cand.CanEnroll() {
+		return false
+	}
+	// validation must be ok
+	if d.ValidationOK != nil && !*d.ValidationOK {
+		return false
+	}
+	return true
+}

--- a/internal/app/confenge/validators_test.go
+++ b/internal/app/confenge/validators_test.go
@@ -1,0 +1,120 @@
+package confenge
+
+import (
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestValidateDraftRejectsEmDash(t *testing.T) {
+	acc := &models.OutreachAccount{ServiceCode: "ADDITIVE_REVIEW", FactToMention: "contrato prorrogado"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	out := &DraftOutput{
+		Subject: "Oi", BodyText: "Texto com travessão — aqui", FactUsed: "contrato prorrogado",
+		ServiceCode: "ADDITIVE_REVIEW", EvidenceIDs: []string{"e1"},
+	}
+	res := ValidateDraft(out, acc, cand, 120)
+	if res.OK {
+		t.Fatal("em dash must fail")
+	}
+}
+
+func TestValidateDraftRejectsBannedPhrase(t *testing.T) {
+	acc := &models.OutreachAccount{ServiceCode: "X", FactToMention: "fato"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	out := &DraftOutput{
+		Subject: "Oi", BodyText: "Identificamos dinheiro a receber na conta.", FactUsed: "fato",
+		ServiceCode: "X", EvidenceIDs: []string{"e1"},
+	}
+	res := ValidateDraft(out, acc, cand, 120)
+	if res.OK {
+		t.Fatal("banned phrase must fail")
+	}
+}
+
+func TestValidateDraftRejectsUnverified(t *testing.T) {
+	acc := &models.OutreachAccount{ServiceCode: "X", FactToMention: "fato publico"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyCandidateUnverified,
+	}
+	out := &DraftOutput{
+		Subject: "Oi", BodyText: "Mensagem curta com fato publico. Faz sentido?", FactUsed: "fato publico",
+		ServiceCode: "X", EvidenceIDs: []string{"e1"},
+	}
+	res := ValidateDraft(out, acc, cand, 120)
+	if res.OK {
+		t.Fatal("unverified must not enroll")
+	}
+}
+
+func TestValidateDraftAcceptsClean(t *testing.T) {
+	acc := &models.OutreachAccount{ServiceCode: "ADDITIVE_REVIEW", FactToMention: "prorrogacao do contrato 001"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	out := &DraftOutput{
+		Subject:     "Sobre a prorrogacao",
+		BodyText:    "Ola Ana,\n\nNotei a prorrogacao do contrato 001. Faz sentido conversarmos sobre aditivos?\n\nPosso enviar um checklist?",
+		FactUsed:    "prorrogacao do contrato 001",
+		ServiceCode: "ADDITIVE_REVIEW",
+		EvidenceIDs: []string{"e1"},
+		Question:    "Faz sentido conversarmos?",
+		CTA:         "Posso enviar um checklist?",
+	}
+	res := ValidateDraft(out, acc, cand, 120)
+	if !res.OK {
+		t.Fatalf("expected ok, got %v", res.Errors)
+	}
+}
+
+func TestClassifyRiskRedForCredit(t *testing.T) {
+	acc := &models.OutreachAccount{MomentCode: "CREDIT_CLAIM", FactToMention: "x"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	class, flags := ClassifyRisk(acc, cand, &DraftOutput{BodyText: "ola"}, ValidationResult{OK: true})
+	if class != "RED" {
+		t.Fatalf("want RED got %s flags=%v", class, flags)
+	}
+}
+
+func TestClassifyRiskGreenOfficial(t *testing.T) {
+	acc := &models.OutreachAccount{MomentCode: "WARM_INTRO", FactToMention: "publicacao no portal", ServiceCode: "DIAGNOSTIC"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Role: "Analista",
+	}
+	class, _ := ClassifyRisk(acc, cand, &DraftOutput{BodyText: "ola", Subject: "oi"}, ValidationResult{OK: true})
+	if class != "GREEN" {
+		t.Fatalf("want GREEN got %s", class)
+	}
+}
+
+func TestTemplateDraftNoEmDash(t *testing.T) {
+	acc := &models.OutreachAccount{
+		RazaoSocial: "ACME", FactToMention: "contrato X", ServiceName: "revisao",
+		QuestionToAsk: "Faz sentido?", CTA: "Posso enviar?",
+	}
+	cand := &models.OutreachContactCandidate{Name: "Ana Silva", Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource}
+	out := TemplateDraft(acc, cand)
+	if emDashRe.MatchString(out.BodyText + out.Subject) {
+		t.Fatal("template must not contain em dash")
+	}
+	if out.BodyText == "" || out.Subject == "" {
+		t.Fatal("template empty")
+	}
+}
+
+func TestParseDraftJSONStripsFence(t *testing.T) {
+	raw := "```json\n{\"subject\":\"Oi\",\"body_text\":\"Corpo\",\"fact_used\":\"f\",\"service_code\":\"S\",\"evidence_ids\":[\"1\"],\"followups\":[],\"question\":\"?\",\"cta\":\"c\",\"risk_flags\":[]}\n```"
+	out, err := parseDraftJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Subject != "Oi" {
+		t.Fatalf("got %q", out.Subject)
+	}
+}

--- a/internal/app/consumer/event_inbound_bounce.go
+++ b/internal/app/consumer/event_inbound_bounce.go
@@ -12,15 +12,20 @@ import (
 // feed the deliverability breaker. Best-effort — a bounce we can't attribute is
 // logged, not retried.
 func (s *JobsService) HandleInboundBounce(ctx context.Context, e *models.JobEventInboundBounce) error {
-	if s.AdvancedService == nil {
-		return nil
+	if s.AdvancedService != nil {
+		if xerr := s.AdvancedService.RecordInboundBounce(ctx, e.EmailID, e.OriginalMessageID, e.FailedRecipient, e.Reason); xerr != nil {
+			log.Warn().
+				Str("email_id", e.EmailID.String()).
+				Str("original_message_id", e.OriginalMessageID).
+				Str("error", xerr.Message).
+				Msg("Failed to record inbound bounce")
+		}
 	}
-	if xerr := s.AdvancedService.RecordInboundBounce(ctx, e.EmailID, e.OriginalMessageID, e.FailedRecipient, e.Reason); xerr != nil {
-		log.Warn().
-			Str("email_id", e.EmailID.String()).
-			Str("original_message_id", e.OriginalMessageID).
-			Str("error", xerr.Message).
-			Msg("Failed to record inbound bounce")
+	// CONFENGE: attribute bounce to staged contact when org is known.
+	if s.ConfengeOutcomes != nil && s.ConfengeOutcomes.Enabled() && s.EmailRepository != nil {
+		if account, err := s.EmailRepository.GetByID(ctx, e.EmailID); err == nil && account != nil && account.OrganizationID != nil {
+			_ = s.ConfengeOutcomes.NoteBounce(ctx, *account.OrganizationID, e.FailedRecipient, e.Reason)
+		}
 	}
 	return nil
 }

--- a/internal/app/consumer/event_new_email.go
+++ b/internal/app/consumer/event_new_email.go
@@ -74,6 +74,20 @@ func (s *JobsService) HandleNewEmail(ctx context.Context, e *models.JobEventNewE
 		_ = s.AdvancedService.ProcessIncomingReply(ctx, e.Message.EmailID, e.Message)
 	}
 
+	// CONFENGE outcome loop: attribute human-looking inbound mail to staged leads.
+	if s.ConfengeOutcomes != nil && s.ConfengeOutcomes.Enabled() && e.Message != nil {
+		if account, err := s.EmailRepository.GetByID(ctx, e.Message.EmailID); err == nil && account != nil && account.OrganizationID != nil {
+			from := ""
+			if len(e.Message.FromAddr) > 0 {
+				from = e.Message.FromAddr[0]
+			}
+			_ = s.ConfengeOutcomes.NoteReply(ctx, *account.OrganizationID, from, map[string]any{
+				"subject":    e.Message.Subject,
+				"message_id": e.Message.ID.String(),
+			})
+		}
+	}
+
 	return nil
 }
 

--- a/internal/app/consumer/service.go
+++ b/internal/app/consumer/service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/warmbly/warmbly/internal/app/advanced"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	workerapp "github.com/warmbly/warmbly/internal/app/worker"
 	"github.com/warmbly/warmbly/internal/events"
@@ -41,6 +42,9 @@ type JobsService struct {
 	// Pub/Sub for real-time notifications to users
 	StreamingPublisher *pubsub.StreamingPublisher
 	AdvancedService    advanced.Service
+
+	// ConfengeOutcomes attributes reply/bounce/DNC back to staged leads (optional).
+	ConfengeOutcomes confenge.OutcomeSink
 
 	// Cache for dead worker detection
 	Cache *cache.Cache

--- a/internal/infrastructure/db/migrations/000080_outreach_staging.down.sql
+++ b/internal/infrastructure/db/migrations/000080_outreach_staging.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS outreach_evidence;
+DROP TABLE IF EXISTS outreach_contact_candidates;
+DROP TABLE IF EXISTS outreach_accounts;
+DROP TABLE IF EXISTS outreach_import_runs;

--- a/internal/infrastructure/db/migrations/000080_outreach_staging.up.sql
+++ b/internal/infrastructure/db/migrations/000080_outreach_staging.up.sql
@@ -1,0 +1,227 @@
+-- Outreach staging: multi-tenant company staging queue for intelligence-plane
+-- feeds (e.g. extra-cli confenge.outreach.v1). Companies may exist without a
+-- validated email; they are not forced into the contacts table until promoted.
+-- Feature flag: CONFENGE_OUTREACH_ENABLED (see internal/app/confenge).
+
+CREATE TABLE IF NOT EXISTS outreach_import_runs (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    source_system       text NOT NULL DEFAULT 'extra-cli',
+    source_run_id       text NOT NULL DEFAULT '',
+    schema_version      text NOT NULL DEFAULT 'confenge.outreach.v1',
+    snapshot_hash       text NOT NULL DEFAULT '',
+    repo_sha            text NOT NULL DEFAULT '',
+    payload_hash        text NOT NULL DEFAULT '',
+    profile_id          text NOT NULL DEFAULT '',
+    profile_version     text NOT NULL DEFAULT '',
+
+    status              text NOT NULL DEFAULT 'pending',
+    dry_run             boolean NOT NULL DEFAULT false,
+    started_at          timestamptz NOT NULL DEFAULT now(),
+    finished_at         timestamptz,
+    cursor_in           text NOT NULL DEFAULT '',
+    cursor_out          text NOT NULL DEFAULT '',
+
+    counts              jsonb NOT NULL DEFAULT '{}'::jsonb,
+    errors              jsonb NOT NULL DEFAULT '[]'::jsonb,
+    warnings            jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    created_by_user_id  uuid REFERENCES users(id) ON DELETE SET NULL,
+    idempotency_key     text NOT NULL DEFAULT '',
+    source_uri          text NOT NULL DEFAULT '',
+
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_import_runs_status_check
+        CHECK (status IN ('pending', 'running', 'completed', 'failed', 'partial'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_import_runs_org_idempotency_uidx
+    ON outreach_import_runs (organization_id, idempotency_key)
+    WHERE idempotency_key <> '';
+
+CREATE INDEX IF NOT EXISTS outreach_import_runs_org_started_idx
+    ON outreach_import_runs (organization_id, started_at DESC);
+
+-- Company / account staging (no email required).
+CREATE TABLE IF NOT EXISTS outreach_accounts (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    source_lead_id      text NOT NULL DEFAULT '',
+    cnpj14              text NOT NULL,
+    cnpj_root           text NOT NULL DEFAULT '',
+    razao_social        text NOT NULL DEFAULT '',
+    nome_fantasia       text NOT NULL DEFAULT '',
+    municipio           text NOT NULL DEFAULT '',
+    uf                  text NOT NULL DEFAULT '',
+    website             text NOT NULL DEFAULT '',
+
+    priority_rank       int NOT NULL DEFAULT 0,
+    priority_score      double precision NOT NULL DEFAULT 0,
+    priority_tier       text NOT NULL DEFAULT '',
+    priority_confidence text NOT NULL DEFAULT '',
+
+    moment_code         text NOT NULL DEFAULT '',
+    moment_summary      text NOT NULL DEFAULT '',
+    moment_observed_at  date,
+    moment_confidence   text NOT NULL DEFAULT '',
+    moment_evidence_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    service_code        text NOT NULL DEFAULT '',
+    service_name        text NOT NULL DEFAULT '',
+    entry_offer         text NOT NULL DEFAULT '',
+    offer_rationale     text NOT NULL DEFAULT '',
+
+    fact_to_mention     text NOT NULL DEFAULT '',
+    question_to_ask     text NOT NULL DEFAULT '',
+    cta                 text NOT NULL DEFAULT '',
+    claims_to_avoid     jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    commercial_state    text NOT NULL DEFAULT 'NEW',
+    queue_state         text NOT NULL DEFAULT 'NEEDS_CONTACT',
+    human_override      boolean NOT NULL DEFAULT false,
+    blocked             boolean NOT NULL DEFAULT false,
+    block_reason        text NOT NULL DEFAULT '',
+    do_not_contact      boolean NOT NULL DEFAULT false,
+
+    source_system       text NOT NULL DEFAULT 'extra-cli',
+    source_run_id       text NOT NULL DEFAULT '',
+    last_import_run_id  uuid REFERENCES outreach_import_runs(id) ON DELETE SET NULL,
+    last_payload_hash   text NOT NULL DEFAULT '',
+    contracts_json      jsonb NOT NULL DEFAULT '[]'::jsonb,
+    raw_snapshot        jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_accounts_cnpj14_check
+        CHECK (cnpj14 ~ '^[0-9]{14}$'),
+    CONSTRAINT outreach_accounts_queue_state_check
+        CHECK (queue_state IN (
+            'NEEDS_CONTACT',
+            'READY_TO_GENERATE',
+            'NEEDS_REVIEW',
+            'APPROVED',
+            'ENROLLED',
+            'SENT',
+            'REPLIED',
+            'MEETING',
+            'PROPOSAL',
+            'WON',
+            'LOST',
+            'BLOCKED',
+            'BOUNCED',
+            'DO_NOT_CONTACT',
+            'SKIPPED'
+        ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_accounts_org_cnpj14_uidx
+    ON outreach_accounts (organization_id, cnpj14);
+
+CREATE INDEX IF NOT EXISTS outreach_accounts_org_queue_idx
+    ON outreach_accounts (organization_id, queue_state);
+
+CREATE INDEX IF NOT EXISTS outreach_accounts_org_source_lead_idx
+    ON outreach_accounts (organization_id, source_lead_id)
+    WHERE source_lead_id <> '';
+
+-- Contact candidates (may lack email or verification).
+CREATE TABLE IF NOT EXISTS outreach_contact_candidates (
+    id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id         uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    account_id              uuid NOT NULL REFERENCES outreach_accounts(id) ON DELETE CASCADE,
+
+    source_contact_id       text NOT NULL DEFAULT '',
+    name                    text NOT NULL DEFAULT '',
+    role                    text NOT NULL DEFAULT '',
+    email                   text NOT NULL DEFAULT '',
+    phone                   text NOT NULL DEFAULT '',
+    linkedin_url            text NOT NULL DEFAULT '',
+    source_url              text NOT NULL DEFAULT '',
+    source_document         text NOT NULL DEFAULT '',
+    source_date             date,
+    verification_status     text NOT NULL DEFAULT 'NOT_FOUND',
+    confidence              text NOT NULL DEFAULT '',
+    recommended             boolean NOT NULL DEFAULT false,
+
+    warmbly_contact_id      uuid REFERENCES contacts(id) ON DELETE SET NULL,
+    promoted_at             timestamptz,
+    blocked                 boolean NOT NULL DEFAULT false,
+    block_reason            text NOT NULL DEFAULT '',
+    do_not_contact          boolean NOT NULL DEFAULT false,
+    bounced                 boolean NOT NULL DEFAULT false,
+
+    last_import_run_id      uuid REFERENCES outreach_import_runs(id) ON DELETE SET NULL,
+    created_at              timestamptz NOT NULL DEFAULT now(),
+    updated_at              timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_contact_candidates_verification_check
+        CHECK (verification_status IN (
+            'OFFICIAL_SOURCE',
+            'PUBLIC_DOCUMENT_RECENT',
+            'MULTIPLE_PUBLIC_SOURCES',
+            'INSTITUTIONAL_GENERIC',
+            'PUBLIC_POSSIBLY_STALE',
+            'CANDIDATE_UNVERIFIED',
+            'NOT_FOUND',
+            'INVALID',
+            'BOUNCED',
+            'DO_NOT_CONTACT'
+        ))
+);
+
+CREATE INDEX IF NOT EXISTS outreach_contact_candidates_account_idx
+    ON outreach_contact_candidates (organization_id, account_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_contact_candidates_org_source_uidx
+    ON outreach_contact_candidates (organization_id, account_id, source_contact_id)
+    WHERE source_contact_id <> '';
+
+CREATE INDEX IF NOT EXISTS outreach_contact_candidates_email_idx
+    ON outreach_contact_candidates (organization_id, lower(email))
+    WHERE email <> '';
+
+-- Normalized evidence per account (sanitized text only; no raw HTML).
+CREATE TABLE IF NOT EXISTS outreach_evidence (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    account_id          uuid NOT NULL REFERENCES outreach_accounts(id) ON DELETE CASCADE,
+
+    source_evidence_id  text NOT NULL,
+    evidence_type       text NOT NULL DEFAULT '',
+    title               text NOT NULL DEFAULT '',
+    url                 text NOT NULL DEFAULT '',
+    document            text NOT NULL DEFAULT '',
+    evidence_date       date,
+    location            text NOT NULL DEFAULT '',
+    excerpt             text NOT NULL DEFAULT '',
+    synthesis           text NOT NULL DEFAULT '',
+    epistemic_class     text NOT NULL DEFAULT 'COMMERCIAL_HYPOTHESIS',
+    reliability         text NOT NULL DEFAULT '',
+    consulted_at        date,
+
+    last_import_run_id  uuid REFERENCES outreach_import_runs(id) ON DELETE SET NULL,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_evidence_epistemic_check
+        CHECK (epistemic_class IN (
+            'CONFIRMED_FACT',
+            'STRONG_INFERENCE',
+            'WEAK_INFERENCE',
+            'COMMERCIAL_HYPOTHESIS',
+            'NOT_FOUND',
+            'REQUIRES_COMPANY_CONFIRMATION',
+            'CONTRADICTORY_EVIDENCE'
+        ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_evidence_org_source_uidx
+    ON outreach_evidence (organization_id, account_id, source_evidence_id);
+
+CREATE INDEX IF NOT EXISTS outreach_evidence_account_idx
+    ON outreach_evidence (organization_id, account_id);

--- a/internal/infrastructure/db/migrations/000081_outreach_drafts.down.sql
+++ b/internal/infrastructure/db/migrations/000081_outreach_drafts.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS outreach_org_settings;
+DROP TABLE IF EXISTS outreach_drafts;

--- a/internal/infrastructure/db/migrations/000081_outreach_drafts.up.sql
+++ b/internal/infrastructure/db/migrations/000081_outreach_drafts.up.sql
@@ -1,0 +1,86 @@
+-- Outreach drafts: evidence-bound message generation + human review for
+-- CONFENGE staging accounts. Feature-flagged with CONFENGE_OUTREACH_ENABLED.
+
+CREATE TABLE IF NOT EXISTS outreach_drafts (
+    id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id         uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    account_id              uuid NOT NULL REFERENCES outreach_accounts(id) ON DELETE CASCADE,
+    contact_candidate_id    uuid REFERENCES outreach_contact_candidates(id) ON DELETE SET NULL,
+
+    recipient_name          text NOT NULL DEFAULT '',
+    recipient_role          text NOT NULL DEFAULT '',
+    recipient_email         text NOT NULL DEFAULT '',
+    verification_status     text NOT NULL DEFAULT '',
+
+    subject                 text NOT NULL DEFAULT '',
+    body_text               text NOT NULL DEFAULT '',
+    body_html               text NOT NULL DEFAULT '',
+    followups_json          jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    service_code            text NOT NULL DEFAULT '',
+    strategy_code           text NOT NULL DEFAULT '',
+    fact_used               text NOT NULL DEFAULT '',
+    evidence_ids            jsonb NOT NULL DEFAULT '[]'::jsonb,
+    question                text NOT NULL DEFAULT '',
+    cta                     text NOT NULL DEFAULT '',
+
+    provider                text NOT NULL DEFAULT '',
+    model                   text NOT NULL DEFAULT '',
+    prompt_version          text NOT NULL DEFAULT 'confenge.draft.v1',
+    generation              int NOT NULL DEFAULT 0,
+
+    validation_json         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    risk_class              text NOT NULL DEFAULT 'YELLOW',
+    risk_flags              jsonb NOT NULL DEFAULT '[]'::jsonb,
+    red_team_result         text NOT NULL DEFAULT '',
+    red_team_reasons        jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    status                  text NOT NULL DEFAULT 'NOT_GENERATED',
+    human_edited            boolean NOT NULL DEFAULT false,
+    approved_by             uuid REFERENCES users(id) ON DELETE SET NULL,
+    approved_at             timestamptz,
+    review_seconds          int NOT NULL DEFAULT 0,
+
+    campaign_id             uuid REFERENCES campaigns(id) ON DELETE SET NULL,
+    enrollment_contact_id   uuid REFERENCES contacts(id) ON DELETE SET NULL,
+    enrolled_at             timestamptz,
+
+    created_at              timestamptz NOT NULL DEFAULT now(),
+    updated_at              timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_drafts_status_check
+        CHECK (status IN (
+            'NOT_GENERATED',
+            'GENERATING',
+            'NEEDS_REVIEW',
+            'APPROVED',
+            'REJECTED',
+            'SKIPPED',
+            'BLOCKED',
+            'ENROLLED',
+            'SENT',
+            'REPLIED'
+        )),
+    CONSTRAINT outreach_drafts_risk_check
+        CHECK (risk_class IN ('GREEN', 'YELLOW', 'RED'))
+);
+
+CREATE INDEX IF NOT EXISTS outreach_drafts_org_status_idx
+    ON outreach_drafts (organization_id, status);
+
+CREATE INDEX IF NOT EXISTS outreach_drafts_account_idx
+    ON outreach_drafts (organization_id, account_id);
+
+-- One active review draft per account (not terminal).
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_drafts_org_account_active_uidx
+    ON outreach_drafts (organization_id, account_id)
+    WHERE status IN ('NOT_GENERATED', 'GENERATING', 'NEEDS_REVIEW', 'APPROVED');
+
+-- Org-scoped confenge campaign pointer (bootstrap idempotency).
+CREATE TABLE IF NOT EXISTS outreach_org_settings (
+    organization_id     uuid PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+    campaign_id         uuid REFERENCES campaigns(id) ON DELETE SET NULL,
+    campaign_name       text NOT NULL DEFAULT 'CONFENGE | Outreach consultivo inicial',
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now()
+);

--- a/internal/infrastructure/db/migrations/000082_outreach_outcomes.down.sql
+++ b/internal/infrastructure/db/migrations/000082_outreach_outcomes.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS outreach_outcome_outbox;

--- a/internal/infrastructure/db/migrations/000082_outreach_outcomes.up.sql
+++ b/internal/infrastructure/db/migrations/000082_outreach_outcomes.up.sql
@@ -1,0 +1,47 @@
+-- Outcome outbox: commercial events returned to extra-cli via HMAC webhook.
+-- Warmbly never writes the datalake; delivery is async with retries.
+
+CREATE TABLE IF NOT EXISTS outreach_outcome_outbox (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    event_id            uuid NOT NULL DEFAULT gen_random_uuid(),
+    idempotency_key     text NOT NULL,
+    source_lead_id      text NOT NULL DEFAULT '',
+    cnpj14              text NOT NULL DEFAULT '',
+    contact_email       text NOT NULL DEFAULT '',
+    event_type          text NOT NULL,
+    payload             jsonb NOT NULL DEFAULT '{}'::jsonb,
+    occurred_at         timestamptz NOT NULL DEFAULT now(),
+
+    attempts            int NOT NULL DEFAULT 0,
+    next_attempt_at     timestamptz NOT NULL DEFAULT now(),
+    delivered_at        timestamptz,
+    last_error          text NOT NULL DEFAULT '',
+    dead_letter         boolean NOT NULL DEFAULT false,
+
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_outcome_outbox_type_check
+        CHECK (event_type IN (
+            'LEAD_IMPORTED',
+            'LEAD_REVIEWED',
+            'CONTACT_APPROVED',
+            'CONTACTED',
+            'REPLIED',
+            'MEETING',
+            'PROPOSAL',
+            'WON',
+            'LOST',
+            'DO_NOT_CONTACT',
+            'BOUNCED'
+        ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_outcome_outbox_org_idempotency_uidx
+    ON outreach_outcome_outbox (organization_id, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS outreach_outcome_outbox_pending_idx
+    ON outreach_outcome_outbox (next_attempt_at)
+    WHERE delivered_at IS NULL AND dead_letter = false;

--- a/internal/models/audit.go
+++ b/internal/models/audit.go
@@ -116,6 +116,10 @@ const (
 	// background evaluation that opened or resolved findings. Rides the audit
 	// spine so every teammate's advisor strips and nav badges stay live.
 	AuditEntityAdvisorFinding AuditEntityType = "advisor_finding"
+
+	// CONFENGE / outreach staging (intelligence-plane import + company queue).
+	AuditEntityOutreachImportRun AuditEntityType = "outreach_import_run"
+	AuditEntityOutreachAccount   AuditEntityType = "outreach_account"
 )
 
 // AuditActor is the minimal identity of the member who performed an action,

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -351,3 +351,24 @@ type OutreachOrgSettings struct {
 	CreatedAt      time.Time  `json:"created_at"`
 	UpdatedAt      time.Time  `json:"updated_at"`
 }
+
+// OutreachOutcome is one outbox row for confenge.outcome.v1 delivery.
+type OutreachOutcome struct {
+	ID             uuid.UUID  `json:"id"`
+	OrganizationID uuid.UUID  `json:"organization_id"`
+	EventID        uuid.UUID  `json:"event_id"`
+	IdempotencyKey string     `json:"idempotency_key"`
+	SourceLeadID   string     `json:"source_lead_id"`
+	CNPJ14         string     `json:"cnpj14"`
+	ContactEmail   string     `json:"contact_email"`
+	EventType      string     `json:"event_type"`
+	Payload        []byte     `json:"payload,omitempty"`
+	OccurredAt     time.Time  `json:"occurred_at"`
+	Attempts       int        `json:"attempts"`
+	NextAttemptAt  time.Time  `json:"next_attempt_at"`
+	DeliveredAt    *time.Time `json:"delivered_at,omitempty"`
+	LastError      string     `json:"last_error,omitempty"`
+	DeadLetter     bool       `json:"dead_letter"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -275,3 +275,79 @@ type OutreachImportRunListResult struct {
 	Data       []OutreachImportRun `json:"data"`
 	Pagination Pagination          `json:"pagination"`
 }
+
+// Draft statuses.
+const (
+	OutreachDraftNotGenerated = "NOT_GENERATED"
+	OutreachDraftGenerating   = "GENERATING"
+	OutreachDraftNeedsReview  = "NEEDS_REVIEW"
+	OutreachDraftApproved     = "APPROVED"
+	OutreachDraftRejected     = "REJECTED"
+	OutreachDraftSkipped      = "SKIPPED"
+	OutreachDraftBlocked      = "BLOCKED"
+	OutreachDraftEnrolled     = "ENROLLED"
+	OutreachDraftSent         = "SENT"
+	OutreachDraftReplied      = "REPLIED"
+)
+
+// OutreachDraft is one generated/reviewed message for a staged account.
+type OutreachDraft struct {
+	ID                 uuid.UUID  `json:"id"`
+	OrganizationID     uuid.UUID  `json:"organization_id"`
+	AccountID          uuid.UUID  `json:"account_id"`
+	ContactCandidateID *uuid.UUID `json:"contact_candidate_id,omitempty"`
+
+	RecipientName      string `json:"recipient_name"`
+	RecipientRole      string `json:"recipient_role"`
+	RecipientEmail     string `json:"recipient_email"`
+	VerificationStatus string `json:"verification_status"`
+
+	Subject       string `json:"subject"`
+	BodyText      string `json:"body_text"`
+	BodyHTML      string `json:"body_html"`
+	FollowupsJSON []byte `json:"followups,omitempty"`
+
+	ServiceCode  string   `json:"service_code"`
+	StrategyCode string   `json:"strategy_code"`
+	FactUsed     string   `json:"fact_used"`
+	EvidenceIDs  []string `json:"evidence_ids,omitempty"`
+	Question     string   `json:"question"`
+	CTA          string   `json:"cta"`
+
+	Provider      string `json:"provider"`
+	Model         string `json:"model"`
+	PromptVersion string `json:"prompt_version"`
+	Generation    int    `json:"generation"`
+
+	ValidationJSON []byte   `json:"validation,omitempty"`
+	ValidationOK   *bool    `json:"validation_ok,omitempty"`
+	RiskClass      string   `json:"risk_class"`
+	RiskFlags      []string `json:"risk_flags,omitempty"`
+	RedTeamResult  string   `json:"red_team_result,omitempty"`
+	RedTeamReasons []string `json:"red_team_reasons,omitempty"`
+
+	Status        string     `json:"status"`
+	HumanEdited   bool       `json:"human_edited"`
+	ApprovedBy    *uuid.UUID `json:"approved_by,omitempty"`
+	ApprovedAt    *time.Time `json:"approved_at,omitempty"`
+	ReviewSeconds int        `json:"review_seconds"`
+
+	CampaignID          *uuid.UUID `json:"campaign_id,omitempty"`
+	EnrollmentContactID *uuid.UUID `json:"enrollment_contact_id,omitempty"`
+	EnrolledAt          *time.Time `json:"enrolled_at,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// Joined for review UI
+	Account *OutreachAccount `json:"account,omitempty"`
+}
+
+// OutreachOrgSettings stores confenge campaign bootstrap pointer.
+type OutreachOrgSettings struct {
+	OrganizationID uuid.UUID  `json:"organization_id"`
+	CampaignID     *uuid.UUID `json:"campaign_id,omitempty"`
+	CampaignName   string     `json:"campaign_name"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -1,0 +1,277 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Outreach staging models: intelligence-plane feed import into a multi-tenant
+// company staging queue. Companies may lack email; they are not forced into
+// contacts until a candidate is promoted.
+
+// Schema versions for the confenge/extra-cli integration contracts.
+const (
+	OutreachSchemaV1        = "confenge.outreach.v1"
+	OutreachOutcomeSchemaV1 = "confenge.outcome.v1"
+)
+
+// Contact verification statuses allowed on outreach contact candidates.
+const (
+	OutreachVerifyOfficialSource       = "OFFICIAL_SOURCE"
+	OutreachVerifyPublicDocumentRecent = "PUBLIC_DOCUMENT_RECENT"
+	OutreachVerifyMultipleSources      = "MULTIPLE_PUBLIC_SOURCES"
+	OutreachVerifyInstitutionalGeneric = "INSTITUTIONAL_GENERIC"
+	OutreachVerifyPublicPossiblyStale  = "PUBLIC_POSSIBLY_STALE"
+	OutreachVerifyCandidateUnverified  = "CANDIDATE_UNVERIFIED"
+	OutreachVerifyNotFound             = "NOT_FOUND"
+	OutreachVerifyInvalid              = "INVALID"
+	OutreachVerifyBounced              = "BOUNCED"
+	OutreachVerifyDoNotContact         = "DO_NOT_CONTACT"
+)
+
+// Epistemic classifications for evidence.
+const (
+	OutreachEpistemicConfirmedFact          = "CONFIRMED_FACT"
+	OutreachEpistemicStrongInference        = "STRONG_INFERENCE"
+	OutreachEpistemicWeakInference          = "WEAK_INFERENCE"
+	OutreachEpistemicCommercialHypothesis   = "COMMERCIAL_HYPOTHESIS"
+	OutreachEpistemicNotFound               = "NOT_FOUND"
+	OutreachEpistemicRequiresCompanyConfirm = "REQUIRES_COMPANY_CONFIRMATION"
+	OutreachEpistemicContradictoryEvidence  = "CONTRADICTORY_EVIDENCE"
+)
+
+// Queue states for outreach accounts (dashboard pipeline).
+const (
+	OutreachQueueNeedsContact    = "NEEDS_CONTACT"
+	OutreachQueueReadyToGenerate = "READY_TO_GENERATE"
+	OutreachQueueNeedsReview     = "NEEDS_REVIEW"
+	OutreachQueueApproved        = "APPROVED"
+	OutreachQueueEnrolled        = "ENROLLED"
+	OutreachQueueSent            = "SENT"
+	OutreachQueueReplied         = "REPLIED"
+	OutreachQueueMeeting         = "MEETING"
+	OutreachQueueProposal        = "PROPOSAL"
+	OutreachQueueWon             = "WON"
+	OutreachQueueLost            = "LOST"
+	OutreachQueueBlocked         = "BLOCKED"
+	OutreachQueueBounced         = "BOUNCED"
+	OutreachQueueDoNotContact    = "DO_NOT_CONTACT"
+	OutreachQueueSkipped         = "SKIPPED"
+)
+
+// Import run statuses.
+const (
+	OutreachImportPending   = "pending"
+	OutreachImportRunning   = "running"
+	OutreachImportCompleted = "completed"
+	OutreachImportFailed    = "failed"
+	OutreachImportPartial   = "partial"
+)
+
+// Verification statuses that must never be enrolled into a campaign.
+var OutreachUnenrollableVerification = map[string]bool{
+	OutreachVerifyCandidateUnverified: true,
+	OutreachVerifyNotFound:            true,
+	OutreachVerifyInvalid:             true,
+	OutreachVerifyBounced:             true,
+	OutreachVerifyDoNotContact:        true,
+}
+
+// OutreachImportCounts is the dry-run / apply summary for one import run.
+type OutreachImportCounts struct {
+	Creates           int `json:"creates"`
+	Updates           int `json:"updates"`
+	Unchanged         int `json:"unchanged"`
+	MissingContact    int `json:"missing_contact"`
+	Invalid           int `json:"invalid"`
+	Blocked           int `json:"blocked"`
+	Conflicts         int `json:"conflicts"`
+	EvidenceAdded     int `json:"evidence_added"`
+	ContactsPromoted  int `json:"contacts_promoted"`
+	Warnings          int `json:"warnings"`
+	LeadsProcessed    int `json:"leads_processed"`
+	LeadsSkippedError int `json:"leads_skipped_error"`
+}
+
+// OutreachImportError is a per-lead error recorded without aborting the run.
+type OutreachImportError struct {
+	SourceLeadID string `json:"source_lead_id,omitempty"`
+	CNPJ14       string `json:"cnpj14,omitempty"`
+	Message      string `json:"message"`
+}
+
+// OutreachImportRun is one feed import attempt (dry-run or apply).
+type OutreachImportRun struct {
+	ID              uuid.UUID             `json:"id"`
+	OrganizationID  uuid.UUID             `json:"organization_id"`
+	SourceSystem    string                `json:"source_system"`
+	SourceRunID     string                `json:"source_run_id"`
+	SchemaVersion   string                `json:"schema_version"`
+	SnapshotHash    string                `json:"snapshot_hash"`
+	RepoSHA         string                `json:"repo_sha"`
+	PayloadHash     string                `json:"payload_hash"`
+	ProfileID       string                `json:"profile_id"`
+	ProfileVersion  string                `json:"profile_version"`
+	Status          string                `json:"status"`
+	DryRun          bool                  `json:"dry_run"`
+	StartedAt       time.Time             `json:"started_at"`
+	FinishedAt      *time.Time            `json:"finished_at,omitempty"`
+	CursorIn        string                `json:"cursor_in,omitempty"`
+	CursorOut       string                `json:"cursor_out,omitempty"`
+	Counts          OutreachImportCounts  `json:"counts"`
+	Errors          []OutreachImportError `json:"errors,omitempty"`
+	Warnings        []string              `json:"warnings,omitempty"`
+	CreatedByUserID *uuid.UUID            `json:"created_by_user_id,omitempty"`
+	IdempotencyKey  string                `json:"idempotency_key,omitempty"`
+	SourceURI       string                `json:"source_uri,omitempty"`
+	CreatedAt       time.Time             `json:"created_at"`
+	UpdatedAt       time.Time             `json:"updated_at"`
+}
+
+// OutreachAccount is a staged company from the intelligence feed.
+type OutreachAccount struct {
+	ID                 uuid.UUID  `json:"id"`
+	OrganizationID     uuid.UUID  `json:"organization_id"`
+	SourceLeadID       string     `json:"source_lead_id"`
+	CNPJ14             string     `json:"cnpj14"`
+	CNPJRoot           string     `json:"cnpj_root"`
+	RazaoSocial        string     `json:"razao_social"`
+	NomeFantasia       string     `json:"nome_fantasia"`
+	Municipio          string     `json:"municipio"`
+	UF                 string     `json:"uf"`
+	Website            string     `json:"website"`
+	PriorityRank       int        `json:"priority_rank"`
+	PriorityScore      float64    `json:"priority_score"`
+	PriorityTier       string     `json:"priority_tier"`
+	PriorityConfidence string     `json:"priority_confidence"`
+	MomentCode         string     `json:"moment_code"`
+	MomentSummary      string     `json:"moment_summary"`
+	MomentObservedAt   *time.Time `json:"moment_observed_at,omitempty"`
+	MomentConfidence   string     `json:"moment_confidence"`
+	MomentEvidenceIDs  []string   `json:"moment_evidence_ids,omitempty"`
+	ServiceCode        string     `json:"service_code"`
+	ServiceName        string     `json:"service_name"`
+	EntryOffer         string     `json:"entry_offer"`
+	OfferRationale     string     `json:"offer_rationale"`
+	FactToMention      string     `json:"fact_to_mention"`
+	QuestionToAsk      string     `json:"question_to_ask"`
+	CTA                string     `json:"cta"`
+	ClaimsToAvoid      []string   `json:"claims_to_avoid,omitempty"`
+	CommercialState    string     `json:"commercial_state"`
+	QueueState         string     `json:"queue_state"`
+	HumanOverride      bool       `json:"human_override"`
+	Blocked            bool       `json:"blocked"`
+	BlockReason        string     `json:"block_reason,omitempty"`
+	DoNotContact       bool       `json:"do_not_contact"`
+	SourceSystem       string     `json:"source_system"`
+	SourceRunID        string     `json:"source_run_id"`
+	LastImportRunID    *uuid.UUID `json:"last_import_run_id,omitempty"`
+	LastPayloadHash    string     `json:"last_payload_hash,omitempty"`
+	ContractsJSON      []byte     `json:"contracts,omitempty"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+
+	// Joined / computed (not always filled).
+	Contacts  []OutreachContactCandidate `json:"contacts,omitempty"`
+	Evidence  []OutreachEvidence         `json:"evidence,omitempty"`
+	ContactN  int                        `json:"contact_count,omitempty"`
+	EvidenceN int                        `json:"evidence_count,omitempty"`
+}
+
+// OutreachContactCandidate is a possible recipient before promotion to contacts.
+type OutreachContactCandidate struct {
+	ID                 uuid.UUID  `json:"id"`
+	OrganizationID     uuid.UUID  `json:"organization_id"`
+	AccountID          uuid.UUID  `json:"account_id"`
+	SourceContactID    string     `json:"source_contact_id"`
+	Name               string     `json:"name"`
+	Role               string     `json:"role"`
+	Email              string     `json:"email"`
+	Phone              string     `json:"phone"`
+	LinkedInURL        string     `json:"linkedin_url,omitempty"`
+	SourceURL          string     `json:"source_url,omitempty"`
+	SourceDocument     string     `json:"source_document,omitempty"`
+	SourceDate         *time.Time `json:"source_date,omitempty"`
+	VerificationStatus string     `json:"verification_status"`
+	Confidence         string     `json:"confidence"`
+	Recommended        bool       `json:"recommended"`
+	WarmblyContactID   *uuid.UUID `json:"warmbly_contact_id,omitempty"`
+	PromotedAt         *time.Time `json:"promoted_at,omitempty"`
+	Blocked            bool       `json:"blocked"`
+	BlockReason        string     `json:"block_reason,omitempty"`
+	DoNotContact       bool       `json:"do_not_contact"`
+	Bounced            bool       `json:"bounced"`
+	LastImportRunID    *uuid.UUID `json:"last_import_run_id,omitempty"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+}
+
+// CanEnroll reports whether this candidate may be put into a campaign.
+func (c *OutreachContactCandidate) CanEnroll() bool {
+	if c == nil {
+		return false
+	}
+	if c.Blocked || c.DoNotContact || c.Bounced {
+		return false
+	}
+	if c.Email == "" {
+		return false
+	}
+	if OutreachUnenrollableVerification[c.VerificationStatus] {
+		return false
+	}
+	return true
+}
+
+// OutreachEvidence is one sanitized evidence row for an account.
+type OutreachEvidence struct {
+	ID               uuid.UUID  `json:"id"`
+	OrganizationID   uuid.UUID  `json:"organization_id"`
+	AccountID        uuid.UUID  `json:"account_id"`
+	SourceEvidenceID string     `json:"source_evidence_id"`
+	EvidenceType     string     `json:"evidence_type"`
+	Title            string     `json:"title"`
+	URL              string     `json:"url"`
+	Document         string     `json:"document"`
+	EvidenceDate     *time.Time `json:"evidence_date,omitempty"`
+	Location         string     `json:"location"`
+	Excerpt          string     `json:"excerpt"`
+	Synthesis        string     `json:"synthesis"`
+	EpistemicClass   string     `json:"epistemic_class"`
+	Reliability      string     `json:"reliability"`
+	ConsultedAt      *time.Time `json:"consulted_at,omitempty"`
+	LastImportRunID  *uuid.UUID `json:"last_import_run_id,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+}
+
+// OutreachQueueSummary is the dashboard overview counters.
+type OutreachQueueSummary struct {
+	NeedsContact    int `json:"needs_contact"`
+	ReadyToGenerate int `json:"ready_to_generate"`
+	NeedsReview     int `json:"needs_review"`
+	Approved        int `json:"approved"`
+	Enrolled        int `json:"enrolled"`
+	Sent            int `json:"sent"`
+	Replied         int `json:"replied"`
+	Meeting         int `json:"meeting"`
+	Proposal        int `json:"proposal"`
+	Won             int `json:"won"`
+	Blocked         int `json:"blocked"`
+	Bounced         int `json:"bounced"`
+	DoNotContact    int `json:"do_not_contact"`
+	Total           int `json:"total"`
+}
+
+// OutreachAccountListResult is a cursor-paginated account list.
+type OutreachAccountListResult struct {
+	Data       []OutreachAccount `json:"data"`
+	Pagination Pagination        `json:"pagination"`
+}
+
+// OutreachImportRunListResult lists recent import runs.
+type OutreachImportRunListResult struct {
+	Data       []OutreachImportRun `json:"data"`
+	Pagination Pagination          `json:"pagination"`
+}

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -56,6 +56,7 @@ type OutreachRepository interface {
 	MarkOutcomeDelivered(ctx context.Context, orgID, id uuid.UUID) error
 	MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, attempts int, next time.Time, lastErr string, dead bool) error
 	GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error)
+	FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error)
 }
 
 // OutreachAccountFilter filters staged accounts.

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -1,0 +1,679 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// OutreachRepository owns multi-tenant staging tables for intelligence feeds.
+// Every query requires organization_id.
+type OutreachRepository interface {
+	// Import runs
+	CreateImportRun(ctx context.Context, run *models.OutreachImportRun) error
+	UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error
+	GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error)
+	GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error)
+	ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error)
+
+	// Accounts
+	GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error)
+	GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error)
+	UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (created bool, err error)
+	ListAccounts(ctx context.Context, orgID uuid.UUID, filter OutreachAccountFilter) ([]models.OutreachAccount, error)
+	CountByQueueState(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, error)
+	SetAccountHumanFlags(ctx context.Context, orgID, id uuid.UUID, blocked, dnc bool, reason, queueState string) error
+
+	// Contacts
+	ListCandidates(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachContactCandidate, error)
+	UpsertCandidate(ctx context.Context, c *models.OutreachContactCandidate) (created bool, err error)
+	GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error)
+
+	// Evidence
+	ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error)
+	UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (created bool, err error)
+}
+
+// OutreachAccountFilter filters staged accounts.
+type OutreachAccountFilter struct {
+	QueueState string
+	CNPJ14     string
+	Search     string
+	Limit      int
+	Offset     int
+}
+
+type outreachRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewOutreachRepository constructs the Postgres-backed outreach staging repo.
+func NewOutreachRepository(db *pgxpool.Pool) OutreachRepository {
+	return &outreachRepository{db: db}
+}
+
+func (r *outreachRepository) CreateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	if run.ID == uuid.Nil {
+		run.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	run.CreatedAt = now
+	run.UpdatedAt = now
+	if run.StartedAt.IsZero() {
+		run.StartedAt = now
+	}
+	counts, _ := json.Marshal(run.Counts)
+	errs, _ := json.Marshal(run.Errors)
+	if errs == nil {
+		errs = []byte("[]")
+	}
+	warns, _ := json.Marshal(run.Warnings)
+	if warns == nil {
+		warns = []byte("[]")
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_import_runs (
+			id, organization_id, source_system, source_run_id, schema_version,
+			snapshot_hash, repo_sha, payload_hash, profile_id, profile_version,
+			status, dry_run, started_at, finished_at, cursor_in, cursor_out,
+			counts, errors, warnings, created_by_user_id, idempotency_key, source_uri,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,
+			$6,$7,$8,$9,$10,
+			$11,$12,$13,$14,$15,$16,
+			$17,$18,$19,$20,$21,$22,
+			$23,$23
+		)`,
+		run.ID, run.OrganizationID, run.SourceSystem, run.SourceRunID, run.SchemaVersion,
+		run.SnapshotHash, run.RepoSHA, run.PayloadHash, run.ProfileID, run.ProfileVersion,
+		run.Status, run.DryRun, run.StartedAt, run.FinishedAt, run.CursorIn, run.CursorOut,
+		counts, errs, warns, run.CreatedByUserID, run.IdempotencyKey, run.SourceURI,
+		now,
+	)
+	return err
+}
+
+func (r *outreachRepository) UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	run.UpdatedAt = time.Now().UTC()
+	counts, _ := json.Marshal(run.Counts)
+	errs, _ := json.Marshal(run.Errors)
+	if errs == nil {
+		errs = []byte("[]")
+	}
+	warns, _ := json.Marshal(run.Warnings)
+	if warns == nil {
+		warns = []byte("[]")
+	}
+	ct, err := r.db.Exec(ctx, `
+		UPDATE outreach_import_runs SET
+			status=$3, finished_at=$4, cursor_out=$5,
+			counts=$6, errors=$7, warnings=$8, updated_at=$9
+		WHERE id=$1 AND organization_id=$2`,
+		run.ID, run.OrganizationID, run.Status, run.FinishedAt, run.CursorOut,
+		counts, errs, warns, run.UpdatedAt,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+func (r *outreachRepository) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error) {
+	row := r.db.QueryRow(ctx, outreachImportRunSelect+`
+		FROM outreach_import_runs WHERE id=$1 AND organization_id=$2`, id, orgID)
+	return scanImportRun(row)
+}
+
+func (r *outreachRepository) GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error) {
+	if key == "" {
+		return nil, nil
+	}
+	row := r.db.QueryRow(ctx, outreachImportRunSelect+`
+		FROM outreach_import_runs WHERE organization_id=$1 AND idempotency_key=$2`, orgID, key)
+	run, err := scanImportRun(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return run, err
+}
+
+func (r *outreachRepository) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	rows, err := r.db.Query(ctx, outreachImportRunSelect+`
+		FROM outreach_import_runs WHERE organization_id=$1
+		ORDER BY started_at DESC LIMIT $2`, orgID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachImportRun
+	for rows.Next() {
+		run, err := scanImportRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *run)
+	}
+	return out, rows.Err()
+}
+
+const outreachImportRunSelect = `
+	SELECT id, organization_id, source_system, source_run_id, schema_version,
+		snapshot_hash, repo_sha, payload_hash, profile_id, profile_version,
+		status, dry_run, started_at, finished_at, COALESCE(cursor_in,''), COALESCE(cursor_out,''),
+		counts, errors, warnings, created_by_user_id, COALESCE(idempotency_key,''), COALESCE(source_uri,''),
+		created_at, updated_at `
+
+type scannable interface {
+	Scan(dest ...any) error
+}
+
+func scanImportRun(row scannable) (*models.OutreachImportRun, error) {
+	var run models.OutreachImportRun
+	var counts, errs, warns []byte
+	err := row.Scan(
+		&run.ID, &run.OrganizationID, &run.SourceSystem, &run.SourceRunID, &run.SchemaVersion,
+		&run.SnapshotHash, &run.RepoSHA, &run.PayloadHash, &run.ProfileID, &run.ProfileVersion,
+		&run.Status, &run.DryRun, &run.StartedAt, &run.FinishedAt, &run.CursorIn, &run.CursorOut,
+		&counts, &errs, &warns, &run.CreatedByUserID, &run.IdempotencyKey, &run.SourceURI,
+		&run.CreatedAt, &run.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal(counts, &run.Counts)
+	_ = json.Unmarshal(errs, &run.Errors)
+	_ = json.Unmarshal(warns, &run.Warnings)
+	return &run, nil
+}
+
+func (r *outreachRepository) GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error) {
+	row := r.db.QueryRow(ctx, outreachAccountSelect+`
+		FROM outreach_accounts WHERE organization_id=$1 AND cnpj14=$2`, orgID, cnpj14)
+	acc, err := scanAccount(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return acc, err
+}
+
+func (r *outreachRepository) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error) {
+	row := r.db.QueryRow(ctx, outreachAccountSelect+`
+		FROM outreach_accounts WHERE organization_id=$1 AND id=$2`, orgID, id)
+	acc, err := scanAccount(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return acc, err
+}
+
+const outreachAccountSelect = `
+	SELECT id, organization_id, COALESCE(source_lead_id,''), cnpj14, COALESCE(cnpj_root,''),
+		COALESCE(razao_social,''), COALESCE(nome_fantasia,''), COALESCE(municipio,''), COALESCE(uf,''), COALESCE(website,''),
+		priority_rank, priority_score, COALESCE(priority_tier,''), COALESCE(priority_confidence,''),
+		COALESCE(moment_code,''), COALESCE(moment_summary,''), moment_observed_at, COALESCE(moment_confidence,''), moment_evidence_ids,
+		COALESCE(service_code,''), COALESCE(service_name,''), COALESCE(entry_offer,''), COALESCE(offer_rationale,''),
+		COALESCE(fact_to_mention,''), COALESCE(question_to_ask,''), COALESCE(cta,''), claims_to_avoid,
+		COALESCE(commercial_state,''), queue_state, human_override, blocked, COALESCE(block_reason,''), do_not_contact,
+		COALESCE(source_system,''), COALESCE(source_run_id,''), last_import_run_id, COALESCE(last_payload_hash,''),
+		contracts_json, created_at, updated_at `
+
+func scanAccount(row scannable) (*models.OutreachAccount, error) {
+	var a models.OutreachAccount
+	var momentEvid, claims []byte
+	var contracts []byte
+	err := row.Scan(
+		&a.ID, &a.OrganizationID, &a.SourceLeadID, &a.CNPJ14, &a.CNPJRoot,
+		&a.RazaoSocial, &a.NomeFantasia, &a.Municipio, &a.UF, &a.Website,
+		&a.PriorityRank, &a.PriorityScore, &a.PriorityTier, &a.PriorityConfidence,
+		&a.MomentCode, &a.MomentSummary, &a.MomentObservedAt, &a.MomentConfidence, &momentEvid,
+		&a.ServiceCode, &a.ServiceName, &a.EntryOffer, &a.OfferRationale,
+		&a.FactToMention, &a.QuestionToAsk, &a.CTA, &claims,
+		&a.CommercialState, &a.QueueState, &a.HumanOverride, &a.Blocked, &a.BlockReason, &a.DoNotContact,
+		&a.SourceSystem, &a.SourceRunID, &a.LastImportRunID, &a.LastPayloadHash,
+		&contracts, &a.CreatedAt, &a.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal(momentEvid, &a.MomentEvidenceIDs)
+	_ = json.Unmarshal(claims, &a.ClaimsToAvoid)
+	a.ContractsJSON = contracts
+	return &a, nil
+}
+
+func (r *outreachRepository) UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (bool, error) {
+	if acc.ID == uuid.Nil {
+		acc.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	acc.UpdatedAt = now
+	if acc.CreatedAt.IsZero() {
+		acc.CreatedAt = now
+	}
+	momentEvid, _ := json.Marshal(acc.MomentEvidenceIDs)
+	if momentEvid == nil {
+		momentEvid = []byte("[]")
+	}
+	claims, _ := json.Marshal(acc.ClaimsToAvoid)
+	if claims == nil {
+		claims = []byte("[]")
+	}
+	contracts := acc.ContractsJSON
+	if len(contracts) == 0 {
+		contracts = []byte("[]")
+	}
+	// Machine fields update; human_override / blocked / dnc preserved when set on existing.
+	var created bool
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO outreach_accounts (
+			id, organization_id, source_lead_id, cnpj14, cnpj_root,
+			razao_social, nome_fantasia, municipio, uf, website,
+			priority_rank, priority_score, priority_tier, priority_confidence,
+			moment_code, moment_summary, moment_observed_at, moment_confidence, moment_evidence_ids,
+			service_code, service_name, entry_offer, offer_rationale,
+			fact_to_mention, question_to_ask, cta, claims_to_avoid,
+			commercial_state, queue_state, human_override, blocked, block_reason, do_not_contact,
+			source_system, source_run_id, last_import_run_id, last_payload_hash, contracts_json,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,
+			$6,$7,$8,$9,$10,
+			$11,$12,$13,$14,
+			$15,$16,$17,$18,$19,
+			$20,$21,$22,$23,
+			$24,$25,$26,$27,
+			$28,$29,$30,$31,$32,$33,
+			$34,$35,$36,$37,$38,
+			$39,$40
+		)
+		ON CONFLICT (organization_id, cnpj14) DO UPDATE SET
+			source_lead_id = EXCLUDED.source_lead_id,
+			cnpj_root = EXCLUDED.cnpj_root,
+			razao_social = CASE WHEN outreach_accounts.human_override THEN outreach_accounts.razao_social ELSE EXCLUDED.razao_social END,
+			nome_fantasia = CASE WHEN outreach_accounts.human_override THEN outreach_accounts.nome_fantasia ELSE EXCLUDED.nome_fantasia END,
+			municipio = EXCLUDED.municipio,
+			uf = EXCLUDED.uf,
+			website = EXCLUDED.website,
+			priority_rank = EXCLUDED.priority_rank,
+			priority_score = EXCLUDED.priority_score,
+			priority_tier = EXCLUDED.priority_tier,
+			priority_confidence = EXCLUDED.priority_confidence,
+			moment_code = EXCLUDED.moment_code,
+			moment_summary = EXCLUDED.moment_summary,
+			moment_observed_at = EXCLUDED.moment_observed_at,
+			moment_confidence = EXCLUDED.moment_confidence,
+			moment_evidence_ids = EXCLUDED.moment_evidence_ids,
+			service_code = EXCLUDED.service_code,
+			service_name = EXCLUDED.service_name,
+			entry_offer = EXCLUDED.entry_offer,
+			offer_rationale = EXCLUDED.offer_rationale,
+			fact_to_mention = EXCLUDED.fact_to_mention,
+			question_to_ask = EXCLUDED.question_to_ask,
+			cta = EXCLUDED.cta,
+			claims_to_avoid = EXCLUDED.claims_to_avoid,
+			commercial_state = EXCLUDED.commercial_state,
+			queue_state = EXCLUDED.queue_state,
+			-- never clear human DNC / block via machine reimport
+			blocked = outreach_accounts.blocked OR EXCLUDED.blocked,
+			block_reason = CASE WHEN outreach_accounts.blocked THEN outreach_accounts.block_reason ELSE EXCLUDED.block_reason END,
+			do_not_contact = outreach_accounts.do_not_contact OR EXCLUDED.do_not_contact,
+			source_system = EXCLUDED.source_system,
+			source_run_id = EXCLUDED.source_run_id,
+			last_import_run_id = EXCLUDED.last_import_run_id,
+			last_payload_hash = EXCLUDED.last_payload_hash,
+			contracts_json = EXCLUDED.contracts_json,
+			updated_at = EXCLUDED.updated_at,
+			id = outreach_accounts.id
+		RETURNING (xmax = 0) AS inserted, id`,
+		acc.ID, acc.OrganizationID, acc.SourceLeadID, acc.CNPJ14, acc.CNPJRoot,
+		acc.RazaoSocial, acc.NomeFantasia, acc.Municipio, acc.UF, acc.Website,
+		acc.PriorityRank, acc.PriorityScore, acc.PriorityTier, acc.PriorityConfidence,
+		acc.MomentCode, acc.MomentSummary, acc.MomentObservedAt, acc.MomentConfidence, momentEvid,
+		acc.ServiceCode, acc.ServiceName, acc.EntryOffer, acc.OfferRationale,
+		acc.FactToMention, acc.QuestionToAsk, acc.CTA, claims,
+		acc.CommercialState, acc.QueueState, acc.HumanOverride, acc.Blocked, acc.BlockReason, acc.DoNotContact,
+		acc.SourceSystem, acc.SourceRunID, acc.LastImportRunID, acc.LastPayloadHash, contracts,
+		acc.CreatedAt, acc.UpdatedAt,
+	).Scan(&created, &acc.ID)
+	return created, err
+}
+
+func (r *outreachRepository) ListAccounts(ctx context.Context, orgID uuid.UUID, filter OutreachAccountFilter) ([]models.OutreachAccount, error) {
+	limit := filter.Limit
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	q := outreachAccountSelect + ` FROM outreach_accounts WHERE organization_id=$1`
+	args := []any{orgID}
+	n := 2
+	if filter.QueueState != "" {
+		q += fmt.Sprintf(` AND queue_state=$%d`, n)
+		args = append(args, filter.QueueState)
+		n++
+	}
+	if filter.CNPJ14 != "" {
+		q += fmt.Sprintf(` AND cnpj14=$%d`, n)
+		args = append(args, filter.CNPJ14)
+		n++
+	}
+	if filter.Search != "" {
+		q += fmt.Sprintf(` AND (razao_social ILIKE $%d OR nome_fantasia ILIKE $%d OR cnpj14 LIKE $%d)`, n, n, n)
+		args = append(args, "%"+filter.Search+"%")
+		n++
+	}
+	q += fmt.Sprintf(` ORDER BY priority_rank ASC NULLS LAST, updated_at DESC LIMIT $%d OFFSET $%d`, n, n+1)
+	args = append(args, limit, offset)
+
+	rows, err := r.db.Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachAccount
+	for rows.Next() {
+		acc, err := scanAccount(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *acc)
+	}
+	return out, rows.Err()
+}
+
+func (r *outreachRepository) CountByQueueState(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT queue_state, COUNT(*)::int
+		FROM outreach_accounts WHERE organization_id=$1
+		GROUP BY queue_state`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	sum := &models.OutreachQueueSummary{}
+	for rows.Next() {
+		var state string
+		var n int
+		if err := rows.Scan(&state, &n); err != nil {
+			return nil, err
+		}
+		sum.Total += n
+		switch state {
+		case models.OutreachQueueNeedsContact:
+			sum.NeedsContact = n
+		case models.OutreachQueueReadyToGenerate:
+			sum.ReadyToGenerate = n
+		case models.OutreachQueueNeedsReview:
+			sum.NeedsReview = n
+		case models.OutreachQueueApproved:
+			sum.Approved = n
+		case models.OutreachQueueEnrolled:
+			sum.Enrolled = n
+		case models.OutreachQueueSent:
+			sum.Sent = n
+		case models.OutreachQueueReplied:
+			sum.Replied = n
+		case models.OutreachQueueMeeting:
+			sum.Meeting = n
+		case models.OutreachQueueProposal:
+			sum.Proposal = n
+		case models.OutreachQueueWon:
+			sum.Won = n
+		case models.OutreachQueueBlocked:
+			sum.Blocked = n
+		case models.OutreachQueueBounced:
+			sum.Bounced = n
+		case models.OutreachQueueDoNotContact:
+			sum.DoNotContact = n
+		}
+	}
+	return sum, rows.Err()
+}
+
+func (r *outreachRepository) SetAccountHumanFlags(ctx context.Context, orgID, id uuid.UUID, blocked, dnc bool, reason, queueState string) error {
+	ct, err := r.db.Exec(ctx, `
+		UPDATE outreach_accounts SET
+			blocked=$3, do_not_contact=$4, block_reason=$5, queue_state=$6,
+			human_override=true, updated_at=now()
+		WHERE organization_id=$1 AND id=$2`,
+		orgID, id, blocked, dnc, reason, queueState,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+func (r *outreachRepository) ListCandidates(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachContactCandidate, error) {
+	rows, err := r.db.Query(ctx, outreachCandidateSelect+`
+		FROM outreach_contact_candidates
+		WHERE organization_id=$1 AND account_id=$2
+		ORDER BY recommended DESC, created_at ASC`, orgID, accountID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachContactCandidate
+	for rows.Next() {
+		c, err := scanCandidate(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *c)
+	}
+	return out, rows.Err()
+}
+
+const outreachCandidateSelect = `
+	SELECT id, organization_id, account_id, COALESCE(source_contact_id,''),
+		COALESCE(name,''), COALESCE(role,''), COALESCE(email,''), COALESCE(phone,''),
+		COALESCE(linkedin_url,''), COALESCE(source_url,''), COALESCE(source_document,''), source_date,
+		verification_status, COALESCE(confidence,''), recommended,
+		warmbly_contact_id, promoted_at, blocked, COALESCE(block_reason,''), do_not_contact, bounced,
+		last_import_run_id, created_at, updated_at `
+
+func scanCandidate(row scannable) (*models.OutreachContactCandidate, error) {
+	var c models.OutreachContactCandidate
+	err := row.Scan(
+		&c.ID, &c.OrganizationID, &c.AccountID, &c.SourceContactID,
+		&c.Name, &c.Role, &c.Email, &c.Phone,
+		&c.LinkedInURL, &c.SourceURL, &c.SourceDocument, &c.SourceDate,
+		&c.VerificationStatus, &c.Confidence, &c.Recommended,
+		&c.WarmblyContactID, &c.PromotedAt, &c.Blocked, &c.BlockReason, &c.DoNotContact, &c.Bounced,
+		&c.LastImportRunID, &c.CreatedAt, &c.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (r *outreachRepository) GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error) {
+	row := r.db.QueryRow(ctx, outreachCandidateSelect+`
+		FROM outreach_contact_candidates WHERE organization_id=$1 AND id=$2`, orgID, id)
+	c, err := scanCandidate(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return c, err
+}
+
+func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.OutreachContactCandidate) (bool, error) {
+	if c.ID == uuid.Nil {
+		c.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	c.UpdatedAt = now
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = now
+	}
+	// Prefer unique (org, account, source_contact_id) when source id present.
+	if c.SourceContactID != "" {
+		var created bool
+		err := r.db.QueryRow(ctx, `
+			INSERT INTO outreach_contact_candidates (
+				id, organization_id, account_id, source_contact_id,
+				name, role, email, phone, linkedin_url, source_url, source_document, source_date,
+				verification_status, confidence, recommended,
+				blocked, block_reason, do_not_contact, bounced,
+				last_import_run_id, created_at, updated_at
+			) VALUES (
+				$1,$2,$3,$4,
+				$5,$6,$7,$8,$9,$10,$11,$12,
+				$13,$14,$15,
+				$16,$17,$18,$19,
+				$20,$21,$22
+			)
+			ON CONFLICT (organization_id, account_id, source_contact_id) WHERE source_contact_id <> '' DO UPDATE SET
+				name = EXCLUDED.name,
+				role = EXCLUDED.role,
+				email = CASE WHEN outreach_contact_candidates.do_not_contact OR outreach_contact_candidates.bounced
+					THEN outreach_contact_candidates.email ELSE EXCLUDED.email END,
+				phone = EXCLUDED.phone,
+				linkedin_url = EXCLUDED.linkedin_url,
+				source_url = EXCLUDED.source_url,
+				source_document = EXCLUDED.source_document,
+				source_date = EXCLUDED.source_date,
+				verification_status = CASE WHEN outreach_contact_candidates.do_not_contact OR outreach_contact_candidates.bounced
+					THEN outreach_contact_candidates.verification_status ELSE EXCLUDED.verification_status END,
+				confidence = EXCLUDED.confidence,
+				recommended = EXCLUDED.recommended,
+				do_not_contact = outreach_contact_candidates.do_not_contact OR EXCLUDED.do_not_contact,
+				bounced = outreach_contact_candidates.bounced OR EXCLUDED.bounced,
+				blocked = outreach_contact_candidates.blocked OR EXCLUDED.blocked,
+				last_import_run_id = EXCLUDED.last_import_run_id,
+				updated_at = EXCLUDED.updated_at,
+				id = outreach_contact_candidates.id
+			RETURNING (xmax = 0), id`,
+			c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
+			c.Name, c.Role, c.Email, c.Phone, c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
+			c.VerificationStatus, c.Confidence, c.Recommended,
+			c.Blocked, c.BlockReason, c.DoNotContact, c.Bounced,
+			c.LastImportRunID, c.CreatedAt, c.UpdatedAt,
+		).Scan(&created, &c.ID)
+		return created, err
+	}
+	// No source id: insert only (cannot safely dedupe).
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_contact_candidates (
+			id, organization_id, account_id, source_contact_id,
+			name, role, email, phone, linkedin_url, source_url, source_document, source_date,
+			verification_status, confidence, recommended,
+			blocked, block_reason, do_not_contact, bounced,
+			last_import_run_id, created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22
+		)`,
+		c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
+		c.Name, c.Role, c.Email, c.Phone, c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
+		c.VerificationStatus, c.Confidence, c.Recommended,
+		c.Blocked, c.BlockReason, c.DoNotContact, c.Bounced,
+		c.LastImportRunID, c.CreatedAt, c.UpdatedAt,
+	)
+	return true, err
+}
+
+func (r *outreachRepository) ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error) {
+	rows, err := r.db.Query(ctx, outreachEvidenceSelect+`
+		FROM outreach_evidence WHERE organization_id=$1 AND account_id=$2
+		ORDER BY evidence_date DESC NULLS LAST, created_at DESC`, orgID, accountID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachEvidence
+	for rows.Next() {
+		e, err := scanEvidence(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *e)
+	}
+	return out, rows.Err()
+}
+
+const outreachEvidenceSelect = `
+	SELECT id, organization_id, account_id, source_evidence_id,
+		COALESCE(evidence_type,''), COALESCE(title,''), COALESCE(url,''), COALESCE(document,''),
+		evidence_date, COALESCE(location,''), COALESCE(excerpt,''), COALESCE(synthesis,''),
+		epistemic_class, COALESCE(reliability,''), consulted_at,
+		last_import_run_id, created_at, updated_at `
+
+func scanEvidence(row scannable) (*models.OutreachEvidence, error) {
+	var e models.OutreachEvidence
+	err := row.Scan(
+		&e.ID, &e.OrganizationID, &e.AccountID, &e.SourceEvidenceID,
+		&e.EvidenceType, &e.Title, &e.URL, &e.Document,
+		&e.EvidenceDate, &e.Location, &e.Excerpt, &e.Synthesis,
+		&e.EpistemicClass, &e.Reliability, &e.ConsultedAt,
+		&e.LastImportRunID, &e.CreatedAt, &e.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *outreachRepository) UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (bool, error) {
+	if e.ID == uuid.Nil {
+		e.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	e.UpdatedAt = now
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = now
+	}
+	var created bool
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO outreach_evidence (
+			id, organization_id, account_id, source_evidence_id,
+			evidence_type, title, url, document, evidence_date, location,
+			excerpt, synthesis, epistemic_class, reliability, consulted_at,
+			last_import_run_id, created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18
+		)
+		ON CONFLICT (organization_id, account_id, source_evidence_id) DO UPDATE SET
+			evidence_type = EXCLUDED.evidence_type,
+			title = EXCLUDED.title,
+			url = EXCLUDED.url,
+			document = EXCLUDED.document,
+			evidence_date = EXCLUDED.evidence_date,
+			location = EXCLUDED.location,
+			excerpt = EXCLUDED.excerpt,
+			synthesis = EXCLUDED.synthesis,
+			epistemic_class = EXCLUDED.epistemic_class,
+			reliability = EXCLUDED.reliability,
+			consulted_at = EXCLUDED.consulted_at,
+			last_import_run_id = EXCLUDED.last_import_run_id,
+			updated_at = EXCLUDED.updated_at,
+			id = outreach_evidence.id
+		RETURNING (xmax = 0), id`,
+		e.ID, e.OrganizationID, e.AccountID, e.SourceEvidenceID,
+		e.EvidenceType, e.Title, e.URL, e.Document, e.EvidenceDate, e.Location,
+		e.Excerpt, e.Synthesis, e.EpistemicClass, e.Reliability, e.ConsultedAt,
+		e.LastImportRunID, e.CreatedAt, e.UpdatedAt,
+	).Scan(&created, &e.ID)
+	return created, err
+}

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -40,6 +40,15 @@ type OutreachRepository interface {
 	// Evidence
 	ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error)
 	UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (created bool, err error)
+
+	// Drafts + org settings (review / enrollment)
+	UpsertDraft(ctx context.Context, d *models.OutreachDraft) error
+	GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error)
+	GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error)
+	ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, error)
+	UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error
+	GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error)
+	UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error
 }
 
 // OutreachAccountFilter filters staged accounts.

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -49,6 +49,13 @@ type OutreachRepository interface {
 	UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error
 	GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error)
 	UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error
+
+	// Outcome outbox
+	EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error
+	ListPendingOutcomes(ctx context.Context, limit int) ([]models.OutreachOutcome, error)
+	MarkOutcomeDelivered(ctx context.Context, orgID, id uuid.UUID) error
+	MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, attempts int, next time.Time, lastErr string, dead bool) error
+	GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error)
 }
 
 // OutreachAccountFilter filters staged accounts.

--- a/internal/repository/pg_outreach_drafts.go
+++ b/internal/repository/pg_outreach_drafts.go
@@ -1,0 +1,257 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Draft methods for OutreachRepository are in this file (same interface extension).
+
+// OutreachDraftRepository is satisfied by outreachRepository.
+type OutreachDraftStore interface {
+	UpsertDraft(ctx context.Context, d *models.OutreachDraft) error
+	GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error)
+	GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error)
+	ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, error)
+	UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error
+	GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error)
+	UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error
+}
+
+func (r *outreachRepository) UpsertDraft(ctx context.Context, d *models.OutreachDraft) error {
+	if d.ID == uuid.Nil {
+		d.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	d.UpdatedAt = now
+	if d.CreatedAt.IsZero() {
+		d.CreatedAt = now
+	}
+	evid, _ := json.Marshal(d.EvidenceIDs)
+	if evid == nil {
+		evid = []byte("[]")
+	}
+	flags, _ := json.Marshal(d.RiskFlags)
+	if flags == nil {
+		flags = []byte("[]")
+	}
+	reasons, _ := json.Marshal(d.RedTeamReasons)
+	if reasons == nil {
+		reasons = []byte("[]")
+	}
+	follow := d.FollowupsJSON
+	if len(follow) == 0 {
+		follow = []byte("[]")
+	}
+	val := d.ValidationJSON
+	if len(val) == 0 {
+		val = []byte("{}")
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_drafts (
+			id, organization_id, account_id, contact_candidate_id,
+			recipient_name, recipient_role, recipient_email, verification_status,
+			subject, body_text, body_html, followups_json,
+			service_code, strategy_code, fact_used, evidence_ids, question, cta,
+			provider, model, prompt_version, generation,
+			validation_json, risk_class, risk_flags, red_team_result, red_team_reasons,
+			status, human_edited, approved_by, approved_at, review_seconds,
+			campaign_id, enrollment_contact_id, enrolled_at,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,
+			$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37
+		)
+		ON CONFLICT (id) DO UPDATE SET
+			contact_candidate_id = EXCLUDED.contact_candidate_id,
+			recipient_name = EXCLUDED.recipient_name,
+			recipient_role = EXCLUDED.recipient_role,
+			recipient_email = EXCLUDED.recipient_email,
+			verification_status = EXCLUDED.verification_status,
+			subject = EXCLUDED.subject,
+			body_text = EXCLUDED.body_text,
+			body_html = EXCLUDED.body_html,
+			followups_json = EXCLUDED.followups_json,
+			service_code = EXCLUDED.service_code,
+			strategy_code = EXCLUDED.strategy_code,
+			fact_used = EXCLUDED.fact_used,
+			evidence_ids = EXCLUDED.evidence_ids,
+			question = EXCLUDED.question,
+			cta = EXCLUDED.cta,
+			provider = EXCLUDED.provider,
+			model = EXCLUDED.model,
+			prompt_version = EXCLUDED.prompt_version,
+			generation = EXCLUDED.generation,
+			validation_json = EXCLUDED.validation_json,
+			risk_class = EXCLUDED.risk_class,
+			risk_flags = EXCLUDED.risk_flags,
+			red_team_result = EXCLUDED.red_team_result,
+			red_team_reasons = EXCLUDED.red_team_reasons,
+			status = EXCLUDED.status,
+			human_edited = EXCLUDED.human_edited,
+			approved_by = EXCLUDED.approved_by,
+			approved_at = EXCLUDED.approved_at,
+			review_seconds = EXCLUDED.review_seconds,
+			campaign_id = EXCLUDED.campaign_id,
+			enrollment_contact_id = EXCLUDED.enrollment_contact_id,
+			enrolled_at = EXCLUDED.enrolled_at,
+			updated_at = EXCLUDED.updated_at
+	`,
+		d.ID, d.OrganizationID, d.AccountID, d.ContactCandidateID,
+		d.RecipientName, d.RecipientRole, d.RecipientEmail, d.VerificationStatus,
+		d.Subject, d.BodyText, d.BodyHTML, follow,
+		d.ServiceCode, d.StrategyCode, d.FactUsed, evid, d.Question, d.CTA,
+		d.Provider, d.Model, d.PromptVersion, d.Generation,
+		val, d.RiskClass, flags, d.RedTeamResult, reasons,
+		d.Status, d.HumanEdited, d.ApprovedBy, d.ApprovedAt, d.ReviewSeconds,
+		d.CampaignID, d.EnrollmentContactID, d.EnrolledAt,
+		d.CreatedAt, d.UpdatedAt,
+	)
+	return err
+}
+
+const outreachDraftSelect = `
+	SELECT id, organization_id, account_id, contact_candidate_id,
+		COALESCE(recipient_name,''), COALESCE(recipient_role,''), COALESCE(recipient_email,''), COALESCE(verification_status,''),
+		COALESCE(subject,''), COALESCE(body_text,''), COALESCE(body_html,''), followups_json,
+		COALESCE(service_code,''), COALESCE(strategy_code,''), COALESCE(fact_used,''), evidence_ids,
+		COALESCE(question,''), COALESCE(cta,''),
+		COALESCE(provider,''), COALESCE(model,''), COALESCE(prompt_version,''), generation,
+		validation_json, risk_class, risk_flags, COALESCE(red_team_result,''), red_team_reasons,
+		status, human_edited, approved_by, approved_at, review_seconds,
+		campaign_id, enrollment_contact_id, enrolled_at,
+		created_at, updated_at `
+
+func scanDraft(row scannable) (*models.OutreachDraft, error) {
+	var d models.OutreachDraft
+	var evid, flags, reasons []byte
+	err := row.Scan(
+		&d.ID, &d.OrganizationID, &d.AccountID, &d.ContactCandidateID,
+		&d.RecipientName, &d.RecipientRole, &d.RecipientEmail, &d.VerificationStatus,
+		&d.Subject, &d.BodyText, &d.BodyHTML, &d.FollowupsJSON,
+		&d.ServiceCode, &d.StrategyCode, &d.FactUsed, &evid,
+		&d.Question, &d.CTA,
+		&d.Provider, &d.Model, &d.PromptVersion, &d.Generation,
+		&d.ValidationJSON, &d.RiskClass, &flags, &d.RedTeamResult, &reasons,
+		&d.Status, &d.HumanEdited, &d.ApprovedBy, &d.ApprovedAt, &d.ReviewSeconds,
+		&d.CampaignID, &d.EnrollmentContactID, &d.EnrolledAt,
+		&d.CreatedAt, &d.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal(evid, &d.EvidenceIDs)
+	_ = json.Unmarshal(flags, &d.RiskFlags)
+	_ = json.Unmarshal(reasons, &d.RedTeamReasons)
+	var val struct {
+		OK bool `json:"ok"`
+	}
+	if json.Unmarshal(d.ValidationJSON, &val) == nil {
+		ok := val.OK
+		d.ValidationOK = &ok
+	}
+	return &d, nil
+}
+
+func (r *outreachRepository) GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error) {
+	row := r.db.QueryRow(ctx, outreachDraftSelect+`
+		FROM outreach_drafts WHERE organization_id=$1 AND id=$2`, orgID, id)
+	d, err := scanDraft(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return d, err
+}
+
+func (r *outreachRepository) GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error) {
+	row := r.db.QueryRow(ctx, outreachDraftSelect+`
+		FROM outreach_drafts
+		WHERE organization_id=$1 AND account_id=$2
+		  AND status IN ('NOT_GENERATED','GENERATING','NEEDS_REVIEW','APPROVED')
+		ORDER BY updated_at DESC LIMIT 1`, orgID, accountID)
+	d, err := scanDraft(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return d, err
+}
+
+func (r *outreachRepository) ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var rows pgx.Rows
+	var err error
+	if status != "" {
+		rows, err = r.db.Query(ctx, outreachDraftSelect+`
+			FROM outreach_drafts WHERE organization_id=$1 AND status=$2
+			ORDER BY updated_at DESC LIMIT $3 OFFSET $4`, orgID, status, limit, offset)
+	} else {
+		rows, err = r.db.Query(ctx, outreachDraftSelect+`
+			FROM outreach_drafts WHERE organization_id=$1
+			ORDER BY updated_at DESC LIMIT $2 OFFSET $3`, orgID, limit, offset)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachDraft
+	for rows.Next() {
+		d, err := scanDraft(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *d)
+	}
+	return out, rows.Err()
+}
+
+func (r *outreachRepository) UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error {
+	return r.UpsertDraft(ctx, d)
+}
+
+func (r *outreachRepository) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT organization_id, campaign_id, COALESCE(campaign_name,''), created_at, updated_at
+		FROM outreach_org_settings WHERE organization_id=$1`, orgID)
+	var s models.OutreachOrgSettings
+	err := row.Scan(&s.OrganizationID, &s.CampaignID, &s.CampaignName, &s.CreatedAt, &s.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (r *outreachRepository) UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error {
+	now := time.Now().UTC()
+	s.UpdatedAt = now
+	if s.CreatedAt.IsZero() {
+		s.CreatedAt = now
+	}
+	if s.CampaignName == "" {
+		s.CampaignName = "CONFENGE | Outreach consultivo inicial"
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_org_settings (organization_id, campaign_id, campaign_name, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5)
+		ON CONFLICT (organization_id) DO UPDATE SET
+			campaign_id = EXCLUDED.campaign_id,
+			campaign_name = EXCLUDED.campaign_name,
+			updated_at = EXCLUDED.updated_at`,
+		s.OrganizationID, s.CampaignID, s.CampaignName, s.CreatedAt, s.UpdatedAt,
+	)
+	return err
+}

--- a/internal/repository/pg_outreach_outcomes.go
+++ b/internal/repository/pg_outreach_outcomes.go
@@ -1,0 +1,119 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func (r *outreachRepository) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
+	if ev.ID == uuid.Nil {
+		ev.ID = uuid.New()
+	}
+	if ev.EventID == uuid.Nil {
+		ev.EventID = uuid.New()
+	}
+	now := time.Now().UTC()
+	ev.CreatedAt = now
+	ev.UpdatedAt = now
+	if ev.OccurredAt.IsZero() {
+		ev.OccurredAt = now
+	}
+	if ev.NextAttemptAt.IsZero() {
+		ev.NextAttemptAt = now
+	}
+	payload := ev.Payload
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_outcome_outbox (
+			id, organization_id, event_id, idempotency_key, source_lead_id, cnpj14,
+			contact_email, event_type, payload, occurred_at, attempts, next_attempt_at,
+			created_at, updated_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,0,$11,$12,$12)`,
+		ev.ID, ev.OrganizationID, ev.EventID, ev.IdempotencyKey, ev.SourceLeadID, ev.CNPJ14,
+		ev.ContactEmail, ev.EventType, payload, ev.OccurredAt, ev.NextAttemptAt, now,
+	)
+	return err
+}
+
+func (r *outreachRepository) ListPendingOutcomes(ctx context.Context, limit int) ([]models.OutreachOutcome, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 50
+	}
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, event_id, idempotency_key, COALESCE(source_lead_id,''), COALESCE(cnpj14,''),
+			COALESCE(contact_email,''), event_type, payload, occurred_at, attempts, next_attempt_at,
+			delivered_at, COALESCE(last_error,''), dead_letter, created_at, updated_at
+		FROM outreach_outcome_outbox
+		WHERE delivered_at IS NULL AND dead_letter = false AND next_attempt_at <= now()
+		ORDER BY next_attempt_at ASC
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachOutcome
+	for rows.Next() {
+		var ev models.OutreachOutcome
+		if err := rows.Scan(
+			&ev.ID, &ev.OrganizationID, &ev.EventID, &ev.IdempotencyKey, &ev.SourceLeadID, &ev.CNPJ14,
+			&ev.ContactEmail, &ev.EventType, &ev.Payload, &ev.OccurredAt, &ev.Attempts, &ev.NextAttemptAt,
+			&ev.DeliveredAt, &ev.LastError, &ev.DeadLetter, &ev.CreatedAt, &ev.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+func (r *outreachRepository) MarkOutcomeDelivered(ctx context.Context, orgID, id uuid.UUID) error {
+	ct, err := r.db.Exec(ctx, `
+		UPDATE outreach_outcome_outbox SET delivered_at=now(), updated_at=now(), last_error=''
+		WHERE organization_id=$1 AND id=$2`, orgID, id)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+func (r *outreachRepository) MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, attempts int, next time.Time, lastErr string, dead bool) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE outreach_outcome_outbox SET
+			attempts=$3, next_attempt_at=$4, last_error=$5, dead_letter=$6, updated_at=now()
+		WHERE organization_id=$1 AND id=$2`,
+		orgID, id, attempts, next, lastErr, dead,
+	)
+	return err
+}
+
+func (r *outreachRepository) GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, event_id, idempotency_key, COALESCE(source_lead_id,''), COALESCE(cnpj14,''),
+			COALESCE(contact_email,''), event_type, payload, occurred_at, attempts, next_attempt_at,
+			delivered_at, COALESCE(last_error,''), dead_letter, created_at, updated_at
+		FROM outreach_outcome_outbox WHERE organization_id=$1 AND idempotency_key=$2`, orgID, key)
+	var ev models.OutreachOutcome
+	err := row.Scan(
+		&ev.ID, &ev.OrganizationID, &ev.EventID, &ev.IdempotencyKey, &ev.SourceLeadID, &ev.CNPJ14,
+		&ev.ContactEmail, &ev.EventType, &ev.Payload, &ev.OccurredAt, &ev.Attempts, &ev.NextAttemptAt,
+		&ev.DeliveredAt, &ev.LastError, &ev.DeadLetter, &ev.CreatedAt, &ev.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}

--- a/internal/repository/pg_outreach_outcomes.go
+++ b/internal/repository/pg_outreach_outcomes.go
@@ -117,3 +117,25 @@ func (r *outreachRepository) GetOutcomeByIdempotency(ctx context.Context, orgID 
 	}
 	return &ev, nil
 }
+
+// FindCandidateByEmail returns the recommended-or-latest candidate for an email in the org,
+// plus its account. Used to attribute replies/bounces back to confenge staging.
+func (r *outreachRepository) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	row := r.db.QueryRow(ctx, outreachCandidateSelect+`
+		FROM outreach_contact_candidates
+		WHERE organization_id=$1 AND lower(email)=lower($2)
+		ORDER BY recommended DESC, updated_at DESC
+		LIMIT 1`, orgID, email)
+	c, err := scanCandidate(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	acc, err := r.GetAccount(ctx, orgID, c.AccountID)
+	if err != nil {
+		return c, nil, err
+	}
+	return c, acc, nil
+}

--- a/site/package.json
+++ b/site/package.json
@@ -22,7 +22,9 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml": "4.3.1"
+      "js-yaml": "4.3.1",
+      "postcss": "8.5.23",
+      "svgo": "^4.0.2"
     }
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -19,5 +19,10 @@
     "motion": "^12.34.0",
     "reading-time": "^1.5.0",
     "tailwindcss": "^4.1.10"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml": "4.3.1"
+    }
   }
 }

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -5,8 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: ^4.3.0
-  svgo: ^4.0.2
+  js-yaml: 4.3.1
 
 importers:
 
@@ -452,105 +451,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -643,79 +626,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -816,28 +786,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1306,8 +1272,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsonc-parser@3.3.1:
@@ -1348,28 +1314,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2084,7 +2046,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.3.0
@@ -2780,7 +2742,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
@@ -3313,7 +3275,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   js-yaml: 4.3.1
+  postcss: 8.5.23
+  svgo: ^4.0.2
 
 importers:
 
@@ -1645,8 +1647,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.20:
-    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prismjs@1.30.0:
@@ -3884,7 +3886,7 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.20:
+  postcss@8.5.23:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -4301,7 +4303,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.20
+      postcss: 8.5.23
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -7,6 +7,8 @@ import {
     useConfengeDrafts,
     useConfengeStatus,
     useConfengeSummary,
+    useBootstrapConfengeCampaign,
+    useEnrollConfengeDraft,
     useGenerateConfengeDraft,
     useReviewConfengeDraft,
 } from "@/lib/api/hooks/app/confenge/useConfenge";
@@ -19,8 +21,11 @@ export default function ConfengePage() {
     const ready = useConfengeAccounts("READY_TO_GENERATE", enabled);
     const needsContact = useConfengeAccounts("NEEDS_CONTACT", enabled);
     const drafts = useConfengeDrafts("NEEDS_REVIEW", enabled);
+    const approved = useConfengeDrafts("APPROVED", enabled);
     const generate = useGenerateConfengeDraft();
     const review = useReviewConfengeDraft();
+    const enroll = useEnrollConfengeDraft();
+    const bootstrap = useBootstrapConfengeCampaign();
 
     const [idx, setIdx] = useState(0);
     const queue = drafts.data ?? [];
@@ -70,7 +75,16 @@ export default function ConfengePage() {
             <PageTopbar
                 eyebrow="CONFENGE"
                 subtitle="Review queue for intelligence-plane leads. Metric: commercial outcomes per human minute."
-            />
+            >
+                <button
+                    type="button"
+                    className="h-7 px-2.5 rounded-md border border-slate-200 text-[12.5px] text-slate-700 hover:bg-slate-50"
+                    disabled={bootstrap.isPending}
+                    onClick={() => bootstrap.mutate()}
+                >
+                    Bootstrap campaign
+                </button>
+            </PageTopbar>
             <div className="flex flex-col gap-4 p-4 md:p-6 max-w-6xl mx-auto w-full">
 
                 <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2">
@@ -138,6 +152,32 @@ export default function ConfengePage() {
                         </ul>
                     </section>
                 </div>
+
+                {(approved.data?.length ?? 0) > 0 && (
+                    <section className="rounded-md border border-slate-200 bg-white">
+                        <div className="px-3 h-10 flex items-center border-b border-slate-200 text-[12.5px] font-medium text-slate-900">
+                            Approved — ready to enroll ({approved.data?.length ?? 0})
+                        </div>
+                        <ul className="divide-y divide-slate-100">
+                            {(approved.data ?? []).map((d) => (
+                                <li key={d.id} className="px-3 py-2 flex items-center justify-between gap-2 text-[12.5px]">
+                                    <div className="min-w-0">
+                                        <div className="font-medium truncate">{d.recipient_email}</div>
+                                        <div className="text-slate-500 truncate">{d.subject}</div>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        className="shrink-0 h-7 px-2 rounded-md bg-sky-600 text-white hover:bg-sky-700"
+                                        disabled={enroll.isPending}
+                                        onClick={() => enroll.mutate(d.id)}
+                                    >
+                                        Enroll
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+                )}
 
                 <section className="rounded-md border border-slate-200 bg-white">
                     <div className="px-3 h-10 flex items-center justify-between border-b border-slate-200">

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -7,6 +7,7 @@ import {
     useConfengeDrafts,
     useConfengeStatus,
     useConfengeSummary,
+    useBatchApproveConfengeDrafts,
     useBootstrapConfengeCampaign,
     useEnrollConfengeDraft,
     useGenerateConfengeDraft,
@@ -26,6 +27,7 @@ export default function ConfengePage() {
     const review = useReviewConfengeDraft();
     const enroll = useEnrollConfengeDraft();
     const bootstrap = useBootstrapConfengeCampaign();
+    const batchApprove = useBatchApproveConfengeDrafts();
 
     const [idx, setIdx] = useState(0);
     const queue = drafts.data ?? [];
@@ -185,6 +187,30 @@ export default function ConfengePage() {
                             Review queue ({queue.length})
                             {current ? ` · ${idx + 1}/${queue.length}` : ""}
                         </span>
+                        {queue.length > 0 && (
+                            <button
+                                type="button"
+                                className="h-7 px-2 rounded-md border border-slate-200 text-[12px] text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+                                disabled={batchApprove.isPending}
+                                title="Only GREEN, validated, enrollable drafts"
+                                onClick={() => {
+                                    const green = queue
+                                        .filter(
+                                            (d) =>
+                                                d.risk_class === "GREEN" &&
+                                                d.validation_ok !== false &&
+                                                d.status === "NEEDS_REVIEW",
+                                        )
+                                        .map((d) => d.id);
+                                    if (green.length === 0) {
+                                        return;
+                                    }
+                                    batchApprove.mutate(green);
+                                }}
+                            >
+                                Batch approve GREEN
+                            </button>
+                        )}
                         {current && (
                             <span
                                 className={

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useMemo, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { Check, Loader2, RefreshCw, SkipForward, X } from "lucide-react";
+import { Page, PageTopbar } from "@/components/layout/Page";
+import {
+    useConfengeAccounts,
+    useConfengeDrafts,
+    useConfengeStatus,
+    useConfengeSummary,
+    useGenerateConfengeDraft,
+    useReviewConfengeDraft,
+} from "@/lib/api/hooks/app/confenge/useConfenge";
+import type { ConfengeDraft } from "@/lib/api/models/app/confenge/Confenge";
+
+export default function ConfengePage() {
+    const status = useConfengeStatus();
+    const enabled = !!status.data?.enabled;
+    const summary = useConfengeSummary(enabled);
+    const ready = useConfengeAccounts("READY_TO_GENERATE", enabled);
+    const needsContact = useConfengeAccounts("NEEDS_CONTACT", enabled);
+    const drafts = useConfengeDrafts("NEEDS_REVIEW", enabled);
+    const generate = useGenerateConfengeDraft();
+    const review = useReviewConfengeDraft();
+
+    const [idx, setIdx] = useState(0);
+    const queue = drafts.data ?? [];
+    const current: ConfengeDraft | undefined = queue[idx];
+
+    const [subject, setSubject] = useState("");
+    const [body, setBody] = useState("");
+
+    useEffect(() => {
+        if (current) {
+            setSubject(current.subject);
+            setBody(current.body_text);
+        }
+    }, [current?.id]);
+
+    const stats = useMemo(() => {
+        const s = summary.data;
+        if (!s) return [];
+        return [
+            { label: "Needs contact", value: s.needs_contact },
+            { label: "Ready", value: s.ready_to_generate },
+            { label: "Review", value: s.needs_review },
+            { label: "Approved", value: s.approved },
+            { label: "Enrolled", value: s.enrolled },
+            { label: "Sent", value: s.sent },
+            { label: "Replied", value: s.replied },
+            { label: "Blocked", value: s.blocked + s.do_not_contact },
+        ];
+    }, [summary.data]);
+
+    if (status.isLoading) {
+        return (
+            <Page>
+                <div className="flex items-center gap-2 text-slate-500 text-[12.5px] p-6">
+                    <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+                </div>
+            </Page>
+        );
+    }
+
+    if (!enabled) {
+        return <Navigate to="/app" replace />;
+    }
+
+    return (
+        <Page>
+            <PageTopbar
+                eyebrow="CONFENGE"
+                subtitle="Review queue for intelligence-plane leads. Metric: commercial outcomes per human minute."
+            />
+            <div className="flex flex-col gap-4 p-4 md:p-6 max-w-6xl mx-auto w-full">
+
+                <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2">
+                    {stats.map((s) => (
+                        <div
+                            key={s.label}
+                            className="rounded-md border border-slate-200 bg-white px-2.5 py-2"
+                        >
+                            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">{s.label}</div>
+                            <div className="text-lg font-semibold text-slate-900 tabular-nums">{s.value}</div>
+                        </div>
+                    ))}
+                </div>
+
+                <div className="grid md:grid-cols-2 gap-4">
+                    <section className="rounded-md border border-slate-200 bg-white">
+                        <div className="px-3 h-10 flex items-center border-b border-slate-200 text-[12.5px] font-medium text-slate-900">
+                            Ready to generate ({ready.data?.length ?? 0})
+                        </div>
+                        <ul className="divide-y divide-slate-100 max-h-64 overflow-auto">
+                            {(ready.data ?? []).map((a) => (
+                                <li key={a.id} className="px-3 py-2 flex items-center justify-between gap-2 text-[12.5px]">
+                                    <div className="min-w-0">
+                                        <div className="font-medium text-slate-900 truncate">
+                                            {a.nome_fantasia || a.razao_social}
+                                        </div>
+                                        <div className="text-slate-500 truncate">
+                                            {a.cnpj14} · {a.municipio}/{a.uf} · {a.service_code}
+                                        </div>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        className="shrink-0 h-7 px-2 rounded-md bg-sky-50 text-sky-700 border border-sky-200 hover:bg-sky-100"
+                                        disabled={generate.isPending}
+                                        onClick={() => generate.mutate({ accountId: a.id })}
+                                    >
+                                        Generate
+                                    </button>
+                                </li>
+                            ))}
+                            {!ready.data?.length && (
+                                <li className="px-3 py-6 text-center text-slate-400 text-[12.5px]">No accounts ready</li>
+                            )}
+                        </ul>
+                    </section>
+
+                    <section className="rounded-md border border-slate-200 bg-white">
+                        <div className="px-3 h-10 flex items-center border-b border-slate-200 text-[12.5px] font-medium text-slate-900">
+                            Needs contact ({needsContact.data?.length ?? 0})
+                        </div>
+                        <ul className="divide-y divide-slate-100 max-h-64 overflow-auto">
+                            {(needsContact.data ?? []).map((a) => (
+                                <li key={a.id} className="px-3 py-2 text-[12.5px]">
+                                    <div className="font-medium text-slate-900 truncate">
+                                        {a.nome_fantasia || a.razao_social}
+                                    </div>
+                                    <div className="text-slate-500 truncate">
+                                        {a.cnpj14} · {a.moment_code || "—"} · {a.fact_to_mention || "no fact"}
+                                    </div>
+                                </li>
+                            ))}
+                            {!needsContact.data?.length && (
+                                <li className="px-3 py-6 text-center text-slate-400 text-[12.5px]">None waiting</li>
+                            )}
+                        </ul>
+                    </section>
+                </div>
+
+                <section className="rounded-md border border-slate-200 bg-white">
+                    <div className="px-3 h-10 flex items-center justify-between border-b border-slate-200">
+                        <span className="text-[12.5px] font-medium text-slate-900">
+                            Review queue ({queue.length})
+                            {current ? ` · ${idx + 1}/${queue.length}` : ""}
+                        </span>
+                        {current && (
+                            <span
+                                className={
+                                    "text-[10px] uppercase tracking-[0.14em] px-1.5 py-0.5 rounded " +
+                                    (current.risk_class === "GREEN"
+                                        ? "bg-emerald-50 text-emerald-700"
+                                        : current.risk_class === "RED"
+                                          ? "bg-rose-50 text-rose-700"
+                                          : "bg-amber-50 text-amber-700")
+                                }
+                            >
+                                {current.risk_class}
+                            </span>
+                        )}
+                    </div>
+
+                    {!current ? (
+                        <div className="px-3 py-10 text-center text-slate-400 text-[12.5px]">
+                            No drafts waiting for review. Generate from ready accounts first.
+                        </div>
+                    ) : (
+                        <div className="p-3 grid md:grid-cols-2 gap-4">
+                            <div className="space-y-2 text-[12.5px]">
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Recipient</div>
+                                    <div className="text-slate-900 font-medium">
+                                        {current.recipient_name || "—"} · {current.recipient_role || "—"}
+                                    </div>
+                                    <div className="text-slate-600">{current.recipient_email}</div>
+                                    <div className="text-slate-500">{current.verification_status}</div>
+                                </div>
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Fact</div>
+                                    <div className="text-slate-800">{current.fact_used || "—"}</div>
+                                </div>
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Service</div>
+                                    <div className="text-slate-800">{current.service_code}</div>
+                                </div>
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Provider</div>
+                                    <div className="text-slate-800">
+                                        {current.provider}/{current.model}
+                                        {current.provider === "template" ? " (fallback, not AI)" : ""}
+                                    </div>
+                                </div>
+                                {!!current.risk_flags?.length && (
+                                    <div>
+                                        <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Flags</div>
+                                        <div className="text-slate-600">{current.risk_flags.join(", ")}</div>
+                                    </div>
+                                )}
+                            </div>
+
+                            <div className="space-y-2">
+                                <label className="block text-[10px] uppercase tracking-[0.14em] text-slate-500">
+                                    Subject
+                                    <input
+                                        className="mt-1 w-full h-7 rounded-md border border-slate-200 px-2 text-[12.5px] text-slate-900 focus:border-sky-400 focus:ring-1 focus:ring-sky-100 outline-none"
+                                        value={subject}
+                                        onChange={(e) => setSubject(e.target.value)}
+                                    />
+                                </label>
+                                <label className="block text-[10px] uppercase tracking-[0.14em] text-slate-500">
+                                    Message
+                                    <textarea
+                                        className="mt-1 w-full min-h-[160px] rounded-md border border-slate-200 px-2 py-1.5 text-[12.5px] text-slate-900 focus:border-sky-400 focus:ring-1 focus:ring-sky-100 outline-none font-sans"
+                                        value={body}
+                                        onChange={(e) => setBody(e.target.value)}
+                                    />
+                                </label>
+
+                                <div className="flex flex-wrap gap-1.5 pt-1">
+                                    <ActionBtn
+                                        icon={<Check className="h-3.5 w-3.5" />}
+                                        label="Approve"
+                                        accent
+                                        disabled={review.isPending}
+                                        onClick={() =>
+                                            review.mutate(
+                                                {
+                                                    id: current.id,
+                                                    action: "edit",
+                                                    subject,
+                                                    body_text: body,
+                                                },
+                                                {
+                                                    onSuccess: () =>
+                                                        review.mutate({ id: current.id, action: "approve" }),
+                                                },
+                                            )
+                                        }
+                                    />
+                                    <ActionBtn
+                                        icon={<RefreshCw className="h-3.5 w-3.5" />}
+                                        label="Save edit"
+                                        disabled={review.isPending}
+                                        onClick={() =>
+                                            review.mutate({
+                                                id: current.id,
+                                                action: "edit",
+                                                subject,
+                                                body_text: body,
+                                            })
+                                        }
+                                    />
+                                    <ActionBtn
+                                        icon={<SkipForward className="h-3.5 w-3.5" />}
+                                        label="Skip"
+                                        disabled={review.isPending}
+                                        onClick={() => {
+                                            review.mutate({ id: current.id, action: "skip" });
+                                            setIdx((i) => Math.min(i, Math.max(0, queue.length - 2)));
+                                        }}
+                                    />
+                                    <ActionBtn
+                                        icon={<X className="h-3.5 w-3.5" />}
+                                        label="Block"
+                                        danger
+                                        disabled={review.isPending}
+                                        onClick={() =>
+                                            review.mutate({
+                                                id: current.id,
+                                                action: "block",
+                                                do_not_contact: false,
+                                            })
+                                        }
+                                    />
+                                </div>
+                                <p className="text-[11px] text-slate-400">
+                                    Shortcuts later: A approve · S skip · E edit focus. Auto-send stays off.
+                                </p>
+                            </div>
+                        </div>
+                    )}
+                </section>
+            </div>
+        </Page>
+    );
+}
+
+function ActionBtn({
+    icon,
+    label,
+    onClick,
+    disabled,
+    accent,
+    danger,
+}: {
+    icon: React.ReactNode;
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+    accent?: boolean;
+    danger?: boolean;
+}) {
+    const cls = accent
+        ? "bg-sky-600 text-white border-sky-600 hover:bg-sky-700"
+        : danger
+          ? "bg-white text-rose-700 border-rose-200 hover:bg-rose-50"
+          : "bg-white text-slate-700 border-slate-200 hover:bg-slate-50";
+    return (
+        <button
+            type="button"
+            disabled={disabled}
+            onClick={onClick}
+            className={`h-7 px-2.5 inline-flex items-center gap-1 rounded-md border text-[12.5px] disabled:opacity-50 ${cls}`}
+        >
+            {icon}
+            {label}
+        </button>
+    );
+}

--- a/web/src/components/layout/AppNav.tsx
+++ b/web/src/components/layout/AppNav.tsx
@@ -17,6 +17,7 @@ import {
     FlameIcon,
     GitBranchIcon,
     InboxIcon,
+    Building2Icon,
     KeyIcon,
     ListChecksIcon,
     type LucideIcon,
@@ -48,6 +49,7 @@ import useTemplates from "@/lib/api/hooks/app/templates/useTemplates";
 import useUsageOverview from "@/lib/api/hooks/app/analytics/useUsageOverview";
 import useDashboard from "@/lib/api/hooks/app/analytics/useDashboard";
 import mailboxDisplayStatus from "@/lib/mailboxStatus";
+import { useConfengeStatus } from "@/lib/api/hooks/app/confenge/useConfenge";
 import useAPIKeys from "@/lib/api/hooks/app/api-keys/useAPIKeys";
 import useIntegrationConnections from "@/lib/api/hooks/app/integrations/useIntegrationConnections";
 import AnimatedNumber from "@/components/ui/AnimatedNumber";
@@ -102,6 +104,8 @@ interface NavItem {
         | "analytics"
         | "apikeys"
         | "integrations";
+    /** Optional server feature flag; currently only "confenge". */
+    featureFlag?: "confenge";
 }
 
 // Plan badge shown on locked sidebar rows. Plan names + colors come
@@ -139,6 +143,7 @@ const sections: NavSection[] = [
             { title: "Accounts", url: "/app/emails", icon: MailIcon, indicator: "accounts", advisorSurface: "emails", permission: "MANAGE_EMAILS", permissionLabel: "Manage mailboxes" },
             { title: "Campaigns", url: "/app/campaigns", icon: MegaphoneIcon, indicator: "campaigns", advisorSurface: "campaigns", permission: "VIEW_CAMPAIGNS", permissionLabel: "View campaigns" },
             { title: "Contacts", url: "/app/contacts", icon: UsersIcon, indicator: "contacts", advisorSurface: "contacts", permission: "VIEW_CONTACTS", permissionLabel: "View contacts" },
+            { title: "CONFENGE", url: "/app/confenge", icon: Building2Icon, permission: "VIEW_CONTACTS", permissionLabel: "View contacts", featureFlag: "confenge" },
             { title: "Analytics", url: "/app/analytics", icon: BarChart3Icon, indicator: "analytics", permission: "VIEW_ANALYTICS", permissionLabel: "View analytics" },
             { title: "Deliverability", url: "/app/deliverability", icon: ShieldCheckIcon, advisorSurface: "deliverability", permission: "VIEW_ANALYTICS", permissionLabel: "View analytics" },
         ],
@@ -169,10 +174,14 @@ function NavRow({ item }: { item: NavItem }) {
     const unseen = useAppStore((s) => s.unseenCount);
     const access = useFeatureAccess();
     const hasItemPermission = usePermission(item.permission ?? "VIEW_CAMPAIGNS");
+    const confengeStatus = useConfengeStatus();
     const [deniedOpen, setDeniedOpen] = useState(false);
     const active =
         pathname === item.url || pathname.startsWith(item.url + "/");
     const badge = item.badgeStoreKey === "unseenCount" ? unseen : undefined;
+
+    // Feature-flagged rows (CONFENGE) only appear when the backend flag is on.
+    if (item.featureFlag === "confenge" && !confengeStatus.data?.enabled) return null;
 
     // Role-gated items disappear from the sidebar for users that
     // can't access them, instead of showing a lock — these are

--- a/web/src/hooks/useRealtimeEvents.ts
+++ b/web/src/hooks/useRealtimeEvents.ts
@@ -322,6 +322,8 @@ export function useRealtimeEvents() {
           // or a teammate applying/snoozing/dismissing one. Refreshes every
           // strip and every nav badge at once.
           advisor_finding: [['advisor']],
+          outreach_import_run: [['confenge']],
+          outreach_account: [['confenge']],
           settings: [['organizations', 'current']],
           unibox: [['unibox']],
           crm_note: [['crm'], ['contacts']],

--- a/web/src/lib/api/client/app/confenge/confenge.ts
+++ b/web/src/lib/api/client/app/confenge/confenge.ts
@@ -88,3 +88,23 @@ export async function reviewConfengeDraft(
     });
     return res.data;
 }
+
+export async function enrollConfengeDraft(id: string): Promise<ConfengeDraft> {
+    const res = await Request<{ data: ConfengeDraft }>({
+        method: "POST",
+        url: `/confenge/drafts/${id}/enroll`,
+        authorization: true,
+        data: {},
+    });
+    return res.data;
+}
+
+export async function bootstrapConfengeCampaign(): Promise<{ id: string; name: string }> {
+    const res = await Request<{ data: { id: string; name: string } }>({
+        method: "POST",
+        url: "/confenge/campaign/bootstrap",
+        authorization: true,
+        data: {},
+    });
+    return res.data;
+}

--- a/web/src/lib/api/client/app/confenge/confenge.ts
+++ b/web/src/lib/api/client/app/confenge/confenge.ts
@@ -108,3 +108,18 @@ export async function bootstrapConfengeCampaign(): Promise<{ id: string; name: s
     });
     return res.data;
 }
+
+export async function batchApproveConfengeDrafts(draftIds: string[]): Promise<{
+    approved: string[];
+    skipped: { id: string; reason: string }[];
+}> {
+    const res = await Request<{
+        data: { approved: string[]; skipped: { id: string; reason: string }[] };
+    }>({
+        method: "POST",
+        url: "/confenge/drafts/batch-approve",
+        authorization: true,
+        data: { draft_ids: draftIds },
+    });
+    return res.data;
+}

--- a/web/src/lib/api/client/app/confenge/confenge.ts
+++ b/web/src/lib/api/client/app/confenge/confenge.ts
@@ -1,0 +1,90 @@
+import type {
+    ConfengeAccount,
+    ConfengeDraft,
+    ConfengeStatus,
+    ConfengeSummary,
+} from "@/lib/api/models/app/confenge/Confenge";
+import Request from "../../Request";
+
+export async function getConfengeStatus(): Promise<ConfengeStatus> {
+    return await Request<ConfengeStatus>({
+        method: "GET",
+        url: "/confenge/status",
+        authorization: true,
+    });
+}
+
+export async function getConfengeSummary(): Promise<ConfengeSummary> {
+    const res = await Request<{ data: ConfengeSummary }>({
+        method: "GET",
+        url: "/confenge/summary",
+        authorization: true,
+    });
+    return res.data;
+}
+
+export async function listConfengeAccounts(params?: {
+    queue_state?: string;
+    q?: string;
+    limit?: number;
+}): Promise<ConfengeAccount[]> {
+    const sp = new URLSearchParams();
+    if (params?.queue_state) sp.set("queue_state", params.queue_state);
+    if (params?.q) sp.set("q", params.q);
+    if (params?.limit) sp.set("limit", String(params.limit));
+    const qs = sp.toString();
+    const res = await Request<{ data: ConfengeAccount[] }>({
+        method: "GET",
+        url: `/confenge/accounts${qs ? `?${qs}` : ""}`,
+        authorization: true,
+    });
+    return res.data ?? [];
+}
+
+export async function getConfengeAccount(id: string): Promise<ConfengeAccount> {
+    const res = await Request<{ data: ConfengeAccount }>({
+        method: "GET",
+        url: `/confenge/accounts/${id}`,
+        authorization: true,
+    });
+    return res.data;
+}
+
+export async function generateConfengeDraft(accountId: string, contactCandidateId?: string): Promise<ConfengeDraft> {
+    const res = await Request<{ data: ConfengeDraft }>({
+        method: "POST",
+        url: `/confenge/accounts/${accountId}/generate`,
+        authorization: true,
+        data: contactCandidateId ? { contact_candidate_id: contactCandidateId } : {},
+    });
+    return res.data;
+}
+
+export async function listConfengeDrafts(status?: string): Promise<ConfengeDraft[]> {
+    const qs = status ? `?status=${encodeURIComponent(status)}` : "";
+    const res = await Request<{ data: ConfengeDraft[] }>({
+        method: "GET",
+        url: `/confenge/drafts${qs}`,
+        authorization: true,
+    });
+    return res.data ?? [];
+}
+
+export async function reviewConfengeDraft(
+    id: string,
+    body: {
+        action: "approve" | "reject" | "skip" | "edit" | "block";
+        subject?: string;
+        body_text?: string;
+        reason?: string;
+        do_not_contact?: boolean;
+    },
+): Promise<ConfengeDraft> {
+    const res = await Request<{ data: ConfengeDraft }>({
+        method: "POST",
+        url: `/confenge/drafts/${id}/review`,
+        authorization: true,
+        data: body,
+    });
+    return res.data;
+}

--- a/web/src/lib/api/hooks/app/confenge/useConfenge.ts
+++ b/web/src/lib/api/hooks/app/confenge/useConfenge.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import {
+    bootstrapConfengeCampaign,
+    enrollConfengeDraft,
     generateConfengeDraft,
     getConfengeAccount,
     getConfengeStatus,
@@ -82,5 +84,25 @@ export function useReviewConfengeDraft() {
             toast.success(`Draft ${vars.action}d`);
         },
         onError: (e: Error) => toast.error(e.message || "Review failed"),
+    });
+}
+
+export function useEnrollConfengeDraft() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (id: string) => enrollConfengeDraft(id),
+        onSuccess: () => {
+            void qc.invalidateQueries({ queryKey: KEY });
+            toast.success("Enrolled in CONFENGE campaign");
+        },
+        onError: (e: Error) => toast.error(e.message || "Enroll failed"),
+    });
+}
+
+export function useBootstrapConfengeCampaign() {
+    return useMutation({
+        mutationFn: () => bootstrapConfengeCampaign(),
+        onSuccess: (c) => toast.success(`Campaign ready: ${c.name}`),
+        onError: (e: Error) => toast.error(e.message || "Bootstrap failed"),
     });
 }

--- a/web/src/lib/api/hooks/app/confenge/useConfenge.ts
+++ b/web/src/lib/api/hooks/app/confenge/useConfenge.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import {
+    batchApproveConfengeDrafts,
     bootstrapConfengeCampaign,
     enrollConfengeDraft,
     generateConfengeDraft,
@@ -104,5 +105,17 @@ export function useBootstrapConfengeCampaign() {
         mutationFn: () => bootstrapConfengeCampaign(),
         onSuccess: (c) => toast.success(`Campaign ready: ${c.name}`),
         onError: (e: Error) => toast.error(e.message || "Bootstrap failed"),
+    });
+}
+
+export function useBatchApproveConfengeDrafts() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (ids: string[]) => batchApproveConfengeDrafts(ids),
+        onSuccess: (res) => {
+            void qc.invalidateQueries({ queryKey: KEY });
+            toast.success(`Approved ${res.approved?.length ?? 0}, skipped ${res.skipped?.length ?? 0}`);
+        },
+        onError: (e: Error) => toast.error(e.message || "Batch approve failed"),
     });
 }

--- a/web/src/lib/api/hooks/app/confenge/useConfenge.ts
+++ b/web/src/lib/api/hooks/app/confenge/useConfenge.ts
@@ -1,0 +1,86 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import {
+    generateConfengeDraft,
+    getConfengeAccount,
+    getConfengeStatus,
+    getConfengeSummary,
+    listConfengeAccounts,
+    listConfengeDrafts,
+    reviewConfengeDraft,
+} from "@/lib/api/client/app/confenge/confenge";
+
+const KEY = ["confenge"] as const;
+
+export function useConfengeStatus() {
+    return useQuery({
+        queryKey: [...KEY, "status"],
+        queryFn: getConfengeStatus,
+        staleTime: 60_000,
+    });
+}
+
+export function useConfengeSummary(enabled = true) {
+    return useQuery({
+        queryKey: [...KEY, "summary"],
+        queryFn: getConfengeSummary,
+        enabled,
+        staleTime: 15_000,
+    });
+}
+
+export function useConfengeAccounts(queueState?: string, enabled = true) {
+    return useQuery({
+        queryKey: [...KEY, "accounts", queueState ?? ""],
+        queryFn: () => listConfengeAccounts({ queue_state: queueState, limit: 100 }),
+        enabled,
+    });
+}
+
+export function useConfengeAccount(id: string | null) {
+    return useQuery({
+        queryKey: [...KEY, "account", id],
+        queryFn: () => getConfengeAccount(id!),
+        enabled: !!id,
+    });
+}
+
+export function useConfengeDrafts(status?: string, enabled = true) {
+    return useQuery({
+        queryKey: [...KEY, "drafts", status ?? ""],
+        queryFn: () => listConfengeDrafts(status),
+        enabled,
+    });
+}
+
+export function useGenerateConfengeDraft() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: ({ accountId, contactId }: { accountId: string; contactId?: string }) =>
+            generateConfengeDraft(accountId, contactId),
+        onSuccess: () => {
+            void qc.invalidateQueries({ queryKey: KEY });
+            toast.success("Draft generated");
+        },
+        onError: (e: Error) => toast.error(e.message || "Generate failed"),
+    });
+}
+
+export function useReviewConfengeDraft() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (args: {
+            id: string;
+            action: "approve" | "reject" | "skip" | "edit" | "block";
+            subject?: string;
+            body_text?: string;
+            reason?: string;
+            do_not_contact?: boolean;
+        }) => reviewConfengeDraft(args.id, args),
+        onSuccess: (_d, vars) => {
+            void qc.invalidateQueries({ queryKey: KEY });
+            toast.success(`Draft ${vars.action}d`);
+        },
+        onError: (e: Error) => toast.error(e.message || "Review failed"),
+    });
+}

--- a/web/src/lib/api/models/app/confenge/Confenge.ts
+++ b/web/src/lib/api/models/app/confenge/Confenge.ts
@@ -1,0 +1,99 @@
+export type ConfengeStatus = {
+    enabled: boolean;
+    auto_send_enabled: boolean;
+    require_human_approval: boolean;
+    default_daily_limit: number;
+    max_initial_email_words: number;
+    feed_configured: boolean;
+};
+
+export type ConfengeSummary = {
+    needs_contact: number;
+    ready_to_generate: number;
+    needs_review: number;
+    approved: number;
+    enrolled: number;
+    sent: number;
+    replied: number;
+    meeting: number;
+    proposal: number;
+    won: number;
+    blocked: number;
+    bounced: number;
+    do_not_contact: number;
+    total: number;
+};
+
+export type ConfengeAccount = {
+    id: string;
+    organization_id: string;
+    source_lead_id: string;
+    cnpj14: string;
+    cnpj_root: string;
+    razao_social: string;
+    nome_fantasia: string;
+    municipio: string;
+    uf: string;
+    website: string;
+    priority_rank: number;
+    priority_score: number;
+    priority_tier: string;
+    moment_code: string;
+    moment_summary: string;
+    service_code: string;
+    service_name: string;
+    entry_offer: string;
+    fact_to_mention: string;
+    question_to_ask: string;
+    cta: string;
+    commercial_state: string;
+    queue_state: string;
+    blocked: boolean;
+    do_not_contact: boolean;
+    contacts?: ConfengeContact[];
+    evidence?: ConfengeEvidence[];
+};
+
+export type ConfengeContact = {
+    id: string;
+    name: string;
+    role: string;
+    email: string;
+    verification_status: string;
+    recommended: boolean;
+    do_not_contact: boolean;
+    bounced: boolean;
+};
+
+export type ConfengeEvidence = {
+    id: string;
+    source_evidence_id: string;
+    title: string;
+    url: string;
+    excerpt: string;
+    synthesis: string;
+    epistemic_class: string;
+};
+
+export type ConfengeDraft = {
+    id: string;
+    account_id: string;
+    recipient_name: string;
+    recipient_role: string;
+    recipient_email: string;
+    verification_status: string;
+    subject: string;
+    body_text: string;
+    service_code: string;
+    fact_used: string;
+    evidence_ids?: string[];
+    question: string;
+    cta: string;
+    provider: string;
+    model: string;
+    risk_class: string;
+    risk_flags?: string[];
+    status: string;
+    human_edited: boolean;
+    validation_ok?: boolean;
+};

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -50,6 +50,7 @@ import ReferralSettingsPage from './app/app/settings/referral/page';
 import LimitsSettingsPage from './app/app/settings/limits/page';
 import RolesSettingsPage from './app/app/settings/roles/page';
 import UniboxPage from './app/app/unibox/page';
+import ConfengePage from './app/app/confenge/page';
 import DashboardNotFound from './app/app/not-found';
 import NotFound from './app/not-found';
 
@@ -217,6 +218,10 @@ const router = createBrowserRouter([
           {
             path: "contacts",
             element: <ContactsPage />,
+          },
+          {
+            path: "confenge",
+            element: <ConfengePage />,
           },
           {
             path: "campaigns",


### PR DESCRIPTION
## Summary

Full CONFENGE stack (all three logical PRs) for CI against `main`.

Includes:

1. **Import / staging** — `confenge.outreach.v1`, legacy adapter, multi-tenant staging, dry-run, idempotency
2. **Review** — drafts, validators, risk class, AI/template generation, dashboard `/app/confenge`
3. **Ops** — campaign bootstrap + enroll, outcome outbox + HMAC worker, reply/bounce hooks, CRM pipeline bootstrap, reply-class → task/deal mapping (never auto-WON)

Feature flag: `CONFENGE_OUTREACH_ENABLED=false` by default.

## Test plan

- [x] `go test ./internal/app/confenge/ -count=1`
- [x] `make lint`
- [x] `go test ./cmd/backend/ ./cmd/consumer/ -count=0`
- [ ] GitHub Actions Go CI + Web CI on this PR

## Stacked review PRs (same commits, for review granularity)

- Import only: #3
- Review: #1 (base import)
- Ops: #2 (base review)

## External blockers

See `docs/confenge/external-blockers.md` (upstream Actions approval, Netcup inventory, M365 OAuth smoke, extra-cli receptor).