### PR TITLE
feat(channels): add policy-gated WhatsApp transport via Evolution API

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -85,6 +85,8 @@ import (
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/app/warmupcontent"
 	"github.com/warmbly/warmbly/internal/app/webhook"
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+	"github.com/warmbly/warmbly/internal/app/whatsapp/evolution"
 	"github.com/warmbly/warmbly/internal/app/worker"
 	"github.com/warmbly/warmbly/internal/app/worker_orchestrator"
 	"github.com/warmbly/warmbly/internal/config"
@@ -177,6 +179,8 @@ func main() {
 	var tagService group.GroupService
 	var categoryService group.GroupService
 	var crmService crm.CRMService
+	var whatsAppService *whatsapp.Service
+	var whatsAppRepo repository.WhatsAppRepository
 	var teamService team.TeamService
 	var apiKeyService apikey.APIKeyService
 	var idempotencyService idempotencyapp.Service
@@ -976,6 +980,33 @@ func main() {
 
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)
+
+		// WhatsApp channel (Evolution gateway). Disabled by default; Cloud API first.
+		waCfg := whatsapp.LoadConfig()
+		if err := waCfg.ValidateStartup(); err != nil {
+			log.Fatalf("whatsapp config: %v", err)
+		}
+		whatsapp.LogBaileysWarning(waCfg)
+		whatsAppRepo = repository.NewWhatsAppRepository(primaryDB.Pool)
+		var waProvider whatsapp.Provider
+		if waCfg.Enabled && (waCfg.Provider == whatsapp.ProviderEvolution || waCfg.Provider == "") {
+			evoClient := evolution.NewClient(evolution.ClientConfig{
+				BaseURL:    waCfg.EvolutionBaseURL,
+				APIKey:     waCfg.EvolutionAPIKey,
+				Timeout:    20 * time.Second,
+				MaxRetries: 2,
+			})
+			waProvider = evolution.NewProvider(evoClient, waCfg.EvolutionInstance)
+		}
+		if waCfg.Enabled && waCfg.Provider == whatsapp.ProviderMock {
+			waProvider = whatsapp.NewMockProvider()
+		}
+		// Template approval checked via Static catalog + DB lookups at send sites.
+		// Full repo-backed catalog is used by confenge orchestration (W2).
+		whatsAppService = whatsapp.NewService(waCfg, waProvider, whatsapp.NewStaticTemplateCatalog())
+		if waCfg.Enabled {
+			log.Printf("whatsapp channel enabled provider=%s baileys_allowed=%v auto_send=%v", waCfg.Provider, waCfg.AllowBaileys, waCfg.AutoSendEnabled)
+		}
 		teamRepository := repository.NewTeamRepository(primaryDB.Pool)
 		teamService = team.NewService(teamRepository)
 		socketService = socket.NewService(cache, tokenService)
@@ -1403,6 +1434,10 @@ func main() {
 
 		// CRM
 		CRMService: crmService,
+
+		// WhatsApp channel
+		WhatsAppService: whatsAppService,
+		WhatsAppRepo:    whatsAppRepo,
 
 		// Teams
 		TeamService: teamService,

--- a/deploy/config/env.example
+++ b/deploy/config/env.example
@@ -170,3 +170,20 @@ CHECK_ORIGIN=false
 # === Observability ===
 # Optional in dev; REQUIRED (fatal at boot) on every Go service when APP_ENV=prod.
 # SENTRY_DSN=
+
+# === WhatsApp channel (Evolution gateway; optional) ===
+# All defaults keep the channel fully off. Cloud API is the production path.
+# Baileys is lab-only and rejected when APP_ENV=production.
+# CONFENGE_WHATSAPP_ENABLED=false
+# CONFENGE_WHATSAPP_AUTO_SEND_ENABLED=false
+# CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED=false
+# WHATSAPP_PROVIDER=evolution
+# WHATSAPP_EVOLUTION_BASE_URL=http://127.0.0.1:8089
+# WHATSAPP_EVOLUTION_API_KEY=
+# WHATSAPP_EVOLUTION_INSTANCE=
+# WHATSAPP_EVOLUTION_ALLOW_BAILEYS=false
+# WHATSAPP_WEBHOOK_SECRET=
+# CONFENGE_CROSS_CHANNEL_MIN_INTERVAL_HOURS=24
+# WHATSAPP_SERVICE_WINDOW_HOURS=24
+# WHATSAPP_MAX_WEBHOOK_BYTES=1048576
+# See docs/confenge/whatsapp-channel.md and docs/confenge/evolution-api-compliance.md

--- a/deploy/evolution/.env.example
+++ b/deploy/evolution/.env.example
@@ -1,0 +1,14 @@
+# Evolution API isolated stack (project: evolution-confenge)
+# Copy to .env and fill secrets. Never commit real values.
+
+EVOLUTION_API_KEY=change-me-long-random
+EVOLUTION_DB_NAME=evolution
+EVOLUTION_DB_USER=evolution
+EVOLUTION_DB_PASSWORD=change-me-db-password
+EVOLUTION_SERVER_URL=http://127.0.0.1:8089
+EVOLUTION_HOST_BIND=127.0.0.1
+EVOLUTION_HOST_PORT=8089
+EVOLUTION_LOG_LEVEL=ERROR,WARN,INFO
+
+# Image pin (documented; compose hardcodes 2.3.7):
+# evoapicloud/evolution-api:2.3.7

--- a/deploy/evolution/docker-compose.yml
+++ b/deploy/evolution/docker-compose.yml
@@ -1,0 +1,122 @@
+# Isolated Evolution API stack for CONFENGE WhatsApp transport.
+# Project name: evolution-confenge
+# Does NOT share Postgres/Redis with Warmbly or extra-cli.
+#
+# Pin: Evolution API v2.3.7 (stable). Do not deploy 2.4.0-rc to production.
+# Image: evoapicloud/evolution-api:2.3.7
+#
+# Usage:
+#   cp .env.example .env   # fill secrets
+#   docker compose -p evolution-confenge --env-file .env up -d
+#
+# Network: keep Evolution on a private network. Warmbly reaches it privately;
+# public ingress should hit Warmbly's webhook, not Evolution Manager.
+
+name: evolution-confenge
+
+services:
+  evolution-postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${EVOLUTION_DB_NAME:-evolution}
+      POSTGRES_USER: ${EVOLUTION_DB_USER:-evolution}
+      POSTGRES_PASSWORD: ${EVOLUTION_DB_PASSWORD:?set EVOLUTION_DB_PASSWORD}
+    volumes:
+      - evolution_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${EVOLUTION_DB_USER:-evolution} -d ${EVOLUTION_DB_NAME:-evolution}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - evolution_net
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  evolution-redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes", "--maxmemory", "128mb", "--maxmemory-policy", "allkeys-lru"]
+    volumes:
+      - evolution_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+    networks:
+      - evolution_net
+    deploy:
+      resources:
+        limits:
+          memory: 192M
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "3"
+
+  evolution-api:
+    # Stable pin — not a release candidate.
+    image: evoapicloud/evolution-api:2.3.7
+    restart: unless-stopped
+    depends_on:
+      evolution-postgres:
+        condition: service_healthy
+      evolution-redis:
+        condition: service_healthy
+    environment:
+      SERVER_URL: ${EVOLUTION_SERVER_URL:-http://evolution-api:8080}
+      AUTHENTICATION_API_KEY: ${EVOLUTION_API_KEY:?set EVOLUTION_API_KEY}
+      DATABASE_ENABLED: "true"
+      DATABASE_PROVIDER: postgresql
+      DATABASE_CONNECTION_URI: postgresql://${EVOLUTION_DB_USER:-evolution}:${EVOLUTION_DB_PASSWORD}@evolution-postgres:5432/${EVOLUTION_DB_NAME:-evolution}?schema=public
+      CACHE_REDIS_ENABLED: "true"
+      CACHE_REDIS_URI: redis://evolution-redis:6379
+      CACHE_REDIS_PREFIX_KEY: evolution
+      # Production path: WhatsApp Business / Cloud API.
+      # Do not enable Baileys for production CONFENGE traffic.
+      LOG_LEVEL: ${EVOLUTION_LOG_LEVEL:-ERROR,WARN,INFO}
+      DEL_INSTANCE: "false"
+    # Bind only on loopback / private interface in production via reverse proxy.
+    # Default: no public publish; attach Warmbly network externally if needed.
+    ports:
+      - "${EVOLUTION_HOST_BIND:-127.0.0.1}:${EVOLUTION_HOST_PORT:-8089}:8080"
+    volumes:
+      - evolution_instances:/evolution/instances
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+    networks:
+      - evolution_net
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "5"
+
+volumes:
+  evolution_pg_data:
+  evolution_redis_data:
+  evolution_instances:
+
+networks:
+  evolution_net:
+    name: evolution_confenge_net
+    driver: bridge
+    internal: false

--- a/docs/confenge/evolution-api-compliance.md
+++ b/docs/confenge/evolution-api-compliance.md
@@ -1,0 +1,77 @@
+# Evolution API compliance notes (CONFENGE / Warmbly)
+
+## Role
+
+Evolution API is an **external WhatsApp gateway** only.
+
+- Warmbly remains the CRM, policy engine, and execution plane.
+- Evolution is not a second CRM. Contacts, pipeline, consent, and commercial state live in Warmbly.
+- We do **not** vendor Evolution source into this repository.
+
+## Version pin
+
+| Item | Value |
+|------|--------|
+| Product | Evolution API |
+| Stable pin | **v2.3.7** |
+| Docker image | `evoapicloud/evolution-api:2.3.7` |
+| Why | Latest stable (non-RC) as of research; 2.4.0-rc series introduces mandatory licensing activation and is pre-release |
+| Do not ship | `2.4.0-rc*` for production |
+
+Re-evaluate the pin only after a stable 2.4+ release and a license review.
+
+## License
+
+Evolution API is licensed under **Apache License 2.0** with additional commercial conditions from Evolution Foundation / Evolution API:
+
+1. **Console logo and copyright**: You may not remove or modify logos/copyright in the Evolution API console or frontend components. This does not apply when you do not use those frontend components.
+2. **Usage notification**: If Evolution is used as part of a project (including closed-source), display a clear notification that Evolution API is utilized, visible to system administrators and accessible from documentation or settings. Failure may require a commercial license.
+3. Contact for commercial licensing: `contato@evolution-api.com`.
+
+Warmbly obligations for CONFENGE ops:
+
+- Keep this document and Netcup runbooks as the admin-visible usage notice.
+- Do not strip Evolution console branding if the Manager UI is deployed.
+- Do not bypass activation, telemetry, or license servers.
+- Do not modify Evolution source to avoid license terms.
+
+## Production integration mode
+
+| Mode | Status |
+|------|--------|
+| `WHATSAPP-BUSINESS` / Meta Cloud API | **Default production path** |
+| `WHATSAPP-BAILEYS` | **Disabled by default**; forbidden when `APP_ENV=production` |
+
+Env:
+
+```env
+WHATSAPP_EVOLUTION_ALLOW_BAILEYS=false
+```
+
+Baileys (WhatsApp Web multi-device sessions) is **not** a substitute for WhatsApp Business Platform policies. Do not use Baileys to circumvent Meta rules.
+
+## Forbidden practices
+
+Warmbly will not implement:
+
+- Mass cold broadcast
+- Number rotation / QR farms
+- Anti-ban, fingerprint spoofing, humanization-for-evasion
+- Bulk `isOnWhatsApp` enumeration of cold contacts
+- Auto-send to public phones without opt-in
+
+## Secrets and network
+
+- Evolution runs in its **own** Compose project with its **own** Postgres volume.
+- Do not share Warmbly or extra-cli PostgreSQL with Evolution.
+- Prefer private network: internet → reverse proxy → Warmbly webhook; Warmbly → private network → Evolution.
+- Do not expose the Evolution Manager publicly without strong auth.
+
+## Telemetry
+
+Document any official telemetry toggles from the Evolution release notes for the pinned version. Do not hack or strip telemetry in violation of license terms. If a supported env var disables non-essential telemetry, choose it consciously and record the choice in the Netcup runbook.
+
+## Related docs
+
+- `docs/confenge/whatsapp-channel.md` — Warmbly channel architecture
+- `deploy/evolution/` — isolated Compose project

--- a/docs/confenge/whatsapp-channel.md
+++ b/docs/confenge/whatsapp-channel.md
@@ -1,0 +1,82 @@
+# WhatsApp channel (policy-gated)
+
+## Architecture
+
+```text
+extra-cli → intelligence → Warmbly
+                            ├─ Email channel
+                            └─ WhatsApp channel
+                                 └─ Provider interface
+                                      └─ Evolution adapter
+                                           └─ WhatsApp Cloud API (production)
+```
+
+Inbound:
+
+```text
+WhatsApp → Evolution webhook → POST /api/v1/webhooks/evolution/:instance
+        → auth + size limit → normalize → idempotency → CRM / consent / stop sequences
+```
+
+## Fundamental rule
+
+**A public phone number is not consent.**
+
+```text
+phone found → normalize → consent status → eligibility → template/session type → review gate → send
+```
+
+Never: `phone found → send WhatsApp`.
+
+## Feature flags (all default false / safe)
+
+```env
+CONFENGE_WHATSAPP_ENABLED=false
+CONFENGE_WHATSAPP_AUTO_SEND_ENABLED=false
+CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED=false
+WHATSAPP_PROVIDER=evolution
+WHATSAPP_EVOLUTION_BASE_URL=
+WHATSAPP_EVOLUTION_API_KEY=
+WHATSAPP_EVOLUTION_INSTANCE=
+WHATSAPP_EVOLUTION_ALLOW_BAILEYS=false
+WHATSAPP_WEBHOOK_SECRET=
+CONFENGE_CROSS_CHANNEL_MIN_INTERVAL_HOURS=24
+WHATSAPP_SERVICE_WINDOW_HOURS=24
+```
+
+## Consent statuses
+
+| Status | Automated send |
+|--------|----------------|
+| UNKNOWN / NO_OPT_IN | Blocked |
+| OPTED_IN (+ provenance) | Allowed per window/template rules |
+| USER_INITIATED | Free text inside service window |
+| OPTED_OUT / DO_NOT_CONTACT | Always blocked (sticky) |
+
+## Packages
+
+| Path | Role |
+|------|------|
+| `internal/app/whatsapp` | Domain: provider interface, eligibility, phone, opt-out, service |
+| `internal/app/whatsapp/evolution` | Sole Evolution HTTP adapter + webhook normalizer |
+| `internal/models/whatsapp.go` | Persistence models |
+| `internal/repository/pg_whatsapp.go` | Postgres repository |
+| migration `000080_whatsapp_channel` | Schema |
+
+## Provider boundary
+
+Domain code depends only on `whatsapp.Provider`. Evolution DTOs stay inside `evolution/`. Future Meta Cloud API direct or other BSP adapters implement the same interface.
+
+## Testing
+
+- Unit tests use `MockProvider` and `httptest` for Evolution client.
+- Never send real WhatsApp to leads during development.
+- Operator-controlled numbers / sandbox only for live smoke.
+
+## External blockers (channel not live until)
+
+1. Meta Business / WABA verification
+2. Cloud API phone number connected on Evolution instance
+3. Official templates approved for cold-start messaging
+4. Webhook URL reachable by Evolution with valid secret
+5. `CONFENGE_WHATSAPP_ENABLED=true` only after the above

--- a/docs/package.json
+++ b/docs/package.json
@@ -37,7 +37,11 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml": "4.3.1"
+      "js-yaml": "4.3.1",
+      "postcss": "8.5.23",
+      "picomatch": "^4.0.4",
+      "path-to-regexp": "^8.4.0",
+      "sharp": "^0.35.0"
     }
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,5 +34,10 @@
     "postcss": "^8.5.23",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml": "4.3.1"
+    }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 overrides:
   js-yaml: 4.3.1
+  postcss: 8.5.23
+  picomatch: ^4.0.4
+  path-to-regexp: ^8.4.0
+  sharp: ^0.35.0
 
 importers:
 
@@ -16,13 +20,13 @@ importers:
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.4.11
-        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 14.2.6
-        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: 16.4.11
-        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
@@ -31,7 +35,7 @@ importers:
         version: 11.16.0
       next:
         specifier: 16.2.11
-        version: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -67,7 +71,7 @@ importers:
         specifier: 16.2.11
         version: 16.2.11(@typescript-eslint/parser@8.59.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       postcss:
-        specifier: ^8.5.23
+        specifier: 8.5.23
         version: 8.5.23
       tailwindcss:
         specifier: ^4.1.18
@@ -428,136 +432,145 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -2159,7 +2172,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3061,10 +3074,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -3082,10 +3091,6 @@ packages:
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -3282,9 +3287,14 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3882,9 +3892,9 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.0
       tslib: 2.8.1
 
-  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
+  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
     dependencies:
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss-selector-parser: 7.1.1
       react: 19.2.4
@@ -3892,7 +3902,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
 
   '@humanfs/core@0.19.1': {}
@@ -3917,98 +3927,108 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.34.5':
+  '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
+  '@img/sharp-darwin-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.3.2
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
+  '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
+  '@img/sharp-libvips-linux-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
+  '@img/sharp-libvips-linux-arm@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
+  '@img/sharp-libvips-linux-s390x@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+  '@img/sharp-libvips-linux-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.5':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-arm@0.34.5':
+  '@img/sharp-linux-arm@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.3.2
     optional: true
 
-  '@img/sharp-linux-ppc64@0.34.5':
+  '@img/sharp-linux-ppc64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-riscv64@0.34.5':
+  '@img/sharp-linux-riscv64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.5':
+  '@img/sharp-linux-s390x@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.3.2
     optional: true
 
-  '@img/sharp-linux-x64@0.34.5':
+  '@img/sharp-linux-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
+  '@img/sharp-linuxmusl-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
+  '@img/sharp-linuxmusl-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
     optional: true
 
-  '@img/sharp-wasm32@0.34.5':
+  '@img/sharp-wasm32@0.35.3':
     dependencies:
       '@emnapi/runtime': 1.11.2
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
+  '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -5871,7 +5891,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
+  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.0
       '@orama/orama': 3.1.18
@@ -5895,21 +5915,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
       lucide-react: 0.563.0(react@19.2.4)
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       js-yaml: 4.3.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -5924,14 +5944,14 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
+  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
     dependencies:
-      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -5943,7 +5963,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.10)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       lucide-react: 0.563.0(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -5952,7 +5972,7 @@ snapshots:
       scroll-into-view-if-needed: 3.1.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -6884,7 +6904,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   minimatch@10.2.5:
     dependencies:
@@ -6915,13 +6935,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.3
       caniuse-lite: 1.0.30001806
-      postcss: 8.4.31
+      postcss: 8.5.23
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -6934,9 +6954,10 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.11
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
-      sharp: 0.34.5
+      sharp: 0.35.3(@types/node@25.1.0)
     transitivePeerDependencies:
       - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
   node-exports-info@1.6.0:
@@ -7051,8 +7072,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
   picomatch@4.0.4: {}
 
   points-on-curve@0.2.0: {}
@@ -7068,12 +7087,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
@@ -7338,36 +7351,38 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
 
-  sharp@0.34.5:
+  sharp@0.35.3(@types/node@25.1.0):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 25.1.0
     optional: true
 
   shebang-command@2.0.0:

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -5,11 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  picomatch: ^4.0.4
-  path-to-regexp: ^8.4.0
-  js-yaml: ^4.3.0
-  sharp: ^0.35.0
-  postcss: ^8.5.23
+  js-yaml: 4.3.1
 
 importers:
 
@@ -20,13 +16,13 @@ importers:
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.4.11
-        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 14.2.6
-        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: 16.4.11
-        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
@@ -35,7 +31,7 @@ importers:
         version: 11.16.0
       next:
         specifier: 16.2.11
-        version: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -432,161 +428,136 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.35.3':
-    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.35.3':
-    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
-    engines: {node: '>=20.9.0'}
-    os: [freebsd]
-
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
-    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
-    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
-    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
-    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-linux-arm64@0.35.3':
-    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-arm@0.35.3':
-    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.3':
-    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.35.3':
-    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.3':
-    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-x64@0.35.3':
-    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-wasm32@0.35.3':
-    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
-    engines: {node: '>=20.9.0'}
-
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.35.3':
-    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.3':
-    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
-    engines: {node: ^20.9.0}
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.35.3':
-    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
@@ -641,28 +612,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.11':
     resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.11':
     resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.11':
     resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.11':
     resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
@@ -1135,28 +1102,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1437,61 +1400,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -2206,7 +2159,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2616,8 +2569,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2709,28 +2662,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3112,6 +3061,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -3129,6 +3082,10 @@ packages:
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -3325,14 +3282,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.35.3:
-    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
-    engines: {node: '>=20.9.0'}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3889,7 +3841,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3930,9 +3882,9 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.0
       tslib: 2.8.1
 
-  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
+  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
     dependencies:
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss-selector-parser: 7.1.1
       react: 19.2.4
@@ -3940,7 +3892,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
 
   '@humanfs/core@0.19.1': {}
@@ -3965,108 +3917,98 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.35.3':
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.3':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
+  '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.35.3':
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.35.3':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.3':
+  '@img/sharp-linux-ppc64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-riscv64@0.35.3':
+  '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.3':
+  '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.35.3':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
+  '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.35.3':
+  '@img/sharp-wasm32@0.34.5':
     dependencies:
       '@emnapi/runtime': 1.11.2
     optional: true
 
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.3':
+  '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.3':
-    optional: true
-
-  '@img/sharp-win32-x64@0.35.3':
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -5929,7 +5871,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
+  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.0
       '@orama/orama': 3.1.18
@@ -5953,22 +5895,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
       lucide-react: 0.563.0(react@19.2.4)
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
-      js-yaml: 4.3.0
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      js-yaml: 4.3.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
       picomatch: 4.0.4
@@ -5982,14 +5924,14 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
+  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
     dependencies:
-      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6001,7 +5943,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.10)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       lucide-react: 0.563.0(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -6010,7 +5952,7 @@ snapshots:
       scroll-into-view-if-needed: 3.1.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -6353,7 +6295,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -6942,7 +6884,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   minimatch@10.2.5:
     dependencies:
@@ -6973,13 +6915,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.3
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.23
+      postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -6992,10 +6934,9 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.11
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
-      sharp: 0.35.3(@types/node@25.1.0)
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
-      - '@types/node'
       - babel-plugin-macros
 
   node-exports-info@1.6.0:
@@ -7110,6 +7051,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   points-on-curve@0.2.0: {}
@@ -7125,6 +7068,12 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
@@ -7389,38 +7338,36 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
 
-  sharp@0.35.3(@types/node@25.1.0):
+  sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 25.1.0
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     optional: true
 
   shebang-command@2.0.0:

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/mileusna/useragent v1.3.5
 	github.com/nats-io/nats-server/v2 v2.14.1
 	github.com/nats-io/nats.go v1.52.0
+	github.com/nyaruka/phonenumbers v1.6.5
 	github.com/openai/openai-go/v2 v2.7.1
 	github.com/oschwald/geoip2-golang/v2 v2.0.0
 	github.com/redis/go-redis/v9 v9.11.0
@@ -310,6 +311,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/arch v0.19.0 // indirect
+	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -695,6 +695,8 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/nunnatsa/ginkgolinter v0.19.1 h1:mjwbOlDQxZi9Cal+KfbEJTCz327OLNfwNvoZ70NJ+c4=
 github.com/nunnatsa/ginkgolinter v0.19.1/go.mod h1:jkQ3naZDmxaZMXPWaS9rblH+i+GWXQCaS/JFIWcOH2s=
+github.com/nyaruka/phonenumbers v1.6.5 h1:aBCaUhfpRA7hU6fsXk+p7KF1aNx4nQlq9hGeo2qdFg8=
+github.com/nyaruka/phonenumbers v1.6.5/go.mod h1:7gjs+Lchqm49adhAKB5cdcng5ZXgt6x7Jgvi0ZorUtU=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
@@ -1032,8 +1034,8 @@ golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWBtpfqks2bwGcexMxgtk=
-golang.org/x/exp v0.0.0-20240909161429-701f63a606c0/go.mod h1:2TbTHSBQa924w8M6Xs1QcRcFwyucIwBGpK1p2f1YFFY=
+golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 h1:nDVHiLt8aIbd/VzvPWN6kSOPE7+F/fNFDSXLVYkE/Iw=
+golang.org/x/exp v0.0.0-20250305212735-054e65f0b394/go.mod h1:sIifuuw/Yco/y6yb6+bDNfyeQ/MdPUy/hKEMYQV17cM=
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac h1:TSSpLIG4v+p0rPv1pNOQtl1I8knsO4S9trOxNMOLVP4=

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -52,6 +52,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/app/warmupcontent"
 	"github.com/warmbly/warmbly/internal/app/webhook"
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
 	"github.com/warmbly/warmbly/internal/app/worker"
 	"github.com/warmbly/warmbly/internal/app/worker_orchestrator"
 	"github.com/warmbly/warmbly/internal/pkg/generation"
@@ -111,6 +112,10 @@ type Handler struct {
 
 	// CRM
 	CRMService crm.CRMService
+
+	// WhatsApp channel (Evolution gateway; policy-gated)
+	WhatsAppService *whatsapp.Service
+	WhatsAppRepo    repository.WhatsAppRepository
 
 	// Teams
 	TeamService team.TeamService

--- a/internal/api/handler/whatsapp.go
+++ b/internal/api/handler/whatsapp.go
@@ -19,12 +19,12 @@ import (
 // EvolutionWebhook is the public ingress for Evolution API events.
 // POST /api/v1/webhooks/evolution/:instance
 //
-// Auth: Authorization Bearer <secret> or X-Webhook-Secret, matched against
-// the instance's stored secret (or WHATSAPP_WEBHOOK_SECRET when single-tenant).
-// Body is size-limited; duplicates are idempotent on provider event id.
+// Auth: Authorization Bearer <secret> or X-Webhook-Secret.
+// Requires a mapped whatsapp_instances row (organization binding). Production
+// never silently drops CRM effects into "lab_mode".
 func (h *Handler) EvolutionWebhook(c *gin.Context) {
 	if h.WhatsAppService == nil || !h.WhatsAppService.Config().Enabled {
-		c.JSON(http.StatusNotFound, gin.H{"error": "whatsapp channel disabled"})
+		c.JSON(http.StatusNotFound, gin.H{"error": "whatsapp channel disabled", "code": "disabled"})
 		return
 	}
 	cfg := h.WhatsAppService.Config()
@@ -38,45 +38,42 @@ func (h *Handler) EvolutionWebhook(c *gin.Context) {
 	if maxBytes <= 0 {
 		maxBytes = whatsapp.DefaultMaxWebhookBytes
 	}
-	// Prefer Content-Length check before reading.
 	if c.Request.ContentLength > maxBytes {
 		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "payload too large", "code": "payload_too_large"})
 		return
 	}
 
-	secret := cfg.WebhookSecret
-	var orgID uuid.UUID
-	if h.WhatsAppRepo != nil {
-		inst, xerr := h.WhatsAppRepo.GetInstanceByName(c.Request.Context(), whatsapp.ProviderEvolution, instance)
-		if xerr != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup failed", "code": "internal"})
-			return
-		}
-		if inst == nil {
-			// Fall back to configured default instance only.
-			if cfg.EvolutionInstance == "" || !strings.EqualFold(instance, cfg.EvolutionInstance) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
-				return
-			}
-			// Single-tenant: org mapping deferred; require global secret.
-		} else {
-			orgID = inst.OrganizationID
-			if inst.WebhookSecret != "" {
-				secret = inst.WebhookSecret
-			}
-			// Baileys mode must not be used in production; warn only.
-			if inst.IntegrationMode == "WHATSAPP-BAILEYS" && cfg.IsProduction() {
-				log.Error().Str("instance", instance).Msg("rejecting baileys instance webhook in production")
-				c.JSON(http.StatusForbidden, gin.H{"error": "baileys disabled in production", "code": "baileys_forbidden"})
-				return
-			}
-		}
-	} else if cfg.EvolutionInstance != "" && !strings.EqualFold(instance, cfg.EvolutionInstance) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
+	if h.WhatsAppRepo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "whatsapp repository unavailable", "code": "no_repo"})
 		return
 	}
 
-	auth := whatsapp.WebhookAuth{Secret: secret, InstanceAllow: "", MaxBytes: maxBytes}
+	inst, xerr := h.WhatsAppRepo.GetInstanceByName(c.Request.Context(), whatsapp.ProviderEvolution, instance)
+	if xerr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup failed", "code": "internal"})
+		return
+	}
+	if inst == nil {
+		// Fail closed: unmapped instance never reaches CRM/outcomes.
+		c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
+		return
+	}
+	orgID := inst.OrganizationID
+	secret := inst.WebhookSecret
+	if secret == "" {
+		secret = cfg.WebhookSecret
+	}
+	if secret == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "webhook secret not configured", "code": "missing_secret"})
+		return
+	}
+	if inst.IntegrationMode == "WHATSAPP-BAILEYS" && cfg.IsProduction() {
+		log.Error().Str("instance", instance).Msg("rejecting baileys instance webhook in production")
+		c.JSON(http.StatusForbidden, gin.H{"error": "baileys disabled in production", "code": "baileys_forbidden"})
+		return
+	}
+
+	auth := whatsapp.WebhookAuth{Secret: secret, MaxBytes: maxBytes}
 	if err := auth.ValidateHeaders(
 		c.GetHeader("Authorization"),
 		c.GetHeader("X-Webhook-Secret"),
@@ -106,103 +103,61 @@ func (h *Handler) EvolutionWebhook(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "malformed payload", "code": "malformed"})
 		return
 	}
-	if ev.Instance == "" {
-		ev.Instance = instance
-	}
-	if !strings.EqualFold(ev.Instance, instance) && ev.Instance != "" {
-		// Path instance is authoritative for mapping.
-		ev.Instance = instance
-	}
+	ev.Instance = instance
+	ev.OrganizationID = orgID
 	if ev.EventType == whatsapp.EventUnsupported {
 		c.JSON(http.StatusOK, gin.H{"received": true, "ignored": true})
 		return
 	}
 
-	// Persist idempotency when org is known.
-	if orgID != uuid.Nil && h.WhatsAppRepo != nil {
-		sum := sha256.Sum256(body)
-		inserted, xerr := h.WhatsAppRepo.InsertWebhookEvent(
-			c.Request.Context(), orgID, whatsapp.ProviderEvolution,
-			ev.IdempotencyKey(), ev.EventType, ev.ExternalMessageID, hex.EncodeToString(sum[:]),
-		)
-		if xerr != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "idempotency failed", "code": "internal"})
-			return
-		}
-		if !inserted {
-			c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
-			return
-		}
-		ev.OrganizationID = orgID
-
-		// Load or create contact channel state by phone.
-		phone := ev.FromE164
-		if phone == "" {
-			phone = ev.ToE164
-		}
-		var state *models.WhatsAppContactState
-		if phone != "" {
-			state, _ = h.WhatsAppRepo.GetContactStateByPhone(c.Request.Context(), orgID, phone)
-		}
-		domainState := modelsToDomainState(state, orgID)
-		if domainState.PhoneE164 == "" {
-			domainState.PhoneE164 = phone
-		}
-
-		inRes, _ := h.WhatsAppService.ProcessInbound(c.Request.Context(), &domainState, ev)
-		if inRes.Duplicate {
-			c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
-			return
-		}
-
-		// Persist inbound message.
-		if ev.EventType == whatsapp.EventMessageReceived {
-			msg := &models.WhatsAppMessage{
-				OrganizationID:    orgID,
-				ThreadKey:         phone,
-				Direction:         "inbound",
-				Channel:           whatsapp.ChannelWhatsApp,
-				Provider:          whatsapp.ProviderEvolution,
-				ProviderMessageID: ev.ExternalMessageID,
-				IdempotencyKey:    ev.IdempotencyKey(),
-				BodyText:          ev.Content.Text,
-				Status:            "received",
-				OccurredAt:        ev.OccurredAt,
-			}
-			if state != nil && state.ContactID != nil {
-				msg.ContactID = state.ContactID
-			}
-			_, _ = h.WhatsAppRepo.InsertMessage(c.Request.Context(), msg)
-
-			// Persist updated consent / service window.
-			persistState := domainToModelsState(domainState, state)
-			persistState.OrganizationID = orgID
-			if state != nil {
-				persistState.ID = state.ID
-				persistState.ContactID = state.ContactID
-			}
-			_ = h.WhatsAppRepo.UpsertContactState(c.Request.Context(), &persistState)
-		}
-
-		c.JSON(http.StatusOK, gin.H{
-			"received":       true,
-			"event_type":     ev.EventType,
-			"stop_sequences": inRes.StopSequences,
-			"needs_review":   inRes.NeedsHumanReview,
-			"opt_out":        inRes.OptOut.Matched && inRes.OptOut.Confident,
-		})
+	sum := sha256.Sum256(body)
+	inserted, xerr := h.WhatsAppRepo.InsertWebhookEvent(
+		c.Request.Context(), orgID, whatsapp.ProviderEvolution,
+		ev.IdempotencyKey(), ev.EventType, ev.ExternalMessageID, hex.EncodeToString(sum[:]),
+	)
+	if xerr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "idempotency failed", "code": "internal"})
+		return
+	}
+	if !inserted {
+		c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
 		return
 	}
 
-	// No org mapping: still ack valid authenticated events (single-node lab).
-	// In-process idempotency only.
-	var domainState whatsapp.ContactChannelState
+	// Fallback without confenge: persist message + open service window only.
+	phone := ev.FromE164
+	if phone == "" {
+		phone = ev.ToE164
+	}
+	domainState := whatsapp.ContactChannelState{OrganizationID: orgID, PhoneE164: phone, ConsentStatus: whatsapp.ConsentUnknown}
+	if st, _ := h.WhatsAppRepo.GetContactStateByPhone(c.Request.Context(), orgID, phone); st != nil {
+		domainState = modelsToDomainState(st, orgID)
+	}
 	inRes, _ := h.WhatsAppService.ProcessInbound(c.Request.Context(), &domainState, ev)
+	if !inRes.Duplicate && ev.EventType == whatsapp.EventMessageReceived {
+		msg := &models.WhatsAppMessage{
+			OrganizationID:    orgID,
+			ThreadKey:         phone,
+			Direction:         "inbound",
+			Channel:           whatsapp.ChannelWhatsApp,
+			Provider:          whatsapp.ProviderEvolution,
+			ProviderMessageID: ev.ExternalMessageID,
+			IdempotencyKey:    ev.IdempotencyKey(),
+			BodyText:          ev.Content.Text,
+			Status:            "received",
+			OccurredAt:        ev.OccurredAt,
+		}
+		_, _ = h.WhatsAppRepo.InsertMessage(c.Request.Context(), msg)
+		persist := domainToModelsState(domainState, nil)
+		persist.OrganizationID = orgID
+		_ = h.WhatsAppRepo.UpsertContactState(c.Request.Context(), &persist)
+	}
 	c.JSON(http.StatusOK, gin.H{
-		"received":   true,
-		"event_type": ev.EventType,
-		"duplicate":  inRes.Duplicate,
-		"lab_mode":   true,
+		"received":       true,
+		"event_type":     ev.EventType,
+		"stop_sequences": inRes.StopSequences,
+		"opt_out":        inRes.OptOut.Matched && inRes.OptOut.Confident,
+		"duplicate":      inRes.Duplicate,
 	})
 }
 

--- a/internal/api/handler/whatsapp.go
+++ b/internal/api/handler/whatsapp.go
@@ -1,0 +1,270 @@
+package handler
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+	"github.com/warmbly/warmbly/internal/app/whatsapp/evolution"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// EvolutionWebhook is the public ingress for Evolution API events.
+// POST /api/v1/webhooks/evolution/:instance
+//
+// Auth: Authorization Bearer <secret> or X-Webhook-Secret, matched against
+// the instance's stored secret (or WHATSAPP_WEBHOOK_SECRET when single-tenant).
+// Body is size-limited; duplicates are idempotent on provider event id.
+func (h *Handler) EvolutionWebhook(c *gin.Context) {
+	if h.WhatsAppService == nil || !h.WhatsAppService.Config().Enabled {
+		c.JSON(http.StatusNotFound, gin.H{"error": "whatsapp channel disabled"})
+		return
+	}
+	cfg := h.WhatsAppService.Config()
+	instance := strings.TrimSpace(c.Param("instance"))
+	if instance == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "instance required", "code": "missing_instance"})
+		return
+	}
+
+	maxBytes := cfg.MaxWebhookBytes
+	if maxBytes <= 0 {
+		maxBytes = whatsapp.DefaultMaxWebhookBytes
+	}
+	// Prefer Content-Length check before reading.
+	if c.Request.ContentLength > maxBytes {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "payload too large", "code": "payload_too_large"})
+		return
+	}
+
+	secret := cfg.WebhookSecret
+	var orgID uuid.UUID
+	if h.WhatsAppRepo != nil {
+		inst, xerr := h.WhatsAppRepo.GetInstanceByName(c.Request.Context(), whatsapp.ProviderEvolution, instance)
+		if xerr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup failed", "code": "internal"})
+			return
+		}
+		if inst == nil {
+			// Fall back to configured default instance only.
+			if cfg.EvolutionInstance == "" || !strings.EqualFold(instance, cfg.EvolutionInstance) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
+				return
+			}
+			// Single-tenant: org mapping deferred; require global secret.
+		} else {
+			orgID = inst.OrganizationID
+			if inst.WebhookSecret != "" {
+				secret = inst.WebhookSecret
+			}
+			// Baileys mode must not be used in production; warn only.
+			if inst.IntegrationMode == "WHATSAPP-BAILEYS" && cfg.IsProduction() {
+				log.Error().Str("instance", instance).Msg("rejecting baileys instance webhook in production")
+				c.JSON(http.StatusForbidden, gin.H{"error": "baileys disabled in production", "code": "baileys_forbidden"})
+				return
+			}
+		}
+	} else if cfg.EvolutionInstance != "" && !strings.EqualFold(instance, cfg.EvolutionInstance) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
+		return
+	}
+
+	auth := whatsapp.WebhookAuth{Secret: secret, InstanceAllow: "", MaxBytes: maxBytes}
+	if err := auth.ValidateHeaders(
+		c.GetHeader("Authorization"),
+		c.GetHeader("X-Webhook-Secret"),
+		c.GetHeader("Content-Type"),
+		c.Request.ContentLength,
+	); err != nil {
+		if ae, ok := err.(*whatsapp.AuthError); ok {
+			c.JSON(ae.StatusCode, gin.H{"error": ae.Message, "code": ae.Code})
+			return
+		}
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized", "code": "unauthorized"})
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxBytes+1))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "read body failed", "code": "bad_body"})
+		return
+	}
+	if int64(len(body)) > maxBytes {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "payload too large", "code": "payload_too_large"})
+		return
+	}
+
+	ev, err := evolution.NormalizeWebhook(body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "malformed payload", "code": "malformed"})
+		return
+	}
+	if ev.Instance == "" {
+		ev.Instance = instance
+	}
+	if !strings.EqualFold(ev.Instance, instance) && ev.Instance != "" {
+		// Path instance is authoritative for mapping.
+		ev.Instance = instance
+	}
+	if ev.EventType == whatsapp.EventUnsupported {
+		c.JSON(http.StatusOK, gin.H{"received": true, "ignored": true})
+		return
+	}
+
+	// Persist idempotency when org is known.
+	if orgID != uuid.Nil && h.WhatsAppRepo != nil {
+		sum := sha256.Sum256(body)
+		inserted, xerr := h.WhatsAppRepo.InsertWebhookEvent(
+			c.Request.Context(), orgID, whatsapp.ProviderEvolution,
+			ev.IdempotencyKey(), ev.EventType, ev.ExternalMessageID, hex.EncodeToString(sum[:]),
+		)
+		if xerr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "idempotency failed", "code": "internal"})
+			return
+		}
+		if !inserted {
+			c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
+			return
+		}
+		ev.OrganizationID = orgID
+
+		// Load or create contact channel state by phone.
+		phone := ev.FromE164
+		if phone == "" {
+			phone = ev.ToE164
+		}
+		var state *models.WhatsAppContactState
+		if phone != "" {
+			state, _ = h.WhatsAppRepo.GetContactStateByPhone(c.Request.Context(), orgID, phone)
+		}
+		domainState := modelsToDomainState(state, orgID)
+		if domainState.PhoneE164 == "" {
+			domainState.PhoneE164 = phone
+		}
+
+		inRes, _ := h.WhatsAppService.ProcessInbound(c.Request.Context(), &domainState, ev)
+		if inRes.Duplicate {
+			c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
+			return
+		}
+
+		// Persist inbound message.
+		if ev.EventType == whatsapp.EventMessageReceived {
+			msg := &models.WhatsAppMessage{
+				OrganizationID:    orgID,
+				ThreadKey:         phone,
+				Direction:         "inbound",
+				Channel:           whatsapp.ChannelWhatsApp,
+				Provider:          whatsapp.ProviderEvolution,
+				ProviderMessageID: ev.ExternalMessageID,
+				IdempotencyKey:    ev.IdempotencyKey(),
+				BodyText:          ev.Content.Text,
+				Status:            "received",
+				OccurredAt:        ev.OccurredAt,
+			}
+			if state != nil && state.ContactID != nil {
+				msg.ContactID = state.ContactID
+			}
+			_, _ = h.WhatsAppRepo.InsertMessage(c.Request.Context(), msg)
+
+			// Persist updated consent / service window.
+			persistState := domainToModelsState(domainState, state)
+			persistState.OrganizationID = orgID
+			if state != nil {
+				persistState.ID = state.ID
+				persistState.ContactID = state.ContactID
+			}
+			_ = h.WhatsAppRepo.UpsertContactState(c.Request.Context(), &persistState)
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"received":       true,
+			"event_type":     ev.EventType,
+			"stop_sequences": inRes.StopSequences,
+			"needs_review":   inRes.NeedsHumanReview,
+			"opt_out":        inRes.OptOut.Matched && inRes.OptOut.Confident,
+		})
+		return
+	}
+
+	// No org mapping: still ack valid authenticated events (single-node lab).
+	// In-process idempotency only.
+	var domainState whatsapp.ContactChannelState
+	inRes, _ := h.WhatsAppService.ProcessInbound(c.Request.Context(), &domainState, ev)
+	c.JSON(http.StatusOK, gin.H{
+		"received":   true,
+		"event_type": ev.EventType,
+		"duplicate":  inRes.Duplicate,
+		"lab_mode":   true,
+	})
+}
+
+func modelsToDomainState(st *models.WhatsAppContactState, orgID uuid.UUID) whatsapp.ContactChannelState {
+	out := whatsapp.ContactChannelState{
+		OrganizationID: orgID,
+		ConsentStatus:  whatsapp.ConsentUnknown,
+	}
+	if st == nil {
+		return out
+	}
+	if st.ContactID != nil {
+		out.ContactID = *st.ContactID
+	}
+	out.PhoneE164 = st.PhoneE164
+	out.PhoneSource = st.PhoneSource
+	out.PhoneSourceURL = st.PhoneSourceURL
+	out.PhoneVerifiedAt = st.PhoneVerifiedAt
+	out.ConsentStatus = st.ConsentStatus
+	out.ConsentSource = st.ConsentSource
+	out.ConsentAt = st.ConsentAt
+	out.ConsentScope = st.ConsentScope
+	out.ConsentProvenanceOK = st.ConsentProvenanceOK
+	out.LastInboundAt = st.LastInboundAt
+	out.ServiceWindowUntil = st.ServiceWindowUntil
+	out.ChannelStatus = st.ChannelStatus
+	out.OptOutAt = st.OptOutAt
+	out.DoNotContact = st.DoNotContact
+	out.LastEmailOutboundAt = st.LastEmailOutboundAt
+	out.LastWhatsAppOutboundAt = st.LastWhatsAppOutboundAt
+	return out
+}
+
+func domainToModelsState(d whatsapp.ContactChannelState, prev *models.WhatsAppContactState) models.WhatsAppContactState {
+	out := models.WhatsAppContactState{
+		OrganizationID:         d.OrganizationID,
+		PhoneE164:              d.PhoneE164,
+		PhoneSource:            d.PhoneSource,
+		PhoneSourceURL:         d.PhoneSourceURL,
+		PhoneVerifiedAt:        d.PhoneVerifiedAt,
+		ConsentStatus:          d.ConsentStatus,
+		ConsentSource:          d.ConsentSource,
+		ConsentAt:              d.ConsentAt,
+		ConsentScope:           d.ConsentScope,
+		ConsentProvenanceOK:    d.ConsentProvenanceOK,
+		LastInboundAt:          d.LastInboundAt,
+		ServiceWindowUntil:     d.ServiceWindowUntil,
+		ChannelStatus:          d.ChannelStatus,
+		OptOutAt:               d.OptOutAt,
+		DoNotContact:           d.DoNotContact,
+		LastEmailOutboundAt:    d.LastEmailOutboundAt,
+		LastWhatsAppOutboundAt: d.LastWhatsAppOutboundAt,
+		UpdatedAt:              time.Now().UTC(),
+	}
+	if d.ContactID != uuid.Nil {
+		id := d.ContactID
+		out.ContactID = &id
+	}
+	if prev != nil {
+		out.PhoneRaw = prev.PhoneRaw
+		out.PhoneCountry = prev.PhoneCountry
+		out.PhoneValid = prev.PhoneValid
+	}
+	return out
+}

--- a/internal/api/handler/whatsapp_webhook_test.go
+++ b/internal/api/handler/whatsapp_webhook_test.go
@@ -1,0 +1,159 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+type memWARepo struct {
+	instances map[string]*models.WhatsAppInstance
+	events    map[string]bool
+	messages  int
+	states    int
+}
+
+func (m *memWARepo) GetInstanceByName(_ context.Context, provider, instance string) (*models.WhatsAppInstance, *errx.Error) {
+	if m.instances == nil {
+		return nil, nil
+	}
+	return m.instances[provider+":"+instance], nil
+}
+func (m *memWARepo) InsertWebhookEvent(_ context.Context, orgID uuid.UUID, provider, idemKey, eventType, externalMsgID, payloadHash string) (bool, *errx.Error) {
+	if m.events == nil {
+		m.events = map[string]bool{}
+	}
+	k := orgID.String() + ":" + idemKey
+	if m.events[k] {
+		return false, nil
+	}
+	m.events[k] = true
+	return true, nil
+}
+func (m *memWARepo) UpsertContactState(context.Context, *models.WhatsAppContactState) *errx.Error {
+	m.states++
+	return nil
+}
+func (m *memWARepo) GetContactStateByPhone(context.Context, uuid.UUID, string) (*models.WhatsAppContactState, *errx.Error) {
+	return nil, nil
+}
+func (m *memWARepo) GetContactStateByContact(context.Context, uuid.UUID, uuid.UUID) (*models.WhatsAppContactState, *errx.Error) {
+	return nil, nil
+}
+func (m *memWARepo) InsertMessage(context.Context, *models.WhatsAppMessage) (bool, *errx.Error) {
+	m.messages++
+	return true, nil
+}
+func (m *memWARepo) GetTemplateStatus(context.Context, uuid.UUID, string, string) (string, *errx.Error) {
+	return "MISSING", nil
+}
+func (m *memWARepo) ListMessagesByThread(context.Context, uuid.UUID, string, int) ([]models.WhatsAppMessage, *errx.Error) {
+	return nil, nil
+}
+
+func TestEvolutionWebhookUnmappedInstance(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	wa := whatsapp.NewService(whatsapp.Config{
+		Enabled: true, WebhookSecret: "sec", MaxWebhookBytes: 1 << 20,
+	}, whatsapp.NewMockProvider(), nil)
+	h := &Handler{
+		WhatsAppService: wa,
+		WhatsAppRepo:    &memWARepo{},
+	}
+	r := gin.New()
+	r.POST("/api/v1/webhooks/evolution/:instance", h.EvolutionWebhook)
+
+	body := []byte(`{"event":"messages.upsert","instance":"unknown","data":{"key":{"id":"1","remoteJid":"5548@s.whatsapp.net","fromMe":false},"message":{"conversation":"hi"}}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/evolution/unknown", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sec")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["code"] != "instance_mismatch" {
+		t.Fatalf("resp=%v", resp)
+	}
+}
+
+func TestEvolutionWebhookMappedIdempotent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.New()
+	repo := &memWARepo{instances: map[string]*models.WhatsAppInstance{
+		"evolution:confenge": {
+			ID: uuid.New(), OrganizationID: org, Provider: "evolution",
+			InstanceName: "confenge", WebhookSecret: "sec", IntegrationMode: "WHATSAPP-BUSINESS",
+		},
+	}}
+	wa := whatsapp.NewService(whatsapp.Config{
+		Enabled: true, WebhookSecret: "sec", MaxWebhookBytes: 1 << 20, ServiceWindow: 24 * time.Hour,
+	}, whatsapp.NewMockProvider(), nil)
+	h := &Handler{WhatsAppService: wa, WhatsAppRepo: repo}
+	r := gin.New()
+	r.POST("/api/v1/webhooks/evolution/:instance", h.EvolutionWebhook)
+
+	body := []byte(`{"event":"messages.upsert","instance":"confenge","data":{"key":{"id":"MSG99","remoteJid":"5548999887766@s.whatsapp.net","fromMe":false},"message":{"conversation":"Olá"},"messageTimestamp":1710000000}}`)
+	do := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/evolution/confenge", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer sec")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+	w1 := do()
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first status=%d body=%s", w1.Code, w1.Body.String())
+	}
+	if repo.messages != 1 {
+		t.Fatalf("messages=%d", repo.messages)
+	}
+	w2 := do()
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second status=%d", w2.Code)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w2.Body.Bytes(), &resp)
+	if resp["duplicate"] != true {
+		t.Fatalf("expected duplicate resp=%v", resp)
+	}
+	if repo.messages != 1 {
+		t.Fatalf("duplicate must not insert again messages=%d", repo.messages)
+	}
+}
+
+func TestEvolutionWebhookInvalidSecret(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.New()
+	repo := &memWARepo{instances: map[string]*models.WhatsAppInstance{
+		"evolution:confenge": {OrganizationID: org, Provider: "evolution", InstanceName: "confenge", WebhookSecret: "sec"},
+	}}
+	h := &Handler{
+		WhatsAppService: whatsapp.NewService(whatsapp.Config{Enabled: true, MaxWebhookBytes: 1 << 20}, nil, nil),
+		WhatsAppRepo:    repo,
+	}
+	r := gin.New()
+	r.POST("/api/v1/webhooks/evolution/:instance", h.EvolutionWebhook)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/evolution/confenge", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer wrong")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d", w.Code)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -38,6 +38,10 @@ func Run(
 	// credential, resolving to one automation that runs with the JSON body.
 	r.POST("/api/v1/integrations/inbound/automation/:token", h.InboundAutomation)
 
+	// Evolution API WhatsApp webhooks (provider gateway → Warmbly). Auth is the
+	// per-instance webhook secret (Bearer or X-Webhook-Secret).
+	r.POST("/api/v1/webhooks/evolution/:instance", h.EvolutionWebhook)
+
 	// OAuth 2.1 authorization-server discovery (RFC 8414): public + unversioned.
 	r.GET("/.well-known/oauth-authorization-server", h.OAuthServerMetadata)
 

--- a/internal/app/whatsapp/config.go
+++ b/internal/app/whatsapp/config.go
@@ -1,0 +1,176 @@
+package whatsapp
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Env keys for the WhatsApp channel. Documented in deploy/config/env.example.
+const (
+	EnvEnabled               = "CONFENGE_WHATSAPP_ENABLED"
+	EnvAutoSend              = "CONFENGE_WHATSAPP_AUTO_SEND_ENABLED"
+	EnvAutoReply             = "CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED"
+	EnvProvider              = "WHATSAPP_PROVIDER"
+	EnvEvolutionBaseURL      = "WHATSAPP_EVOLUTION_BASE_URL"
+	EnvEvolutionAPIKey       = "WHATSAPP_EVOLUTION_API_KEY"
+	EnvEvolutionInstance     = "WHATSAPP_EVOLUTION_INSTANCE"
+	EnvEvolutionAllowBaileys = "WHATSAPP_EVOLUTION_ALLOW_BAILEYS"
+	EnvWebhookSecret         = "WHATSAPP_WEBHOOK_SECRET"
+	EnvCrossChannelHours     = "CONFENGE_CROSS_CHANNEL_MIN_INTERVAL_HOURS"
+	EnvServiceWindowHours    = "WHATSAPP_SERVICE_WINDOW_HOURS"
+	EnvMaxWebhookBytes       = "WHATSAPP_MAX_WEBHOOK_BYTES"
+	EnvAppEnv                = "APP_ENV"
+)
+
+// Defaults keep the channel fully off and conservative.
+const (
+	DefaultCrossChannelHours  = 24
+	DefaultServiceWindowHours = 24
+	DefaultMaxWebhookBytes    = 1 << 20 // 1 MiB
+	DefaultProvider           = ProviderEvolution
+)
+
+// Config is runtime configuration for WhatsApp transport + policy.
+type Config struct {
+	Enabled              bool
+	AutoSendEnabled      bool
+	AutoReplyEnabled     bool
+	Provider             string
+	EvolutionBaseURL     string
+	EvolutionAPIKey      string
+	EvolutionInstance    string
+	AllowBaileys         bool
+	WebhookSecret        string
+	CrossChannelInterval time.Duration
+	ServiceWindow        time.Duration
+	MaxWebhookBytes      int64
+	AppEnv               string
+}
+
+// LoadConfig reads WhatsApp-related env vars. Safe defaults keep features off.
+func LoadConfig() Config {
+	hours := envInt(EnvCrossChannelHours, DefaultCrossChannelHours)
+	if hours < 0 {
+		hours = DefaultCrossChannelHours
+	}
+	sw := envInt(EnvServiceWindowHours, DefaultServiceWindowHours)
+	if sw < 1 {
+		sw = DefaultServiceWindowHours
+	}
+	maxBytes := envInt(EnvMaxWebhookBytes, DefaultMaxWebhookBytes)
+	if maxBytes < 1024 {
+		maxBytes = DefaultMaxWebhookBytes
+	}
+	provider := strings.ToLower(strings.TrimSpace(os.Getenv(EnvProvider)))
+	if provider == "" {
+		provider = DefaultProvider
+	}
+	return Config{
+		Enabled:              envBool(EnvEnabled, false),
+		AutoSendEnabled:      envBool(EnvAutoSend, false),
+		AutoReplyEnabled:     envBool(EnvAutoReply, false),
+		Provider:             provider,
+		EvolutionBaseURL:     strings.TrimSpace(os.Getenv(EnvEvolutionBaseURL)),
+		EvolutionAPIKey:      strings.TrimSpace(os.Getenv(EnvEvolutionAPIKey)),
+		EvolutionInstance:    strings.TrimSpace(os.Getenv(EnvEvolutionInstance)),
+		AllowBaileys:         envBool(EnvEvolutionAllowBaileys, false),
+		WebhookSecret:        strings.TrimSpace(os.Getenv(EnvWebhookSecret)),
+		CrossChannelInterval: time.Duration(hours) * time.Hour,
+		ServiceWindow:        time.Duration(sw) * time.Hour,
+		MaxWebhookBytes:      int64(maxBytes),
+		AppEnv:               strings.TrimSpace(os.Getenv(EnvAppEnv)),
+	}
+}
+
+// IsProduction reports whether APP_ENV is production-like.
+func (c Config) IsProduction() bool {
+	e := strings.ToLower(c.AppEnv)
+	return e == "prod" || e == "production"
+}
+
+// ValidateStartup fails closed on insecure or policy-violating combinations.
+// Called when the WhatsApp feature is enabled at boot.
+func (c Config) ValidateStartup() error {
+	if !c.Enabled {
+		return nil
+	}
+	// Baileys must never enable under production.
+	if c.IsProduction() && c.AllowBaileys {
+		return fmt.Errorf("%s cannot be true when APP_ENV is production (Cloud API only)", EnvEvolutionAllowBaileys)
+	}
+	if c.AllowBaileys && !c.IsProduction() {
+		// Visible warning is logged by the caller; config still validates.
+	}
+	if c.Provider == ProviderEvolution || c.Provider == "" {
+		if c.EvolutionBaseURL == "" {
+			return fmt.Errorf("%s is required when WhatsApp is enabled with evolution provider", EnvEvolutionBaseURL)
+		}
+		if c.IsProduction() && !strings.HasPrefix(strings.ToLower(c.EvolutionBaseURL), "https://") {
+			// Allow http only for private network URLs in non-strict self-host;
+			// production prefers https or private network — require non-empty.
+			if !isPrivateOrLocalURL(c.EvolutionBaseURL) {
+				return fmt.Errorf("%s must be https or a private-network URL in production", EnvEvolutionBaseURL)
+			}
+		}
+		if c.EvolutionAPIKey == "" {
+			return fmt.Errorf("%s is required when WhatsApp is enabled", EnvEvolutionAPIKey)
+		}
+		if c.EvolutionInstance == "" {
+			return fmt.Errorf("%s is required when WhatsApp is enabled", EnvEvolutionInstance)
+		}
+	}
+	if c.WebhookSecret == "" && c.IsProduction() {
+		return fmt.Errorf("%s is required in production when WhatsApp is enabled", EnvWebhookSecret)
+	}
+	if c.CrossChannelInterval < 0 {
+		return fmt.Errorf("%s must be >= 0", EnvCrossChannelHours)
+	}
+	return nil
+}
+
+// BaileysWarning returns a non-empty operator warning when Baileys is allowed.
+func (c Config) BaileysWarning() string {
+	if !c.AllowBaileys {
+		return ""
+	}
+	return "WHATSAPP_EVOLUTION_ALLOW_BAILEYS=true: Baileys/WhatsApp-Web sessions are LAB ONLY. " +
+		"Do not use as a substitute for WhatsApp Business Platform policies. " +
+		"Cloud API remains the production path."
+}
+
+func isPrivateOrLocalURL(raw string) bool {
+	lower := strings.ToLower(raw)
+	return strings.Contains(lower, "://10.") ||
+		strings.Contains(lower, "://192.168.") ||
+		strings.Contains(lower, "://172.") ||
+		strings.Contains(lower, "://localhost") ||
+		strings.Contains(lower, "://127.0.0.1") ||
+		strings.Contains(lower, "://evolution")
+}
+
+func envBool(key string, def bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+func envInt(key string, def int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}

--- a/internal/app/whatsapp/eligibility.go
+++ b/internal/app/whatsapp/eligibility.go
@@ -118,24 +118,24 @@ func EvaluateEligibility(state ContactChannelState, intent SendIntent) Decision 
 		inServiceWindow = true
 	}
 
-	// USER_INITIATED with open window: free-text reply allowed (human or system
-	// if auto-reply flag is on — that flag is checked by the caller for auto-reply).
-	if consent == ConsentUserInitiated || inServiceWindow {
+	// Free-text is only allowed inside an open service window (last inbound + TTL).
+	// USER_INITIATED alone does not keep free-text forever after the window closes.
+	if inServiceWindow {
 		if intent.Mode == ModeFreeText || intent.Mode == ModeTemplate {
 			if intent.Automated && !intent.AutoSendEnabled {
-				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled", OpenServiceWindow: inServiceWindow}
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled", OpenServiceWindow: true}
 			}
 			if intent.Automated && intent.RequireHumanApproval {
-				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "requires_human_approval", OpenServiceWindow: inServiceWindow}
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "requires_human_approval", OpenServiceWindow: true}
 			}
 			if blocked, why := crossChannelBlocked(state, now, cross); blocked {
-				return Decision{Allowed: false, Eligibility: EligBlocked, Reason: why, OpenServiceWindow: inServiceWindow}
+				return Decision{Allowed: false, Eligibility: EligBlocked, Reason: why, OpenServiceWindow: true}
 			}
 			elig := EligServiceWindow
 			if consent == ConsentOptedIn && state.ConsentProvenanceOK {
 				elig = EligAutomatedAllowed
 			}
-			return Decision{Allowed: true, Eligibility: elig, Reason: "service_window_or_user_initiated", OpenServiceWindow: true}
+			return Decision{Allowed: true, Eligibility: elig, Reason: "service_window_open", OpenServiceWindow: true}
 		}
 	}
 

--- a/internal/app/whatsapp/eligibility.go
+++ b/internal/app/whatsapp/eligibility.go
@@ -1,0 +1,311 @@
+package whatsapp
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ContactChannelState is the policy input for one contact's WhatsApp eligibility.
+// Public phone numbers must arrive with ConsentStatus UNKNOWN or NO_OPT_IN.
+type ContactChannelState struct {
+	ContactID              uuid.UUID
+	OrganizationID         uuid.UUID
+	PhoneE164              string
+	PhoneSource            string // e.g. official_company_site, form, user_provided
+	PhoneSourceURL         string
+	PhoneVerifiedAt        *time.Time
+	ConsentStatus          string
+	ConsentSource          string
+	ConsentAt              *time.Time
+	ConsentScope           string // marketing | transactional | service
+	ConsentProvenanceOK    bool   // true only when opt-in has recorded provenance
+	LastInboundAt          *time.Time
+	ServiceWindowUntil     *time.Time
+	ChannelStatus          string // operational label; optional
+	OptOutAt               *time.Time
+	DoNotContact           bool
+	LastEmailOutboundAt    *time.Time
+	LastWhatsAppOutboundAt *time.Time
+	LastAnyOutboundAt      *time.Time
+	HasOpenReply           bool // human reply on any channel for active sequence
+}
+
+// SendIntent describes what the caller wants to do.
+type SendIntent struct {
+	// Mode: free_text | template | enroll_sequence
+	Mode string
+	// TemplateApproved is true only when the template is APPROVED at Meta/BSP.
+	TemplateApproved bool
+	// TemplateName for audit; empty for free text.
+	TemplateName string
+	// Automated is true for sequence/scheduler sends (not human-clicked send).
+	Automated bool
+	// Now is the evaluation time (injectable for tests).
+	Now time.Time
+	// CrossChannelMin is the minimum gap between any outbound channels.
+	// Zero means use a default of 24h when Automated.
+	CrossChannelMin time.Duration
+	// ServiceWindow is the allowed reply window after user-initiated inbound.
+	ServiceWindow time.Duration
+	// RequireHumanApproval blocks automated free-text even when consented.
+	RequireHumanApproval bool
+	// FeatureEnabled master switch.
+	FeatureEnabled bool
+	// AutoSendEnabled feature flag for automated sends.
+	AutoSendEnabled bool
+}
+
+// Decision is the policy outcome. Allowed=false means zero provider sends.
+type Decision struct {
+	Allowed     bool
+	Eligibility string
+	Reason      string
+	// UseTemplate forces template path (e.g. outside service window with opt-in).
+	UseTemplate bool
+	// OpenServiceWindow is true when free-text is allowed due to 24h window.
+	OpenServiceWindow bool
+}
+
+const (
+	ModeFreeText       = "free_text"
+	ModeTemplate       = "template"
+	ModeEnrollSequence = "enroll_sequence"
+)
+
+// EvaluateEligibility is the deterministic policy gate.
+// Critical invariant: public phone + no opt-in → zero automated WhatsApp sends.
+func EvaluateEligibility(state ContactChannelState, intent SendIntent) Decision {
+	now := intent.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	sw := intent.ServiceWindow
+	if sw <= 0 {
+		sw = 24 * time.Hour
+	}
+	cross := intent.CrossChannelMin
+	if cross <= 0 && intent.Automated {
+		cross = 24 * time.Hour
+	}
+
+	if !intent.FeatureEnabled {
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "whatsapp_feature_disabled"}
+	}
+
+	// Global DNC / sticky opt-out always wins.
+	if state.DoNotContact || state.ConsentStatus == ConsentDoNotContact {
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "do_not_contact"}
+	}
+	if state.ConsentStatus == ConsentOptedOut || state.OptOutAt != nil {
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "opted_out"}
+	}
+
+	if state.PhoneE164 == "" {
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "missing_phone"}
+	}
+
+	// No inventing consent: UNKNOWN / NO_OPT_IN / empty block automation.
+	consent := state.ConsentStatus
+	if consent == "" {
+		consent = ConsentUnknown
+	}
+
+	inServiceWindow := false
+	if state.ServiceWindowUntil != nil && state.ServiceWindowUntil.After(now) {
+		inServiceWindow = true
+	} else if state.LastInboundAt != nil && state.LastInboundAt.Add(sw).After(now) {
+		inServiceWindow = true
+	}
+
+	// USER_INITIATED with open window: free-text reply allowed (human or system
+	// if auto-reply flag is on — that flag is checked by the caller for auto-reply).
+	if consent == ConsentUserInitiated || inServiceWindow {
+		if intent.Mode == ModeFreeText || intent.Mode == ModeTemplate {
+			if intent.Automated && !intent.AutoSendEnabled {
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled", OpenServiceWindow: inServiceWindow}
+			}
+			if intent.Automated && intent.RequireHumanApproval {
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "requires_human_approval", OpenServiceWindow: inServiceWindow}
+			}
+			if blocked, why := crossChannelBlocked(state, now, cross); blocked {
+				return Decision{Allowed: false, Eligibility: EligBlocked, Reason: why, OpenServiceWindow: inServiceWindow}
+			}
+			elig := EligServiceWindow
+			if consent == ConsentOptedIn && state.ConsentProvenanceOK {
+				elig = EligAutomatedAllowed
+			}
+			return Decision{Allowed: true, Eligibility: elig, Reason: "service_window_or_user_initiated", OpenServiceWindow: true}
+		}
+	}
+
+	switch consent {
+	case ConsentUnknown, ConsentNoOptIn:
+		// Public number is NOT opt-in. Block all automated and sequence enrollment.
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "no_opt_in"}
+
+	case ConsentOptedIn:
+		if !state.ConsentProvenanceOK {
+			// Refuse bare opted_in=true without provenance.
+			return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "opt_in_missing_provenance"}
+		}
+		if blocked, why := crossChannelBlocked(state, now, cross); blocked {
+			return Decision{Allowed: false, Eligibility: EligBlocked, Reason: why}
+		}
+		if intent.Mode == ModeFreeText {
+			if !inServiceWindow {
+				// Outside service window: free text blocked; template may still work.
+				return Decision{
+					Allowed:     false,
+					Eligibility: EligTemplateOnly,
+					Reason:      "outside_service_window_use_template",
+					UseTemplate: true,
+				}
+			}
+		}
+		if intent.Mode == ModeTemplate {
+			if !intent.TemplateApproved {
+				return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "template_not_approved"}
+			}
+		}
+		if intent.Automated && !intent.AutoSendEnabled {
+			return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled"}
+		}
+		if intent.Automated && intent.RequireHumanApproval {
+			return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "requires_human_approval"}
+		}
+		if intent.Mode == ModeTemplate {
+			return Decision{Allowed: true, Eligibility: EligTemplateOnly, Reason: "opted_in_template", UseTemplate: true}
+		}
+		return Decision{Allowed: true, Eligibility: EligAutomatedAllowed, Reason: "opted_in"}
+
+	case ConsentUserInitiated:
+		// Handled above when window open; if we get here window is closed.
+		if intent.Mode == ModeTemplate && intent.TemplateApproved {
+			if intent.Automated && !intent.AutoSendEnabled {
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled"}
+			}
+			return Decision{Allowed: true, Eligibility: EligTemplateOnly, Reason: "user_initiated_template_outside_window", UseTemplate: true}
+		}
+		return Decision{Allowed: false, Eligibility: EligTemplateOnly, Reason: "user_initiated_window_closed", UseTemplate: true}
+
+	default:
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "unknown_consent_status"}
+	}
+}
+
+func crossChannelBlocked(state ContactChannelState, now time.Time, minGap time.Duration) (bool, string) {
+	if minGap <= 0 {
+		return false, ""
+	}
+	last := state.LastAnyOutboundAt
+	if last == nil {
+		// Prefer the more recent of email / whatsapp if aggregate not set.
+		if state.LastEmailOutboundAt != nil {
+			last = state.LastEmailOutboundAt
+		}
+		if state.LastWhatsAppOutboundAt != nil {
+			if last == nil || state.LastWhatsAppOutboundAt.After(*last) {
+				last = state.LastWhatsAppOutboundAt
+			}
+		}
+	}
+	if last == nil {
+		return false, ""
+	}
+	if last.Add(minGap).After(now) {
+		return true, "cross_channel_cooldown"
+	}
+	return false, ""
+}
+
+// OpenServiceWindowFromInbound updates state timestamps after a user message.
+func OpenServiceWindowFromInbound(state *ContactChannelState, at time.Time, window time.Duration) {
+	if state == nil {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	if window <= 0 {
+		window = 24 * time.Hour
+	}
+	state.LastInboundAt = &at
+	until := at.Add(window)
+	state.ServiceWindowUntil = &until
+	if state.ConsentStatus == ConsentUnknown || state.ConsentStatus == ConsentNoOptIn || state.ConsentStatus == "" {
+		state.ConsentStatus = ConsentUserInitiated
+		state.ConsentSource = "inbound_whatsapp"
+		state.ConsentAt = &at
+		state.ConsentProvenanceOK = true
+		state.ConsentScope = "service"
+	}
+}
+
+// ApplyOptOut sets sticky opt-out that survives re-import.
+func ApplyOptOut(state *ContactChannelState, at time.Time, source string) {
+	if state == nil {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	state.ConsentStatus = ConsentOptedOut
+	state.OptOutAt = &at
+	state.ConsentSource = source
+	state.ConsentAt = &at
+	state.ConsentProvenanceOK = true
+}
+
+// ApplyDoNotContact sets permanent DNC.
+func ApplyDoNotContact(state *ContactChannelState, at time.Time, source string) {
+	if state == nil {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	state.DoNotContact = true
+	state.ConsentStatus = ConsentDoNotContact
+	state.OptOutAt = &at
+	state.ConsentSource = source
+	state.ConsentAt = &at
+	state.ConsentProvenanceOK = true
+}
+
+// MergeImportConsent never upgrades sticky opt-out/DNC from a later import.
+// Public phone imports must not invent OPTED_IN.
+func MergeImportConsent(existing ContactChannelState, incomingConsent, incomingSource string, incomingAt *time.Time, provenanceOK bool) ContactChannelState {
+	out := existing
+	if existing.ConsentStatus == ConsentOptedOut || existing.ConsentStatus == ConsentDoNotContact || existing.DoNotContact || existing.OptOutAt != nil {
+		// Sticky: ignore softer incoming status.
+		return out
+	}
+	// Never invent opt-in from public sources.
+	switch incomingConsent {
+	case ConsentOptedIn:
+		if !provenanceOK {
+			// Downgrade to NO_OPT_IN rather than accept bare flag.
+			if out.ConsentStatus == "" || out.ConsentStatus == ConsentUnknown {
+				out.ConsentStatus = ConsentNoOptIn
+			}
+			return out
+		}
+		out.ConsentStatus = ConsentOptedIn
+		out.ConsentSource = incomingSource
+		out.ConsentAt = incomingAt
+		out.ConsentProvenanceOK = true
+	case ConsentUserInitiated, ConsentOptedOut, ConsentDoNotContact, ConsentNoOptIn, ConsentUnknown:
+		if incomingConsent != "" {
+			out.ConsentStatus = incomingConsent
+			out.ConsentSource = incomingSource
+			out.ConsentAt = incomingAt
+			out.ConsentProvenanceOK = provenanceOK || incomingConsent == ConsentUserInitiated
+		}
+	default:
+		if out.ConsentStatus == "" {
+			out.ConsentStatus = ConsentUnknown
+		}
+	}
+	return out
+}

--- a/internal/app/whatsapp/eligibility_test.go
+++ b/internal/app/whatsapp/eligibility_test.go
@@ -1,0 +1,241 @@
+package whatsapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func baseState() ContactChannelState {
+	return ContactChannelState{
+		ContactID:      uuid.New(),
+		OrganizationID: uuid.New(),
+		PhoneE164:      "+5548999999999",
+		PhoneSource:    "official_company_site",
+		ConsentStatus:  ConsentUnknown,
+	}
+}
+
+func TestPublicPhoneNoOptInNeverSends(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 24 * time.Hour, ServiceWindow: 24 * time.Hour}, mock, nil)
+
+	for _, consent := range []string{ConsentUnknown, ConsentNoOptIn, ""} {
+		t.Run(consent, func(t *testing.T) {
+			mock.Reset()
+			st := baseState()
+			st.ConsentStatus = consent
+			intent := SendIntent{
+				Mode:            ModeFreeText,
+				Automated:       true,
+				AutoSendEnabled: true,
+				FeatureEnabled:  true,
+				Now:             time.Now().UTC(),
+			}
+			ext, err := svc.Send(context.Background(), st, intent, &SendTextRequest{
+				ToE164: "5548999999999",
+				Body:   "Olá",
+			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ext.Decision.Allowed {
+				t.Fatalf("public phone with consent=%q must not allow send", consent)
+			}
+			if mock.SendCount() != 0 {
+				t.Fatalf("invariant broken: provider send count=%d want 0", mock.SendCount())
+			}
+		})
+	}
+}
+
+func TestOptedInWithProvenanceAllowsInWindow(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 0, ServiceWindow: 24 * time.Hour}, mock, nil)
+	now := time.Now().UTC()
+	in := now.Add(-1 * time.Hour)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	st.ConsentSource = "website_form"
+	st.LastInboundAt = &in
+	st.ServiceWindowUntil = ptrTime(now.Add(20 * time.Hour))
+
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true, Now: now,
+	}, &SendTextRequest{ToE164: "5548999999999", Body: "Oi"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ext.Decision.Allowed {
+		t.Fatalf("expected allowed, got %+v", ext.Decision)
+	}
+	if mock.SendCount() != 1 {
+		t.Fatalf("send count=%d", mock.SendCount())
+	}
+}
+
+func TestOptedInWithoutProvenanceBlocked(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true}, mock, nil)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = false
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true,
+	}, &SendTextRequest{ToE164: "5548999999999", Body: "Oi"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ext.Decision.Allowed || mock.SendCount() != 0 {
+		t.Fatalf("bare opted_in without provenance must block: %+v count=%d", ext.Decision, mock.SendCount())
+	}
+}
+
+func TestOptedOutAndDNCBlock(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true}, mock, nil)
+	now := time.Now().UTC()
+
+	for _, st := range []ContactChannelState{
+		func() ContactChannelState {
+			s := baseState()
+			s.ConsentStatus = ConsentOptedOut
+			s.OptOutAt = &now
+			return s
+		}(),
+		func() ContactChannelState {
+			s := baseState()
+			s.ConsentStatus = ConsentDoNotContact
+			s.DoNotContact = true
+			return s
+		}(),
+	} {
+		mock.Reset()
+		ext, err := svc.Send(context.Background(), st, SendIntent{
+			Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true, Now: now,
+		}, &SendTextRequest{ToE164: "5548999999999", Body: "Oi"}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ext.Decision.Allowed || mock.SendCount() != 0 {
+			t.Fatalf("opt-out/DNC must block: %+v", ext.Decision)
+		}
+	}
+}
+
+func TestUserInitiatedOpensServiceWindow(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 0, ServiceWindow: 24 * time.Hour}, mock, nil)
+	now := time.Now().UTC()
+	st := baseState()
+	st.ConsentStatus = ConsentUnknown
+	OpenServiceWindowFromInbound(&st, now, 24*time.Hour)
+	if st.ConsentStatus != ConsentUserInitiated {
+		t.Fatalf("consent=%s", st.ConsentStatus)
+	}
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true, Now: now.Add(time.Minute),
+	}, &SendTextRequest{ToE164: "5548999999999", Body: "Resposta"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ext.Decision.Allowed {
+		t.Fatalf("user-initiated window should allow: %+v", ext.Decision)
+	}
+}
+
+func TestCrossChannelCooldown(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 24 * time.Hour, ServiceWindow: 24 * time.Hour}, mock, nil)
+	now := time.Now().UTC()
+	emailAt := now.Add(-1 * time.Hour)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	st.LastEmailOutboundAt = &emailAt
+	st.LastInboundAt = &now
+	st.ServiceWindowUntil = ptrTime(now.Add(20 * time.Hour))
+
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true, Now: now,
+		CrossChannelMin: 24 * time.Hour,
+	}, &SendTextRequest{ToE164: "5548999999999", Body: "Oi"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ext.Decision.Allowed || ext.Decision.Reason != "cross_channel_cooldown" {
+		t.Fatalf("expected cooldown block, got %+v", ext.Decision)
+	}
+	if mock.SendCount() != 0 {
+		t.Fatal("must not send during cooldown")
+	}
+}
+
+func TestStickyOptOutSurvivesImport(t *testing.T) {
+	now := time.Now().UTC()
+	existing := baseState()
+	ApplyOptOut(&existing, now, "inbound_phrase:parar")
+	merged := MergeImportConsent(existing, ConsentOptedIn, "website", &now, true)
+	if merged.ConsentStatus != ConsentOptedOut {
+		t.Fatalf("opt-out must stick over import: %s", merged.ConsentStatus)
+	}
+	// Public import without provenance must not invent opt-in
+	fresh := baseState()
+	fresh.ConsentStatus = ConsentUnknown
+	merged2 := MergeImportConsent(fresh, ConsentOptedIn, "public_site", nil, false)
+	if merged2.ConsentStatus == ConsentOptedIn {
+		t.Fatal("must not invent opt-in from public import without provenance")
+	}
+}
+
+func TestTemplateNotApprovedBlocked(t *testing.T) {
+	mock := NewMockProvider()
+	cat := NewStaticTemplateCatalog()
+	cat.Set("hello", "pt_BR", TemplatePaused)
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 0}, mock, cat)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeTemplate, Automated: true, AutoSendEnabled: true, FeatureEnabled: true,
+	}, nil, &SendTemplateRequest{ToE164: "5548999999999", TemplateName: "hello", Language: "pt_BR"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ext.Decision.Allowed || mock.SendCount() != 0 {
+		t.Fatalf("paused template must not send: %+v", ext.Decision)
+	}
+}
+
+func TestFeatureDisabledBlocks(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: false}, mock, nil)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	ext, err := svc.Send(context.Background(), st, SendIntent{Mode: ModeFreeText, Automated: true}, &SendTextRequest{Body: "x", ToE164: "55"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ext.Decision.Allowed {
+		t.Fatal("disabled feature must block")
+	}
+}
+
+func TestOutsideServiceWindowTemplateOnly(t *testing.T) {
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	// no inbound, window closed
+	d := EvaluateEligibility(st, SendIntent{
+		Mode: ModeFreeText, Automated: false, FeatureEnabled: true, Now: time.Now().UTC(),
+	})
+	if d.Allowed || d.Eligibility != EligTemplateOnly {
+		t.Fatalf("expected template-only outside window: %+v", d)
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/internal/app/whatsapp/eligibility_test.go
+++ b/internal/app/whatsapp/eligibility_test.go
@@ -238,4 +238,41 @@ func TestOutsideServiceWindowTemplateOnly(t *testing.T) {
 	}
 }
 
+// USER_INITIATED after the service window expires must not allow free-text.
+// Free-text requires an open window; outside it is template-only.
+func TestUserInitiatedOutsideWindowBlocksFreeText(t *testing.T) {
+	now := time.Now().UTC()
+	inbound := now.Add(-48 * time.Hour)
+	until := now.Add(-24 * time.Hour) // expired
+	st := baseState()
+	st.ConsentStatus = ConsentUserInitiated
+	st.ConsentProvenanceOK = true
+	st.ConsentSource = "inbound_whatsapp"
+	st.LastInboundAt = &inbound
+	st.ServiceWindowUntil = &until
+
+	d := EvaluateEligibility(st, SendIntent{
+		Mode: ModeFreeText, Automated: false, FeatureEnabled: true, Now: now,
+		ServiceWindow: 24 * time.Hour,
+	})
+	if d.Allowed {
+		t.Fatalf("free-text must be blocked outside service window: %+v", d)
+	}
+	if d.Eligibility != EligTemplateOnly || !d.UseTemplate {
+		t.Fatalf("expected template-only: %+v", d)
+	}
+	if d.OpenServiceWindow {
+		t.Fatal("OpenServiceWindow must be false when window expired")
+	}
+
+	// Approved template may still send outside window for USER_INITIATED.
+	d2 := EvaluateEligibility(st, SendIntent{
+		Mode: ModeTemplate, TemplateApproved: true, Automated: false, FeatureEnabled: true, Now: now,
+		ServiceWindow: 24 * time.Hour,
+	})
+	if !d2.Allowed || !d2.UseTemplate {
+		t.Fatalf("approved template should be allowed: %+v", d2)
+	}
+}
+
 func ptrTime(t time.Time) *time.Time { return &t }

--- a/internal/app/whatsapp/events.go
+++ b/internal/app/whatsapp/events.go
@@ -1,0 +1,45 @@
+package whatsapp
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ChannelEvent is the normalized provider event the rest of Warmbly consumes.
+// Provider-specific payloads never leave the adapter after normalization.
+type ChannelEvent struct {
+	Channel           string    `json:"channel"` // WHATSAPP
+	Provider          string    `json:"provider"`
+	EventType         string    `json:"event_type"`
+	ExternalMessageID string    `json:"external_message_id,omitempty"`
+	ExternalEventID   string    `json:"external_event_id,omitempty"`
+	ExternalThreadID  string    `json:"external_thread_id,omitempty"`
+	Instance          string    `json:"instance,omitempty"`
+	FromE164          string    `json:"from,omitempty"`
+	ToE164            string    `json:"to,omitempty"`
+	OccurredAt        time.Time `json:"occurred_at"`
+	Content           Content   `json:"content"`
+	ConnectionState   string    `json:"connection_state,omitempty"`
+	ErrorCode         string    `json:"error_code,omitempty"`
+	ErrorMessage      string    `json:"error_message,omitempty"`
+	// OrganizationID is filled after instance→org mapping, not by the provider.
+	OrganizationID uuid.UUID `json:"organization_id,omitempty"`
+}
+
+// Content is the message body projection we persist.
+type Content struct {
+	Type string `json:"type"` // text | other
+	Text string `json:"text,omitempty"`
+}
+
+// IdempotencyKey builds a stable key for webhook dedupe.
+func (e ChannelEvent) IdempotencyKey() string {
+	if e.ExternalEventID != "" {
+		return e.Provider + ":" + e.ExternalEventID
+	}
+	if e.ExternalMessageID != "" {
+		return e.Provider + ":" + e.EventType + ":" + e.ExternalMessageID
+	}
+	return e.Provider + ":" + e.EventType + ":" + e.FromE164 + ":" + e.OccurredAt.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/app/whatsapp/evolution/client.go
+++ b/internal/app/whatsapp/evolution/client.go
@@ -1,0 +1,344 @@
+// Package evolution is the single HTTP adapter for Evolution API.
+// Domain packages must not import provider wire DTOs from here for business logic;
+// only this package speaks Evolution's REST shapes.
+package evolution
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Client is a hardened Evolution API HTTP client.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	http       *http.Client
+	maxRetries int
+	userAgent  string
+}
+
+// ClientConfig configures the Evolution HTTP client.
+type ClientConfig struct {
+	BaseURL    string
+	APIKey     string
+	Timeout    time.Duration
+	MaxRetries int
+}
+
+// NewClient builds a client. API key is never logged.
+func NewClient(cfg ClientConfig) *Client {
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 20 * time.Second
+	}
+	retries := cfg.MaxRetries
+	if retries < 0 {
+		retries = 0
+	}
+	if retries > 5 {
+		retries = 5
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/"),
+		apiKey:     cfg.APIKey,
+		http:       &http.Client{Timeout: timeout},
+		maxRetries: retries,
+		userAgent:  "warmbly-whatsapp-evolution/1.0",
+	}
+}
+
+// APIError is a structured provider error with redacted details.
+type APIError struct {
+	StatusCode int
+	Code       string
+	Message    string
+	Retryable  bool
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return "evolution: unknown error"
+	}
+	return fmt.Sprintf("evolution api status=%d code=%s msg=%s", e.StatusCode, e.Code, e.Message)
+}
+
+// RedactedString never includes the API key.
+func (e *APIError) RedactedString() string {
+	return e.Error()
+}
+
+// IsRetryable reports whether the caller should retry.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if ae, ok := err.(*APIError); ok {
+		return ae.Retryable
+	}
+	// Network / timeout style errors are retryable.
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "temporary") ||
+		strings.Contains(msg, "eof")
+}
+
+// sendTextBody is Evolution POST /message/sendText/{instance}
+type sendTextBody struct {
+	Number string `json:"number"`
+	Text   string `json:"text"`
+}
+
+// sendTemplateBody is Evolution template send for Cloud API instances.
+type sendTemplateBody struct {
+	Number     string           `json:"number"`
+	Name       string           `json:"name"`
+	Language   string           `json:"language"`
+	Components []map[string]any `json:"components,omitempty"`
+}
+
+// SendTextResponse is a minimal projection of Evolution send responses.
+type SendTextResponse struct {
+	Key struct {
+		ID string `json:"id"`
+	} `json:"key"`
+	Status string `json:"status"`
+	// Some versions nest message id differently; we also accept top-level.
+	MessageID string `json:"messageId,omitempty"`
+}
+
+// Health checks GET / (welcome) or /instance/fetchInstances.
+func (c *Client) Health(ctx context.Context) error {
+	_, _, err := c.do(ctx, http.MethodGet, "/", nil, nil)
+	return err
+}
+
+// ConnectionState is instance connection state.
+type ConnectionState struct {
+	Instance string `json:"instance"`
+	State    string `json:"state"`
+}
+
+// GetConnectionState GET /instance/connectionState/{instance}
+func (c *Client) GetConnectionState(ctx context.Context, instance string) (*ConnectionState, error) {
+	path := "/instance/connectionState/" + urlPathEscape(instance)
+	body, status, err := c.do(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		Instance ConnectionState `json:"instance"`
+		// some versions return flat
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(body, &wrap); err != nil {
+		return nil, &APIError{StatusCode: status, Code: "decode", Message: "invalid connection state payload"}
+	}
+	out := wrap.Instance
+	if out.State == "" {
+		out.State = wrap.State
+	}
+	if out.Instance == "" {
+		out.Instance = instance
+	}
+	return &out, nil
+}
+
+// SendText POST /message/sendText/{instance}
+func (c *Client) SendText(ctx context.Context, instance, number, text string) (*SendTextResponse, error) {
+	path := "/message/sendText/" + urlPathEscape(instance)
+	payload, _ := json.Marshal(sendTextBody{Number: number, Text: text})
+	body, status, err := c.do(ctx, http.MethodPost, path, payload, map[string]string{
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res SendTextResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, &APIError{StatusCode: status, Code: "decode", Message: "invalid sendText response"}
+	}
+	if res.Key.ID == "" && res.MessageID != "" {
+		res.Key.ID = res.MessageID
+	}
+	return &res, nil
+}
+
+// SendTemplate POST /message/sendTemplate/{instance} (Cloud API / WHATSAPP-BUSINESS).
+func (c *Client) SendTemplate(ctx context.Context, instance, number, name, language string, variables []string) (*SendTextResponse, error) {
+	path := "/message/sendTemplate/" + urlPathEscape(instance)
+	var components []map[string]any
+	if len(variables) > 0 {
+		params := make([]map[string]string, 0, len(variables))
+		for _, v := range variables {
+			params = append(params, map[string]string{"type": "text", "text": v})
+		}
+		components = []map[string]any{{
+			"type":       "body",
+			"parameters": params,
+		}}
+	}
+	payload, _ := json.Marshal(sendTemplateBody{
+		Number:     number,
+		Name:       name,
+		Language:   language,
+		Components: components,
+	})
+	body, status, err := c.do(ctx, http.MethodPost, path, payload, map[string]string{
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res SendTextResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, &APIError{StatusCode: status, Code: "decode", Message: "invalid sendTemplate response"}
+	}
+	if res.Key.ID == "" && res.MessageID != "" {
+		res.Key.ID = res.MessageID
+	}
+	return &res, nil
+}
+
+// SetWebhook POST /webhook/set/{instance}
+func (c *Client) SetWebhook(ctx context.Context, instance, url, secret string, events []string, enabled bool) error {
+	path := "/webhook/set/" + urlPathEscape(instance)
+	headers := map[string]any{}
+	if secret != "" {
+		headers["Authorization"] = "Bearer " + secret
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"webhook": map[string]any{
+			"enabled": enabled,
+			"url":     url,
+			"headers": headers,
+			"events":  events,
+		},
+	})
+	_, _, err := c.do(ctx, http.MethodPost, path, payload, map[string]string{
+		"Content-Type": "application/json",
+	})
+	return err
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body []byte, headers map[string]string) ([]byte, int, error) {
+	if c == nil || c.baseURL == "" {
+		return nil, 0, &APIError{StatusCode: 0, Code: "config", Message: "base URL not configured", Retryable: false}
+	}
+	var lastErr error
+	attempts := c.maxRetries + 1
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			// jittered backoff
+			backoff := time.Duration(50*(1<<uint(attempt-1))) * time.Millisecond
+			jitter := time.Duration(rand.Intn(40)) * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return nil, 0, ctx.Err()
+			case <-time.After(backoff + jitter):
+			}
+		}
+		status, respBody, err := c.once(ctx, method, path, body, headers)
+		if err == nil {
+			return respBody, status, nil
+		}
+		lastErr = err
+		if !IsRetryable(err) {
+			return respBody, status, err
+		}
+		log.Debug().
+			Int("attempt", attempt+1).
+			Int("status", status).
+			Str("path", path).
+			Str("error", redactSecrets(err.Error(), c.apiKey)).
+			Msg("evolution retry")
+	}
+	return nil, 0, lastErr
+}
+
+func (c *Client) once(ctx context.Context, method, path string, body []byte, headers map[string]string) (int, []byte, error) {
+	url := c.baseURL + path
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("apikey", c.apiKey)
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Accept", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return resp.StatusCode, respBody, nil
+	}
+	ae := classifyHTTPError(resp.StatusCode, respBody)
+	return resp.StatusCode, respBody, ae
+}
+
+func classifyHTTPError(status int, body []byte) *APIError {
+	msg := strings.TrimSpace(string(body))
+	if len(msg) > 200 {
+		msg = msg[:200] + "…"
+	}
+	// Never leave API keys in error text if server echoed them.
+	ae := &APIError{
+		StatusCode: status,
+		Code:       http.StatusText(status),
+		Message:    msg,
+	}
+	switch status {
+	case 408, 425, 429, 500, 502, 503, 504:
+		ae.Retryable = true
+	case 400, 401, 403, 404, 409, 422:
+		ae.Retryable = false
+	default:
+		ae.Retryable = status >= 500
+	}
+	if status == 401 {
+		ae.Code = "unauthorized"
+		ae.Message = "invalid or missing api key"
+	}
+	return ae
+}
+
+func urlPathEscape(s string) string {
+	// Instance names are typically alphanumeric + hyphen; reject path traversal.
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "/", "")
+	s = strings.ReplaceAll(s, "..", "")
+	return s
+}
+
+func redactSecrets(s, apiKey string) string {
+	if apiKey != "" && strings.Contains(s, apiKey) {
+		return strings.ReplaceAll(s, apiKey, "[REDACTED]")
+	}
+	return s
+}
+
+// RedactAPIKey replaces the key in arbitrary strings (for tests/logs).
+func RedactAPIKey(s, apiKey string) string {
+	return redactSecrets(s, apiKey)
+}

--- a/internal/app/whatsapp/evolution/client_test.go
+++ b/internal/app/whatsapp/evolution/client_test.go
@@ -1,0 +1,187 @@
+package evolution
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+)
+
+func TestSendTextSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("apikey") != "test-key" {
+			t.Errorf("missing apikey")
+		}
+		if r.URL.Path != "/message/sendText/inst1" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "5548999999999") {
+			t.Errorf("body=%s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":{"id":"ABC123"},"status":"PENDING"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "test-key", Timeout: 2 * time.Second, MaxRetries: 0})
+	p := NewProvider(c, "inst1")
+	res, err := p.SendText(context.Background(), whatsapp.SendTextRequest{
+		ToE164: "+5548999999999",
+		Body:   "Olá",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ProviderMessageID != "ABC123" {
+		t.Fatalf("id=%s", res.ProviderMessageID)
+	}
+}
+
+func TestHTTPStatusMapping(t *testing.T) {
+	codes := []int{400, 401, 403, 404, 429, 500}
+	for _, code := range codes {
+		code := code
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+				_, _ = w.Write([]byte(`{"error":"x"}`))
+			}))
+			defer srv.Close()
+			c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "k", Timeout: time.Second, MaxRetries: 0})
+			_, err := c.SendText(context.Background(), "i", "55", "hi")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			ae, ok := err.(*APIError)
+			if !ok {
+				t.Fatalf("type %T", err)
+			}
+			if ae.StatusCode != code {
+				t.Fatalf("status=%d", ae.StatusCode)
+			}
+			retryable := code == 429 || code == 500
+			if ae.Retryable != retryable {
+				t.Fatalf("retryable=%v want %v", ae.Retryable, retryable)
+			}
+			// secret redaction: error string must not contain api key even if body did
+			if strings.Contains(ae.Error(), "super-secret-key") {
+				t.Fatal("leaked key")
+			}
+		})
+	}
+}
+
+func TestRetryOn500ThenSuccess(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n.Add(1) == 1 {
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`fail`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"key":{"id":"OK"},"status":"PENDING"}`))
+	}))
+	defer srv.Close()
+	c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "k", Timeout: time.Second, MaxRetries: 2})
+	res, err := c.SendText(context.Background(), "i", "55", "hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Key.ID != "OK" {
+		t.Fatal(res.Key.ID)
+	}
+	if n.Load() < 2 {
+		t.Fatalf("attempts=%d", n.Load())
+	}
+}
+
+func TestNoRetryOn400(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n.Add(1)
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte(`bad`))
+	}))
+	defer srv.Close()
+	c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "k", Timeout: time.Second, MaxRetries: 3})
+	_, err := c.SendText(context.Background(), "i", "55", "hi")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if n.Load() != 1 {
+		t.Fatalf("should not retry permanent errors, attempts=%d", n.Load())
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "k", Timeout: 50 * time.Millisecond, MaxRetries: 0})
+	_, err := c.SendText(context.Background(), "i", "55", "hi")
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+}
+
+func TestOffline(t *testing.T) {
+	c := NewClient(ClientConfig{BaseURL: "http://127.0.0.1:1", APIKey: "k", Timeout: 100 * time.Millisecond, MaxRetries: 0})
+	err := c.Health(context.Background())
+	if err == nil {
+		t.Fatal("expected connection error")
+	}
+}
+
+func TestRedactAPIKey(t *testing.T) {
+	s := RedactAPIKey("failed key=super-secret-key-xyz", "super-secret-key-xyz")
+	if strings.Contains(s, "super-secret-key-xyz") {
+		t.Fatal(s)
+	}
+}
+
+func TestNormalizeWebhookInbound(t *testing.T) {
+	raw := []byte(`{
+		"event": "messages.upsert",
+		"instance": "confenge",
+		"data": {
+			"key": {"remoteJid": "5548999887766@s.whatsapp.net", "fromMe": false, "id": "MSG1"},
+			"message": {"conversation": "Olá, quero falar no WhatsApp"},
+			"messageTimestamp": 1710000000
+		}
+	}`)
+	ev, err := NormalizeWebhook(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.EventType != whatsapp.EventMessageReceived {
+		t.Fatalf("type=%s", ev.EventType)
+	}
+	if ev.FromE164 != "+5548999887766" {
+		t.Fatalf("from=%s", ev.FromE164)
+	}
+	if ev.Content.Text != "Olá, quero falar no WhatsApp" {
+		t.Fatalf("text=%s", ev.Content.Text)
+	}
+	if ev.Provider != whatsapp.ProviderEvolution {
+		t.Fatal(ev.Provider)
+	}
+}
+
+func TestNormalizeUnsupported(t *testing.T) {
+	ev, err := NormalizeWebhook([]byte(`{"event":"groups.update","instance":"x","data":{}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.EventType != whatsapp.EventUnsupported {
+		t.Fatal(ev.EventType)
+	}
+}

--- a/internal/app/whatsapp/evolution/normalize.go
+++ b/internal/app/whatsapp/evolution/normalize.go
@@ -1,0 +1,229 @@
+package evolution
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+)
+
+// RawWebhook is a minimal Evolution webhook envelope (v2.x).
+// We only extract fields needed for domain events; unknown fields are ignored.
+type RawWebhook struct {
+	Event    string          `json:"event"`
+	Instance string          `json:"instance"`
+	Data     json.RawMessage `json:"data"`
+	// Some deployments nest differently
+	Sender string `json:"sender,omitempty"`
+	DateAt int64  `json:"date_time,omitempty"`
+}
+
+// NormalizeWebhook maps an Evolution payload into a domain ChannelEvent.
+// Unsupported events return EventUnsupported with Ignored semantics for callers.
+func NormalizeWebhook(raw []byte) (whatsapp.ChannelEvent, error) {
+	var env RawWebhook
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return whatsapp.ChannelEvent{}, err
+	}
+	ev := whatsapp.ChannelEvent{
+		Channel:    whatsapp.ChannelWhatsApp,
+		Provider:   whatsapp.ProviderEvolution,
+		Instance:   env.Instance,
+		OccurredAt: time.Now().UTC(),
+		Content:    whatsapp.Content{Type: whatsapp.ContentOther},
+	}
+
+	eventName := strings.ToUpper(strings.TrimSpace(env.Event))
+	eventName = strings.ReplaceAll(eventName, ".", "_")
+	eventName = strings.ReplaceAll(eventName, "-", "_")
+
+	switch eventName {
+	case "MESSAGES_UPSERT", "MESSAGE_UPSERT", "MESSAGES_SET":
+		return normalizeMessageUpsert(ev, env.Data)
+	case "MESSAGES_UPDATE", "MESSAGE_UPDATE":
+		return normalizeMessageUpdate(ev, env.Data)
+	case "SEND_MESSAGE", "MESSAGES_UPDATE_SEND":
+		ev.EventType = whatsapp.EventMessageSent
+		return normalizeMessageUpsert(ev, env.Data)
+	case "CONNECTION_UPDATE", "CONNECTION_STATE":
+		return normalizeConnection(ev, env.Data)
+	default:
+		ev.EventType = whatsapp.EventUnsupported
+		return ev, nil
+	}
+}
+
+type msgData struct {
+	Key struct {
+		RemoteJid string `json:"remoteJid"`
+		FromMe    bool   `json:"fromMe"`
+		ID        string `json:"id"`
+	} `json:"key"`
+	PushName         string         `json:"pushName"`
+	MessageType      string         `json:"messageType"`
+	Message          map[string]any `json:"message"`
+	MessageTimestamp any            `json:"messageTimestamp"`
+	Status           string         `json:"status"`
+}
+
+func normalizeMessageUpsert(ev whatsapp.ChannelEvent, data json.RawMessage) (whatsapp.ChannelEvent, error) {
+	var m msgData
+	if len(data) > 0 {
+		_ = json.Unmarshal(data, &m)
+		// Evolution sometimes wraps as { messages: [...] } or data is the message.
+		if m.Key.ID == "" {
+			var wrap struct {
+				Messages []msgData `json:"messages"`
+			}
+			if json.Unmarshal(data, &wrap) == nil && len(wrap.Messages) > 0 {
+				m = wrap.Messages[0]
+			}
+		}
+	}
+	if ev.EventType == "" {
+		if m.Key.FromMe {
+			ev.EventType = whatsapp.EventMessageSent
+		} else {
+			ev.EventType = whatsapp.EventMessageReceived
+		}
+	}
+	ev.ExternalMessageID = m.Key.ID
+	ev.ExternalEventID = m.Key.ID + ":" + ev.EventType
+	phone := jidToE164(m.Key.RemoteJid)
+	if m.Key.FromMe {
+		ev.ToE164 = phone
+	} else {
+		ev.FromE164 = phone
+	}
+	ev.ExternalThreadID = phone
+	if ts := parseTS(m.MessageTimestamp); !ts.IsZero() {
+		ev.OccurredAt = ts
+	}
+	text := extractText(m.Message)
+	if text != "" {
+		ev.Content = whatsapp.Content{Type: whatsapp.ContentText, Text: text}
+	}
+	return ev, nil
+}
+
+func normalizeMessageUpdate(ev whatsapp.ChannelEvent, data json.RawMessage) (whatsapp.ChannelEvent, error) {
+	var m msgData
+	_ = json.Unmarshal(data, &m)
+	status := strings.ToUpper(m.Status)
+	// Also try nested keyStatus
+	var alt struct {
+		Key struct {
+			ID        string `json:"id"`
+			RemoteJid string `json:"remoteJid"`
+		} `json:"keyId"`
+		Status    string `json:"status"`
+		MessageID string `json:"messageId"`
+		RemoteJid string `json:"remoteJid"`
+	}
+	_ = json.Unmarshal(data, &alt)
+	if m.Key.ID == "" {
+		m.Key.ID = alt.MessageID
+		if m.Key.ID == "" {
+			m.Key.ID = alt.Key.ID
+		}
+	}
+	if status == "" {
+		status = strings.ToUpper(alt.Status)
+	}
+	switch status {
+	case "DELIVERY_ACK", "DELIVERED", "SERVER_ACK":
+		ev.EventType = whatsapp.EventMessageDelivered
+	case "READ", "PLAYED":
+		ev.EventType = whatsapp.EventMessageRead
+	case "ERROR", "FAILED":
+		ev.EventType = whatsapp.EventMessageFailed
+	default:
+		ev.EventType = whatsapp.EventMessageSent
+	}
+	ev.ExternalMessageID = m.Key.ID
+	ev.ExternalEventID = m.Key.ID + ":" + ev.EventType + ":" + status
+	phone := jidToE164(m.Key.RemoteJid)
+	if phone == "" {
+		phone = jidToE164(alt.RemoteJid)
+	}
+	ev.ToE164 = phone
+	ev.ExternalThreadID = phone
+	return ev, nil
+}
+
+func normalizeConnection(ev whatsapp.ChannelEvent, data json.RawMessage) (whatsapp.ChannelEvent, error) {
+	ev.EventType = whatsapp.EventConnectionState
+	var wrap struct {
+		State    string `json:"state"`
+		Instance struct {
+			State    string `json:"state"`
+			Instance string `json:"instanceName"`
+		} `json:"instance"`
+	}
+	_ = json.Unmarshal(data, &wrap)
+	ev.ConnectionState = wrap.State
+	if ev.ConnectionState == "" {
+		ev.ConnectionState = wrap.Instance.State
+	}
+	if wrap.Instance.Instance != "" {
+		ev.Instance = wrap.Instance.Instance
+	}
+	ev.ExternalEventID = "connection:" + ev.Instance + ":" + ev.ConnectionState + ":" + ev.OccurredAt.Format(time.RFC3339)
+	return ev, nil
+}
+
+func jidToE164(jid string) string {
+	// "5548999999999@s.whatsapp.net" or "5548999999999:xx@s.whatsapp.net"
+	jid = strings.TrimSpace(jid)
+	if jid == "" {
+		return ""
+	}
+	at := strings.Index(jid, "@")
+	if at > 0 {
+		jid = jid[:at]
+	}
+	if colon := strings.Index(jid, ":"); colon > 0 {
+		jid = jid[:colon]
+	}
+	digits := whatsapp.DigitsOnly(jid)
+	if digits == "" {
+		return ""
+	}
+	return "+" + digits
+}
+
+func extractText(msg map[string]any) string {
+	if msg == nil {
+		return ""
+	}
+	if c, ok := msg["conversation"].(string); ok {
+		return c
+	}
+	if ext, ok := msg["extendedTextMessage"].(map[string]any); ok {
+		if t, ok := ext["text"].(string); ok {
+			return t
+		}
+	}
+	return ""
+}
+
+func parseTS(v any) time.Time {
+	switch t := v.(type) {
+	case float64:
+		if t > 1e12 {
+			return time.UnixMilli(int64(t)).UTC()
+		}
+		return time.Unix(int64(t), 0).UTC()
+	case int64:
+		return time.Unix(t, 0).UTC()
+	case json.Number:
+		n, _ := t.Int64()
+		return time.Unix(n, 0).UTC()
+	case string:
+		if n, err := time.Parse(time.RFC3339, t); err == nil {
+			return n.UTC()
+		}
+	}
+	return time.Time{}
+}

--- a/internal/app/whatsapp/evolution/provider.go
+++ b/internal/app/whatsapp/evolution/provider.go
@@ -1,0 +1,106 @@
+package evolution
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+)
+
+// Provider implements whatsapp.Provider using Evolution API (Cloud API first).
+type Provider struct {
+	client   *Client
+	instance string
+}
+
+// NewProvider wraps a Client as a domain Provider.
+func NewProvider(client *Client, defaultInstance string) *Provider {
+	return &Provider{client: client, instance: defaultInstance}
+}
+
+// Name implements whatsapp.Provider.
+func (p *Provider) Name() string { return whatsapp.ProviderEvolution }
+
+func (p *Provider) resolveInstance(instance string) string {
+	if instance != "" {
+		return instance
+	}
+	return p.instance
+}
+
+// SendText implements whatsapp.Provider.
+func (p *Provider) SendText(ctx context.Context, req whatsapp.SendTextRequest) (*whatsapp.SendResult, error) {
+	if p == nil || p.client == nil {
+		return nil, fmt.Errorf("evolution provider not configured")
+	}
+	number := whatsapp.DigitsOnly(req.ToE164)
+	res, err := p.client.SendText(ctx, p.resolveInstance(req.Instance), number, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	id := res.Key.ID
+	if id == "" {
+		id = res.MessageID
+	}
+	return &whatsapp.SendResult{
+		ProviderMessageID: id,
+		Status:            "sent",
+		RawStatus:         res.Status,
+		OccurredAt:        time.Now().UTC(),
+	}, nil
+}
+
+// SendTemplate implements whatsapp.Provider.
+func (p *Provider) SendTemplate(ctx context.Context, req whatsapp.SendTemplateRequest) (*whatsapp.SendResult, error) {
+	if p == nil || p.client == nil {
+		return nil, fmt.Errorf("evolution provider not configured")
+	}
+	number := whatsapp.DigitsOnly(req.ToE164)
+	res, err := p.client.SendTemplate(ctx, p.resolveInstance(req.Instance), number, req.TemplateName, req.Language, req.Variables)
+	if err != nil {
+		return nil, err
+	}
+	id := res.Key.ID
+	if id == "" {
+		id = res.MessageID
+	}
+	return &whatsapp.SendResult{
+		ProviderMessageID: id,
+		Status:            "sent",
+		RawStatus:         res.Status,
+		OccurredAt:        time.Now().UTC(),
+	}, nil
+}
+
+// GetConnectionStatus implements whatsapp.Provider.
+func (p *Provider) GetConnectionStatus(ctx context.Context, instance string) (*whatsapp.ConnectionStatus, error) {
+	st, err := p.client.GetConnectionState(ctx, p.resolveInstance(instance))
+	if err != nil {
+		return nil, err
+	}
+	return &whatsapp.ConnectionStatus{
+		Instance:  st.Instance,
+		State:     st.State,
+		UpdatedAt: time.Now().UTC(),
+	}, nil
+}
+
+// ConfigureWebhook implements whatsapp.Provider.
+func (p *Provider) ConfigureWebhook(ctx context.Context, instance string, cfg whatsapp.WebhookConfig) error {
+	events := cfg.Events
+	if len(events) == 0 {
+		events = []string{
+			"MESSAGES_UPSERT",
+			"MESSAGES_UPDATE",
+			"SEND_MESSAGE",
+			"CONNECTION_UPDATE",
+		}
+	}
+	return p.client.SetWebhook(ctx, p.resolveInstance(instance), cfg.URL, cfg.Secret, events, cfg.Enabled)
+}
+
+// Health implements whatsapp.Provider.
+func (p *Provider) Health(ctx context.Context) error {
+	return p.client.Health(ctx)
+}

--- a/internal/app/whatsapp/mock.go
+++ b/internal/app/whatsapp/mock.go
@@ -1,0 +1,113 @@
+package whatsapp
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MockProvider records sends for tests. Never reaches a real network.
+type MockProvider struct {
+	mu        sync.Mutex
+	Sends     []MockSend
+	Templates []MockSend
+	HealthErr error
+	SendErr   error
+	Status    ConnectionStatus
+}
+
+// MockSend is one recorded outbound attempt.
+type MockSend struct {
+	Kind           string // text | template
+	ToE164         string
+	Body           string
+	TemplateName   string
+	Language       string
+	Variables      []string
+	IdempotencyKey string
+	OrganizationID uuid.UUID
+	At             time.Time
+}
+
+// NewMockProvider returns a ready mock.
+func NewMockProvider() *MockProvider {
+	return &MockProvider{
+		Status: ConnectionStatus{Instance: "mock", State: "open", UpdatedAt: time.Now().UTC()},
+	}
+}
+
+func (m *MockProvider) Name() string { return ProviderMock }
+
+func (m *MockProvider) SendText(_ context.Context, req SendTextRequest) (*SendResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.SendErr != nil {
+		return nil, m.SendErr
+	}
+	m.Sends = append(m.Sends, MockSend{
+		Kind:           "text",
+		ToE164:         req.ToE164,
+		Body:           req.Body,
+		IdempotencyKey: req.IdempotencyKey,
+		OrganizationID: req.OrganizationID,
+		At:             time.Now().UTC(),
+	})
+	id := uuid.New().String()
+	return &SendResult{ProviderMessageID: id, Status: "sent", RawStatus: "MOCK_SENT", OccurredAt: time.Now().UTC()}, nil
+}
+
+func (m *MockProvider) SendTemplate(_ context.Context, req SendTemplateRequest) (*SendResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.SendErr != nil {
+		return nil, m.SendErr
+	}
+	m.Templates = append(m.Templates, MockSend{
+		Kind:           "template",
+		ToE164:         req.ToE164,
+		TemplateName:   req.TemplateName,
+		Language:       req.Language,
+		Variables:      append([]string(nil), req.Variables...),
+		IdempotencyKey: req.IdempotencyKey,
+		OrganizationID: req.OrganizationID,
+		At:             time.Now().UTC(),
+	})
+	id := uuid.New().String()
+	return &SendResult{ProviderMessageID: id, Status: "sent", RawStatus: "MOCK_TEMPLATE_SENT", OccurredAt: time.Now().UTC()}, nil
+}
+
+func (m *MockProvider) GetConnectionStatus(_ context.Context, instance string) (*ConnectionStatus, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := m.Status
+	if instance != "" {
+		s.Instance = instance
+	}
+	return &s, nil
+}
+
+func (m *MockProvider) ConfigureWebhook(context.Context, string, WebhookConfig) error { return nil }
+
+func (m *MockProvider) Health(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.HealthErr
+}
+
+// SendCount returns total text+template sends.
+func (m *MockProvider) SendCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Sends) + len(m.Templates)
+}
+
+// Reset clears recorded sends.
+func (m *MockProvider) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Sends = nil
+	m.Templates = nil
+	m.SendErr = nil
+}

--- a/internal/app/whatsapp/optout.go
+++ b/internal/app/whatsapp/optout.go
@@ -1,0 +1,122 @@
+package whatsapp
+
+import (
+	"strings"
+	"unicode"
+)
+
+// OptOutMatch describes an automatic opt-out phrase detection result.
+type OptOutMatch struct {
+	Matched   bool
+	Category  string // opt_out | do_not_contact | ambiguous | none
+	Phrase    string
+	Confident bool // true only for unequivocal phrases
+}
+
+// unequivocal Portuguese / Spanish / English opt-out phrases.
+// Keep conservative: ambiguous text routes to human review.
+var unequivocalPhrases = []string{
+	"não tenho interesse",
+	"nao tenho interesse",
+	"não me chame mais",
+	"nao me chame mais",
+	"não me ligue mais",
+	"retire meu número",
+	"retire meu numero",
+	"não envie mensagens",
+	"nao envie mensagens",
+	"não envie mais",
+	"nao envie mais",
+	"pare de me enviar",
+	"remover meu número",
+	"remover meu numero",
+	"do not contact",
+	"don't contact me",
+	"dont contact me",
+	"stop messaging me",
+	"remove my number",
+	"unsubscribe",
+	"opt out",
+	"opt-out",
+	"no me contacten",
+	"no me escriban más",
+	"no me escriban mas",
+}
+
+// standaloneOptOutTokens only match as whole-message or whole-word intent.
+var standaloneOptOutTokens = []string{
+	"parar",
+	"sair",
+	"stop",
+	"cancelar",
+	"remover",
+}
+
+// DetectOptOut scans inbound free text for unequivocal opt-out intent.
+// On doubt returns Confident=false so the operator reviews.
+func DetectOptOut(body string) OptOutMatch {
+	norm := normalizeOptOutText(body)
+	if norm == "" {
+		return OptOutMatch{Category: "none"}
+	}
+
+	for _, p := range unequivocalPhrases {
+		if strings.Contains(norm, p) {
+			return OptOutMatch{
+				Matched:   true,
+				Category:  "opt_out",
+				Phrase:    p,
+				Confident: true,
+			}
+		}
+	}
+
+	// Whole-message short tokens only (avoid "não posso parar agora").
+	trimmed := strings.TrimSpace(norm)
+	for _, t := range standaloneOptOutTokens {
+		if trimmed == t {
+			return OptOutMatch{
+				Matched:   true,
+				Category:  "opt_out",
+				Phrase:    t,
+				Confident: true,
+			}
+		}
+	}
+
+	// Soft signals → human review, not auto block.
+	soft := []string{"sem interesse", "agora não", "agora nao", "talvez depois", "não é o momento", "nao e o momento"}
+	for _, p := range soft {
+		if strings.Contains(norm, p) {
+			return OptOutMatch{
+				Matched:   true,
+				Category:  "ambiguous",
+				Phrase:    p,
+				Confident: false,
+			}
+		}
+	}
+
+	return OptOutMatch{Category: "none"}
+}
+
+func normalizeOptOutText(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := false
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			prevSpace = false
+			continue
+		}
+		if unicode.IsSpace(r) || r == '-' || r == '_' {
+			if !prevSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/internal/app/whatsapp/optout_test.go
+++ b/internal/app/whatsapp/optout_test.go
@@ -1,0 +1,27 @@
+package whatsapp
+
+import "testing"
+
+func TestDetectOptOut(t *testing.T) {
+	cases := []struct {
+		body      string
+		matched   bool
+		confident bool
+	}{
+		{"Não tenho interesse, obrigado", true, true},
+		{"PARE de me enviar mensagens", true, true},
+		{"parar", true, true},
+		{"stop", true, true},
+		{"Retire meu número da lista", true, true},
+		{"Agora não, talvez depois", true, false},
+		{"Pode me explicar o serviço?", false, false},
+		{"", false, false},
+	}
+	for _, tc := range cases {
+		m := DetectOptOut(tc.body)
+		if m.Matched != tc.matched || m.Confident != tc.confident {
+			t.Errorf("body=%q got matched=%v conf=%v cat=%s phrase=%q",
+				tc.body, m.Matched, m.Confident, m.Category, m.Phrase)
+		}
+	}
+}

--- a/internal/app/whatsapp/phone.go
+++ b/internal/app/whatsapp/phone.go
@@ -1,0 +1,91 @@
+package whatsapp
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/nyaruka/phonenumbers"
+)
+
+// PhoneResult is the outcome of normalization. Original is always preserved.
+type PhoneResult struct {
+	Original   string `json:"original"`
+	E164       string `json:"e164,omitempty"`        // +E.164
+	E164Digits string `json:"e164_digits,omitempty"` // digits only (no +)
+	Country    string `json:"country,omitempty"`     // ISO region, e.g. BR
+	Valid      bool   `json:"valid"`
+	Error      string `json:"error,omitempty"`
+}
+
+// NormalizePhone parses raw into E.164 using libphonenumber.
+// defaultRegion is used when the number lacks a country code (e.g. "BR").
+// Empty defaultRegion defaults to BR for CONFENGE commercial use.
+func NormalizePhone(raw, defaultRegion string) PhoneResult {
+	out := PhoneResult{Original: raw}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		out.Error = "empty phone"
+		return out
+	}
+	if defaultRegion == "" {
+		defaultRegion = "BR"
+	}
+
+	// Strip common noise; keep leading + for international form.
+	cleaned := stripPhoneNoise(raw)
+
+	num, err := phonenumbers.Parse(cleaned, defaultRegion)
+	if err != nil {
+		out.Error = fmt.Sprintf("parse: %v", err)
+		return out
+	}
+	if !phonenumbers.IsValidNumber(num) {
+		// Still surface the candidate format for operators; mark invalid.
+		formatted := phonenumbers.Format(num, phonenumbers.E164)
+		out.E164 = formatted
+		out.E164Digits = strings.TrimPrefix(formatted, "+")
+		region := phonenumbers.GetRegionCodeForNumber(num)
+		out.Country = region
+		out.Error = "invalid phone number"
+		return out
+	}
+	formatted := phonenumbers.Format(num, phonenumbers.E164)
+	out.E164 = formatted
+	out.E164Digits = strings.TrimPrefix(formatted, "+")
+	out.Country = phonenumbers.GetRegionCodeForNumber(num)
+	out.Valid = true
+	return out
+}
+
+// stripPhoneNoise removes spaces, parentheses, hyphens, dots, and trunk zeros
+// quirks while preserving a leading +.
+func stripPhoneNoise(s string) string {
+	s = strings.TrimSpace(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for i, r := range s {
+		if r == '+' && i == 0 {
+			b.WriteRune(r)
+			continue
+		}
+		if unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+		// drop spaces, (), -, ., and letters like "ext"
+	}
+	out := b.String()
+	// Brazilian operator trunk "0" after country code is handled by libphonenumber
+	// when region is BR; for national forms like 048999999999, Parse with BR works.
+	return out
+}
+
+// DigitsOnly strips non-digits (and leading +) for provider APIs that want raw MSISDN.
+func DigitsOnly(e164 string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsDigit(r) {
+			return r
+		}
+		return -1
+	}, e164)
+}

--- a/internal/app/whatsapp/phone_test.go
+++ b/internal/app/whatsapp/phone_test.go
@@ -1,0 +1,39 @@
+package whatsapp
+
+import "testing"
+
+func TestNormalizePhoneBR(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string // E.164
+		ok   bool
+	}{
+		{"(48) 99999-9999", "+5548999999999", true},
+		{"48999999999", "+5548999999999", true},
+		{"+55 48 99999-9999", "+5548999999999", true},
+		{"5548999999999", "+5548999999999", true},
+		{"048 99999-9999", "+5548999999999", true},
+		{"", "", false},
+		{"123", "", false},
+		{"not-a-phone", "", false},
+	}
+	for _, tc := range cases {
+		got := NormalizePhone(tc.raw, "BR")
+		if got.Valid != tc.ok {
+			t.Errorf("raw=%q valid=%v want %v err=%s", tc.raw, got.Valid, tc.ok, got.Error)
+			continue
+		}
+		if tc.ok && got.E164 != tc.want {
+			t.Errorf("raw=%q e164=%q want %q", tc.raw, got.E164, tc.want)
+		}
+		if got.Original != tc.raw {
+			t.Errorf("original not preserved: %q", got.Original)
+		}
+	}
+}
+
+func TestDigitsOnly(t *testing.T) {
+	if DigitsOnly("+55 48 99999-9999") != "5548999999999" {
+		t.Fatal(DigitsOnly("+55 48 99999-9999"))
+	}
+}

--- a/internal/app/whatsapp/provider.go
+++ b/internal/app/whatsapp/provider.go
@@ -1,0 +1,134 @@
+// Package whatsapp is the policy-gated WhatsApp channel transport for Warmbly.
+// Domain code talks only to the Provider interface; provider-specific DTOs
+// stay inside adapter packages (e.g. evolution).
+package whatsapp
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Provider is the transport abstraction. Implementations: Evolution (Cloud API
+// first), mock, and future Meta/BSP adapters. Domain never imports provider DTOs.
+type Provider interface {
+	// SendText sends free-form text inside an open service window or after
+	// policy has approved free-text. Callers must run eligibility first.
+	SendText(ctx context.Context, req SendTextRequest) (*SendResult, error)
+	// SendTemplate sends an approved WhatsApp Business Platform template.
+	SendTemplate(ctx context.Context, req SendTemplateRequest) (*SendResult, error)
+	// GetConnectionStatus reports instance/WABA connection health.
+	GetConnectionStatus(ctx context.Context, instance string) (*ConnectionStatus, error)
+	// ConfigureWebhook registers the Warmbly ingress URL on the provider when supported.
+	ConfigureWebhook(ctx context.Context, instance string, cfg WebhookConfig) error
+	// Health checks provider reachability without side effects.
+	Health(ctx context.Context) error
+	// Name returns a stable provider id (e.g. "evolution", "mock").
+	Name() string
+}
+
+// SendTextRequest is a domain send of free-form text.
+type SendTextRequest struct {
+	Instance       string
+	ToE164         string // digits with country code, no leading +
+	Body           string
+	IdempotencyKey string
+	// OrganizationID is for multi-tenant logging/audit only; not sent to provider.
+	OrganizationID uuid.UUID
+	ContactID      *uuid.UUID
+}
+
+// SendTemplateRequest is a domain send of an official template.
+type SendTemplateRequest struct {
+	Instance       string
+	ToE164         string
+	TemplateName   string
+	Language       string
+	Variables      []string
+	IdempotencyKey string
+	OrganizationID uuid.UUID
+	ContactID      *uuid.UUID
+}
+
+// SendResult is the provider-normalized send outcome.
+type SendResult struct {
+	ProviderMessageID string
+	Status            string // queued | sent | failed
+	RawStatus         string // provider status string (never secrets)
+	OccurredAt        time.Time
+}
+
+// ConnectionStatus is instance/connection health.
+type ConnectionStatus struct {
+	Instance  string
+	State     string // open | close | connecting | unknown
+	PhoneE164 string
+	UpdatedAt time.Time
+}
+
+// WebhookConfig is what Warmbly asks the provider to post to.
+type WebhookConfig struct {
+	URL     string
+	Secret  string
+	Events  []string
+	Enabled bool
+}
+
+// Consent statuses for WhatsApp (first-class, never inferred from public phone).
+const (
+	ConsentUnknown       = "UNKNOWN"
+	ConsentNoOptIn       = "NO_OPT_IN"
+	ConsentOptedIn       = "OPTED_IN"
+	ConsentUserInitiated = "USER_INITIATED"
+	ConsentOptedOut      = "OPTED_OUT"
+	ConsentDoNotContact  = "DO_NOT_CONTACT"
+)
+
+// Eligibility decisions returned by the policy engine.
+const (
+	EligAutomatedAllowed = "AUTOMATED_ALLOWED"
+	EligTemplateOnly     = "TEMPLATE_ONLY"
+	EligServiceWindow    = "SERVICE_WINDOW"
+	EligManualReview     = "MANUAL_REVIEW"
+	EligBlocked          = "BLOCKED"
+)
+
+// Message / draft channel.
+const (
+	ChannelEmail    = "EMAIL"
+	ChannelWhatsApp = "WHATSAPP"
+)
+
+// Normalized event types (provider-agnostic).
+const (
+	EventMessageReceived  = "MESSAGE_RECEIVED"
+	EventMessageSent      = "MESSAGE_SENT"
+	EventMessageDelivered = "MESSAGE_DELIVERED"
+	EventMessageRead      = "MESSAGE_READ"
+	EventMessageFailed    = "MESSAGE_FAILED"
+	EventConnectionState  = "CONNECTION_STATE"
+	EventTemplateError    = "TEMPLATE_ERROR"
+	EventUnsupported      = "UNSUPPORTED"
+)
+
+// Provider ids.
+const (
+	ProviderEvolution = "evolution"
+	ProviderMock      = "mock"
+)
+
+// Template statuses (WhatsApp Business Platform).
+const (
+	TemplateApproved = "APPROVED"
+	TemplatePaused   = "PAUSED"
+	TemplateRejected = "REJECTED"
+	TemplatePending  = "PENDING"
+	TemplateMissing  = "MISSING"
+)
+
+// Message content types we handle.
+const (
+	ContentText  = "text"
+	ContentOther = "other"
+)

--- a/internal/app/whatsapp/service.go
+++ b/internal/app/whatsapp/service.go
@@ -1,0 +1,208 @@
+package whatsapp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+// TemplateCatalog looks up official template approval state.
+type TemplateCatalog interface {
+	// Status returns APPROVED | PAUSED | REJECTED | PENDING | MISSING.
+	Status(ctx context.Context, orgID uuid.UUID, name, language string) (string, error)
+}
+
+// StaticTemplateCatalog is an in-memory catalog for tests and manual sync ops.
+type StaticTemplateCatalog struct {
+	mu    sync.RWMutex
+	items map[string]string // name|lang -> status
+}
+
+// NewStaticTemplateCatalog builds an empty catalog.
+func NewStaticTemplateCatalog() *StaticTemplateCatalog {
+	return &StaticTemplateCatalog{items: map[string]string{}}
+}
+
+// Set records a template status.
+func (c *StaticTemplateCatalog) Set(name, language, status string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items[name+"|"+language] = status
+}
+
+// Status implements TemplateCatalog.
+func (c *StaticTemplateCatalog) Status(_ context.Context, _ uuid.UUID, name, language string) (string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if s, ok := c.items[name+"|"+language]; ok {
+		return s, nil
+	}
+	return TemplateMissing, nil
+}
+
+// Service is the domain send/inbound gate. All automated sends go through Send.
+type Service struct {
+	cfg      Config
+	provider Provider
+	catalog  TemplateCatalog
+
+	// seenEventIDs is an in-process idempotency set (tests / single-node).
+	// Production persists via repository when wired.
+	mu   sync.Mutex
+	seen map[string]struct{}
+}
+
+// NewService constructs the domain service. provider may be nil when disabled.
+func NewService(cfg Config, provider Provider, catalog TemplateCatalog) *Service {
+	if catalog == nil {
+		catalog = NewStaticTemplateCatalog()
+	}
+	return &Service{
+		cfg:      cfg,
+		provider: provider,
+		catalog:  catalog,
+		seen:     map[string]struct{}{},
+	}
+}
+
+// Config returns a copy of runtime config.
+func (s *Service) Config() Config { return s.cfg }
+
+// ProviderName returns the active provider id.
+func (s *Service) ProviderName() string {
+	if s.provider == nil {
+		return ""
+	}
+	return s.provider.Name()
+}
+
+// SendResultExt wraps provider result with policy decision.
+type SendResultExt struct {
+	Decision Decision
+	Result   *SendResult
+	Skipped  bool
+}
+
+// Send runs eligibility then, if allowed, the provider. Never bypasses policy.
+func (s *Service) Send(ctx context.Context, state ContactChannelState, intent SendIntent, textReq *SendTextRequest, tmplReq *SendTemplateRequest) (*SendResultExt, error) {
+	if s == nil {
+		return nil, fmt.Errorf("whatsapp service is nil")
+	}
+	intent.FeatureEnabled = s.cfg.Enabled
+	if intent.Now.IsZero() {
+		intent.Now = time.Now().UTC()
+	}
+	if intent.CrossChannelMin == 0 {
+		intent.CrossChannelMin = s.cfg.CrossChannelInterval
+	}
+	if intent.ServiceWindow == 0 {
+		intent.ServiceWindow = s.cfg.ServiceWindow
+	}
+	if intent.Mode == ModeTemplate && tmplReq != nil && s.catalog != nil {
+		st, err := s.catalog.Status(ctx, state.OrganizationID, tmplReq.TemplateName, tmplReq.Language)
+		if err != nil {
+			return nil, err
+		}
+		intent.TemplateApproved = st == TemplateApproved
+		if st != TemplateApproved {
+			d := Decision{Allowed: false, Eligibility: EligBlocked, Reason: "template_status_" + st}
+			return &SendResultExt{Decision: d, Skipped: true}, nil
+		}
+	}
+
+	d := EvaluateEligibility(state, intent)
+	if !d.Allowed {
+		return &SendResultExt{Decision: d, Skipped: true}, nil
+	}
+	if s.provider == nil {
+		return nil, fmt.Errorf("whatsapp provider not configured")
+	}
+
+	switch intent.Mode {
+	case ModeTemplate:
+		if tmplReq == nil {
+			return nil, fmt.Errorf("template request required")
+		}
+		res, err := s.provider.SendTemplate(ctx, *tmplReq)
+		return &SendResultExt{Decision: d, Result: res}, err
+	default:
+		if textReq == nil {
+			return nil, fmt.Errorf("text request required")
+		}
+		res, err := s.provider.SendText(ctx, *textReq)
+		return &SendResultExt{Decision: d, Result: res}, err
+	}
+}
+
+// ProcessInbound applies opt-out detection, service window, and idempotency.
+// Persist/CRM hooks are left to the caller (W2 / confenge orchestration).
+func (s *Service) ProcessInbound(ctx context.Context, state *ContactChannelState, ev ChannelEvent) (InboundResult, error) {
+	_ = ctx
+	res := InboundResult{Event: ev}
+	if s == nil {
+		return res, fmt.Errorf("whatsapp service is nil")
+	}
+	key := ev.IdempotencyKey()
+	s.mu.Lock()
+	if _, ok := s.seen[key]; ok {
+		s.mu.Unlock()
+		res.Duplicate = true
+		return res, nil
+	}
+	s.seen[key] = struct{}{}
+	s.mu.Unlock()
+
+	if ev.EventType != EventMessageReceived {
+		res.Ignored = true
+		return res, nil
+	}
+
+	if state != nil {
+		OpenServiceWindowFromInbound(state, ev.OccurredAt, s.cfg.ServiceWindow)
+		if ev.Content.Type == ContentText && ev.Content.Text != "" {
+			match := DetectOptOut(ev.Content.Text)
+			res.OptOut = match
+			if match.Matched && match.Confident {
+				ApplyOptOut(state, ev.OccurredAt, "inbound_phrase:"+match.Phrase)
+				res.StopSequences = true
+			} else if match.Matched && !match.Confident {
+				res.NeedsHumanReview = true
+			} else {
+				// Any human inbound should stop automated follow-ups for the lead.
+				res.StopSequences = true
+			}
+		} else {
+			res.StopSequences = true
+		}
+	}
+	return res, nil
+}
+
+// InboundResult is the domain outcome of one inbound message.
+type InboundResult struct {
+	Event            ChannelEvent
+	Duplicate        bool
+	Ignored          bool
+	StopSequences    bool
+	NeedsHumanReview bool
+	OptOut           OptOutMatch
+}
+
+// SeenReports whether an event key was already processed (tests).
+func (s *Service) Seen(key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.seen[key]
+	return ok
+}
+
+// LogBaileysWarning emits the lab-only warning when configured.
+func LogBaileysWarning(cfg Config) {
+	if w := cfg.BaileysWarning(); w != "" {
+		log.Warn().Str("component", "whatsapp").Msg(w)
+	}
+}

--- a/internal/app/whatsapp/webhook.go
+++ b/internal/app/whatsapp/webhook.go
@@ -1,0 +1,101 @@
+package whatsapp
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"strings"
+)
+
+// WebhookAuth validates inbound Evolution (or future provider) webhooks.
+type WebhookAuth struct {
+	// Secret is compared to Authorization: Bearer <secret> or X-Webhook-Secret.
+	Secret string
+	// InstanceAllow is the expected instance name (empty = any, then map later).
+	InstanceAllow string
+	// MaxBytes body size limit.
+	MaxBytes int64
+}
+
+// AuthError is a webhook authentication / validation failure.
+type AuthError struct {
+	Code       string
+	Message    string
+	StatusCode int
+}
+
+func (e *AuthError) Error() string {
+	if e == nil {
+		return "webhook auth error"
+	}
+	return e.Message
+}
+
+// ValidateHeaders checks secret, content-type, and size before body parse.
+func (a WebhookAuth) ValidateHeaders(authHeader, secretHeader, contentType string, contentLength int64) error {
+	if a.MaxBytes <= 0 {
+		a.MaxBytes = DefaultMaxWebhookBytes
+	}
+	if contentLength > a.MaxBytes {
+		return &AuthError{Code: "payload_too_large", Message: "payload too large", StatusCode: 413}
+	}
+	if contentType != "" && !strings.Contains(strings.ToLower(contentType), "json") {
+		return &AuthError{Code: "unsupported_media_type", Message: "content-type must be application/json", StatusCode: 415}
+	}
+	if a.Secret == "" {
+		// Dev-only: allow empty secret when not configured (startup forbids in prod).
+		return nil
+	}
+	token := bearerToken(authHeader)
+	if token == "" {
+		token = strings.TrimSpace(secretHeader)
+	}
+	if token == "" {
+		return &AuthError{Code: "missing_secret", Message: "missing webhook secret", StatusCode: 401}
+	}
+	if subtle.ConstantTimeCompare([]byte(token), []byte(a.Secret)) != 1 {
+		return &AuthError{Code: "invalid_secret", Message: "invalid webhook secret", StatusCode: 401}
+	}
+	return nil
+}
+
+// ValidateInstance ensures the event instance matches the configured mapping.
+func (a WebhookAuth) ValidateInstance(instance string) error {
+	if a.InstanceAllow == "" {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(instance), strings.TrimSpace(a.InstanceAllow)) {
+		return &AuthError{Code: "instance_mismatch", Message: "instance not mapped", StatusCode: 404}
+	}
+	return nil
+}
+
+func bearerToken(h string) string {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return ""
+	}
+	const p = "Bearer "
+	if len(h) > len(p) && strings.EqualFold(h[:len(p)], p) {
+		return strings.TrimSpace(h[len(p):])
+	}
+	return h
+}
+
+// MapInstanceToOrg is a simple static instance→org mapper for single-tenant deploys.
+// Multi-tenant maps live in the repository when wired.
+type InstanceMapping struct {
+	Instance       string
+	OrganizationID string // uuid string
+	WebhookSecret  string
+}
+
+// ResolveInstance finds a mapping or errors.
+func ResolveInstance(maps []InstanceMapping, instance string) (InstanceMapping, error) {
+	instance = strings.TrimSpace(instance)
+	for _, m := range maps {
+		if strings.EqualFold(m.Instance, instance) {
+			return m, nil
+		}
+	}
+	return InstanceMapping{}, fmt.Errorf("instance not mapped: %s", instance)
+}

--- a/internal/app/whatsapp/webhook_test.go
+++ b/internal/app/whatsapp/webhook_test.go
@@ -1,0 +1,86 @@
+package whatsapp
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWebhookAuthSecret(t *testing.T) {
+	a := WebhookAuth{Secret: "s3cret", MaxBytes: 1024}
+	if err := a.ValidateHeaders("Bearer s3cret", "", "application/json", 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.ValidateHeaders("Bearer wrong", "", "application/json", 10); err == nil {
+		t.Fatal("expected invalid secret")
+	}
+	if err := a.ValidateHeaders("", "s3cret", "application/json", 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.ValidateHeaders("Bearer s3cret", "", "text/plain", 10); err == nil {
+		t.Fatal("expected media type error")
+	}
+	if err := a.ValidateHeaders("Bearer s3cret", "", "application/json", 5000); err == nil {
+		t.Fatal("expected oversize")
+	}
+}
+
+func TestWebhookIdempotencyAndOptOut(t *testing.T) {
+	svc := NewService(Config{Enabled: true, ServiceWindow: 24 * time.Hour}, NewMockProvider(), nil)
+	st := ContactChannelState{
+		PhoneE164:     "+5548999999999",
+		ConsentStatus: ConsentUnknown,
+	}
+	ev := ChannelEvent{
+		Channel:           ChannelWhatsApp,
+		Provider:          ProviderEvolution,
+		EventType:         EventMessageReceived,
+		ExternalMessageID: "msg-1",
+		ExternalEventID:   "msg-1:MESSAGE_RECEIVED",
+		FromE164:          "+5548999999999",
+		OccurredAt:        time.Now().UTC(),
+		Content:           Content{Type: ContentText, Text: "não tenho interesse"},
+	}
+	r1, err := svc.ProcessInbound(context.Background(), &st, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r1.Duplicate || !r1.OptOut.Matched || !r1.StopSequences {
+		t.Fatalf("first inbound: %+v opt=%+v", r1, r1.OptOut)
+	}
+	if st.ConsentStatus != ConsentOptedOut {
+		t.Fatalf("consent=%s", st.ConsentStatus)
+	}
+	r2, err := svc.ProcessInbound(context.Background(), &st, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r2.Duplicate {
+		t.Fatal("duplicate event must be detected")
+	}
+}
+
+func TestConfigBaileysProductionGuard(t *testing.T) {
+	t.Setenv(EnvEnabled, "true")
+	t.Setenv(EnvEvolutionAllowBaileys, "true")
+	t.Setenv(EnvAppEnv, "production")
+	t.Setenv(EnvEvolutionBaseURL, "https://evo.example")
+	t.Setenv(EnvEvolutionAPIKey, "k")
+	t.Setenv(EnvEvolutionInstance, "i")
+	t.Setenv(EnvWebhookSecret, "w")
+	cfg := LoadConfig()
+	if err := cfg.ValidateStartup(); err == nil {
+		t.Fatal("production + baileys must fail validation")
+	}
+}
+
+func TestConfigDefaultsOff(t *testing.T) {
+	t.Setenv(EnvEnabled, "")
+	t.Setenv(EnvAutoSend, "")
+	t.Setenv(EnvAutoReply, "")
+	t.Setenv(EnvEvolutionAllowBaileys, "")
+	cfg := LoadConfig()
+	if cfg.Enabled || cfg.AutoSendEnabled || cfg.AutoReplyEnabled || cfg.AllowBaileys {
+		t.Fatalf("defaults must be off: %+v", cfg)
+	}
+}

--- a/internal/infrastructure/db/migrations/000080_whatsapp_channel.down.sql
+++ b/internal/infrastructure/db/migrations/000080_whatsapp_channel.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS whatsapp_webhook_events;
+DROP TABLE IF EXISTS whatsapp_templates;
+DROP TABLE IF EXISTS whatsapp_instances;
+DROP TABLE IF EXISTS whatsapp_messages;
+DROP TABLE IF EXISTS whatsapp_contact_state;

--- a/internal/infrastructure/db/migrations/000080_whatsapp_channel.up.sql
+++ b/internal/infrastructure/db/migrations/000080_whatsapp_channel.up.sql
@@ -1,0 +1,162 @@
+-- WhatsApp channel: consent/eligibility state, messages, instance mapping,
+-- official templates cache, and webhook idempotency.
+-- Evolution API is external; nothing here stores Evolution as a CRM.
+
+-- Per-contact (or pre-contact) WhatsApp channel state.
+CREATE TABLE IF NOT EXISTS whatsapp_contact_state (
+    id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id         uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    contact_id              uuid REFERENCES contacts(id) ON DELETE SET NULL,
+    outreach_candidate_id   uuid,
+
+    phone_raw               text NOT NULL DEFAULT '',
+    phone_e164              text NOT NULL DEFAULT '',
+    phone_country           text NOT NULL DEFAULT '',
+    phone_valid             boolean NOT NULL DEFAULT false,
+    phone_source            text NOT NULL DEFAULT '',
+    phone_source_url        text NOT NULL DEFAULT '',
+    phone_verified_at       timestamptz,
+
+    whatsapp_consent_status text NOT NULL DEFAULT 'UNKNOWN',
+    whatsapp_consent_source text NOT NULL DEFAULT '',
+    whatsapp_consent_at     timestamptz,
+    whatsapp_consent_scope  text NOT NULL DEFAULT '',
+    whatsapp_consent_provenance_ok boolean NOT NULL DEFAULT false,
+    whatsapp_consent_form_version text NOT NULL DEFAULT '',
+    whatsapp_consent_recorded_by uuid REFERENCES users(id) ON DELETE SET NULL,
+
+    whatsapp_last_inbound_at timestamptz,
+    whatsapp_service_window_until timestamptz,
+    whatsapp_channel_status text NOT NULL DEFAULT '',
+    whatsapp_opt_out_at     timestamptz,
+    do_not_contact          boolean NOT NULL DEFAULT false,
+
+    last_email_outbound_at    timestamptz,
+    last_whatsapp_outbound_at timestamptz,
+
+    created_at              timestamptz NOT NULL DEFAULT now(),
+    updated_at              timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT whatsapp_contact_state_consent_check CHECK (
+        whatsapp_consent_status IN (
+            'UNKNOWN', 'NO_OPT_IN', 'OPTED_IN', 'USER_INITIATED',
+            'OPTED_OUT', 'DO_NOT_CONTACT'
+        )
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_contact_state_org_contact_uidx
+    ON whatsapp_contact_state (organization_id, contact_id)
+    WHERE contact_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS whatsapp_contact_state_org_phone_idx
+    ON whatsapp_contact_state (organization_id, phone_e164)
+    WHERE phone_e164 <> '';
+
+CREATE INDEX IF NOT EXISTS whatsapp_contact_state_org_consent_idx
+    ON whatsapp_contact_state (organization_id, whatsapp_consent_status);
+
+-- Message history (CRM-facing; separate from email threads).
+CREATE TABLE IF NOT EXISTS whatsapp_messages (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    contact_id          uuid REFERENCES contacts(id) ON DELETE SET NULL,
+    thread_key          text NOT NULL,
+    direction           text NOT NULL,
+    channel             text NOT NULL DEFAULT 'WHATSAPP',
+    provider            text NOT NULL DEFAULT 'evolution',
+    provider_message_id text NOT NULL DEFAULT '',
+    idempotency_key     text NOT NULL,
+    body_text           text NOT NULL DEFAULT '',
+    template_name       text NOT NULL DEFAULT '',
+    template_language   text NOT NULL DEFAULT '',
+    status              text NOT NULL DEFAULT 'received',
+    failure_code        text NOT NULL DEFAULT '',
+    draft_id            uuid,
+    campaign_id         uuid,
+    reviewed_by         uuid REFERENCES users(id) ON DELETE SET NULL,
+    approved_at         timestamptz,
+    sent_at             timestamptz,
+    occurred_at         timestamptz NOT NULL DEFAULT now(),
+    created_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT whatsapp_messages_direction_check CHECK (direction IN ('inbound', 'outbound')),
+    CONSTRAINT whatsapp_messages_status_check CHECK (
+        status IN ('received', 'queued', 'sent', 'delivered', 'read', 'failed', 'blocked')
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_messages_org_idem_uidx
+    ON whatsapp_messages (organization_id, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS whatsapp_messages_org_thread_idx
+    ON whatsapp_messages (organization_id, thread_key, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS whatsapp_messages_org_contact_idx
+    ON whatsapp_messages (organization_id, contact_id, occurred_at DESC)
+    WHERE contact_id IS NOT NULL;
+
+-- Provider instance → organization mapping (Evolution instance name).
+CREATE TABLE IF NOT EXISTS whatsapp_instances (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id  uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    provider         text NOT NULL DEFAULT 'evolution',
+    instance_name    text NOT NULL,
+    integration_mode text NOT NULL DEFAULT 'WHATSAPP-BUSINESS',
+    phone_e164       text NOT NULL DEFAULT '',
+    webhook_secret   text NOT NULL DEFAULT '',
+    status           text NOT NULL DEFAULT 'unknown',
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT whatsapp_instances_mode_check CHECK (
+        integration_mode IN ('WHATSAPP-BUSINESS', 'WHATSAPP-BAILEYS')
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_instances_provider_name_uidx
+    ON whatsapp_instances (provider, instance_name);
+
+CREATE INDEX IF NOT EXISTS whatsapp_instances_org_idx
+    ON whatsapp_instances (organization_id);
+
+-- Official template approval cache (Meta/BSP is source of truth).
+CREATE TABLE IF NOT EXISTS whatsapp_templates (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id  uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    provider         text NOT NULL DEFAULT 'evolution',
+    external_id      text NOT NULL DEFAULT '',
+    name             text NOT NULL,
+    language         text NOT NULL DEFAULT 'pt_BR',
+    category         text NOT NULL DEFAULT '',
+    status           text NOT NULL DEFAULT 'PENDING',
+    variables        jsonb NOT NULL DEFAULT '[]'::jsonb,
+    last_sync_at     timestamptz,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT whatsapp_templates_status_check CHECK (
+        status IN ('APPROVED', 'PAUSED', 'REJECTED', 'PENDING', 'MISSING')
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_templates_org_name_lang_uidx
+    ON whatsapp_templates (organization_id, name, language);
+
+-- Webhook idempotency log (duplicate provider events must not double-apply).
+CREATE TABLE IF NOT EXISTS whatsapp_webhook_events (
+    id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id      uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    provider             text NOT NULL DEFAULT 'evolution',
+    idempotency_key      text NOT NULL,
+    event_type           text NOT NULL DEFAULT '',
+    external_message_id  text NOT NULL DEFAULT '',
+    payload_hash         text NOT NULL DEFAULT '',
+    processed_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_webhook_events_org_idem_uidx
+    ON whatsapp_webhook_events (organization_id, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS whatsapp_webhook_events_processed_idx
+    ON whatsapp_webhook_events (processed_at);

--- a/internal/models/whatsapp.go
+++ b/internal/models/whatsapp.go
@@ -1,0 +1,113 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// WhatsApp contact channel state (consent, phone provenance, service window).
+// Stored per organization + contact. Public phone never implies opt-in.
+type WhatsAppContactState struct {
+	ID             uuid.UUID  `json:"id"`
+	OrganizationID uuid.UUID  `json:"organization_id"`
+	ContactID      *uuid.UUID `json:"contact_id,omitempty"`
+	// Optional link to outreach staging candidate when confenge is enabled.
+	OutreachCandidateID *uuid.UUID `json:"outreach_candidate_id,omitempty"`
+
+	PhoneRaw        string     `json:"phone_raw,omitempty"`
+	PhoneE164       string     `json:"phone_e164,omitempty"`
+	PhoneCountry    string     `json:"phone_country,omitempty"`
+	PhoneValid      bool       `json:"phone_valid"`
+	PhoneSource     string     `json:"phone_source,omitempty"`
+	PhoneSourceURL  string     `json:"phone_source_url,omitempty"`
+	PhoneVerifiedAt *time.Time `json:"phone_verified_at,omitempty"`
+
+	ConsentStatus       string     `json:"whatsapp_consent_status"`
+	ConsentSource       string     `json:"whatsapp_consent_source,omitempty"`
+	ConsentAt           *time.Time `json:"whatsapp_consent_at,omitempty"`
+	ConsentScope        string     `json:"whatsapp_consent_scope,omitempty"`
+	ConsentProvenanceOK bool       `json:"whatsapp_consent_provenance_ok"`
+	ConsentFormVersion  string     `json:"whatsapp_consent_form_version,omitempty"`
+	ConsentRecordedBy   *uuid.UUID `json:"whatsapp_consent_recorded_by,omitempty"`
+
+	LastInboundAt      *time.Time `json:"whatsapp_last_inbound_at,omitempty"`
+	ServiceWindowUntil *time.Time `json:"whatsapp_service_window_until,omitempty"`
+	ChannelStatus      string     `json:"whatsapp_channel_status,omitempty"`
+	OptOutAt           *time.Time `json:"whatsapp_opt_out_at,omitempty"`
+	DoNotContact       bool       `json:"do_not_contact"`
+
+	LastEmailOutboundAt    *time.Time `json:"last_email_outbound_at,omitempty"`
+	LastWhatsAppOutboundAt *time.Time `json:"last_whatsapp_outbound_at,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// WhatsAppMessage is one inbound or outbound WhatsApp message in the CRM history.
+type WhatsAppMessage struct {
+	ID                uuid.UUID  `json:"id"`
+	OrganizationID    uuid.UUID  `json:"organization_id"`
+	ContactID         *uuid.UUID `json:"contact_id,omitempty"`
+	ThreadKey         string     `json:"thread_key"` // typically phone E.164
+	Direction         string     `json:"direction"`  // inbound | outbound
+	Channel           string     `json:"channel"`    // WHATSAPP
+	Provider          string     `json:"provider"`
+	ProviderMessageID string     `json:"provider_message_id,omitempty"`
+	IdempotencyKey    string     `json:"idempotency_key"`
+	BodyText          string     `json:"body_text,omitempty"`
+	TemplateName      string     `json:"template_name,omitempty"`
+	TemplateLanguage  string     `json:"template_language,omitempty"`
+	Status            string     `json:"status"` // received | queued | sent | delivered | read | failed
+	FailureCode       string     `json:"failure_code,omitempty"`
+	DraftID           *uuid.UUID `json:"draft_id,omitempty"`
+	CampaignID        *uuid.UUID `json:"campaign_id,omitempty"`
+	ReviewedBy        *uuid.UUID `json:"reviewed_by,omitempty"`
+	ApprovedAt        *time.Time `json:"approved_at,omitempty"`
+	SentAt            *time.Time `json:"sent_at,omitempty"`
+	OccurredAt        time.Time  `json:"occurred_at"`
+	CreatedAt         time.Time  `json:"created_at"`
+}
+
+// WhatsAppInstance maps an Evolution (or other) instance to an organization.
+type WhatsAppInstance struct {
+	ID              uuid.UUID `json:"id"`
+	OrganizationID  uuid.UUID `json:"organization_id"`
+	Provider        string    `json:"provider"`
+	InstanceName    string    `json:"instance_name"`
+	IntegrationMode string    `json:"integration_mode"` // WHATSAPP-BUSINESS | WHATSAPP-BAILEYS
+	PhoneE164       string    `json:"phone_e164,omitempty"`
+	WebhookSecret   string    `json:"-"` // never JSON-serialize secret
+	Status          string    `json:"status"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// WhatsAppTemplate is a local mirror of an official Meta template approval state.
+// Meta/BSP remains source of truth; this is operational cache only.
+type WhatsAppTemplate struct {
+	ID             uuid.UUID  `json:"id"`
+	OrganizationID uuid.UUID  `json:"organization_id"`
+	Provider       string     `json:"provider"`
+	ExternalID     string     `json:"external_id,omitempty"`
+	Name           string     `json:"name"`
+	Language       string     `json:"language"`
+	Category       string     `json:"category,omitempty"`
+	Status         string     `json:"status"` // APPROVED | PAUSED | REJECTED | PENDING
+	VariablesJSON  []byte     `json:"variables,omitempty"`
+	LastSyncAt     *time.Time `json:"last_sync_at,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+// WhatsAppWebhookEvent is the idempotency log for provider webhooks.
+type WhatsAppWebhookEvent struct {
+	ID             uuid.UUID `json:"id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Provider       string    `json:"provider"`
+	IdempotencyKey string    `json:"idempotency_key"`
+	EventType      string    `json:"event_type"`
+	ExternalMsgID  string    `json:"external_message_id,omitempty"`
+	PayloadHash    string    `json:"payload_hash,omitempty"`
+	ProcessedAt    time.Time `json:"processed_at"`
+}

--- a/internal/repository/pg_whatsapp.go
+++ b/internal/repository/pg_whatsapp.go
@@ -1,0 +1,303 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// WhatsAppRepository persists channel state, messages, instances, templates, webhook idempotency.
+type WhatsAppRepository interface {
+	GetInstanceByName(ctx context.Context, provider, instance string) (*models.WhatsAppInstance, *errx.Error)
+	InsertWebhookEvent(ctx context.Context, orgID uuid.UUID, provider, idemKey, eventType, externalMsgID, payloadHash string) (inserted bool, xerr *errx.Error)
+	UpsertContactState(ctx context.Context, st *models.WhatsAppContactState) *errx.Error
+	GetContactStateByPhone(ctx context.Context, orgID uuid.UUID, phoneE164 string) (*models.WhatsAppContactState, *errx.Error)
+	GetContactStateByContact(ctx context.Context, orgID, contactID uuid.UUID) (*models.WhatsAppContactState, *errx.Error)
+	InsertMessage(ctx context.Context, msg *models.WhatsAppMessage) (inserted bool, xerr *errx.Error)
+	GetTemplateStatus(ctx context.Context, orgID uuid.UUID, name, language string) (string, *errx.Error)
+	ListMessagesByThread(ctx context.Context, orgID uuid.UUID, threadKey string, limit int) ([]models.WhatsAppMessage, *errx.Error)
+}
+
+type pgWhatsApp struct {
+	db *pgxpool.Pool
+}
+
+// NewWhatsAppRepository constructs the Postgres implementation.
+func NewWhatsAppRepository(db *pgxpool.Pool) WhatsAppRepository {
+	return &pgWhatsApp{db: db}
+}
+
+func (r *pgWhatsApp) GetInstanceByName(ctx context.Context, provider, instance string) (*models.WhatsAppInstance, *errx.Error) {
+	if r == nil || r.db == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	row := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, provider, instance_name, integration_mode,
+		       phone_e164, webhook_secret, status, created_at, updated_at
+		FROM whatsapp_instances
+		WHERE provider = $1 AND instance_name = $2
+	`, provider, instance)
+	var m models.WhatsAppInstance
+	err := row.Scan(
+		&m.ID, &m.OrganizationID, &m.Provider, &m.InstanceName, &m.IntegrationMode,
+		&m.PhoneE164, &m.WebhookSecret, &m.Status, &m.CreatedAt, &m.UpdatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errx.InternalError()
+	}
+	return &m, nil
+}
+
+// InsertWebhookEvent returns inserted=false when the idempotency key already exists.
+func (r *pgWhatsApp) InsertWebhookEvent(ctx context.Context, orgID uuid.UUID, provider, idemKey, eventType, externalMsgID, payloadHash string) (bool, *errx.Error) {
+	if r == nil || r.db == nil {
+		return false, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	tag, err := r.db.Exec(ctx, `
+		INSERT INTO whatsapp_webhook_events (
+			organization_id, provider, idempotency_key, event_type, external_message_id, payload_hash
+		) VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (organization_id, idempotency_key) DO NOTHING
+	`, orgID, provider, idemKey, eventType, externalMsgID, payloadHash)
+	if err != nil {
+		return false, errx.InternalError()
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (r *pgWhatsApp) UpsertContactState(ctx context.Context, st *models.WhatsAppContactState) *errx.Error {
+	if r == nil || r.db == nil || st == nil {
+		return errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	if st.ID == uuid.Nil {
+		st.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	st.UpdatedAt = now
+	if st.CreatedAt.IsZero() {
+		st.CreatedAt = now
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO whatsapp_contact_state (
+			id, organization_id, contact_id, outreach_candidate_id,
+			phone_raw, phone_e164, phone_country, phone_valid, phone_source, phone_source_url, phone_verified_at,
+			whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_scope,
+			whatsapp_consent_provenance_ok, whatsapp_consent_form_version, whatsapp_consent_recorded_by,
+			whatsapp_last_inbound_at, whatsapp_service_window_until, whatsapp_channel_status,
+			whatsapp_opt_out_at, do_not_contact,
+			last_email_outbound_at, last_whatsapp_outbound_at,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,
+			$5,$6,$7,$8,$9,$10,$11,
+			$12,$13,$14,$15,
+			$16,$17,$18,
+			$19,$20,$21,
+			$22,$23,
+			$24,$25,
+			$26,$27
+		)
+		ON CONFLICT (organization_id, contact_id) WHERE contact_id IS NOT NULL
+		DO UPDATE SET
+			phone_raw = EXCLUDED.phone_raw,
+			phone_e164 = EXCLUDED.phone_e164,
+			phone_country = EXCLUDED.phone_country,
+			phone_valid = EXCLUDED.phone_valid,
+			phone_source = EXCLUDED.phone_source,
+			phone_source_url = EXCLUDED.phone_source_url,
+			phone_verified_at = EXCLUDED.phone_verified_at,
+			-- sticky opt-out / DNC never downgraded by upsert of softer status
+			whatsapp_consent_status = CASE
+				WHEN whatsapp_contact_state.whatsapp_consent_status IN ('OPTED_OUT', 'DO_NOT_CONTACT')
+					THEN whatsapp_contact_state.whatsapp_consent_status
+				WHEN whatsapp_contact_state.do_not_contact OR whatsapp_contact_state.whatsapp_opt_out_at IS NOT NULL
+					THEN whatsapp_contact_state.whatsapp_consent_status
+				ELSE EXCLUDED.whatsapp_consent_status
+			END,
+			whatsapp_consent_source = CASE
+				WHEN whatsapp_contact_state.whatsapp_consent_status IN ('OPTED_OUT', 'DO_NOT_CONTACT')
+					THEN whatsapp_contact_state.whatsapp_consent_source
+				ELSE EXCLUDED.whatsapp_consent_source
+			END,
+			whatsapp_consent_at = CASE
+				WHEN whatsapp_contact_state.whatsapp_consent_status IN ('OPTED_OUT', 'DO_NOT_CONTACT')
+					THEN whatsapp_contact_state.whatsapp_consent_at
+				ELSE EXCLUDED.whatsapp_consent_at
+			END,
+			whatsapp_consent_scope = EXCLUDED.whatsapp_consent_scope,
+			whatsapp_consent_provenance_ok = EXCLUDED.whatsapp_consent_provenance_ok,
+			whatsapp_last_inbound_at = COALESCE(EXCLUDED.whatsapp_last_inbound_at, whatsapp_contact_state.whatsapp_last_inbound_at),
+			whatsapp_service_window_until = COALESCE(EXCLUDED.whatsapp_service_window_until, whatsapp_contact_state.whatsapp_service_window_until),
+			whatsapp_channel_status = EXCLUDED.whatsapp_channel_status,
+			whatsapp_opt_out_at = COALESCE(whatsapp_contact_state.whatsapp_opt_out_at, EXCLUDED.whatsapp_opt_out_at),
+			do_not_contact = whatsapp_contact_state.do_not_contact OR EXCLUDED.do_not_contact,
+			last_email_outbound_at = COALESCE(EXCLUDED.last_email_outbound_at, whatsapp_contact_state.last_email_outbound_at),
+			last_whatsapp_outbound_at = COALESCE(EXCLUDED.last_whatsapp_outbound_at, whatsapp_contact_state.last_whatsapp_outbound_at),
+			updated_at = EXCLUDED.updated_at
+	`, st.ID, st.OrganizationID, st.ContactID, st.OutreachCandidateID,
+		st.PhoneRaw, st.PhoneE164, st.PhoneCountry, st.PhoneValid, st.PhoneSource, st.PhoneSourceURL, st.PhoneVerifiedAt,
+		st.ConsentStatus, st.ConsentSource, st.ConsentAt, st.ConsentScope,
+		st.ConsentProvenanceOK, st.ConsentFormVersion, st.ConsentRecordedBy,
+		st.LastInboundAt, st.ServiceWindowUntil, st.ChannelStatus,
+		st.OptOutAt, st.DoNotContact,
+		st.LastEmailOutboundAt, st.LastWhatsAppOutboundAt,
+		st.CreatedAt, st.UpdatedAt,
+	)
+	if err != nil {
+		return errx.InternalError()
+	}
+	return nil
+}
+
+func (r *pgWhatsApp) GetContactStateByPhone(ctx context.Context, orgID uuid.UUID, phoneE164 string) (*models.WhatsAppContactState, *errx.Error) {
+	return r.scanState(ctx, `
+		SELECT id, organization_id, contact_id, outreach_candidate_id,
+			phone_raw, phone_e164, phone_country, phone_valid, phone_source, phone_source_url, phone_verified_at,
+			whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_scope,
+			whatsapp_consent_provenance_ok, whatsapp_consent_form_version, whatsapp_consent_recorded_by,
+			whatsapp_last_inbound_at, whatsapp_service_window_until, whatsapp_channel_status,
+			whatsapp_opt_out_at, do_not_contact,
+			last_email_outbound_at, last_whatsapp_outbound_at,
+			created_at, updated_at
+		FROM whatsapp_contact_state
+		WHERE organization_id = $1 AND phone_e164 = $2
+		ORDER BY updated_at DESC
+		LIMIT 1
+	`, orgID, phoneE164)
+}
+
+func (r *pgWhatsApp) GetContactStateByContact(ctx context.Context, orgID, contactID uuid.UUID) (*models.WhatsAppContactState, *errx.Error) {
+	return r.scanState(ctx, `
+		SELECT id, organization_id, contact_id, outreach_candidate_id,
+			phone_raw, phone_e164, phone_country, phone_valid, phone_source, phone_source_url, phone_verified_at,
+			whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_scope,
+			whatsapp_consent_provenance_ok, whatsapp_consent_form_version, whatsapp_consent_recorded_by,
+			whatsapp_last_inbound_at, whatsapp_service_window_until, whatsapp_channel_status,
+			whatsapp_opt_out_at, do_not_contact,
+			last_email_outbound_at, last_whatsapp_outbound_at,
+			created_at, updated_at
+		FROM whatsapp_contact_state
+		WHERE organization_id = $1 AND contact_id = $2
+		LIMIT 1
+	`, orgID, contactID)
+}
+
+func (r *pgWhatsApp) scanState(ctx context.Context, q string, args ...any) (*models.WhatsAppContactState, *errx.Error) {
+	if r == nil || r.db == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	row := r.db.QueryRow(ctx, q, args...)
+	var st models.WhatsAppContactState
+	err := row.Scan(
+		&st.ID, &st.OrganizationID, &st.ContactID, &st.OutreachCandidateID,
+		&st.PhoneRaw, &st.PhoneE164, &st.PhoneCountry, &st.PhoneValid, &st.PhoneSource, &st.PhoneSourceURL, &st.PhoneVerifiedAt,
+		&st.ConsentStatus, &st.ConsentSource, &st.ConsentAt, &st.ConsentScope,
+		&st.ConsentProvenanceOK, &st.ConsentFormVersion, &st.ConsentRecordedBy,
+		&st.LastInboundAt, &st.ServiceWindowUntil, &st.ChannelStatus,
+		&st.OptOutAt, &st.DoNotContact,
+		&st.LastEmailOutboundAt, &st.LastWhatsAppOutboundAt,
+		&st.CreatedAt, &st.UpdatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errx.InternalError()
+	}
+	return &st, nil
+}
+
+func (r *pgWhatsApp) InsertMessage(ctx context.Context, msg *models.WhatsAppMessage) (bool, *errx.Error) {
+	if r == nil || r.db == nil || msg == nil {
+		return false, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	if msg.ID == uuid.Nil {
+		msg.ID = uuid.New()
+	}
+	if msg.CreatedAt.IsZero() {
+		msg.CreatedAt = time.Now().UTC()
+	}
+	if msg.Channel == "" {
+		msg.Channel = "WHATSAPP"
+	}
+	tag, err := r.db.Exec(ctx, `
+		INSERT INTO whatsapp_messages (
+			id, organization_id, contact_id, thread_key, direction, channel, provider,
+			provider_message_id, idempotency_key, body_text, template_name, template_language,
+			status, failure_code, draft_id, campaign_id, reviewed_by, approved_at, sent_at, occurred_at, created_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,
+			$8,$9,$10,$11,$12,
+			$13,$14,$15,$16,$17,$18,$19,$20,$21
+		)
+		ON CONFLICT (organization_id, idempotency_key) DO NOTHING
+	`, msg.ID, msg.OrganizationID, msg.ContactID, msg.ThreadKey, msg.Direction, msg.Channel, msg.Provider,
+		msg.ProviderMessageID, msg.IdempotencyKey, msg.BodyText, msg.TemplateName, msg.TemplateLanguage,
+		msg.Status, msg.FailureCode, msg.DraftID, msg.CampaignID, msg.ReviewedBy, msg.ApprovedAt, msg.SentAt, msg.OccurredAt, msg.CreatedAt,
+	)
+	if err != nil {
+		return false, errx.InternalError()
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (r *pgWhatsApp) GetTemplateStatus(ctx context.Context, orgID uuid.UUID, name, language string) (string, *errx.Error) {
+	if r == nil || r.db == nil {
+		return "MISSING", errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	var status string
+	err := r.db.QueryRow(ctx, `
+		SELECT status FROM whatsapp_templates
+		WHERE organization_id = $1 AND name = $2 AND language = $3
+	`, orgID, name, language).Scan(&status)
+	if err == pgx.ErrNoRows {
+		return "MISSING", nil
+	}
+	if err != nil {
+		return "MISSING", errx.InternalError()
+	}
+	return status, nil
+}
+
+func (r *pgWhatsApp) ListMessagesByThread(ctx context.Context, orgID uuid.UUID, threadKey string, limit int) ([]models.WhatsAppMessage, *errx.Error) {
+	if r == nil || r.db == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, contact_id, thread_key, direction, channel, provider,
+			provider_message_id, idempotency_key, body_text, template_name, template_language,
+			status, failure_code, draft_id, campaign_id, reviewed_by, approved_at, sent_at, occurred_at, created_at
+		FROM whatsapp_messages
+		WHERE organization_id = $1 AND thread_key = $2
+		ORDER BY occurred_at DESC
+		LIMIT $3
+	`, orgID, threadKey, limit)
+	if err != nil {
+		return nil, errx.InternalError()
+	}
+	defer rows.Close()
+	var out []models.WhatsAppMessage
+	for rows.Next() {
+		var m models.WhatsAppMessage
+		if err := rows.Scan(
+			&m.ID, &m.OrganizationID, &m.ContactID, &m.ThreadKey, &m.Direction, &m.Channel, &m.Provider,
+			&m.ProviderMessageID, &m.IdempotencyKey, &m.BodyText, &m.TemplateName, &m.TemplateLanguage,
+			&m.Status, &m.FailureCode, &m.DraftID, &m.CampaignID, &m.ReviewedBy, &m.ApprovedAt, &m.SentAt, &m.OccurredAt, &m.CreatedAt,
+		); err != nil {
+			return nil, errx.InternalError()
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}

--- a/site/package.json
+++ b/site/package.json
@@ -22,7 +22,9 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml": "4.3.1"
+      "js-yaml": "4.3.1",
+      "postcss": "8.5.23",
+      "svgo": "^4.0.2"
     }
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -19,5 +19,10 @@
     "motion": "^12.34.0",
     "reading-time": "^1.5.0",
     "tailwindcss": "^4.1.10"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml": "4.3.1"
+    }
   }
 }

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -5,8 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: ^4.3.0
-  svgo: ^4.0.2
+  js-yaml: 4.3.1
 
 importers:
 
@@ -452,105 +451,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -643,79 +626,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -816,28 +786,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1306,8 +1272,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsonc-parser@3.3.1:
@@ -1348,28 +1314,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2084,7 +2046,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.3.0
@@ -2780,7 +2742,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
@@ -3313,7 +3275,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   js-yaml: 4.3.1
+  postcss: 8.5.23
+  svgo: ^4.0.2
 
 importers:
 
@@ -1645,8 +1647,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.20:
-    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prismjs@1.30.0:
@@ -3884,7 +3886,7 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.20:
+  postcss@8.5.23:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -4301,7 +4303,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.20
+      postcss: 8.5.23
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Adds a provider-abstracted WhatsApp channel (`internal/app/whatsapp`) with Evolution API as the sole HTTP adapter (`evolution` package). Domain code never imports Evolution DTOs.
- First-class consent/eligibility policy: public phone + no opt-in never auto-sends; sticky opt-out/DNC; service window; official template gate; cross-channel cooldown helpers.
- Webhook ingress `POST /api/v1/webhooks/evolution/:instance` with secret auth, size limits, event normalization, and idempotency.
- Migration `000080_whatsapp_channel` for contact channel state, messages, instances, templates, webhook events.
- Isolated Evolution Compose project (`deploy/evolution`, pin **v2.3.7** Cloud API first; Baileys disabled by default and rejected in production).
- Compliance notes: `docs/confenge/evolution-api-compliance.md`.

## Feature flags (all default off)
`CONFENGE_WHATSAPP_ENABLED`, `CONFENGE_WHATSAPP_AUTO_SEND_ENABLED`, `CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED`, `WHATSAPP_EVOLUTION_ALLOW_BAILEYS=false`

## Test plan
- [x] `go test ./internal/app/whatsapp/...` (consent, phone, opt-out, webhook auth, Evolution client httptest: 400/401/403/404/429/500, retry, timeout, offline, redaction, normalize)
- [x] `go build ./cmd/backend`
- [x] `gofmt` clean on touched files
- [ ] CI green on this PR
- [ ] No real WhatsApp sends (mock/httptest only)

## Dependencies
- Independent of open CONFENGE PRs #1–#4 (bases on `main`).
- Follow-up PR W2 will stack CONFENGE orchestration (drafts, feed phone/consent, UI) on top of confenge-outcome-ops + this branch.

## External blockers (channel not live until)
- Meta WABA / Cloud API number connected
- Official templates approved
- Webhook reachable with secrets configured