### PR TITLE
feat(confenge): add consent-aware WhatsApp outreach orchestration

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1021,6 +1021,9 @@ func main() {
 		// Template approval checked via Static catalog + DB lookups at send sites.
 		// Full repo-backed catalog is used by confenge orchestration (W2).
 		whatsAppService = whatsapp.NewService(waCfg, waProvider, whatsapp.NewStaticTemplateCatalog())
+		if confengeServiceForHandler != nil && whatsAppService != nil {
+			confengeServiceForHandler.WireWhatsApp(whatsAppService, whatsAppRepo)
+		}
 		if waCfg.Enabled {
 			log.Printf("whatsapp channel enabled provider=%s baileys_allowed=%v auto_send=%v", waCfg.Provider, waCfg.AllowBaileys, waCfg.AutoSendEnabled)
 		}

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -984,7 +984,10 @@ func main() {
 			log.Fatalf("confenge config: %v", err)
 		}
 		outreachRepo := repository.NewOutreachRepository(primaryDB.Pool)
-		confengeServiceForHandler = confenge.NewService(confengeCfg, outreachRepo, auditService)
+		confengeServiceForHandler = confenge.NewServiceWithAI(confengeCfg, outreachRepo, auditService, aiProvider)
+		if confengeServiceForHandler != nil && aiProvider != nil {
+			confengeServiceForHandler.SetAI(aiProvider)
+		}
 
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -988,6 +988,8 @@ func main() {
 		if confengeServiceForHandler != nil && aiProvider != nil {
 			confengeServiceForHandler.SetAI(aiProvider)
 		}
+		// Async outcome outbox → extra-cli HMAC webhook (idle when URL/secret unset).
+		go confenge.NewOutcomeDeliveryWorker(outreachRepo, confengeCfg, confenge.OutcomeDeliveryOptions{}).Run(ctx)
 
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)
@@ -1021,6 +1023,10 @@ func main() {
 		templateService = template.NewService(templateRepository)
 		schedulerService := scheduler.NewSchedulerService(taskRepository, warmupRepository, campaignProgressRepository, emailRepostory, campaignRepostory, contactRepostory, campaignLogRepository)
 		campaignService = campaign.NewService(campaignRepostory, taskRepository, emailRepostory, campaignLogRepository, featureGateService, dailyThrottleService, schedulerService, tasksClient, streamingPublisher)
+		// CONFENGE enroll uses campaign + contact services (execution plane).
+		if confengeServiceForHandler != nil {
+			confengeServiceForHandler.WireExecution(campaignService, contactService)
+		}
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
 		composeService = compose.NewService(emailRepostory, repository.NewComposeRepository(primaryDB))
 		// uniboxService is constructed here (rather than alongside the

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -85,6 +85,8 @@ import (
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/app/warmupcontent"
 	"github.com/warmbly/warmbly/internal/app/webhook"
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+	"github.com/warmbly/warmbly/internal/app/whatsapp/evolution"
 	"github.com/warmbly/warmbly/internal/app/worker"
 	"github.com/warmbly/warmbly/internal/app/worker_orchestrator"
 	"github.com/warmbly/warmbly/internal/config"
@@ -177,6 +179,8 @@ func main() {
 	var tagService group.GroupService
 	var categoryService group.GroupService
 	var crmService crm.CRMService
+	var whatsAppService *whatsapp.Service
+	var whatsAppRepo repository.WhatsAppRepository
 	var teamService team.TeamService
 	var apiKeyService apikey.APIKeyService
 	var idempotencyService idempotencyapp.Service
@@ -976,6 +980,33 @@ func main() {
 
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)
+
+		// WhatsApp channel (Evolution gateway). Disabled by default; Cloud API first.
+		waCfg := whatsapp.LoadConfig()
+		if err := waCfg.ValidateStartup(); err != nil {
+			log.Fatalf("whatsapp config: %v", err)
+		}
+		whatsapp.LogBaileysWarning(waCfg)
+		whatsAppRepo = repository.NewWhatsAppRepository(primaryDB.Pool)
+		var waProvider whatsapp.Provider
+		if waCfg.Enabled && (waCfg.Provider == whatsapp.ProviderEvolution || waCfg.Provider == "") {
+			evoClient := evolution.NewClient(evolution.ClientConfig{
+				BaseURL:    waCfg.EvolutionBaseURL,
+				APIKey:     waCfg.EvolutionAPIKey,
+				Timeout:    20 * time.Second,
+				MaxRetries: 2,
+			})
+			waProvider = evolution.NewProvider(evoClient, waCfg.EvolutionInstance)
+		}
+		if waCfg.Enabled && waCfg.Provider == whatsapp.ProviderMock {
+			waProvider = whatsapp.NewMockProvider()
+		}
+		// Template approval checked via Static catalog + DB lookups at send sites.
+		// Full repo-backed catalog is used by confenge orchestration (W2).
+		whatsAppService = whatsapp.NewService(waCfg, waProvider, whatsapp.NewStaticTemplateCatalog())
+		if waCfg.Enabled {
+			log.Printf("whatsapp channel enabled provider=%s baileys_allowed=%v auto_send=%v", waCfg.Provider, waCfg.AllowBaileys, waCfg.AutoSendEnabled)
+		}
 		teamRepository := repository.NewTeamRepository(primaryDB.Pool)
 		teamService = team.NewService(teamRepository)
 		socketService = socket.NewService(cache, tokenService)
@@ -1403,6 +1434,10 @@ func main() {
 
 		// CRM
 		CRMService: crmService,
+
+		// WhatsApp channel
+		WhatsAppService: whatsAppService,
+		WhatsAppRepo:    whatsAppRepo,
 
 		// Teams
 		TeamService: teamService,

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1026,6 +1026,9 @@ func main() {
 		// CONFENGE enroll uses campaign + contact services (execution plane).
 		if confengeServiceForHandler != nil {
 			confengeServiceForHandler.WireExecution(campaignService, contactService)
+			if crmService != nil {
+				confengeServiceForHandler.WireCRM(crmService)
+			}
 		}
 		emailSendService = emailsend.NewService(taskRepository, emailRepostory, userRepostory, schedulerService, tasksClient, featureGateService, dailyThrottleService)
 		composeService = compose.NewService(emailRepostory, repository.NewComposeRepository(primaryDB))
@@ -1171,6 +1174,10 @@ func main() {
 		// agent wired onto the advanced service so any reply processed here also
 		// drafts. Paid + opt-in checked inside; nil provider leaves it inert.
 		aiDraftRepo = repository.NewAIDraftRepository(primaryDB.Pool)
+		// CONFENGE reply attribution (outbox + CRM) when outreach feature is on.
+		if confengeServiceForHandler != nil && confengeServiceForHandler.Enabled() {
+			advancedService.WireConfengeReply(confengeServiceForHandler)
+		}
 		advancedService.WireInboxAgent(inboxagent.NewService(
 			aiProvider, creditService, featureGateService,
 			organizationRepository, uniboxRepository, skillsService,

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/app/compose"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/app/contact"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/app/creditwatch"
@@ -239,6 +240,7 @@ func main() {
 	var contactRepoForHandler repository.ContactRepository
 	var attachmentRepoForHandler repository.AttachmentRepository
 	var leadSyncServiceForHandler leadsync.Service
+	var confengeServiceForHandler confenge.Service
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -974,6 +976,16 @@ func main() {
 		leadSyncRepository := repository.NewLeadSyncRepository(primaryDB.Pool)
 		leadSyncServiceForHandler = leadsync.NewService(leadSyncRepository, integrationServiceForHandler, contactService)
 
+		// CONFENGE outreach staging: extra-cli feed import. Off by default
+		// (CONFENGE_OUTREACH_ENABLED=false). Fail closed on insecure prod config.
+		confengeCfg := confenge.LoadConfig()
+		if err := confengeCfg.ValidateStartup(os.Getenv("APP_ENV")); err != nil {
+			sentry.CaptureException(err)
+			log.Fatalf("confenge config: %v", err)
+		}
+		outreachRepo := repository.NewOutreachRepository(primaryDB.Pool)
+		confengeServiceForHandler = confenge.NewService(confengeCfg, outreachRepo, auditService)
+
 		apiKeyService = apikey.NewService(cache, apiKeyRepository)
 		crmService = crm.NewService(crmRepository)
 		teamRepository := repository.NewTeamRepository(primaryDB.Pool)
@@ -1469,6 +1481,9 @@ func main() {
 
 		// On-demand Google Sheets -> leads sync
 		LeadSyncService: leadSyncServiceForHandler,
+
+		// CONFENGE outreach staging (feature-flagged)
+		ConfengeService: confengeServiceForHandler,
 
 		WebsocketURI: websocketURI,
 

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getsentry/sentry-go"
 	"github.com/warmbly/warmbly/internal/app/advanced"
 	"github.com/warmbly/warmbly/internal/app/cipher"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	jobs "github.com/warmbly/warmbly/internal/app/consumer"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/app/creditwatch"
@@ -354,6 +355,13 @@ func main() {
 
 	eventsPublisher := events.NewPublisher(consumerBus, s3Client, consumerCodec, cipherService)
 
+	// CONFENGE outcome sink (feature-flagged; no-op when disabled).
+	confengeCfgC := confenge.LoadConfig()
+	var confengeSink confenge.OutcomeSink
+	if confengeCfgC.Enabled {
+		confengeSink = confenge.NewService(confengeCfgC, repository.NewOutreachRepository(primaryDB.Pool), nil).(confenge.OutcomeSink)
+	}
+
 	// JobsService
 	jobsService := &jobs.JobsService{
 		Bus:                         consumerBus,
@@ -372,6 +380,7 @@ func main() {
 		Publisher:                   eventsPublisher,
 		StreamingPublisher:          streamingPublisher,
 		AdvancedService:             advancedService,
+		ConfengeOutcomes:            confengeSink,
 		Cache:                       redisCache,
 		AdminRepo:                   repository.NewAdminRepository(primaryDB.Pool),
 		AssignmentService:           workerAssignmentSvc,

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -351,16 +351,23 @@ func main() {
 		repository.NewAIDraftRepository(primaryDB.Pool),
 		streamingPublisher,
 	)
+	// CONFENGE outcome sink (feature-flagged; no-op when disabled).
+	confengeCfgC := confenge.LoadConfig()
+	var confengeSvc confenge.Service
+	var confengeSink confenge.OutcomeSink
+	if confengeCfgC.Enabled {
+		confengeSvc = confenge.NewService(confengeCfgC, repository.NewOutreachRepository(primaryDB.Pool), nil)
+		if sink, ok := confengeSvc.(confenge.OutcomeSink); ok {
+			confengeSink = sink
+		}
+		// CRM not wired on consumer (control-plane tasks/deals stay on backend);
+		// outbox + staging updates still run via OnClassifiedReply.
+		advancedService.WireConfengeReply(confengeSvc)
+	}
+
 	advancedService.WireInboxAgent(inboxAgentServiceC)
 
 	eventsPublisher := events.NewPublisher(consumerBus, s3Client, consumerCodec, cipherService)
-
-	// CONFENGE outcome sink (feature-flagged; no-op when disabled).
-	confengeCfgC := confenge.LoadConfig()
-	var confengeSink confenge.OutcomeSink
-	if confengeCfgC.Enabled {
-		confengeSink = confenge.NewService(confengeCfgC, repository.NewOutreachRepository(primaryDB.Pool), nil).(confenge.OutcomeSink)
-	}
 
 	// JobsService
 	jobsService := &jobs.JobsService{

--- a/deploy/config/env.example
+++ b/deploy/config/env.example
@@ -167,6 +167,21 @@ CHECK_ORIGIN=false
 # SEARCH_API_URL=
 # SEARCH_API_KEY=
 
+# === CONFENGE outreach (optional; off by default) ===
+# Intelligence plane remains extra-cli. Warmbly only imports a versioned feed
+# into multi-tenant staging. Do not point these at the extra-cli Postgres.
+# CONFENGE_OUTREACH_ENABLED=false
+# CONFENGE_AUTO_SEND_ENABLED=false
+# CONFENGE_REQUIRE_HUMAN_APPROVAL=true
+# CONFENGE_EXTRA_CLI_FEED_URL=        # https://... or file:///path/to/feed.json
+# CONFENGE_EXTRA_CLI_FEED_TOKEN=      # optional Bearer for HTTPS feed
+# CONFENGE_EXTRA_CLI_ALLOWED_HOSTS=   # comma-separated host allowlist (required in prod with feed URL)
+# CONFENGE_OUTCOME_WEBHOOK_URL=       # HTTPS webhook back to extra-cli (PR3)
+# CONFENGE_OUTCOME_WEBHOOK_SECRET=    # HMAC secret for outcome webhooks
+# CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=10
+# CONFENGE_MAX_INITIAL_EMAIL_WORDS=120
+# CONFENGE_MAX_FEED_PAYLOAD_BYTES=33554432
+
 # === Observability ===
 # Optional in dev; REQUIRED (fatal at boot) on every Go service when APP_ENV=prod.
 # SENTRY_DSN=

--- a/deploy/config/env.example
+++ b/deploy/config/env.example
@@ -170,3 +170,20 @@ CHECK_ORIGIN=false
 # === Observability ===
 # Optional in dev; REQUIRED (fatal at boot) on every Go service when APP_ENV=prod.
 # SENTRY_DSN=
+
+# === WhatsApp channel (Evolution gateway; optional) ===
+# All defaults keep the channel fully off. Cloud API is the production path.
+# Baileys is lab-only and rejected when APP_ENV=production.
+# CONFENGE_WHATSAPP_ENABLED=false
+# CONFENGE_WHATSAPP_AUTO_SEND_ENABLED=false
+# CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED=false
+# WHATSAPP_PROVIDER=evolution
+# WHATSAPP_EVOLUTION_BASE_URL=http://127.0.0.1:8089
+# WHATSAPP_EVOLUTION_API_KEY=
+# WHATSAPP_EVOLUTION_INSTANCE=
+# WHATSAPP_EVOLUTION_ALLOW_BAILEYS=false
+# WHATSAPP_WEBHOOK_SECRET=
+# CONFENGE_CROSS_CHANNEL_MIN_INTERVAL_HOURS=24
+# WHATSAPP_SERVICE_WINDOW_HOURS=24
+# WHATSAPP_MAX_WEBHOOK_BYTES=1048576
+# See docs/confenge/whatsapp-channel.md and docs/confenge/evolution-api-compliance.md

--- a/deploy/evolution/.env.example
+++ b/deploy/evolution/.env.example
@@ -1,0 +1,14 @@
+# Evolution API isolated stack (project: evolution-confenge)
+# Copy to .env and fill secrets. Never commit real values.
+
+EVOLUTION_API_KEY=change-me-long-random
+EVOLUTION_DB_NAME=evolution
+EVOLUTION_DB_USER=evolution
+EVOLUTION_DB_PASSWORD=change-me-db-password
+EVOLUTION_SERVER_URL=http://127.0.0.1:8089
+EVOLUTION_HOST_BIND=127.0.0.1
+EVOLUTION_HOST_PORT=8089
+EVOLUTION_LOG_LEVEL=ERROR,WARN,INFO
+
+# Image pin (documented; compose hardcodes 2.3.7):
+# evoapicloud/evolution-api:2.3.7

--- a/deploy/evolution/docker-compose.yml
+++ b/deploy/evolution/docker-compose.yml
@@ -1,0 +1,122 @@
+# Isolated Evolution API stack for CONFENGE WhatsApp transport.
+# Project name: evolution-confenge
+# Does NOT share Postgres/Redis with Warmbly or extra-cli.
+#
+# Pin: Evolution API v2.3.7 (stable). Do not deploy 2.4.0-rc to production.
+# Image: evoapicloud/evolution-api:2.3.7
+#
+# Usage:
+#   cp .env.example .env   # fill secrets
+#   docker compose -p evolution-confenge --env-file .env up -d
+#
+# Network: keep Evolution on a private network. Warmbly reaches it privately;
+# public ingress should hit Warmbly's webhook, not Evolution Manager.
+
+name: evolution-confenge
+
+services:
+  evolution-postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${EVOLUTION_DB_NAME:-evolution}
+      POSTGRES_USER: ${EVOLUTION_DB_USER:-evolution}
+      POSTGRES_PASSWORD: ${EVOLUTION_DB_PASSWORD:?set EVOLUTION_DB_PASSWORD}
+    volumes:
+      - evolution_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${EVOLUTION_DB_USER:-evolution} -d ${EVOLUTION_DB_NAME:-evolution}"]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+    networks:
+      - evolution_net
+    deploy:
+      resources:
+        limits:
+          memory: 512M
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "3"
+
+  evolution-redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--appendonly", "yes", "--maxmemory", "128mb", "--maxmemory-policy", "allkeys-lru"]
+    volumes:
+      - evolution_redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 3s
+      retries: 10
+    networks:
+      - evolution_net
+    deploy:
+      resources:
+        limits:
+          memory: 192M
+    logging:
+      driver: json-file
+      options:
+        max-size: "5m"
+        max-file: "3"
+
+  evolution-api:
+    # Stable pin — not a release candidate.
+    image: evoapicloud/evolution-api:2.3.7
+    restart: unless-stopped
+    depends_on:
+      evolution-postgres:
+        condition: service_healthy
+      evolution-redis:
+        condition: service_healthy
+    environment:
+      SERVER_URL: ${EVOLUTION_SERVER_URL:-http://evolution-api:8080}
+      AUTHENTICATION_API_KEY: ${EVOLUTION_API_KEY:?set EVOLUTION_API_KEY}
+      DATABASE_ENABLED: "true"
+      DATABASE_PROVIDER: postgresql
+      DATABASE_CONNECTION_URI: postgresql://${EVOLUTION_DB_USER:-evolution}:${EVOLUTION_DB_PASSWORD}@evolution-postgres:5432/${EVOLUTION_DB_NAME:-evolution}?schema=public
+      CACHE_REDIS_ENABLED: "true"
+      CACHE_REDIS_URI: redis://evolution-redis:6379
+      CACHE_REDIS_PREFIX_KEY: evolution
+      # Production path: WhatsApp Business / Cloud API.
+      # Do not enable Baileys for production CONFENGE traffic.
+      LOG_LEVEL: ${EVOLUTION_LOG_LEVEL:-ERROR,WARN,INFO}
+      DEL_INSTANCE: "false"
+    # Bind only on loopback / private interface in production via reverse proxy.
+    # Default: no public publish; attach Warmbly network externally if needed.
+    ports:
+      - "${EVOLUTION_HOST_BIND:-127.0.0.1}:${EVOLUTION_HOST_PORT:-8089}:8080"
+    volumes:
+      - evolution_instances:/evolution/instances
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:8080/ || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+    networks:
+      - evolution_net
+    deploy:
+      resources:
+        limits:
+          memory: 1G
+    logging:
+      driver: json-file
+      options:
+        max-size: "20m"
+        max-file: "5"
+
+volumes:
+  evolution_pg_data:
+  evolution_redis_data:
+  evolution_instances:
+
+networks:
+  evolution_net:
+    name: evolution_confenge_net
+    driver: bridge
+    internal: false

--- a/docs/confenge/README.md
+++ b/docs/confenge/README.md
@@ -1,0 +1,149 @@
+# CONFENGE outreach on Warmbly
+
+Warmbly is the **execution plane** for CONFENGE commercial outreach. The
+`extra-cli` remains the **intelligence plane** (datalake, signals, evidence,
+scoring, Decision & Outcome Memory).
+
+```text
+datalake (VPS) → extra-cli → versioned feed → Warmbly staging → review → campaign → outcomes → extra-cli
+```
+
+This document covers **PR1**: feed contract, import, staging models, API, and
+feature flag. Message generation, review UI, campaign enrollment, and outcome
+webhooks land in follow-up PRs.
+
+## Separation of concerns
+
+| Warmbly | extra-cli |
+| --- | --- |
+| Contacts, mailboxes, campaigns, sequences | Datalake, public contracts |
+| Send limits, follow-ups, stop-on-reply | Commercial signals, facts |
+| Inbox, replies, bounces, suppression | Evidence, hypotheses |
+| CRM, tasks, analytics | Prioritization, provenance |
+| Staging import + review queue | Canonical decision/outcome memory |
+
+Warmbly **must not**:
+
+- connect to the extra-cli production Postgres
+- write into the datalake
+- re-score leads or re-run commercial analytics
+
+## Feature flag
+
+| Variable | Default | Meaning |
+| --- | --- | --- |
+| `CONFENGE_OUTREACH_ENABLED` | `false` | Master switch for API + import |
+| `CONFENGE_AUTO_SEND_ENABLED` | `false` | Reserved; never default on |
+| `CONFENGE_REQUIRE_HUMAN_APPROVAL` | `true` | Safety default for later send paths |
+| `CONFENGE_EXTRA_CLI_FEED_URL` | empty | HTTPS or `file://` feed |
+| `CONFENGE_EXTRA_CLI_FEED_TOKEN` | empty | Optional Bearer for HTTPS |
+| `CONFENGE_EXTRA_CLI_ALLOWED_HOSTS` | empty | Required in prod when feed URL set |
+| `CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT` | `10` | Future campaign bootstrap |
+| `CONFENGE_MAX_INITIAL_EMAIL_WORDS` | `120` | Future copy validators |
+| `CONFENGE_MAX_FEED_PAYLOAD_BYTES` | `33554432` | Import payload cap |
+
+In production, feed and outcome URLs must be `https://`, and the feed host
+must be on the allowlist. Fetch uses the SSRF-hardened HTTP client.
+
+## Contract `confenge.outreach.v1`
+
+Top-level:
+
+```json
+{
+  "schema_version": "confenge.outreach.v1",
+  "generated_at": "2026-08-06T12:00:00Z",
+  "source": {
+    "system": "extra-cli",
+    "run_id": "...",
+    "snapshot_hash": "...",
+    "repo_sha": "...",
+    "profile_id": "confenge",
+    "profile_version": "1.0.0"
+  },
+  "pagination": { "cursor": null, "next_cursor": null, "has_more": false },
+  "leads": []
+}
+```
+
+Each lead carries company (CNPJ14), priority (opaque scores from extra-cli),
+moment, offer, messaging_context, contacts, contracts, evidence, and
+`commercial_state`. Missing email is valid: the company enters as
+`NEEDS_CONTACT`, never discarded.
+
+Synthetic fixtures: `internal/app/confenge/testdata/`.
+
+### Legacy adapters
+
+If `schema_version` is absent, the importer normalizes:
+
+- top-level `leads.json` arrays
+- commercial run objects with a `leads` key
+- flat contact fields (`email`, `contact_name`, …)
+
+Missing fields are left empty. Nothing is invented.
+
+## Data model (staging)
+
+Multi-tenant tables (migration `000080_outreach_staging`):
+
+- `outreach_import_runs` — audit of each dry-run/apply
+- `outreach_accounts` — company staging, unique `(organization_id, cnpj14)`
+- `outreach_contact_candidates` — candidates before Warmbly contact promotion
+- `outreach_evidence` — sanitized text evidence per account
+
+Human flags (`do_not_contact`, `blocked`, post-send queue states) survive
+reimport. Machine fields (score, moment, offer) update on content-hash change.
+
+## API (JWT + org context)
+
+Base: `/api/v1/confenge` (requires organization).
+
+| Method | Path | Permission | Notes |
+| --- | --- | --- | --- |
+| GET | `/status` | any org member | Works even when disabled |
+| GET | `/summary` | view contacts | Queue counters |
+| GET | `/accounts` | view contacts | Filters: `queue_state`, `cnpj14`, `q` |
+| GET | `/accounts/:id` | view contacts | Includes contacts + evidence |
+| POST | `/accounts/:id/block` | manage contacts | Optional `do_not_contact` |
+| POST | `/import` | manage contacts | Body = feed JSON or `{"uri":"..."}` |
+| GET | `/import-runs` | view contacts | Recent runs |
+| GET | `/import-runs/:id` | view contacts | Run detail + counts |
+
+Import query/header:
+
+- `?dry_run=true` — validate + count only
+- `Idempotency-Key` — same key + same payload returns prior run; different payload → `409`
+
+## Local quickstart
+
+1. Set `CONFENGE_OUTREACH_ENABLED=true` on the backend env.
+2. Apply migrations (`make backend` applies embedded migrations).
+3. Import fixture:
+
+```bash
+curl -sS -X POST "$API/api/v1/confenge/import?dry_run=true" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @internal/app/confenge/testdata/native_feed_v1.json
+```
+
+4. Apply (no dry_run), then `GET /confenge/summary` and `GET /confenge/accounts`.
+
+## Tests
+
+```bash
+go test ./internal/app/confenge/ -count=1
+```
+
+Covers native + legacy parse, dry-run, idempotency, DNC preservation, multi-tenant
+isolation, evidence add, invalid feed, queue states for missing/unverified contacts.
+
+## Upstream maintenance
+
+See [upstream-maintenance.md](./upstream-maintenance.md).
+
+## Outcome loop (PR3)
+
+Outcome webhook env vars are reserved. Delivery uses HMAC + outbox; Warmbly
+never writes to the extra-cli database.

--- a/docs/confenge/evolution-api-compliance.md
+++ b/docs/confenge/evolution-api-compliance.md
@@ -1,0 +1,77 @@
+# Evolution API compliance notes (CONFENGE / Warmbly)
+
+## Role
+
+Evolution API is an **external WhatsApp gateway** only.
+
+- Warmbly remains the CRM, policy engine, and execution plane.
+- Evolution is not a second CRM. Contacts, pipeline, consent, and commercial state live in Warmbly.
+- We do **not** vendor Evolution source into this repository.
+
+## Version pin
+
+| Item | Value |
+|------|--------|
+| Product | Evolution API |
+| Stable pin | **v2.3.7** |
+| Docker image | `evoapicloud/evolution-api:2.3.7` |
+| Why | Latest stable (non-RC) as of research; 2.4.0-rc series introduces mandatory licensing activation and is pre-release |
+| Do not ship | `2.4.0-rc*` for production |
+
+Re-evaluate the pin only after a stable 2.4+ release and a license review.
+
+## License
+
+Evolution API is licensed under **Apache License 2.0** with additional commercial conditions from Evolution Foundation / Evolution API:
+
+1. **Console logo and copyright**: You may not remove or modify logos/copyright in the Evolution API console or frontend components. This does not apply when you do not use those frontend components.
+2. **Usage notification**: If Evolution is used as part of a project (including closed-source), display a clear notification that Evolution API is utilized, visible to system administrators and accessible from documentation or settings. Failure may require a commercial license.
+3. Contact for commercial licensing: `contato@evolution-api.com`.
+
+Warmbly obligations for CONFENGE ops:
+
+- Keep this document and Netcup runbooks as the admin-visible usage notice.
+- Do not strip Evolution console branding if the Manager UI is deployed.
+- Do not bypass activation, telemetry, or license servers.
+- Do not modify Evolution source to avoid license terms.
+
+## Production integration mode
+
+| Mode | Status |
+|------|--------|
+| `WHATSAPP-BUSINESS` / Meta Cloud API | **Default production path** |
+| `WHATSAPP-BAILEYS` | **Disabled by default**; forbidden when `APP_ENV=production` |
+
+Env:
+
+```env
+WHATSAPP_EVOLUTION_ALLOW_BAILEYS=false
+```
+
+Baileys (WhatsApp Web multi-device sessions) is **not** a substitute for WhatsApp Business Platform policies. Do not use Baileys to circumvent Meta rules.
+
+## Forbidden practices
+
+Warmbly will not implement:
+
+- Mass cold broadcast
+- Number rotation / QR farms
+- Anti-ban, fingerprint spoofing, humanization-for-evasion
+- Bulk `isOnWhatsApp` enumeration of cold contacts
+- Auto-send to public phones without opt-in
+
+## Secrets and network
+
+- Evolution runs in its **own** Compose project with its **own** Postgres volume.
+- Do not share Warmbly or extra-cli PostgreSQL with Evolution.
+- Prefer private network: internet → reverse proxy → Warmbly webhook; Warmbly → private network → Evolution.
+- Do not expose the Evolution Manager publicly without strong auth.
+
+## Telemetry
+
+Document any official telemetry toggles from the Evolution release notes for the pinned version. Do not hack or strip telemetry in violation of license terms. If a supported env var disables non-essential telemetry, choose it consciously and record the choice in the Netcup runbook.
+
+## Related docs
+
+- `docs/confenge/whatsapp-channel.md` — Warmbly channel architecture
+- `deploy/evolution/` — isolated Compose project

--- a/docs/confenge/external-blockers.md
+++ b/docs/confenge/external-blockers.md
@@ -1,0 +1,89 @@
+# External blockers (honest status)
+
+These items cannot be completed from this agent session without operator /
+maintainer action. Code paths are implemented and unit-tested; production
+proof remains open.
+
+## 1. GitHub Actions on warmbly/warmbly#91
+
+| Item | Status |
+| --- | --- |
+| Upstream PR | https://github.com/warmbly/warmbly/pull/91 |
+| CI run | https://github.com/warmbly/warmbly/actions/runs/31142042410 |
+| Conclusion | `action_required` |
+
+First-time contributor workflows from the fork require **maintainer approval**
+before jobs run. This agent cannot approve Actions on `warmbly/warmbly`
+(403 admin rights). After approval, CI should run `make lint` + `go test -race
+./...` and web typecheck.
+
+## 2. Fork CI (`tjsasakifln/warmbly`)
+
+`.github/workflows/ci.yml` only triggers on:
+
+```yaml
+push:
+  branches: [main]
+pull_request:
+  branches: [main]
+```
+
+Stacked PRs targeting intermediate branches (review → import, ops → review)
+therefore **do not** run GitHub Actions. PR #3 (import → `main`) is the only
+fork PR eligible for CI. Actions history on the fork showed zero runs at last
+check; if that persists after a new push to a `main`-targeted PR, check
+Actions enablement and billing for the personal fork.
+
+**Workaround for full-stack CI:** open or use a tip PR
+`feat/confenge-outcome-ops` → `main` so the complete commit stack is tested
+against the same workflow as production PRs.
+
+## 3. Netcup VPS deploy
+
+No live inventory of the Netcup box (ports, compose projects, reverse proxy,
+extra-cli containers) was available in this environment.  
+`docs/confenge/netcup-ops.md` describes an isolated `warmbly-confenge` project.
+Do **not** declare production until preflight + smoke on the real VPS.
+
+## 4. Microsoft 365 / Graph
+
+Warmbly already supports Outlook OAuth (`BOX_OUTLOOK_CLIENT_ID` /
+`BOX_OUTLOOK_CLIENT_SECRET`, redirect `/addresses/outlook/callback`).  
+No operator Azure app credentials or test mailbox were available here.
+Smoke steps for Tiago:
+
+1. Register / reuse Azure app with Mail.Send, Mail.Read, offline_access
+2. Set BOX_OUTLOOK_* on backend + workers
+3. Connect confenge.com.br mailbox in dashboard
+4. Send test to an address Tiago owns (never to real leads)
+
+## 5. extra-cli feed / outcome receptor
+
+Legacy import works (`leads.json` / commercial run shapes).  
+Native `confenge.outreach.v1` exporter and HMAC outcome endpoint on extra-cli
+are **not** required for Warmbly unit tests; they remain optional separate PRs
+on `tjsasakifln/extra-cli` if production wants HTTPS feed + Decision & Outcome
+Memory writeback.
+
+## 6. Frontend typecheck in this environment
+
+Host Node is v20; pnpm 11 requires Node ≥ 22.13. Web CI uses Node 20 + pnpm 10
+and is the authoritative frontend gate once Actions run. Local
+`pnpm typecheck` may fail on this machine for toolchain reasons, not app code.
+
+## Local verification that did pass
+
+```bash
+go test ./internal/app/confenge/ -count=1   # import, drafts, enroll, CRM, e2e, HMAC
+make lint
+go test ./cmd/backend/ ./cmd/consumer/ ./internal/api/handler/ -count=0
+```
+
+## What is NOT a blocker for merging code review
+
+- Intelligence / execution separation (feed + outbox only)
+- Multi-tenant staging + DNC preservation
+- Validators + template AI fallback
+- Campaign bootstrap + enroll
+- Outcome HMAC outbox worker
+- CRM pipeline bootstrap + reply-class mapping

--- a/docs/confenge/netcup-ops.md
+++ b/docs/confenge/netcup-ops.md
@@ -1,0 +1,65 @@
+# Netcup deployment notes (CONFENGE Warmbly)
+
+Deploy Warmbly as an **isolated Compose project** next to extra-cli. Do not share
+Postgres, Redis, or Kafka with the intelligence plane.
+
+## Preflight checklist
+
+- Inventory ports, volumes, reverse proxy, DNS, TLS, disk, RAM, and extra-cli
+  services already running on the VPS.
+- Choose non-colliding names: project `warmbly-confenge`, network
+  `warmbly_confenge_net`, volumes `warmbly_confenge_pg` / `_redis`.
+- Do not mount the extra-cli datalake volume into Warmbly.
+- Do not grant Warmbly credentials to the extra-cli database.
+
+## Integration path
+
+```text
+extra-cli export feed (HTTPS or file drop)
+        → Warmbly CONFENGE_EXTRA_CLI_FEED_URL
+Warmbly outcome outbox
+        → CONFENGE_OUTCOME_WEBHOOK_URL (extra-cli receiver)
+```
+
+## Required env (minimum)
+
+```env
+CONFENGE_OUTREACH_ENABLED=true
+CONFENGE_AUTO_SEND_ENABLED=false
+CONFENGE_REQUIRE_HUMAN_APPROVAL=true
+CONFENGE_EXTRA_CLI_FEED_URL=https://...
+CONFENGE_EXTRA_CLI_ALLOWED_HOSTS=...
+CONFENGE_OUTCOME_WEBHOOK_URL=https://...
+CONFENGE_OUTCOME_WEBHOOK_SECRET=...
+BOX_OUTLOOK_CLIENT_ID=...
+BOX_OUTLOOK_CLIENT_SECRET=...
+```
+
+Use Microsoft Graph OAuth already supported by Warmbly. Do not put mailbox
+passwords in `.env`.
+
+## Ops
+
+| Action | Notes |
+| --- | --- |
+| Deploy | Isolated compose up; migrations apply on backend boot |
+| Smoke | `/health`, import fixture dry-run, generate template draft |
+| Backup | Postgres volume only for Warmbly project |
+| Restore | Restore volume, restart backend, verify migration version |
+| Rollback | Set `CONFENGE_OUTREACH_ENABLED=false`; optional down migrations |
+| Upgrade | Pull image/tag, recreate containers, watch migrations |
+
+## External access
+
+If DNS/TLS is not ready, use SSH tunnel to the dashboard/API. Do not expose an
+unauthenticated panel.
+
+## Proof bar
+
+Do not declare production ready without:
+
+1. Clean import of synthetic feed
+2. Review + approve path
+3. Mailbox Graph connection test to an operator-owned address
+4. Outcome outbox delivery or documented export path
+5. Backup/restore drill

--- a/docs/confenge/outcomes.md
+++ b/docs/confenge/outcomes.md
@@ -1,0 +1,69 @@
+# Outcome contract `confenge.outcome.v1`
+
+Warmbly returns commercial outcomes to extra-cli through an **outbox + HTTPS
+HMAC webhook**. Warmbly never writes the datalake database.
+
+## Envelope
+
+```json
+{
+  "schema_version": "confenge.outcome.v1",
+  "event_id": "uuid",
+  "idempotency_key": "string",
+  "occurred_at": "RFC3339",
+  "source": "warmbly",
+  "source_lead_id": "string",
+  "cnpj14": "string",
+  "contact_email": "string",
+  "event_type": "REPLIED",
+  "campaign_id": "string",
+  "message_id": "string",
+  "metadata": {}
+}
+```
+
+## Event types
+
+`LEAD_IMPORTED`, `LEAD_REVIEWED`, `CONTACT_APPROVED`, `CONTACTED`, `REPLIED`,
+`MEETING`, `PROPOSAL`, `WON`, `LOST`, `DO_NOT_CONTACT`, `BOUNCED`.
+
+## Transport
+
+| Setting | Purpose |
+| --- | --- |
+| `CONFENGE_OUTCOME_WEBHOOK_URL` | HTTPS endpoint on extra-cli |
+| `CONFENGE_OUTCOME_WEBHOOK_SECRET` | HMAC shared secret |
+
+Header: `X-Warmbly-Signature: t=<unix>,v1=<hex(hmac_sha256(secret, "<unix>." + body))>`
+
+Receivers must:
+
+1. Reject non-HTTPS in production
+2. Verify signature with constant-time compare
+3. Reject timestamps outside a short skew window (for example 5 minutes)
+4. Deduplicate on `idempotency_key` / `event_id`
+
+## Delivery semantics
+
+- Enqueue is transactional with the user action path (outbox table).
+- A background worker (or manual replay) drains pending rows with exponential
+  backoff and a dead-letter flag after repeated failure.
+- Replays are safe: same idempotency key must not create a second ledger entry
+  in extra-cli Decision & Outcome Memory.
+
+## Mapping to extra-cli commercial states
+
+| Outcome | Suggested extra-cli state |
+| --- | --- |
+| LEAD_IMPORTED | IMPORTED / known in Warmbly |
+| CONTACT_APPROVED | READY |
+| CONTACTED | CONTACTED |
+| REPLIED | REPLIED |
+| MEETING | MEETING |
+| PROPOSAL | PROPOSAL |
+| WON | WON (human only) |
+| LOST | LOST (human or explicit rule) |
+| DO_NOT_CONTACT | DNC |
+| BOUNCED | BOUNCED |
+
+Do not auto-mark WON from machine classification alone.

--- a/docs/confenge/upstream-maintenance.md
+++ b/docs/confenge/upstream-maintenance.md
@@ -1,0 +1,52 @@
+# Upstream maintenance notes (CONFENGE outreach)
+
+Fork: `tjsasakifln/warmbly` · Upstream: `warmbly/warmbly`
+
+## Files introduced (PR1)
+
+| Area | Paths |
+| --- | --- |
+| Migration | `internal/infrastructure/db/migrations/000080_outreach_staging.{up,down}.sql` |
+| Models | `internal/models/outreach.go`; audit entity constants in `audit.go` |
+| App | `internal/app/confenge/*` |
+| Repository | `internal/repository/pg_outreach.go` |
+| API | `internal/api/handler/confenge.go`; routes in `routes.go`; `handler.go` field |
+| Wire | `cmd/backend/main.go` (config load + service) |
+| Config sample | `deploy/config/env.example` |
+| Realtime spine | `web/src/hooks/useRealtimeEvents.ts` (`outreach_*` keys) |
+| Docs | `docs/confenge/*` |
+
+## Extension points used
+
+- Feature flag via env (no change to billing/feature gate matrix)
+- Org-scoped routes with existing `RequireAccess` / contact permissions
+- Audit spine (`AuditEntityOutreachImportRun`, `AuditEntityOutreachAccount`)
+- Embedded migrations (same as other features)
+- SSRF client (`internal/pkg/safehttp`) for remote feeds
+
+## Probable upstream conflicts
+
+- Migration number `000080` if upstream adds migrations in the same band — renumber before merge
+- `cmd/backend/main.go` and `handler.go` are high-churn; keep confenge wiring in a tight block
+- `routes.go` advisor/contacts region
+
+## Update strategy
+
+1. Fetch upstream `main`, rebase or merge carefully.
+2. If migration collision: renumber `000080` and keep down migration paired.
+3. Re-run `gofmt`, `make lint`, `go test ./internal/app/confenge/`.
+4. Keep confenge packages self-contained; avoid editing campaign/send cores.
+
+## Disable
+
+Set `CONFENGE_OUTREACH_ENABLED=false` (default). Routes still expose
+`GET /confenge/status` with `"enabled": false`. Import/list return not found.
+
+## Remove customization
+
+1. Drop env vars and docs.
+2. Delete `internal/app/confenge`, handler, repo, models, migration (new down).
+3. Remove wiring in `main.go` / `handler.go` / `routes.go` / realtime spine.
+
+Do not leave staging tables with PII if decommissioning a deployment: export then
+drop via down migration after backup.

--- a/docs/confenge/whatsapp-channel.md
+++ b/docs/confenge/whatsapp-channel.md
@@ -80,3 +80,27 @@ Domain code depends only on `whatsapp.Provider`. Evolution DTOs stay inside `evo
 3. Official templates approved for cold-start messaging
 4. Webhook URL reachable by Evolution with valid secret
 5. `CONFENGE_WHATSAPP_ENABLED=true` only after the above
+
+## CONFENGE orchestration (W2)
+
+Deterministic channel orchestrator: `internal/app/confenge/whatsapp_orchestrator.go`.
+
+| Case | Situation | Result |
+|------|-----------|--------|
+| A | Public phone, no opt-in | Email allowed; WhatsApp blocked |
+| B | Reply requests WhatsApp / opt-in with provenance | WhatsApp eligible (review gate) |
+| C | User-initiated inbound | Service window + USER_INITIATED |
+| D | Site form opt-in with provenance | Template outside window; free text inside |
+| E | Opt-out / DNC | Stop all WhatsApp automation (sticky) |
+
+Feed extension (backward compatible):
+
+```json
+{
+  "phone": "(48) 99999-9999",
+  "phone_detail": { "raw": "...", "e164": "+55...", "source_kind": "official_company_site" },
+  "whatsapp": { "consent_status": "UNKNOWN", "consent_source": null, "consent_at": null }
+}
+```
+
+extra-cli supplies facts; Warmbly applies eligibility. Migrations `000083` (channel state) and `000084` (draft channel + candidate phone/consent columns).

--- a/docs/confenge/whatsapp-channel.md
+++ b/docs/confenge/whatsapp-channel.md
@@ -1,0 +1,82 @@
+# WhatsApp channel (policy-gated)
+
+## Architecture
+
+```text
+extra-cli → intelligence → Warmbly
+                            ├─ Email channel
+                            └─ WhatsApp channel
+                                 └─ Provider interface
+                                      └─ Evolution adapter
+                                           └─ WhatsApp Cloud API (production)
+```
+
+Inbound:
+
+```text
+WhatsApp → Evolution webhook → POST /api/v1/webhooks/evolution/:instance
+        → auth + size limit → normalize → idempotency → CRM / consent / stop sequences
+```
+
+## Fundamental rule
+
+**A public phone number is not consent.**
+
+```text
+phone found → normalize → consent status → eligibility → template/session type → review gate → send
+```
+
+Never: `phone found → send WhatsApp`.
+
+## Feature flags (all default false / safe)
+
+```env
+CONFENGE_WHATSAPP_ENABLED=false
+CONFENGE_WHATSAPP_AUTO_SEND_ENABLED=false
+CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED=false
+WHATSAPP_PROVIDER=evolution
+WHATSAPP_EVOLUTION_BASE_URL=
+WHATSAPP_EVOLUTION_API_KEY=
+WHATSAPP_EVOLUTION_INSTANCE=
+WHATSAPP_EVOLUTION_ALLOW_BAILEYS=false
+WHATSAPP_WEBHOOK_SECRET=
+CONFENGE_CROSS_CHANNEL_MIN_INTERVAL_HOURS=24
+WHATSAPP_SERVICE_WINDOW_HOURS=24
+```
+
+## Consent statuses
+
+| Status | Automated send |
+|--------|----------------|
+| UNKNOWN / NO_OPT_IN | Blocked |
+| OPTED_IN (+ provenance) | Allowed per window/template rules |
+| USER_INITIATED | Free text inside service window |
+| OPTED_OUT / DO_NOT_CONTACT | Always blocked (sticky) |
+
+## Packages
+
+| Path | Role |
+|------|------|
+| `internal/app/whatsapp` | Domain: provider interface, eligibility, phone, opt-out, service |
+| `internal/app/whatsapp/evolution` | Sole Evolution HTTP adapter + webhook normalizer |
+| `internal/models/whatsapp.go` | Persistence models |
+| `internal/repository/pg_whatsapp.go` | Postgres repository |
+| migration `000080_whatsapp_channel` | Schema |
+
+## Provider boundary
+
+Domain code depends only on `whatsapp.Provider`. Evolution DTOs stay inside `evolution/`. Future Meta Cloud API direct or other BSP adapters implement the same interface.
+
+## Testing
+
+- Unit tests use `MockProvider` and `httptest` for Evolution client.
+- Never send real WhatsApp to leads during development.
+- Operator-controlled numbers / sandbox only for live smoke.
+
+## External blockers (channel not live until)
+
+1. Meta Business / WABA verification
+2. Cloud API phone number connected on Evolution instance
+3. Official templates approved for cold-start messaging
+4. Webhook URL reachable by Evolution with valid secret
+5. `CONFENGE_WHATSAPP_ENABLED=true` only after the above

--- a/docs/confenge/whatsapp-netcup.md
+++ b/docs/confenge/whatsapp-netcup.md
@@ -1,0 +1,48 @@
+# Netcup ops: Evolution API for CONFENGE WhatsApp
+
+## Compose project
+
+```bash
+cd deploy/evolution
+cp .env.example .env
+# fill EVOLUTION_API_KEY, EVOLUTION_DB_PASSWORD
+docker compose -p evolution-confenge --env-file .env up -d
+docker compose -p evolution-confenge ps
+```
+
+- Image pin: `evoapicloud/evolution-api:2.3.7`
+- Own Postgres + Redis volumes (`evolution_pg_data`, `evolution_redis_data`)
+- Bound to `127.0.0.1:8089` by default
+- Do not share Warmbly/extra-cli databases
+
+## Warmbly env (private network)
+
+```env
+CONFENGE_WHATSAPP_ENABLED=false
+WHATSAPP_PROVIDER=evolution
+WHATSAPP_EVOLUTION_BASE_URL=http://127.0.0.1:8089
+WHATSAPP_EVOLUTION_API_KEY=...
+WHATSAPP_EVOLUTION_INSTANCE=confenge
+WHATSAPP_EVOLUTION_ALLOW_BAILEYS=false
+WHATSAPP_WEBHOOK_SECRET=...
+CONFENGE_CROSS_CHANNEL_MIN_INTERVAL_HOURS=24
+```
+
+Webhook: Evolution → `https://<warmbly-host>/api/v1/webhooks/evolution/<instance>` with Bearer secret.
+
+## Manual Meta steps (external)
+
+1. Meta Business verification / WABA
+2. Connect Cloud API number on Evolution (`WHATSAPP-BUSINESS`)
+3. Approve official templates
+4. Enable `CONFENGE_WHATSAPP_ENABLED` only after smoke on operator-controlled numbers
+
+## Rollback
+
+1. Set `CONFENGE_WHATSAPP_ENABLED=false` (and auto-send/auto-reply off)
+2. `docker compose -p evolution-confenge stop`
+3. Keep volumes for backup; do not drop unless intentional
+
+## License notice
+
+Evolution API is used as a WhatsApp transport gateway. See `evolution-api-compliance.md`.

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -1,0 +1,64 @@
+---
+title: CONFENGE outreach staging
+description: Import versioned commercial feeds from extra-cli into a multi-tenant staging queue without writing to the datalake.
+---
+
+CONFENGE outreach is an optional, feature-flagged staging layer. It lets an organization import a versioned commercial feed (for example from `extra-cli`) into Warmbly so companies can sit in a queue even when no verified email exists yet.
+
+Warmbly stays the execution plane: contacts, mailboxes, campaigns, inbox, CRM. The intelligence plane (datalake, signals, evidence scoring) stays outside Warmbly. Warmbly never connects to that database and never writes into it.
+
+## Enable
+
+Set on the backend:
+
+```env
+CONFENGE_OUTREACH_ENABLED=true
+```
+
+Leave `CONFENGE_AUTO_SEND_ENABLED=false` unless you have an explicit operational policy. Human approval remains the default.
+
+Optional feed source:
+
+```env
+CONFENGE_EXTRA_CLI_FEED_URL=https://feed.example.com/confenge/outreach.json
+CONFENGE_EXTRA_CLI_FEED_TOKEN=
+CONFENGE_EXTRA_CLI_ALLOWED_HOSTS=feed.example.com
+```
+
+In production the feed URL must be HTTPS and the host must be on the allowlist. Local development may use a `file://` path.
+
+## Import
+
+`POST /api/v1/confenge/import` accepts:
+
+- the full feed JSON body (`schema_version: confenge.outreach.v1` or legacy shapes)
+- or `{"uri":"https://...","dry_run":true}` to fetch then import
+
+Use `?dry_run=true` for counts only (`creates`, `updates`, `unchanged`, `missing_contact`, and related fields). Send `Idempotency-Key` for safe retries.
+
+Companies without an enrollable contact enter as `NEEDS_CONTACT`. They are not discarded and are not forced into the contacts table.
+
+## Reimport rules
+
+Reimport updates machine-owned fields (priority, moment, offer, messaging, evidence). It preserves:
+
+- human `DO_NOT_CONTACT` and block flags
+- post-send queue states (enrolled, sent, replied, and later CRM states)
+- prior approvals once those exist in later PRs
+
+## API surface
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /confenge/status` | Whether the feature is on |
+| `GET /confenge/summary` | Queue counters |
+| `GET /confenge/accounts` | Staged companies |
+| `GET /confenge/accounts/:id` | Company with candidates and evidence |
+| `POST /confenge/import` | Dry-run or apply feed |
+| `GET /confenge/import-runs` | Import audit history |
+
+Permissions follow contacts: view for reads, manage for import and block.
+
+## What this does not do yet
+
+Message generation, review UI, campaign enrollment, Microsoft Graph send, and outcome webhooks back to `extra-cli` ship in follow-up work. See `docs/confenge/` in the repository for architecture and upstream maintenance notes.

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -29,6 +29,7 @@
     "---Integrations---",
     "webhooks",
     "integrations",
+    "confenge-outreach",
     "zapier",
     "make",
     "---Account and team---",

--- a/docs/package.json
+++ b/docs/package.json
@@ -37,7 +37,11 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml": "4.3.1"
+      "js-yaml": "4.3.1",
+      "postcss": "8.5.23",
+      "picomatch": "^4.0.4",
+      "path-to-regexp": "^8.4.0",
+      "sharp": "^0.35.0"
     }
   }
 }

--- a/docs/package.json
+++ b/docs/package.json
@@ -34,5 +34,10 @@
     "postcss": "^8.5.23",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml": "4.3.1"
+    }
   }
 }

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -6,6 +6,10 @@ settings:
 
 overrides:
   js-yaml: 4.3.1
+  postcss: 8.5.23
+  picomatch: ^4.0.4
+  path-to-regexp: ^8.4.0
+  sharp: ^0.35.0
 
 importers:
 
@@ -16,13 +20,13 @@ importers:
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.4.11
-        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 14.2.6
-        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: 16.4.11
-        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
@@ -31,7 +35,7 @@ importers:
         version: 11.16.0
       next:
         specifier: 16.2.11
-        version: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -67,7 +71,7 @@ importers:
         specifier: 16.2.11
         version: 16.2.11(@typescript-eslint/parser@8.59.4(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       postcss:
-        specifier: ^8.5.23
+        specifier: 8.5.23
         version: 8.5.23
       tailwindcss:
         specifier: ^4.1.18
@@ -428,136 +432,145 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.34.5':
-    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-arm64@0.35.3':
+    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.34.5':
-    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-darwin-x64@0.35.3':
+    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
-    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
+    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
-    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+  '@img/sharp-libvips-darwin-x64@1.3.2':
+    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
-    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+  '@img/sharp-libvips-linux-arm64@1.3.2':
+    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
-    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+  '@img/sharp-libvips-linux-arm@1.3.2':
+    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
-    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
+    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
-    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
+    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
-    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+  '@img/sharp-libvips-linux-s390x@1.3.2':
+    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
-    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+  '@img/sharp-libvips-linux-x64@1.3.2':
+    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
-    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
-    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linux-arm64@0.34.5':
-    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm64@0.35.3':
+    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linux-arm@0.34.5':
-    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-arm@0.35.3':
+    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
 
-  '@img/sharp-linux-ppc64@0.34.5':
-    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-ppc64@0.35.3':
+    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
+    engines: {node: '>=20.9.0'}
     cpu: [ppc64]
     os: [linux]
 
-  '@img/sharp-linux-riscv64@0.34.5':
-    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-riscv64@0.35.3':
+    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
 
-  '@img/sharp-linux-s390x@0.34.5':
-    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-s390x@0.35.3':
+    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
+    engines: {node: '>=20.9.0'}
     cpu: [s390x]
     os: [linux]
 
-  '@img/sharp-linux-x64@0.34.5':
-    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linux-x64@0.35.3':
+    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
-    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-arm64@0.35.3':
+    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [linux]
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
-    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-linuxmusl-x64@0.35.3':
+    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
 
-  '@img/sharp-wasm32@0.34.5':
-    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-wasm32@0.35.3':
+    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
+    engines: {node: '>=20.9.0'}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.34.5':
-    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-arm64@0.35.3':
+    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.34.5':
-    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-ia32@0.35.3':
+    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
+    engines: {node: ^20.9.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.34.5':
-    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  '@img/sharp-win32-x64@0.35.3':
+    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -2159,7 +2172,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: ^4.0.4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -3061,10 +3074,6 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
-
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -3082,10 +3091,6 @@ packages:
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -3282,9 +3287,14 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.34.5:
-    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
-    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+  sharp@0.35.3:
+    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
+    engines: {node: '>=20.9.0'}
+    peerDependencies:
+      '@types/node': '*'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3882,9 +3892,9 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.0
       tslib: 2.8.1
 
-  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
+  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
     dependencies:
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss-selector-parser: 7.1.1
       react: 19.2.4
@@ -3892,7 +3902,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
 
   '@humanfs/core@0.19.1': {}
@@ -3917,98 +3927,108 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.34.5':
+  '@img/sharp-darwin-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-darwin-x64@0.34.5':
+  '@img/sharp-darwin-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.3.2
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.2.4':
+  '@img/sharp-freebsd-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.2.4':
+  '@img/sharp-libvips-darwin-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.2.4':
+  '@img/sharp-libvips-darwin-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.2.4':
+  '@img/sharp-libvips-linux-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.2.4':
+  '@img/sharp-libvips-linux-arm@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.2.4':
+  '@img/sharp-libvips-linux-ppc64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.2.4':
+  '@img/sharp-libvips-linux-riscv64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.2.4':
+  '@img/sharp-libvips-linux-s390x@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+  '@img/sharp-libvips-linux-x64@1.3.2':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
     optional: true
 
-  '@img/sharp-linux-arm64@0.34.5':
+  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-arm@0.34.5':
+  '@img/sharp-linux-arm@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.3.2
     optional: true
 
-  '@img/sharp-linux-ppc64@0.34.5':
+  '@img/sharp-linux-ppc64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-riscv64@0.34.5':
+  '@img/sharp-linux-riscv64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
     optional: true
 
-  '@img/sharp-linux-s390x@0.34.5':
+  '@img/sharp-linux-s390x@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.3.2
     optional: true
 
-  '@img/sharp-linux-x64@0.34.5':
+  '@img/sharp-linux-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.34.5':
+  '@img/sharp-linuxmusl-arm64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.34.5':
+  '@img/sharp-linuxmusl-x64@0.35.3':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
     optional: true
 
-  '@img/sharp-wasm32@0.34.5':
+  '@img/sharp-wasm32@0.35.3':
     dependencies:
       '@emnapi/runtime': 1.11.2
     optional: true
 
-  '@img/sharp-win32-arm64@0.34.5':
+  '@img/sharp-webcontainers-wasm32@0.35.3':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.3
     optional: true
 
-  '@img/sharp-win32-ia32@0.34.5':
+  '@img/sharp-win32-arm64@0.35.3':
     optional: true
 
-  '@img/sharp-win32-x64@0.34.5':
+  '@img/sharp-win32-ia32@0.35.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.3':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -5871,7 +5891,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
+  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.0
       '@orama/orama': 3.1.18
@@ -5895,21 +5915,21 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
       lucide-react: 0.563.0(react@19.2.4)
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       js-yaml: 4.3.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
@@ -5924,14 +5944,14 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
+  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
     dependencies:
-      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -5943,7 +5963,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.10)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       lucide-react: 0.563.0(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -5952,7 +5972,7 @@ snapshots:
       scroll-into-view-if-needed: 3.1.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -6884,7 +6904,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   minimatch@10.2.5:
     dependencies:
@@ -6915,13 +6935,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.3
       caniuse-lite: 1.0.30001806
-      postcss: 8.4.31
+      postcss: 8.5.23
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -6934,9 +6954,10 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.11
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
-      sharp: 0.34.5
+      sharp: 0.35.3(@types/node@25.1.0)
     transitivePeerDependencies:
       - '@babel/core'
+      - '@types/node'
       - babel-plugin-macros
 
   node-exports-info@1.6.0:
@@ -7051,8 +7072,6 @@ snapshots:
 
   picocolors@1.1.1: {}
 
-  picomatch@2.3.2: {}
-
   picomatch@4.0.4: {}
 
   points-on-curve@0.2.0: {}
@@ -7068,12 +7087,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
@@ -7338,36 +7351,38 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
 
-  sharp@0.34.5:
+  sharp@0.35.3(@types/node@25.1.0):
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-libvips-darwin-arm64': 1.2.4
-      '@img/sharp-libvips-darwin-x64': 1.2.4
-      '@img/sharp-libvips-linux-arm': 1.2.4
-      '@img/sharp-libvips-linux-arm64': 1.2.4
-      '@img/sharp-libvips-linux-ppc64': 1.2.4
-      '@img/sharp-libvips-linux-riscv64': 1.2.4
-      '@img/sharp-libvips-linux-s390x': 1.2.4
-      '@img/sharp-libvips-linux-x64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
-      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-ppc64': 0.34.5
-      '@img/sharp-linux-riscv64': 0.34.5
-      '@img/sharp-linux-s390x': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-wasm32': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-ia32': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@img/sharp-darwin-arm64': 0.35.3
+      '@img/sharp-darwin-x64': 0.35.3
+      '@img/sharp-freebsd-wasm32': 0.35.3
+      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-linux-arm': 0.35.3
+      '@img/sharp-linux-arm64': 0.35.3
+      '@img/sharp-linux-ppc64': 0.35.3
+      '@img/sharp-linux-riscv64': 0.35.3
+      '@img/sharp-linux-s390x': 0.35.3
+      '@img/sharp-linux-x64': 0.35.3
+      '@img/sharp-linuxmusl-arm64': 0.35.3
+      '@img/sharp-linuxmusl-x64': 0.35.3
+      '@img/sharp-webcontainers-wasm32': 0.35.3
+      '@img/sharp-win32-arm64': 0.35.3
+      '@img/sharp-win32-ia32': 0.35.3
+      '@img/sharp-win32-x64': 0.35.3
+      '@types/node': 25.1.0
     optional: true
 
   shebang-command@2.0.0:

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -5,11 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  picomatch: ^4.0.4
-  path-to-regexp: ^8.4.0
-  js-yaml: ^4.3.0
-  sharp: ^0.35.0
-  postcss: ^8.5.23
+  js-yaml: 4.3.1
 
 importers:
 
@@ -20,13 +16,13 @@ importers:
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       fumadocs-core:
         specifier: 16.4.11
-        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+        version: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       fumadocs-mdx:
         specifier: 14.2.6
-        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        version: 14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       fumadocs-ui:
         specifier: 16.4.11
-        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+        version: 16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       lucide-react:
         specifier: ^0.563.0
         version: 0.563.0(react@19.2.4)
@@ -35,7 +31,7 @@ importers:
         version: 11.16.0
       next:
         specifier: 16.2.11
-        version: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -432,161 +428,136 @@ packages:
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
-  '@img/sharp-darwin-arm64@0.35.3':
-    resolution: {integrity: sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-darwin-x64@0.35.3':
-    resolution: {integrity: sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    resolution: {integrity: sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==}
-    engines: {node: '>=20.9.0'}
-    os: [freebsd]
-
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
-    resolution: {integrity: sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==}
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
     cpu: [arm64]
     os: [darwin]
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
-    resolution: {integrity: sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==}
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
     cpu: [x64]
     os: [darwin]
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
-    resolution: {integrity: sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==}
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
-    resolution: {integrity: sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==}
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
-    resolution: {integrity: sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==}
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
-    resolution: {integrity: sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==}
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
-    resolution: {integrity: sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==}
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
-    resolution: {integrity: sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==}
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
-    resolution: {integrity: sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==}
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    resolution: {integrity: sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==}
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-linux-arm64@0.35.3':
-    resolution: {integrity: sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-arm@0.35.3':
-    resolution: {integrity: sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-ppc64@0.35.3':
-    resolution: {integrity: sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-riscv64@0.35.3':
-    resolution: {integrity: sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-s390x@0.35.3':
-    resolution: {integrity: sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linux-x64@0.35.3':
-    resolution: {integrity: sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
-    resolution: {integrity: sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
-    resolution: {integrity: sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@img/sharp-wasm32@0.35.3':
-    resolution: {integrity: sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==}
-    engines: {node: '>=20.9.0'}
-
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    resolution: {integrity: sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
-  '@img/sharp-win32-arm64@0.35.3':
-    resolution: {integrity: sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [win32]
 
-  '@img/sharp-win32-ia32@0.35.3':
-    resolution: {integrity: sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==}
-    engines: {node: ^20.9.0}
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
     os: [win32]
 
-  '@img/sharp-win32-x64@0.35.3':
-    resolution: {integrity: sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==}
-    engines: {node: '>=20.9.0'}
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [win32]
 
@@ -641,28 +612,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.11':
     resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.11':
     resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.11':
     resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.11':
     resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
@@ -1135,28 +1102,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -1437,61 +1400,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -2206,7 +2159,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^4.0.4
+      picomatch: ^3 || ^4
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -2616,8 +2569,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2709,28 +2662,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -3112,6 +3061,10 @@ packages:
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
@@ -3129,6 +3082,10 @@ packages:
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.23:
     resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
@@ -3325,14 +3282,9 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.35.3:
-    resolution: {integrity: sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==}
-    engines: {node: '>=20.9.0'}
-    peerDependencies:
-      '@types/node': '*'
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -3889,7 +3841,7 @@ snapshots:
       globals: 14.0.0
       ignore: 5.3.2
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -3930,9 +3882,9 @@ snapshots:
       '@formatjs/fast-memoize': 3.1.0
       tslib: 2.8.1
 
-  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
+  '@fumadocs/ui@16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)':
     dependencies:
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       postcss-selector-parser: 7.1.1
       react: 19.2.4
@@ -3940,7 +3892,7 @@ snapshots:
       tailwind-merge: 3.4.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
 
   '@humanfs/core@0.19.1': {}
@@ -3965,108 +3917,98 @@ snapshots:
   '@img/colour@1.1.0':
     optional: true
 
-  '@img/sharp-darwin-arm64@0.35.3':
+  '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-darwin-x64@0.35.3':
+  '@img/sharp-darwin-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-darwin-x64': 1.3.2
+      '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
-  '@img/sharp-freebsd-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-arm64@1.3.2':
+  '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-darwin-x64@1.3.2':
+  '@img/sharp-libvips-linux-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm64@1.3.2':
+  '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-arm@1.3.2':
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-ppc64@1.3.2':
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-riscv64@1.3.2':
+  '@img/sharp-libvips-linux-s390x@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-s390x@1.3.2':
+  '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linux-x64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-arm64@1.3.2':
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     optional: true
 
-  '@img/sharp-libvips-linuxmusl-x64@1.3.2':
-    optional: true
-
-  '@img/sharp-linux-arm64@0.35.3':
+  '@img/sharp-linux-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm64': 1.3.2
+      '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-arm@0.35.3':
+  '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-arm': 1.3.2
+      '@img/sharp-libvips-linux-arm': 1.2.4
     optional: true
 
-  '@img/sharp-linux-ppc64@0.35.3':
+  '@img/sharp-linux-ppc64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-riscv64@0.35.3':
+  '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
     optional: true
 
-  '@img/sharp-linux-s390x@0.35.3':
+  '@img/sharp-linux-s390x@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-s390x': 1.3.2
+      '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
-  '@img/sharp-linux-x64@0.35.3':
+  '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linux-x64': 1.3.2
+      '@img/sharp-libvips-linux-x64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-arm64@0.35.3':
+  '@img/sharp-linuxmusl-arm64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
-  '@img/sharp-linuxmusl-x64@0.35.3':
+  '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
     optional: true
 
-  '@img/sharp-wasm32@0.35.3':
+  '@img/sharp-wasm32@0.34.5':
     dependencies:
       '@emnapi/runtime': 1.11.2
     optional: true
 
-  '@img/sharp-webcontainers-wasm32@0.35.3':
-    dependencies:
-      '@img/sharp-wasm32': 0.35.3
+  '@img/sharp-win32-arm64@0.34.5':
     optional: true
 
-  '@img/sharp-win32-arm64@0.35.3':
+  '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
-  '@img/sharp-win32-ia32@0.35.3':
-    optional: true
-
-  '@img/sharp-win32-x64@0.35.3':
+  '@img/sharp-win32-x64@0.34.5':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -5929,7 +5871,7 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
-  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
+  fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.8.0
       '@orama/orama': 3.1.18
@@ -5953,22 +5895,22 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.10
       lucide-react: 0.563.0(react@19.2.4)
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       zod: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
+  fumadocs-mdx@14.2.6(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.1.0
       chokidar: 5.0.0
       esbuild: 0.27.2
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
-      js-yaml: 4.3.0
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      js-yaml: 4.3.1
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
       picomatch: 4.0.4
@@ -5982,14 +5924,14 @@ snapshots:
       zod: 4.3.6
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
+  fumadocs-ui@16.4.11(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18):
     dependencies:
-      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
+      '@fumadocs/ui': 16.4.11(@types/react@19.2.10)(fumadocs-core@16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.1.18)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -6001,7 +5943,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.10)(react@19.2.4)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.10))(@types/react@19.2.10)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
+      fumadocs-core: 16.4.11(@types/react@19.2.10)(lucide-react@0.563.0(react@19.2.4))(next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(zod@4.4.3)
       lucide-react: 0.563.0(react@19.2.4)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
@@ -6010,7 +5952,7 @@ snapshots:
       scroll-into-view-if-needed: 3.1.0
     optionalDependencies:
       '@types/react': 19.2.10
-      next: 16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       tailwindcss: 4.1.18
     transitivePeerDependencies:
       - '@types/react-dom'
@@ -6353,7 +6295,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -6942,7 +6884,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 4.0.4
+      picomatch: 2.3.2
 
   minimatch@10.2.5:
     dependencies:
@@ -6973,13 +6915,13 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.11(@babel/core@7.29.0)(@types/node@25.1.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.11(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.3
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.23
+      postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
@@ -6992,10 +6934,9 @@ snapshots:
       '@next/swc-linux-x64-musl': 16.2.11
       '@next/swc-win32-arm64-msvc': 16.2.11
       '@next/swc-win32-x64-msvc': 16.2.11
-      sharp: 0.35.3(@types/node@25.1.0)
+      sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
-      - '@types/node'
       - babel-plugin-macros
 
   node-exports-info@1.6.0:
@@ -7110,6 +7051,8 @@ snapshots:
 
   picocolors@1.1.1: {}
 
+  picomatch@2.3.2: {}
+
   picomatch@4.0.4: {}
 
   points-on-curve@0.2.0: {}
@@ -7125,6 +7068,12 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.23:
     dependencies:
@@ -7389,38 +7338,36 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.2
 
-  sharp@0.35.3(@types/node@25.1.0):
+  sharp@0.34.5:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
       semver: 7.8.5
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.35.3
-      '@img/sharp-darwin-x64': 0.35.3
-      '@img/sharp-freebsd-wasm32': 0.35.3
-      '@img/sharp-libvips-darwin-arm64': 1.3.2
-      '@img/sharp-libvips-darwin-x64': 1.3.2
-      '@img/sharp-libvips-linux-arm': 1.3.2
-      '@img/sharp-libvips-linux-arm64': 1.3.2
-      '@img/sharp-libvips-linux-ppc64': 1.3.2
-      '@img/sharp-libvips-linux-riscv64': 1.3.2
-      '@img/sharp-libvips-linux-s390x': 1.3.2
-      '@img/sharp-libvips-linux-x64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-arm64': 1.3.2
-      '@img/sharp-libvips-linuxmusl-x64': 1.3.2
-      '@img/sharp-linux-arm': 0.35.3
-      '@img/sharp-linux-arm64': 0.35.3
-      '@img/sharp-linux-ppc64': 0.35.3
-      '@img/sharp-linux-riscv64': 0.35.3
-      '@img/sharp-linux-s390x': 0.35.3
-      '@img/sharp-linux-x64': 0.35.3
-      '@img/sharp-linuxmusl-arm64': 0.35.3
-      '@img/sharp-linuxmusl-x64': 0.35.3
-      '@img/sharp-webcontainers-wasm32': 0.35.3
-      '@img/sharp-win32-arm64': 0.35.3
-      '@img/sharp-win32-ia32': 0.35.3
-      '@img/sharp-win32-x64': 0.35.3
-      '@types/node': 25.1.0
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
     optional: true
 
   shebang-command@2.0.0:

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/mileusna/useragent v1.3.5
 	github.com/nats-io/nats-server/v2 v2.14.1
 	github.com/nats-io/nats.go v1.52.0
+	github.com/nyaruka/phonenumbers v1.6.5
 	github.com/openai/openai-go/v2 v2.7.1
 	github.com/oschwald/geoip2-golang/v2 v2.0.0
 	github.com/redis/go-redis/v9 v9.11.0
@@ -310,6 +311,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/arch v0.19.0 // indirect
+	golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 // indirect
 	golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac // indirect
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -695,6 +695,8 @@ github.com/nishanths/predeclared v0.2.2 h1:V2EPdZPliZymNAn79T8RkNApBjMmVKh5XRpLm
 github.com/nishanths/predeclared v0.2.2/go.mod h1:RROzoN6TnGQupbC+lqggsOlcgysk3LMK/HI84Mp280c=
 github.com/nunnatsa/ginkgolinter v0.19.1 h1:mjwbOlDQxZi9Cal+KfbEJTCz327OLNfwNvoZ70NJ+c4=
 github.com/nunnatsa/ginkgolinter v0.19.1/go.mod h1:jkQ3naZDmxaZMXPWaS9rblH+i+GWXQCaS/JFIWcOH2s=
+github.com/nyaruka/phonenumbers v1.6.5 h1:aBCaUhfpRA7hU6fsXk+p7KF1aNx4nQlq9hGeo2qdFg8=
+github.com/nyaruka/phonenumbers v1.6.5/go.mod h1:7gjs+Lchqm49adhAKB5cdcng5ZXgt6x7Jgvi0ZorUtU=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
@@ -1032,8 +1034,8 @@ golang.org/x/crypto v0.14.0/go.mod h1:MVFd36DqK4CsrnJYDkBA3VC4m2GkXAM0PvzMCn4JQf
 golang.org/x/crypto v0.53.0 h1:QZ4Muo8THX6CizN2vPPd5fBGHyogrdK9fG4wLPFUsto=
 golang.org/x/crypto v0.53.0/go.mod h1:DNLU434OwVakk9PzuwV8w62mAJpRJL3vsgcfp4Qnsio=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20240909161429-701f63a606c0 h1:e66Fs6Z+fZTbFBAxKfP3PALWBtpfqks2bwGcexMxgtk=
-golang.org/x/exp v0.0.0-20240909161429-701f63a606c0/go.mod h1:2TbTHSBQa924w8M6Xs1QcRcFwyucIwBGpK1p2f1YFFY=
+golang.org/x/exp v0.0.0-20250305212735-054e65f0b394 h1:nDVHiLt8aIbd/VzvPWN6kSOPE7+F/fNFDSXLVYkE/Iw=
+golang.org/x/exp v0.0.0-20250305212735-054e65f0b394/go.mod h1:sIifuuw/Yco/y6yb6+bDNfyeQ/MdPUy/hKEMYQV17cM=
 golang.org/x/exp/typeparams v0.0.0-20220428152302-39d4317da171/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20230203172020-98cc5a0785f9/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/exp/typeparams v0.0.0-20250210185358-939b2ce775ac h1:TSSpLIG4v+p0rPv1pNOQtl1I8knsO4S9trOxNMOLVP4=

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -411,3 +411,17 @@ func (h *Handler) EnrollConfengeDraft(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"data": d})
 }
+
+// BootstrapConfengePipeline — POST /confenge/crm/bootstrap
+func (h *Handler) BootstrapConfengePipeline(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	pipe, xerr := h.ConfengeService.BootstrapPipeline(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": pipe})
+}

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -368,3 +368,46 @@ func (h *Handler) ReviewConfengeDraft(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"data": d})
 }
+
+// BootstrapConfengeCampaign — POST /confenge/campaign/bootstrap
+func (h *Handler) BootstrapConfengeCampaign(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	camp, xerr := h.ConfengeService.BootstrapCampaign(c.Request.Context(), orgID, userID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": camp})
+}
+
+// EnrollConfengeDraft — POST /confenge/drafts/:id/enroll
+func (h *Handler) EnrollConfengeDraft(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	d, xerr := h.ConfengeService.EnrollDraft(c.Request.Context(), orgID, userID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": d})
+}

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -1,0 +1,258 @@
+package handler
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/app/confenge"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// confengeOrg resolves the org when CONFENGE outreach is wired and enabled.
+func (h *Handler) confengeOrg(c *gin.Context) (uuid.UUID, bool) {
+	if h.ConfengeService == nil || !h.ConfengeService.Enabled() {
+		errx.JSON(c, errx.New(errx.NotFound, "CONFENGE outreach is not enabled on this server"))
+		return uuid.Nil, false
+	}
+	orgID := middleware.GetOrganizationID(c)
+	if orgID == nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "no organization selected"))
+		return uuid.Nil, false
+	}
+	return *orgID, true
+}
+
+// GetConfengeStatus — GET /confenge/status
+// Reports whether the feature is on (always 200 when authenticated with org).
+func (h *Handler) GetConfengeStatus(c *gin.Context) {
+	enabled := h.ConfengeService != nil && h.ConfengeService.Enabled()
+	cfg := confenge.Config{}
+	if h.ConfengeService != nil {
+		cfg = h.ConfengeService.Config()
+	}
+	c.JSON(http.StatusOK, gin.H{
+		"enabled":                 enabled,
+		"auto_send_enabled":       enabled && cfg.AutoSendEnabled,
+		"require_human_approval":  cfg.RequireHumanApproval,
+		"default_daily_limit":     cfg.DefaultDailyLimit,
+		"max_initial_email_words": cfg.MaxInitialEmailWords,
+		"feed_configured":         enabled && cfg.FeedURL != "",
+	})
+}
+
+// GetConfengeSummary — GET /confenge/summary
+func (h *Handler) GetConfengeSummary(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	sum, xerr := h.ConfengeService.Summary(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": sum})
+}
+
+// ListConfengeAccounts — GET /confenge/accounts
+func (h *Handler) ListConfengeAccounts(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	filter := repository.OutreachAccountFilter{
+		QueueState: c.Query("queue_state"),
+		CNPJ14:     c.Query("cnpj14"),
+		Search:     c.Query("q"),
+	}
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > 200 {
+			errx.JSON(c, errx.New(errx.BadRequest, "limit must be between 1 and 200"))
+			return
+		}
+		filter.Limit = n
+	}
+	if raw := c.Query("offset"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 0 {
+			errx.JSON(c, errx.New(errx.BadRequest, "invalid offset"))
+			return
+		}
+		filter.Offset = n
+	}
+	list, xerr := h.ConfengeService.ListAccounts(c.Request.Context(), orgID, filter)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": list})
+}
+
+// GetConfengeAccount — GET /confenge/accounts/:id
+func (h *Handler) GetConfengeAccount(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	acc, xerr := h.ConfengeService.GetAccount(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": acc})
+}
+
+// BlockConfengeAccount — POST /confenge/accounts/:id/block
+func (h *Handler) BlockConfengeAccount(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	var body struct {
+		Reason       string `json:"reason"`
+		DoNotContact bool   `json:"do_not_contact"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil && err.Error() != "EOF" {
+		// empty body is fine
+		if c.Request.ContentLength != 0 {
+			errx.JSON(c, errx.ErrInvalid)
+			return
+		}
+	}
+	acc, xerr := h.ConfengeService.BlockAccount(c.Request.Context(), orgID, userID, id, body.Reason, body.DoNotContact)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": acc})
+}
+
+// ImportConfengeFeed — POST /confenge/import
+// Accepts a raw feed body (native confenge.outreach.v1 or legacy) or
+// {"uri":"https://...","dry_run":true}. Honour Idempotency-Key.
+func (h *Handler) ImportConfengeFeed(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	var userPtr *uuid.UUID
+	if uid, err := middleware.GetUserUUID(c); err == nil {
+		userPtr = &uid
+	}
+	opts := confenge.ImportOptions{
+		DryRun:         queryBool(c, "dry_run"),
+		IdempotencyKey: strings.TrimSpace(c.GetHeader("Idempotency-Key")),
+	}
+
+	raw, err := io.ReadAll(io.LimitReader(c.Request.Body, 33<<20))
+	if err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "failed to read body"))
+		return
+	}
+	if len(raw) == 0 {
+		// Empty body: import from configured feed URL.
+		run, xerr := h.ConfengeService.ImportFromURI(c.Request.Context(), orgID, userPtr, "", opts)
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"data": run})
+		return
+	}
+
+	// Envelope: fetch by URI without embedding the full feed.
+	var env struct {
+		URI           string          `json:"uri"`
+		DryRun        *bool           `json:"dry_run"`
+		SchemaVersion string          `json:"schema_version"`
+		Leads         json.RawMessage `json:"leads"`
+	}
+	if err := json.Unmarshal(raw, &env); err == nil && env.URI != "" && env.SchemaVersion == "" && len(env.Leads) == 0 {
+		if env.DryRun != nil {
+			opts.DryRun = *env.DryRun
+		}
+		run, xerr := h.ConfengeService.ImportFromURI(c.Request.Context(), orgID, userPtr, env.URI, opts)
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		c.JSON(http.StatusOK, gin.H{"data": run})
+		return
+	}
+
+	run, xerr := h.ConfengeService.ImportFromBytes(c.Request.Context(), orgID, userPtr, raw, opts)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": run})
+}
+
+// ListConfengeImportRuns — GET /confenge/import-runs
+func (h *Handler) ListConfengeImportRuns(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	limit := 20
+	if raw := c.Query("limit"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err == nil && n > 0 && n <= 100 {
+			limit = n
+		}
+	}
+	list, xerr := h.ConfengeService.ListImportRuns(c.Request.Context(), orgID, limit)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": list})
+}
+
+// GetConfengeImportRun — GET /confenge/import-runs/:id
+func (h *Handler) GetConfengeImportRun(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	run, xerr := h.ConfengeService.GetImportRun(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": run})
+}
+
+func queryBool(c *gin.Context, key string) bool {
+	v := strings.ToLower(strings.TrimSpace(c.Query(key)))
+	return v == "1" || v == "true" || v == "yes"
+}

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -425,3 +425,92 @@ func (h *Handler) BootstrapConfengePipeline(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"data": pipe})
 }
+
+// DecideConfengeChannel returns the deterministic multichannel decision for an account.
+func (h *Handler) DecideConfengeChannel(c *gin.Context) {
+	if h.ConfengeService == nil {
+		errx.JSON(c, errx.New(errx.NotFound, "confenge disabled"))
+		return
+	}
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	accountID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid account id"))
+		return
+	}
+	var contactID *uuid.UUID
+	if s := strings.TrimSpace(c.Query("contact_id")); s != "" {
+		id, err := uuid.Parse(s)
+		if err != nil {
+			errx.JSON(c, errx.New(errx.BadRequest, "invalid contact_id"))
+			return
+		}
+		contactID = &id
+	}
+	d, xerr := h.ConfengeService.DecideChannel(c.Request.Context(), orgID, accountID, contactID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, d)
+}
+
+// GenerateConfengeWhatsAppDraft creates a short WhatsApp draft for human review.
+func (h *Handler) GenerateConfengeWhatsAppDraft(c *gin.Context) {
+	if h.ConfengeService == nil {
+		errx.JSON(c, errx.New(errx.NotFound, "confenge disabled"))
+		return
+	}
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, _ := c.Get("user_id")
+	uid, _ := userID.(uuid.UUID)
+	accountID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid account id"))
+		return
+	}
+	var contactID *uuid.UUID
+	if s := strings.TrimSpace(c.Query("contact_id")); s != "" {
+		id, err := uuid.Parse(s)
+		if err == nil {
+			contactID = &id
+		}
+	}
+	d, xerr := h.ConfengeService.GenerateWhatsAppDraft(c.Request.Context(), orgID, uid, accountID, contactID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, d)
+}
+
+// SendConfengeWhatsAppDraft sends an APPROVED WhatsApp draft via Evolution after policy gate.
+func (h *Handler) SendConfengeWhatsAppDraft(c *gin.Context) {
+	if h.ConfengeService == nil {
+		errx.JSON(c, errx.New(errx.NotFound, "confenge disabled"))
+		return
+	}
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, _ := c.Get("user_id")
+	uid, _ := userID.(uuid.UUID)
+	draftID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid draft id"))
+		return
+	}
+	d, xerr := h.ConfengeService.SendApprovedWhatsApp(c.Request.Context(), orgID, uid, draftID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, d)
+}

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -256,3 +256,115 @@ func queryBool(c *gin.Context, key string) bool {
 	v := strings.ToLower(strings.TrimSpace(c.Query(key)))
 	return v == "1" || v == "true" || v == "yes"
 }
+
+// ListConfengeDrafts — GET /confenge/drafts
+func (h *Handler) ListConfengeDrafts(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	limit, offset := 50, 0
+	if raw := c.Query("limit"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n > 0 && n <= 200 {
+			limit = n
+		}
+	}
+	if raw := c.Query("offset"); raw != "" {
+		if n, err := strconv.Atoi(raw); err == nil && n >= 0 {
+			offset = n
+		}
+	}
+	list, xerr := h.ConfengeService.ListDrafts(c.Request.Context(), orgID, c.Query("status"), limit, offset)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": list})
+}
+
+// GetConfengeDraft — GET /confenge/drafts/:id
+func (h *Handler) GetConfengeDraft(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	d, xerr := h.ConfengeService.GetDraft(c.Request.Context(), orgID, id)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": d})
+}
+
+// GenerateConfengeDraft — POST /confenge/accounts/:id/generate
+func (h *Handler) GenerateConfengeDraft(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	accountID, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	var body struct {
+		ContactCandidateID *uuid.UUID `json:"contact_candidate_id"`
+	}
+	_ = c.ShouldBindJSON(&body)
+	d, xerr := h.ConfengeService.GenerateDraft(c.Request.Context(), orgID, userID, accountID, body.ContactCandidateID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": d})
+}
+
+// ReviewConfengeDraft — POST /confenge/drafts/:id/review
+// Body: {"action":"approve|reject|skip|edit|block", "subject":"...", "body_text":"...", "do_not_contact":false}
+func (h *Handler) ReviewConfengeDraft(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	userID, err := middleware.GetUserUUID(c)
+	if err != nil {
+		errx.JSON(c, errx.ErrUnauthorized)
+		return
+	}
+	id, err := uuid.Parse(c.Param("id"))
+	if err != nil {
+		errx.JSON(c, errx.ErrUuid)
+		return
+	}
+	var body struct {
+		Action       string  `json:"action" binding:"required"`
+		Subject      *string `json:"subject"`
+		BodyText     *string `json:"body_text"`
+		Reason       *string `json:"reason"`
+		DoNotContact bool    `json:"do_not_contact"`
+	}
+	if err := c.ShouldBindJSON(&body); err != nil {
+		errx.JSON(c, errx.ErrInvalid)
+		return
+	}
+	edit := &confenge.DraftEdit{
+		Subject: body.Subject, BodyText: body.BodyText,
+		Reason: body.Reason, DoNotContact: body.DoNotContact,
+	}
+	d, xerr := h.ConfengeService.ReviewDraft(c.Request.Context(), orgID, userID, id, body.Action, edit)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": d})
+}

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -114,7 +114,7 @@ type Handler struct {
 	// CRM
 	CRMService crm.CRMService
 
-// CONFENGE outreach staging (extra-cli feed import). Nil or disabled when
+	// CONFENGE outreach staging (extra-cli feed import). Nil or disabled when
 	// CONFENGE_OUTREACH_ENABLED is false.
 	ConfengeService confenge.Service
 

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -52,6 +52,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/app/warmupcontent"
 	"github.com/warmbly/warmbly/internal/app/webhook"
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
 	"github.com/warmbly/warmbly/internal/app/worker"
 	"github.com/warmbly/warmbly/internal/app/worker_orchestrator"
 	"github.com/warmbly/warmbly/internal/pkg/generation"
@@ -111,6 +112,10 @@ type Handler struct {
 
 	// CRM
 	CRMService crm.CRMService
+
+	// WhatsApp channel (Evolution gateway; policy-gated)
+	WhatsAppService *whatsapp.Service
+	WhatsAppRepo    repository.WhatsAppRepository
 
 	// Teams
 	TeamService team.TeamService

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/auth"
 	"github.com/warmbly/warmbly/internal/app/campaign"
 	"github.com/warmbly/warmbly/internal/app/compose"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/app/contact"
 	"github.com/warmbly/warmbly/internal/app/credits"
 	"github.com/warmbly/warmbly/internal/app/crm"
@@ -111,6 +112,10 @@ type Handler struct {
 
 	// CRM
 	CRMService crm.CRMService
+
+	// CONFENGE outreach staging (extra-cli feed import). Nil or disabled when
+	// CONFENGE_OUTREACH_ENABLED is false.
+	ConfengeService confenge.Service
 
 	// Teams
 	TeamService team.TeamService

--- a/internal/api/handler/whatsapp.go
+++ b/internal/api/handler/whatsapp.go
@@ -19,12 +19,12 @@ import (
 // EvolutionWebhook is the public ingress for Evolution API events.
 // POST /api/v1/webhooks/evolution/:instance
 //
-// Auth: Authorization Bearer <secret> or X-Webhook-Secret, matched against
-// the instance's stored secret (or WHATSAPP_WEBHOOK_SECRET when single-tenant).
-// Body is size-limited; duplicates are idempotent on provider event id.
+// Auth: Authorization Bearer <secret> or X-Webhook-Secret.
+// Requires a mapped whatsapp_instances row (organization binding). Production
+// never silently drops CRM effects into "lab_mode".
 func (h *Handler) EvolutionWebhook(c *gin.Context) {
 	if h.WhatsAppService == nil || !h.WhatsAppService.Config().Enabled {
-		c.JSON(http.StatusNotFound, gin.H{"error": "whatsapp channel disabled"})
+		c.JSON(http.StatusNotFound, gin.H{"error": "whatsapp channel disabled", "code": "disabled"})
 		return
 	}
 	cfg := h.WhatsAppService.Config()
@@ -38,45 +38,42 @@ func (h *Handler) EvolutionWebhook(c *gin.Context) {
 	if maxBytes <= 0 {
 		maxBytes = whatsapp.DefaultMaxWebhookBytes
 	}
-	// Prefer Content-Length check before reading.
 	if c.Request.ContentLength > maxBytes {
 		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "payload too large", "code": "payload_too_large"})
 		return
 	}
 
-	secret := cfg.WebhookSecret
-	var orgID uuid.UUID
-	if h.WhatsAppRepo != nil {
-		inst, xerr := h.WhatsAppRepo.GetInstanceByName(c.Request.Context(), whatsapp.ProviderEvolution, instance)
-		if xerr != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup failed", "code": "internal"})
-			return
-		}
-		if inst == nil {
-			// Fall back to configured default instance only.
-			if cfg.EvolutionInstance == "" || !strings.EqualFold(instance, cfg.EvolutionInstance) {
-				c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
-				return
-			}
-			// Single-tenant: org mapping deferred; require global secret.
-		} else {
-			orgID = inst.OrganizationID
-			if inst.WebhookSecret != "" {
-				secret = inst.WebhookSecret
-			}
-			// Baileys mode must not be used in production; warn only.
-			if inst.IntegrationMode == "WHATSAPP-BAILEYS" && cfg.IsProduction() {
-				log.Error().Str("instance", instance).Msg("rejecting baileys instance webhook in production")
-				c.JSON(http.StatusForbidden, gin.H{"error": "baileys disabled in production", "code": "baileys_forbidden"})
-				return
-			}
-		}
-	} else if cfg.EvolutionInstance != "" && !strings.EqualFold(instance, cfg.EvolutionInstance) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
+	if h.WhatsAppRepo == nil {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "whatsapp repository unavailable", "code": "no_repo"})
 		return
 	}
 
-	auth := whatsapp.WebhookAuth{Secret: secret, InstanceAllow: "", MaxBytes: maxBytes}
+	inst, xerr := h.WhatsAppRepo.GetInstanceByName(c.Request.Context(), whatsapp.ProviderEvolution, instance)
+	if xerr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup failed", "code": "internal"})
+		return
+	}
+	if inst == nil {
+		// Fail closed: unmapped instance never reaches CRM/outcomes.
+		c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
+		return
+	}
+	orgID := inst.OrganizationID
+	secret := inst.WebhookSecret
+	if secret == "" {
+		secret = cfg.WebhookSecret
+	}
+	if secret == "" {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "webhook secret not configured", "code": "missing_secret"})
+		return
+	}
+	if inst.IntegrationMode == "WHATSAPP-BAILEYS" && cfg.IsProduction() {
+		log.Error().Str("instance", instance).Msg("rejecting baileys instance webhook in production")
+		c.JSON(http.StatusForbidden, gin.H{"error": "baileys disabled in production", "code": "baileys_forbidden"})
+		return
+	}
+
+	auth := whatsapp.WebhookAuth{Secret: secret, MaxBytes: maxBytes}
 	if err := auth.ValidateHeaders(
 		c.GetHeader("Authorization"),
 		c.GetHeader("X-Webhook-Secret"),
@@ -106,103 +103,80 @@ func (h *Handler) EvolutionWebhook(c *gin.Context) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "malformed payload", "code": "malformed"})
 		return
 	}
-	if ev.Instance == "" {
-		ev.Instance = instance
-	}
-	if !strings.EqualFold(ev.Instance, instance) && ev.Instance != "" {
-		// Path instance is authoritative for mapping.
-		ev.Instance = instance
-	}
+	ev.Instance = instance
+	ev.OrganizationID = orgID
 	if ev.EventType == whatsapp.EventUnsupported {
 		c.JSON(http.StatusOK, gin.H{"received": true, "ignored": true})
 		return
 	}
 
-	// Persist idempotency when org is known.
-	if orgID != uuid.Nil && h.WhatsAppRepo != nil {
-		sum := sha256.Sum256(body)
-		inserted, xerr := h.WhatsAppRepo.InsertWebhookEvent(
-			c.Request.Context(), orgID, whatsapp.ProviderEvolution,
-			ev.IdempotencyKey(), ev.EventType, ev.ExternalMessageID, hex.EncodeToString(sum[:]),
-		)
-		if xerr != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": "idempotency failed", "code": "internal"})
+	sum := sha256.Sum256(body)
+	inserted, xerr := h.WhatsAppRepo.InsertWebhookEvent(
+		c.Request.Context(), orgID, whatsapp.ProviderEvolution,
+		ev.IdempotencyKey(), ev.EventType, ev.ExternalMessageID, hex.EncodeToString(sum[:]),
+	)
+	if xerr != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "idempotency failed", "code": "internal"})
+		return
+	}
+	if !inserted {
+		c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
+		return
+	}
+
+	// Prefer confenge orchestration when wired (stops sequences, outcomes, CRM).
+	if h.ConfengeService != nil && h.ConfengeService.Enabled() && ev.EventType == whatsapp.EventMessageReceived {
+		inRes, herr := h.ConfengeService.HandleWhatsAppInbound(c.Request.Context(), orgID, ev)
+		if herr != nil {
+			log.Error().Err(herr).Str("instance", instance).Msg("confenge whatsapp inbound failed")
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "inbound processing failed", "code": "process_failed"})
 			return
 		}
-		if !inserted {
-			c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
-			return
-		}
-		ev.OrganizationID = orgID
-
-		// Load or create contact channel state by phone.
-		phone := ev.FromE164
-		if phone == "" {
-			phone = ev.ToE164
-		}
-		var state *models.WhatsAppContactState
-		if phone != "" {
-			state, _ = h.WhatsAppRepo.GetContactStateByPhone(c.Request.Context(), orgID, phone)
-		}
-		domainState := modelsToDomainState(state, orgID)
-		if domainState.PhoneE164 == "" {
-			domainState.PhoneE164 = phone
-		}
-
-		inRes, _ := h.WhatsAppService.ProcessInbound(c.Request.Context(), &domainState, ev)
-		if inRes.Duplicate {
-			c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
-			return
-		}
-
-		// Persist inbound message.
-		if ev.EventType == whatsapp.EventMessageReceived {
-			msg := &models.WhatsAppMessage{
-				OrganizationID:    orgID,
-				ThreadKey:         phone,
-				Direction:         "inbound",
-				Channel:           whatsapp.ChannelWhatsApp,
-				Provider:          whatsapp.ProviderEvolution,
-				ProviderMessageID: ev.ExternalMessageID,
-				IdempotencyKey:    ev.IdempotencyKey(),
-				BodyText:          ev.Content.Text,
-				Status:            "received",
-				OccurredAt:        ev.OccurredAt,
-			}
-			if state != nil && state.ContactID != nil {
-				msg.ContactID = state.ContactID
-			}
-			_, _ = h.WhatsAppRepo.InsertMessage(c.Request.Context(), msg)
-
-			// Persist updated consent / service window.
-			persistState := domainToModelsState(domainState, state)
-			persistState.OrganizationID = orgID
-			if state != nil {
-				persistState.ID = state.ID
-				persistState.ContactID = state.ContactID
-			}
-			_ = h.WhatsAppRepo.UpsertContactState(c.Request.Context(), &persistState)
-		}
-
 		c.JSON(http.StatusOK, gin.H{
 			"received":       true,
 			"event_type":     ev.EventType,
 			"stop_sequences": inRes.StopSequences,
 			"needs_review":   inRes.NeedsHumanReview,
 			"opt_out":        inRes.OptOut.Matched && inRes.OptOut.Confident,
+			"duplicate":      inRes.Duplicate,
 		})
 		return
 	}
 
-	// No org mapping: still ack valid authenticated events (single-node lab).
-	// In-process idempotency only.
-	var domainState whatsapp.ContactChannelState
+	// Fallback without confenge: persist message + open service window only.
+	phone := ev.FromE164
+	if phone == "" {
+		phone = ev.ToE164
+	}
+	domainState := whatsapp.ContactChannelState{OrganizationID: orgID, PhoneE164: phone, ConsentStatus: whatsapp.ConsentUnknown}
+	if st, _ := h.WhatsAppRepo.GetContactStateByPhone(c.Request.Context(), orgID, phone); st != nil {
+		domainState = modelsToDomainState(st, orgID)
+	}
 	inRes, _ := h.WhatsAppService.ProcessInbound(c.Request.Context(), &domainState, ev)
+	if !inRes.Duplicate && ev.EventType == whatsapp.EventMessageReceived {
+		msg := &models.WhatsAppMessage{
+			OrganizationID:    orgID,
+			ThreadKey:         phone,
+			Direction:         "inbound",
+			Channel:           whatsapp.ChannelWhatsApp,
+			Provider:          whatsapp.ProviderEvolution,
+			ProviderMessageID: ev.ExternalMessageID,
+			IdempotencyKey:    ev.IdempotencyKey(),
+			BodyText:          ev.Content.Text,
+			Status:            "received",
+			OccurredAt:        ev.OccurredAt,
+		}
+		_, _ = h.WhatsAppRepo.InsertMessage(c.Request.Context(), msg)
+		persist := domainToModelsState(domainState, nil)
+		persist.OrganizationID = orgID
+		_ = h.WhatsAppRepo.UpsertContactState(c.Request.Context(), &persist)
+	}
 	c.JSON(http.StatusOK, gin.H{
-		"received":   true,
-		"event_type": ev.EventType,
-		"duplicate":  inRes.Duplicate,
-		"lab_mode":   true,
+		"received":       true,
+		"event_type":     ev.EventType,
+		"stop_sequences": inRes.StopSequences,
+		"opt_out":        inRes.OptOut.Matched && inRes.OptOut.Confident,
+		"duplicate":      inRes.Duplicate,
 	})
 }
 

--- a/internal/api/handler/whatsapp.go
+++ b/internal/api/handler/whatsapp.go
@@ -1,0 +1,270 @@
+package handler
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+	"github.com/warmbly/warmbly/internal/app/whatsapp/evolution"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// EvolutionWebhook is the public ingress for Evolution API events.
+// POST /api/v1/webhooks/evolution/:instance
+//
+// Auth: Authorization Bearer <secret> or X-Webhook-Secret, matched against
+// the instance's stored secret (or WHATSAPP_WEBHOOK_SECRET when single-tenant).
+// Body is size-limited; duplicates are idempotent on provider event id.
+func (h *Handler) EvolutionWebhook(c *gin.Context) {
+	if h.WhatsAppService == nil || !h.WhatsAppService.Config().Enabled {
+		c.JSON(http.StatusNotFound, gin.H{"error": "whatsapp channel disabled"})
+		return
+	}
+	cfg := h.WhatsAppService.Config()
+	instance := strings.TrimSpace(c.Param("instance"))
+	if instance == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "instance required", "code": "missing_instance"})
+		return
+	}
+
+	maxBytes := cfg.MaxWebhookBytes
+	if maxBytes <= 0 {
+		maxBytes = whatsapp.DefaultMaxWebhookBytes
+	}
+	// Prefer Content-Length check before reading.
+	if c.Request.ContentLength > maxBytes {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "payload too large", "code": "payload_too_large"})
+		return
+	}
+
+	secret := cfg.WebhookSecret
+	var orgID uuid.UUID
+	if h.WhatsAppRepo != nil {
+		inst, xerr := h.WhatsAppRepo.GetInstanceByName(c.Request.Context(), whatsapp.ProviderEvolution, instance)
+		if xerr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "lookup failed", "code": "internal"})
+			return
+		}
+		if inst == nil {
+			// Fall back to configured default instance only.
+			if cfg.EvolutionInstance == "" || !strings.EqualFold(instance, cfg.EvolutionInstance) {
+				c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
+				return
+			}
+			// Single-tenant: org mapping deferred; require global secret.
+		} else {
+			orgID = inst.OrganizationID
+			if inst.WebhookSecret != "" {
+				secret = inst.WebhookSecret
+			}
+			// Baileys mode must not be used in production; warn only.
+			if inst.IntegrationMode == "WHATSAPP-BAILEYS" && cfg.IsProduction() {
+				log.Error().Str("instance", instance).Msg("rejecting baileys instance webhook in production")
+				c.JSON(http.StatusForbidden, gin.H{"error": "baileys disabled in production", "code": "baileys_forbidden"})
+				return
+			}
+		}
+	} else if cfg.EvolutionInstance != "" && !strings.EqualFold(instance, cfg.EvolutionInstance) {
+		c.JSON(http.StatusNotFound, gin.H{"error": "instance not mapped", "code": "instance_mismatch"})
+		return
+	}
+
+	auth := whatsapp.WebhookAuth{Secret: secret, InstanceAllow: "", MaxBytes: maxBytes}
+	if err := auth.ValidateHeaders(
+		c.GetHeader("Authorization"),
+		c.GetHeader("X-Webhook-Secret"),
+		c.GetHeader("Content-Type"),
+		c.Request.ContentLength,
+	); err != nil {
+		if ae, ok := err.(*whatsapp.AuthError); ok {
+			c.JSON(ae.StatusCode, gin.H{"error": ae.Message, "code": ae.Code})
+			return
+		}
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized", "code": "unauthorized"})
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(c.Request.Body, maxBytes+1))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "read body failed", "code": "bad_body"})
+		return
+	}
+	if int64(len(body)) > maxBytes {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "payload too large", "code": "payload_too_large"})
+		return
+	}
+
+	ev, err := evolution.NormalizeWebhook(body)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "malformed payload", "code": "malformed"})
+		return
+	}
+	if ev.Instance == "" {
+		ev.Instance = instance
+	}
+	if !strings.EqualFold(ev.Instance, instance) && ev.Instance != "" {
+		// Path instance is authoritative for mapping.
+		ev.Instance = instance
+	}
+	if ev.EventType == whatsapp.EventUnsupported {
+		c.JSON(http.StatusOK, gin.H{"received": true, "ignored": true})
+		return
+	}
+
+	// Persist idempotency when org is known.
+	if orgID != uuid.Nil && h.WhatsAppRepo != nil {
+		sum := sha256.Sum256(body)
+		inserted, xerr := h.WhatsAppRepo.InsertWebhookEvent(
+			c.Request.Context(), orgID, whatsapp.ProviderEvolution,
+			ev.IdempotencyKey(), ev.EventType, ev.ExternalMessageID, hex.EncodeToString(sum[:]),
+		)
+		if xerr != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "idempotency failed", "code": "internal"})
+			return
+		}
+		if !inserted {
+			c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
+			return
+		}
+		ev.OrganizationID = orgID
+
+		// Load or create contact channel state by phone.
+		phone := ev.FromE164
+		if phone == "" {
+			phone = ev.ToE164
+		}
+		var state *models.WhatsAppContactState
+		if phone != "" {
+			state, _ = h.WhatsAppRepo.GetContactStateByPhone(c.Request.Context(), orgID, phone)
+		}
+		domainState := modelsToDomainState(state, orgID)
+		if domainState.PhoneE164 == "" {
+			domainState.PhoneE164 = phone
+		}
+
+		inRes, _ := h.WhatsAppService.ProcessInbound(c.Request.Context(), &domainState, ev)
+		if inRes.Duplicate {
+			c.JSON(http.StatusOK, gin.H{"received": true, "duplicate": true})
+			return
+		}
+
+		// Persist inbound message.
+		if ev.EventType == whatsapp.EventMessageReceived {
+			msg := &models.WhatsAppMessage{
+				OrganizationID:    orgID,
+				ThreadKey:         phone,
+				Direction:         "inbound",
+				Channel:           whatsapp.ChannelWhatsApp,
+				Provider:          whatsapp.ProviderEvolution,
+				ProviderMessageID: ev.ExternalMessageID,
+				IdempotencyKey:    ev.IdempotencyKey(),
+				BodyText:          ev.Content.Text,
+				Status:            "received",
+				OccurredAt:        ev.OccurredAt,
+			}
+			if state != nil && state.ContactID != nil {
+				msg.ContactID = state.ContactID
+			}
+			_, _ = h.WhatsAppRepo.InsertMessage(c.Request.Context(), msg)
+
+			// Persist updated consent / service window.
+			persistState := domainToModelsState(domainState, state)
+			persistState.OrganizationID = orgID
+			if state != nil {
+				persistState.ID = state.ID
+				persistState.ContactID = state.ContactID
+			}
+			_ = h.WhatsAppRepo.UpsertContactState(c.Request.Context(), &persistState)
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"received":       true,
+			"event_type":     ev.EventType,
+			"stop_sequences": inRes.StopSequences,
+			"needs_review":   inRes.NeedsHumanReview,
+			"opt_out":        inRes.OptOut.Matched && inRes.OptOut.Confident,
+		})
+		return
+	}
+
+	// No org mapping: still ack valid authenticated events (single-node lab).
+	// In-process idempotency only.
+	var domainState whatsapp.ContactChannelState
+	inRes, _ := h.WhatsAppService.ProcessInbound(c.Request.Context(), &domainState, ev)
+	c.JSON(http.StatusOK, gin.H{
+		"received":   true,
+		"event_type": ev.EventType,
+		"duplicate":  inRes.Duplicate,
+		"lab_mode":   true,
+	})
+}
+
+func modelsToDomainState(st *models.WhatsAppContactState, orgID uuid.UUID) whatsapp.ContactChannelState {
+	out := whatsapp.ContactChannelState{
+		OrganizationID: orgID,
+		ConsentStatus:  whatsapp.ConsentUnknown,
+	}
+	if st == nil {
+		return out
+	}
+	if st.ContactID != nil {
+		out.ContactID = *st.ContactID
+	}
+	out.PhoneE164 = st.PhoneE164
+	out.PhoneSource = st.PhoneSource
+	out.PhoneSourceURL = st.PhoneSourceURL
+	out.PhoneVerifiedAt = st.PhoneVerifiedAt
+	out.ConsentStatus = st.ConsentStatus
+	out.ConsentSource = st.ConsentSource
+	out.ConsentAt = st.ConsentAt
+	out.ConsentScope = st.ConsentScope
+	out.ConsentProvenanceOK = st.ConsentProvenanceOK
+	out.LastInboundAt = st.LastInboundAt
+	out.ServiceWindowUntil = st.ServiceWindowUntil
+	out.ChannelStatus = st.ChannelStatus
+	out.OptOutAt = st.OptOutAt
+	out.DoNotContact = st.DoNotContact
+	out.LastEmailOutboundAt = st.LastEmailOutboundAt
+	out.LastWhatsAppOutboundAt = st.LastWhatsAppOutboundAt
+	return out
+}
+
+func domainToModelsState(d whatsapp.ContactChannelState, prev *models.WhatsAppContactState) models.WhatsAppContactState {
+	out := models.WhatsAppContactState{
+		OrganizationID:         d.OrganizationID,
+		PhoneE164:              d.PhoneE164,
+		PhoneSource:            d.PhoneSource,
+		PhoneSourceURL:         d.PhoneSourceURL,
+		PhoneVerifiedAt:        d.PhoneVerifiedAt,
+		ConsentStatus:          d.ConsentStatus,
+		ConsentSource:          d.ConsentSource,
+		ConsentAt:              d.ConsentAt,
+		ConsentScope:           d.ConsentScope,
+		ConsentProvenanceOK:    d.ConsentProvenanceOK,
+		LastInboundAt:          d.LastInboundAt,
+		ServiceWindowUntil:     d.ServiceWindowUntil,
+		ChannelStatus:          d.ChannelStatus,
+		OptOutAt:               d.OptOutAt,
+		DoNotContact:           d.DoNotContact,
+		LastEmailOutboundAt:    d.LastEmailOutboundAt,
+		LastWhatsAppOutboundAt: d.LastWhatsAppOutboundAt,
+		UpdatedAt:              time.Now().UTC(),
+	}
+	if d.ContactID != uuid.Nil {
+		id := d.ContactID
+		out.ContactID = &id
+	}
+	if prev != nil {
+		out.PhoneRaw = prev.PhoneRaw
+		out.PhoneCountry = prev.PhoneCountry
+		out.PhoneValid = prev.PhoneValid
+	}
+	return out
+}

--- a/internal/api/handler/whatsapp_webhook_test.go
+++ b/internal/api/handler/whatsapp_webhook_test.go
@@ -1,0 +1,159 @@
+package handler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+type memWARepo struct {
+	instances map[string]*models.WhatsAppInstance
+	events    map[string]bool
+	messages  int
+	states    int
+}
+
+func (m *memWARepo) GetInstanceByName(_ context.Context, provider, instance string) (*models.WhatsAppInstance, *errx.Error) {
+	if m.instances == nil {
+		return nil, nil
+	}
+	return m.instances[provider+":"+instance], nil
+}
+func (m *memWARepo) InsertWebhookEvent(_ context.Context, orgID uuid.UUID, provider, idemKey, eventType, externalMsgID, payloadHash string) (bool, *errx.Error) {
+	if m.events == nil {
+		m.events = map[string]bool{}
+	}
+	k := orgID.String() + ":" + idemKey
+	if m.events[k] {
+		return false, nil
+	}
+	m.events[k] = true
+	return true, nil
+}
+func (m *memWARepo) UpsertContactState(context.Context, *models.WhatsAppContactState) *errx.Error {
+	m.states++
+	return nil
+}
+func (m *memWARepo) GetContactStateByPhone(context.Context, uuid.UUID, string) (*models.WhatsAppContactState, *errx.Error) {
+	return nil, nil
+}
+func (m *memWARepo) GetContactStateByContact(context.Context, uuid.UUID, uuid.UUID) (*models.WhatsAppContactState, *errx.Error) {
+	return nil, nil
+}
+func (m *memWARepo) InsertMessage(context.Context, *models.WhatsAppMessage) (bool, *errx.Error) {
+	m.messages++
+	return true, nil
+}
+func (m *memWARepo) GetTemplateStatus(context.Context, uuid.UUID, string, string) (string, *errx.Error) {
+	return "MISSING", nil
+}
+func (m *memWARepo) ListMessagesByThread(context.Context, uuid.UUID, string, int) ([]models.WhatsAppMessage, *errx.Error) {
+	return nil, nil
+}
+
+func TestEvolutionWebhookUnmappedInstance(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	wa := whatsapp.NewService(whatsapp.Config{
+		Enabled: true, WebhookSecret: "sec", MaxWebhookBytes: 1 << 20,
+	}, whatsapp.NewMockProvider(), nil)
+	h := &Handler{
+		WhatsAppService: wa,
+		WhatsAppRepo:    &memWARepo{},
+	}
+	r := gin.New()
+	r.POST("/api/v1/webhooks/evolution/:instance", h.EvolutionWebhook)
+
+	body := []byte(`{"event":"messages.upsert","instance":"unknown","data":{"key":{"id":"1","remoteJid":"5548@s.whatsapp.net","fromMe":false},"message":{"conversation":"hi"}}}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/evolution/unknown", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer sec")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["code"] != "instance_mismatch" {
+		t.Fatalf("resp=%v", resp)
+	}
+}
+
+func TestEvolutionWebhookMappedIdempotent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.New()
+	repo := &memWARepo{instances: map[string]*models.WhatsAppInstance{
+		"evolution:confenge": {
+			ID: uuid.New(), OrganizationID: org, Provider: "evolution",
+			InstanceName: "confenge", WebhookSecret: "sec", IntegrationMode: "WHATSAPP-BUSINESS",
+		},
+	}}
+	wa := whatsapp.NewService(whatsapp.Config{
+		Enabled: true, WebhookSecret: "sec", MaxWebhookBytes: 1 << 20, ServiceWindow: 24 * time.Hour,
+	}, whatsapp.NewMockProvider(), nil)
+	h := &Handler{WhatsAppService: wa, WhatsAppRepo: repo}
+	r := gin.New()
+	r.POST("/api/v1/webhooks/evolution/:instance", h.EvolutionWebhook)
+
+	body := []byte(`{"event":"messages.upsert","instance":"confenge","data":{"key":{"id":"MSG99","remoteJid":"5548999887766@s.whatsapp.net","fromMe":false},"message":{"conversation":"Olá"},"messageTimestamp":1710000000}}`)
+	do := func() *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/evolution/confenge", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer sec")
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w
+	}
+	w1 := do()
+	if w1.Code != http.StatusOK {
+		t.Fatalf("first status=%d body=%s", w1.Code, w1.Body.String())
+	}
+	if repo.messages != 1 {
+		t.Fatalf("messages=%d", repo.messages)
+	}
+	w2 := do()
+	if w2.Code != http.StatusOK {
+		t.Fatalf("second status=%d", w2.Code)
+	}
+	var resp map[string]any
+	_ = json.Unmarshal(w2.Body.Bytes(), &resp)
+	if resp["duplicate"] != true {
+		t.Fatalf("expected duplicate resp=%v", resp)
+	}
+	if repo.messages != 1 {
+		t.Fatalf("duplicate must not insert again messages=%d", repo.messages)
+	}
+}
+
+func TestEvolutionWebhookInvalidSecret(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.New()
+	repo := &memWARepo{instances: map[string]*models.WhatsAppInstance{
+		"evolution:confenge": {OrganizationID: org, Provider: "evolution", InstanceName: "confenge", WebhookSecret: "sec"},
+	}}
+	h := &Handler{
+		WhatsAppService: whatsapp.NewService(whatsapp.Config{Enabled: true, MaxWebhookBytes: 1 << 20}, nil, nil),
+		WhatsAppRepo:    repo,
+	}
+	r := gin.New()
+	r.POST("/api/v1/webhooks/evolution/:instance", h.EvolutionWebhook)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/evolution/confenge", bytes.NewReader([]byte(`{}`)))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer wrong")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("status=%d", w.Code)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -470,8 +470,11 @@ func Run(
 					confengeWrite.POST("/import", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ImportConfengeFeed)
 					confengeWrite.POST("/accounts/:id/block", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BlockConfengeAccount)
 					confengeWrite.POST("/accounts/:id/generate", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.GenerateConfengeDraft)
+					confengeWrite.POST("/accounts/:id/generate-whatsapp", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.GenerateConfengeWhatsAppDraft)
+					confengeGroup.GET("/accounts/:id/channel-decision", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.DecideConfengeChannel)
 					confengeWrite.POST("/drafts/:id/review", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReviewConfengeDraft)
 					confengeWrite.POST("/drafts/:id/enroll", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.EnrollConfengeDraft)
+					confengeWrite.POST("/drafts/:id/send-whatsapp", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.SendConfengeWhatsAppDraft)
 					confengeWrite.POST("/campaign/bootstrap", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.BootstrapConfengeCampaign)
 					confengeWrite.POST("/crm/bootstrap", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.BootstrapConfengePipeline)
 				}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -467,6 +467,8 @@ func Run(
 					confengeWrite.POST("/accounts/:id/block", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BlockConfengeAccount)
 					confengeWrite.POST("/accounts/:id/generate", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.GenerateConfengeDraft)
 					confengeWrite.POST("/drafts/:id/review", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReviewConfengeDraft)
+					confengeWrite.POST("/drafts/:id/enroll", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.EnrollConfengeDraft)
+					confengeWrite.POST("/campaign/bootstrap", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.BootstrapConfengeCampaign)
 				}
 			}
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -457,12 +457,16 @@ func Run(
 				confengeGroup.GET("/accounts/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeAccount)
 				confengeGroup.GET("/import-runs", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeImportRuns)
 				confengeGroup.GET("/import-runs/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeImportRun)
+				confengeGroup.GET("/drafts", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeDrafts)
+				confengeGroup.GET("/drafts/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeDraft)
 
 				confengeWrite := confengeGroup.Group("")
 				confengeWrite.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 				{
 					confengeWrite.POST("/import", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ImportConfengeFeed)
 					confengeWrite.POST("/accounts/:id/block", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BlockConfengeAccount)
+					confengeWrite.POST("/accounts/:id/generate", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.GenerateConfengeDraft)
+					confengeWrite.POST("/drafts/:id/review", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReviewConfengeDraft)
 				}
 			}
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -38,6 +38,10 @@ func Run(
 	// credential, resolving to one automation that runs with the JSON body.
 	r.POST("/api/v1/integrations/inbound/automation/:token", h.InboundAutomation)
 
+	// Evolution API WhatsApp webhooks (provider gateway → Warmbly). Auth is the
+	// per-instance webhook secret (Bearer or X-Webhook-Secret).
+	r.POST("/api/v1/webhooks/evolution/:instance", h.EvolutionWebhook)
+
 	// OAuth 2.1 authorization-server discovery (RFC 8414): public + unversioned.
 	r.GET("/.well-known/oauth-authorization-server", h.OAuthServerMetadata)
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -469,6 +469,7 @@ func Run(
 					confengeWrite.POST("/drafts/:id/review", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReviewConfengeDraft)
 					confengeWrite.POST("/drafts/:id/enroll", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.EnrollConfengeDraft)
 					confengeWrite.POST("/campaign/bootstrap", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.BootstrapConfengeCampaign)
+					confengeWrite.POST("/crm/bootstrap", m.RequireAccess(models.PermManageContacts, models.APIPermWriteCRM), h.BootstrapConfengePipeline)
 				}
 			}
 

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -445,6 +445,27 @@ func Run(
 				}
 			}
 
+			// CONFENGE outreach staging (extra-cli feed import). Feature-flagged
+			// server-side; status is always readable so the dashboard can hide
+			// the nav when disabled. Mutations require manage contacts.
+			confengeGroup := protected.Group("/confenge")
+			confengeGroup.Use(m.RequireOrganization())
+			{
+				confengeGroup.GET("/status", h.GetConfengeStatus)
+				confengeGroup.GET("/summary", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeSummary)
+				confengeGroup.GET("/accounts", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeAccounts)
+				confengeGroup.GET("/accounts/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeAccount)
+				confengeGroup.GET("/import-runs", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeImportRuns)
+				confengeGroup.GET("/import-runs/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeImportRun)
+
+				confengeWrite := confengeGroup.Group("")
+				confengeWrite.Use(m.RateLimitMiddleware(models.RateLimitWrite))
+				{
+					confengeWrite.POST("/import", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ImportConfengeFeed)
+					confengeWrite.POST("/accounts/:id/block", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.BlockConfengeAccount)
+				}
+			}
+
 			contacts := protected.Group("/contacts")
 			contacts.Use(m.RateLimitMiddleware(models.RateLimitWrite))
 			{

--- a/internal/app/advanced/events.go
+++ b/internal/app/advanced/events.go
@@ -100,6 +100,10 @@ func (s *service) WireInboxAgent(a InboxAgent) {
 	s.inboxAgent = a
 }
 
+func (s *service) WireConfengeReply(h ConfengeReplyHook) {
+	s.confengeReply = h
+}
+
 // notify raises an in-app notification off the hot path. It detaches from the
 // request context (the ingest call may return first) and is best-effort.
 func (s *service) notify(userID uuid.UUID, orgID *uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any) {

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -117,6 +117,9 @@ type Service interface {
 	// WireInboxAgent attaches the inbox agent so an inbound human reply drafts a
 	// suggested reply for review (M10). Best-effort; nil = feature off.
 	WireInboxAgent(a InboxAgent)
+	// WireConfengeReply attributes classified replies to CONFENGE staging
+	// (outcome outbox + CRM tasks/deals). Best-effort; nil = feature off.
+	WireConfengeReply(h ConfengeReplyHook)
 
 	// EmitCampaignEvent dispatches a campaign event (e.g. from a sequence
 	// "notify" action node) to customer webhooks and wired integrations.
@@ -159,6 +162,13 @@ type service struct {
 	realtime             ReplyRealtimePublisher
 	automationRunner     AutomationRunner
 	inboxAgent           InboxAgent
+	confengeReply        ConfengeReplyHook
+}
+
+// ConfengeReplyHook is implemented by the CONFENGE outreach service. Kept as a
+// narrow interface so advanced does not import the confenge package.
+type ConfengeReplyHook interface {
+	OnClassifiedReply(ctx context.Context, orgID uuid.UUID, contactEmail, replyClass string, contactID *uuid.UUID) error
 }
 
 func NewService(
@@ -893,6 +903,11 @@ func (s *service) ProcessIncomingReply(ctx context.Context, emailAccountID uuid.
 		// for every reply, so OOO/unsubscribe stay correct even when the gate
 		// skipped the model.
 		_ = s.campaignProgressRepo.RecordReplyClassification(ctx, cID, ctID, sID, replyResult.Class, replyResult.Source, replyResult.Confidence)
+
+		// CONFENGE staging: attribute the class to outbox + CRM (best-effort).
+		if s.confengeReply != nil && account.OrganizationID != nil {
+			_ = s.confengeReply.OnClassifiedReply(ctx, *account.OrganizationID, sender, replyResult.Class, &ctID)
+		}
 
 		// OOO trap fix: only a HUMAN reply stamps replied_at. An auto_reply /
 		// out_of_office must NOT count as a reply, or it would (a) trip

--- a/internal/app/confenge/campaign.go
+++ b/internal/app/confenge/campaign.go
@@ -1,0 +1,278 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Default campaign name for CONFENGE bootstrap (idempotent).
+const DefaultCampaignName = "CONFENGE | Outreach consultivo inicial"
+
+// CampaignAPI is the slice of campaign service used for bootstrap.
+type CampaignAPI interface {
+	Create(ctx context.Context, userID string, orgID *uuid.UUID, data *models.CreateCampaign) (*models.Campaign, *errx.Error)
+	Get(ctx context.Context, orgID, id string) (*models.Campaign, *errx.Error)
+}
+
+// ContactAPI is the slice of contact service used for enrollment.
+type ContactAPI interface {
+	Add(ctx context.Context, userID string, orgID uuid.UUID, contacts []models.AddContact) ([]models.Contact, *errx.Error)
+}
+
+// WireExecution attaches campaign/contact execution-plane services.
+func (s *service) WireExecution(campaigns CampaignAPI, contacts ContactAPI) {
+	s.campaigns = campaigns
+	s.contacts = contacts
+}
+
+// BootstrapCampaign finds or creates the CONFENGE campaign for the org.
+// Idempotent: re-runs return the same campaign_id stored in outreach_org_settings.
+func (s *service) BootstrapCampaign(ctx context.Context, orgID, userID uuid.UUID) (*models.Campaign, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if s.campaigns == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "campaign service not wired")
+	}
+
+	settings, err := s.repo.GetOrgSettings(ctx, orgID)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load org settings")
+	}
+	if settings != nil && settings.CampaignID != nil {
+		c, xerr := s.campaigns.Get(ctx, orgID.String(), settings.CampaignID.String())
+		if xerr == nil && c != nil {
+			return c, nil
+		}
+		// Campaign was deleted; fall through to recreate.
+	}
+
+	tz := "America/Sao_Paulo"
+	limit := s.cfg.DefaultDailyLimit
+	if limit < 1 {
+		limit = DefaultCampaignDailyLimit
+	}
+	stop := true
+	openTrack := false
+	linkTrack := false
+	unsub := true
+	textOnly := true
+	start := "09:00"
+	end := "17:00"
+	// Mon-Fri bitmask: leave Days nil so repository uses DefaultDays().
+	steps := defaultCadenceSteps()
+	desc := "CONFENGE consultive outreach. Human-approved enrollments only. Stop on reply/bounce."
+
+	created, xerr := s.campaigns.Create(ctx, userID.String(), &orgID, &models.CreateCampaign{
+		Name:              DefaultCampaignName,
+		Description:       desc,
+		StopOnReply:       &stop,
+		OpenTracking:      &openTrack,
+		LinkTracking:      &linkTrack,
+		UnsubscribeHeader: &unsub,
+		TextOnly:          &textOnly,
+		DailyLimit:        &limit,
+		Timezone:          &tz,
+		StartTime:         &start,
+		EndTime:           &end,
+		Sequences:         steps,
+	})
+	if xerr != nil {
+		return nil, xerr
+	}
+
+	st := &models.OutreachOrgSettings{
+		OrganizationID: orgID,
+		CampaignID:     &created.ID,
+		CampaignName:   DefaultCampaignName,
+	}
+	if err := s.repo.UpsertOrgSettings(ctx, st); err != nil {
+		return nil, errx.New(errx.Internal, "failed to persist campaign pointer")
+	}
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionCreate, models.AuditEntityCampaign, &created.ID, "", "",
+			map[string]string{"name": DefaultCampaignName, "source": "confenge_bootstrap"},
+			nil,
+		)
+	}
+	return created, nil
+}
+
+func defaultCadenceSteps() []models.CreateSequenceInput {
+	w3, w4, w7 := 3, 4, 7
+	return []models.CreateSequenceInput{
+		{
+			Name:      "Email inicial",
+			Subject:   "{{.Company}} — conversa objetiva",
+			BodyPlain: "Ola{{if .FirstName}} {{.FirstName}}{{end}},\n\nSou da CONFENGE. Acompanhei publicacoes recentes da {{.Company}} e gostaria de entender se faz sentido uma conversa curta sobre aditivos e controle contratual.\n\nPosso enviar um checklist de uma pagina?\n\nAbraço,\nTiago Sasaki\nCONFENGE",
+			WaitAfter: &w3,
+		},
+		{
+			Name:      "Follow-up D+3",
+			Subject:   "Re: {{.Company}}",
+			BodyPlain: "Reenvio com uma pergunta mais objetiva: quem na equipe acompanha aditivos e reajustes?\n\nSe fizer sentido, respondo em poucos minutos.",
+			WaitAfter: &w4,
+		},
+		{
+			Name:      "Follow-up D+7",
+			Subject:   "Re: {{.Company}}",
+			BodyPlain: "Se nao for com voce, pode me indicar a pessoa certa de contratos ou engenharia?\n\nObrigado.",
+			WaitAfter: &w7,
+		},
+		{
+			Name:      "Encerramento D+14",
+			Subject:   "Re: {{.Company}}",
+			BodyPlain: "Encerro por aqui para nao ocupar sua caixa. Se fizer sentido no futuro, e so responder este fio.\n\nAbraço.",
+			WaitAfter: nil,
+		},
+	}
+}
+
+// EnrollDraft promotes an APPROVED, validated draft into a Warmbly contact
+// and campaign lead. Never enrolls unverified / DNC / bounced addresses.
+func (s *service) EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if s.cfg.AutoSendEnabled && !s.cfg.RequireHumanApproval {
+		return nil, errx.New(errx.BadRequest, "refusing enroll: auto-send without human approval is not allowed")
+	}
+	if s.contacts == nil || s.campaigns == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "execution services not wired")
+	}
+
+	d, err := s.repo.GetDraft(ctx, orgID, draftID)
+	if err != nil || d == nil {
+		return nil, errx.New(errx.NotFound, "draft not found")
+	}
+	if d.Status == models.OutreachDraftEnrolled {
+		return d, nil // idempotent
+	}
+	if d.Status != models.OutreachDraftApproved {
+		return nil, errx.New(errx.BadRequest, "draft must be APPROVED before enrollment")
+	}
+
+	acc, err := s.repo.GetAccount(ctx, orgID, d.AccountID)
+	if err != nil || acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	if acc.DoNotContact || acc.Blocked {
+		return nil, errx.New(errx.BadRequest, "account is blocked or DO_NOT_CONTACT")
+	}
+
+	var cand *models.OutreachContactCandidate
+	if d.ContactCandidateID != nil {
+		cand, err = s.repo.GetCandidate(ctx, orgID, *d.ContactCandidateID)
+		if err != nil || cand == nil {
+			return nil, errx.New(errx.NotFound, "contact candidate not found")
+		}
+	}
+	if cand == nil || !cand.CanEnroll() {
+		return nil, errx.New(errx.BadRequest, "contact is not enrollable")
+	}
+
+	out := DraftOutput{
+		Subject: d.Subject, BodyText: d.BodyText, FactUsed: d.FactUsed,
+		ServiceCode: d.ServiceCode, EvidenceIDs: d.EvidenceIDs,
+	}
+	val := ValidateDraft(&out, acc, cand, s.cfg.MaxInitialEmailWords)
+	if !val.OK {
+		return nil, errx.New(errx.BadRequest, "draft failed validation: "+joinErrs(val.Errors))
+	}
+	if d.RiskClass == "RED" {
+		// RED may enroll only after explicit approve (already APPROVED); allowed but audited.
+	}
+
+	camp, xerr := s.BootstrapCampaign(ctx, orgID, userID)
+	if xerr != nil {
+		return nil, xerr
+	}
+
+	first, last := splitName(cand.Name)
+	company := firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
+	added, xerr := s.contacts.Add(ctx, userID.String(), orgID, []models.AddContact{{
+		FirstName: first,
+		LastName:  last,
+		Email:     strings.TrimSpace(strings.ToLower(cand.Email)),
+		Company:   company,
+		Phone:     cand.Phone,
+		Campaigns: []string{camp.ID.String()},
+		CustomFields: map[string]string{
+			"cnpj14":           acc.CNPJ14,
+			"confenge_subject": d.Subject,
+			"confenge_body":    d.BodyText,
+			"confenge_service": d.ServiceCode,
+			"confenge_fact":    d.FactUsed,
+		},
+	}})
+	if xerr != nil {
+		return nil, xerr
+	}
+	if len(added) == 0 {
+		return nil, errx.New(errx.Internal, "contact create returned empty")
+	}
+	contactID := added[0].ID
+
+	// Mark candidate promoted
+	cand.WarmblyContactID = &contactID
+	now := time.Now().UTC()
+	cand.PromotedAt = &now
+	_, _ = s.repo.UpsertCandidate(ctx, cand)
+
+	d.Status = models.OutreachDraftEnrolled
+	d.CampaignID = &camp.ID
+	d.EnrollmentContactID = &contactID
+	d.EnrolledAt = &now
+	if err := s.repo.UpsertDraft(ctx, d); err != nil {
+		return nil, errx.New(errx.Internal, "failed to update draft enrollment")
+	}
+	_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueEnrolled)
+
+	// Outcomes: approved contact + contacted (enrolled into campaign)
+	_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("contact_approved:%s:%s", orgID, d.ID),
+		SourceLeadID:   acc.SourceLeadID,
+		CNPJ14:         acc.CNPJ14,
+		ContactEmail:   cand.Email,
+		EventType:      OutcomeContactApproved,
+		OccurredAt:     now,
+	})
+	_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("contacted:%s:%s", orgID, d.ID),
+		SourceLeadID:   acc.SourceLeadID,
+		CNPJ14:         acc.CNPJ14,
+		ContactEmail:   cand.Email,
+		EventType:      OutcomeContacted,
+		OccurredAt:     now,
+	})
+
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionCreate, models.AuditEntityContact, &contactID, "", "",
+			map[string]string{
+				"draft_id":    d.ID.String(),
+				"campaign_id": camp.ID.String(),
+				"cnpj14":      acc.CNPJ14,
+			},
+			map[string]string{"source": "confenge_enroll"},
+		)
+	}
+	return d, nil
+}
+
+func splitName(full string) (first, last string) {
+	parts := strings.Fields(strings.TrimSpace(full))
+	if len(parts) == 0 {
+		return "", ""
+	}
+	if len(parts) == 1 {
+		return parts[0], ""
+	}
+	return parts[0], strings.Join(parts[1:], " ")
+}

--- a/internal/app/confenge/campaign_test.go
+++ b/internal/app/confenge/campaign_test.go
@@ -2,6 +2,7 @@ package confenge
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/google/uuid"
@@ -246,4 +247,17 @@ func (m *memRepoFull) GetActiveDraftForAccount(ctx context.Context, orgID, accou
 
 func (m *memRepoFull) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
 	return nil
+}
+
+func (m *memRepoFull) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	for _, list := range m.cands {
+		for i := range list {
+			if list[i].OrganizationID == orgID && strings.EqualFold(list[i].Email, email) {
+				acc, _ := m.GetAccount(ctx, orgID, list[i].AccountID)
+				cp := list[i]
+				return &cp, acc, nil
+			}
+		}
+	}
+	return nil, nil, nil
 }

--- a/internal/app/confenge/campaign_test.go
+++ b/internal/app/confenge/campaign_test.go
@@ -1,0 +1,249 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+type mockCampaigns struct {
+	created *models.Campaign
+	gets    map[string]*models.Campaign
+}
+
+func (m *mockCampaigns) Create(ctx context.Context, userID string, orgID *uuid.UUID, data *models.CreateCampaign) (*models.Campaign, *errx.Error) {
+	if data.Name != DefaultCampaignName {
+		return nil, errx.New(errx.BadRequest, "unexpected name")
+	}
+	if data.StopOnReply == nil || !*data.StopOnReply {
+		return nil, errx.New(errx.BadRequest, "stop_on_reply required")
+	}
+	if data.Timezone == nil || *data.Timezone != "America/Sao_Paulo" {
+		return nil, errx.New(errx.BadRequest, "timezone")
+	}
+	if len(data.Sequences) != 4 {
+		return nil, errx.New(errx.BadRequest, "want 4 cadence steps")
+	}
+	c := &models.Campaign{ID: uuid.New(), Name: data.Name, Status: "draft"}
+	m.created = c
+	if m.gets == nil {
+		m.gets = map[string]*models.Campaign{}
+	}
+	m.gets[c.ID.String()] = c
+	return c, nil
+}
+
+func (m *mockCampaigns) Get(ctx context.Context, orgID, id string) (*models.Campaign, *errx.Error) {
+	if c := m.gets[id]; c != nil {
+		return c, nil
+	}
+	return nil, errx.New(errx.NotFound, "missing")
+}
+
+type mockContacts struct {
+	added []models.AddContact
+}
+
+func (m *mockContacts) Add(ctx context.Context, userID string, orgID uuid.UUID, contacts []models.AddContact) ([]models.Contact, *errx.Error) {
+	m.added = append(m.added, contacts...)
+	out := make([]models.Contact, len(contacts))
+	for i, c := range contacts {
+		out[i] = models.Contact{ID: uuid.New(), Email: c.Email, FirstName: c.FirstName, Company: c.Company}
+	}
+	return out, nil
+}
+
+func TestBootstrapCampaignIdempotent(t *testing.T) {
+	repo := newMemRepo()
+	// enrich memRepo for org settings
+	settings := map[uuid.UUID]*models.OutreachOrgSettings{}
+	// override via embedding won't work — use real methods if we stored on memRepo
+	// Patch: use service with mock campaigns that tracks creates
+	camps := &mockCampaigns{}
+	svc := testSvc(repo).(*service)
+	svc.WireExecution(camps, &mockContacts{})
+	// need GetOrgSettings/Upsert on memRepo - already stub returns nil
+	// First create stores settings - but memRepo UpsertOrgSettings is no-op and Get returns nil
+	// so every bootstrap creates again. Fix memRepo to store settings.
+	org := uuid.New()
+	user := uuid.New()
+
+	// Use a settings-aware mem repo extension
+	r2 := newMemRepoWithSettings()
+	svc2 := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120, RequireHumanApproval: true}, r2, nil).(*service)
+	camps2 := &mockCampaigns{}
+	svc2.WireExecution(camps2, &mockContacts{})
+
+	c1, xerr := svc2.BootstrapCampaign(context.Background(), org, user)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	c2, xerr := svc2.BootstrapCampaign(context.Background(), org, user)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if c1.ID != c2.ID {
+		t.Fatalf("bootstrap not idempotent: %s vs %s", c1.ID, c2.ID)
+	}
+	if camps2.created == nil || camps2.created.ID != c1.ID {
+		t.Fatal("expected single create")
+	}
+	_ = settings
+}
+
+func TestEnrollRejectsUnapproved(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120, RequireHumanApproval: true}, r, nil).(*service)
+	svc.WireExecution(&mockCampaigns{}, &mockContacts{})
+	org := uuid.New()
+	// seed account + candidate + draft NEEDS_REVIEW
+	accID := uuid.New()
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", QueueState: models.OutreachQueueReadyToGenerate,
+		FactToMention: "fato", ServiceCode: "S",
+	}
+	_, _ = r.UpsertAccount(context.Background(), acc)
+	candID := uuid.New()
+	cand := &models.OutreachContactCandidate{
+		ID: candID, OrganizationID: org, AccountID: accID,
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Recommended: true,
+	}
+	_, _ = r.UpsertCandidate(context.Background(), cand)
+	d := &models.OutreachDraft{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, ContactCandidateID: &candID,
+		Subject: "Oi", BodyText: "corpo com fato publico ok", FactUsed: "fato",
+		ServiceCode: "S", Status: models.OutreachDraftNeedsReview, RiskClass: "GREEN",
+		RecipientEmail: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	ok := true
+	d.ValidationOK = &ok
+	_ = r.UpsertDraft(context.Background(), d)
+
+	_, xerr := svc.EnrollDraft(context.Background(), org, uuid.New(), d.ID)
+	if xerr == nil {
+		t.Fatal("must reject non-approved")
+	}
+}
+
+func TestEnrollApprovedHappyPath(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120, RequireHumanApproval: true}, r, nil).(*service)
+	contacts := &mockContacts{}
+	svc.WireExecution(&mockCampaigns{}, contacts)
+	org := uuid.New()
+	accID := uuid.New()
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", NomeFantasia: "ACME", QueueState: models.OutreachQueueApproved,
+		FactToMention: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW", SourceLeadID: "L1",
+	}
+	_, _ = r.UpsertAccount(context.Background(), acc)
+	candID := uuid.New()
+	cand := &models.OutreachContactCandidate{
+		ID: candID, OrganizationID: org, AccountID: accID, Name: "Ana Silva",
+		Email: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Recommended: true,
+	}
+	_, _ = r.UpsertCandidate(context.Background(), cand)
+	d := &models.OutreachDraft{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, ContactCandidateID: &candID,
+		Subject: "Sobre ACME", BodyText: "Ola Ana,\n\nNotei a prorrogacao do contrato. Faz sentido conversarmos?\n\nPosso enviar checklist?",
+		FactUsed: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
+		Status: models.OutreachDraftApproved, RiskClass: "GREEN",
+		RecipientEmail: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	ok := true
+	d.ValidationOK = &ok
+	_ = r.UpsertDraft(context.Background(), d)
+
+	out, xerr := svc.EnrollDraft(context.Background(), org, uuid.New(), d.ID)
+	if xerr != nil {
+		t.Fatal(xerr.Message)
+	}
+	if out.Status != models.OutreachDraftEnrolled {
+		t.Fatalf("status %s", out.Status)
+	}
+	if out.CampaignID == nil || out.EnrollmentContactID == nil {
+		t.Fatal("missing campaign/contact ids")
+	}
+	if len(contacts.added) != 1 || contacts.added[0].Email != "ana@example.com" {
+		t.Fatalf("contact add: %+v", contacts.added)
+	}
+	// idempotent re-enroll
+	out2, xerr := svc.EnrollDraft(context.Background(), org, uuid.New(), d.ID)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if out2.ID != out.ID {
+		t.Fatal("re-enroll should return same draft")
+	}
+}
+
+// memRepo with settings + drafts storage
+type memRepoFull struct {
+	*memRepo
+	settings map[uuid.UUID]*models.OutreachOrgSettings
+	drafts   map[uuid.UUID]*models.OutreachDraft
+}
+
+func newMemRepoWithSettings() *memRepoFull {
+	return &memRepoFull{
+		memRepo:  newMemRepo(),
+		settings: map[uuid.UUID]*models.OutreachOrgSettings{},
+		drafts:   map[uuid.UUID]*models.OutreachDraft{},
+	}
+}
+
+func (m *memRepoFull) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error) {
+	s := m.settings[orgID]
+	if s == nil {
+		return nil, nil
+	}
+	cp := *s
+	return &cp, nil
+}
+
+func (m *memRepoFull) UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error {
+	cp := *s
+	m.settings[s.OrganizationID] = &cp
+	return nil
+}
+
+func (m *memRepoFull) UpsertDraft(ctx context.Context, d *models.OutreachDraft) error {
+	if d.ID == uuid.Nil {
+		d.ID = uuid.New()
+	}
+	cp := *d
+	m.drafts[d.ID] = &cp
+	return nil
+}
+
+func (m *memRepoFull) GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error) {
+	d := m.drafts[id]
+	if d == nil || d.OrganizationID != orgID {
+		return nil, nil
+	}
+	cp := *d
+	return &cp, nil
+}
+
+func (m *memRepoFull) GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error) {
+	for _, d := range m.drafts {
+		if d.OrganizationID == orgID && d.AccountID == accountID {
+			switch d.Status {
+			case models.OutreachDraftNotGenerated, models.OutreachDraftGenerating, models.OutreachDraftNeedsReview, models.OutreachDraftApproved:
+				cp := *d
+				return &cp, nil
+			}
+		}
+	}
+	return nil, nil
+}
+
+func (m *memRepoFull) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
+	return nil
+}

--- a/internal/app/confenge/config.go
+++ b/internal/app/confenge/config.go
@@ -1,0 +1,147 @@
+// Package confenge implements the CONFENGE outreach operational layer:
+// import of extra-cli intelligence feeds into Warmbly staging, review queue
+// foundation, and outcome outbox (later PRs). Intelligence stays in extra-cli;
+// Warmbly remains the execution plane (contacts, campaigns, mailboxes, CRM).
+package confenge
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// Env keys for CONFENGE outreach. Documented in deploy/config/env.example
+// and docs/confenge/.
+const (
+	EnvEnabled           = "CONFENGE_OUTREACH_ENABLED"
+	EnvAutoSend          = "CONFENGE_AUTO_SEND_ENABLED"
+	EnvFeedURL           = "CONFENGE_EXTRA_CLI_FEED_URL"
+	EnvFeedToken         = "CONFENGE_EXTRA_CLI_FEED_TOKEN"
+	EnvAllowedHosts      = "CONFENGE_EXTRA_CLI_ALLOWED_HOSTS"
+	EnvOutcomeWebhookURL = "CONFENGE_OUTCOME_WEBHOOK_URL"
+	EnvOutcomeWebhookSec = "CONFENGE_OUTCOME_WEBHOOK_SECRET"
+	EnvDefaultDailyLimit = "CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT"
+	EnvMaxInitialWords   = "CONFENGE_MAX_INITIAL_EMAIL_WORDS"
+	EnvRequireHuman      = "CONFENGE_REQUIRE_HUMAN_APPROVAL"
+	EnvMaxPayloadBytes   = "CONFENGE_MAX_FEED_PAYLOAD_BYTES"
+)
+
+// Defaults for conservative cold outreach.
+const (
+	DefaultCampaignDailyLimit = 10
+	DefaultMaxInitialWords    = 120
+	DefaultMaxPayloadBytes    = 32 << 20 // 32 MiB
+)
+
+// Config is runtime configuration for the confenge outreach feature.
+type Config struct {
+	Enabled              bool
+	AutoSendEnabled      bool
+	FeedURL              string
+	FeedToken            string
+	AllowedHosts         []string
+	OutcomeWebhookURL    string
+	OutcomeWebhookSecret string
+	DefaultDailyLimit    int
+	MaxInitialEmailWords int
+	RequireHumanApproval bool
+	MaxFeedPayloadBytes  int64
+}
+
+// LoadConfig reads CONFENGE_* env vars. Safe defaults keep the feature off.
+func LoadConfig() Config {
+	cfg := Config{
+		Enabled:              envBool(EnvEnabled, false),
+		AutoSendEnabled:      envBool(EnvAutoSend, false),
+		FeedURL:              strings.TrimSpace(os.Getenv(EnvFeedURL)),
+		FeedToken:            strings.TrimSpace(os.Getenv(EnvFeedToken)),
+		AllowedHosts:         splitHosts(os.Getenv(EnvAllowedHosts)),
+		OutcomeWebhookURL:    strings.TrimSpace(os.Getenv(EnvOutcomeWebhookURL)),
+		OutcomeWebhookSecret: strings.TrimSpace(os.Getenv(EnvOutcomeWebhookSec)),
+		DefaultDailyLimit:    envInt(EnvDefaultDailyLimit, DefaultCampaignDailyLimit),
+		MaxInitialEmailWords: envInt(EnvMaxInitialWords, DefaultMaxInitialWords),
+		RequireHumanApproval: envBool(EnvRequireHuman, true),
+		MaxFeedPayloadBytes:  int64(envInt(EnvMaxPayloadBytes, DefaultMaxPayloadBytes)),
+	}
+	return cfg
+}
+
+// ValidateStartup fails closed on insecure production combinations.
+// Called when the feature is enabled.
+func (c Config) ValidateStartup(appEnv string) error {
+	if !c.Enabled {
+		return nil
+	}
+	prod := strings.EqualFold(appEnv, "prod") || strings.EqualFold(appEnv, "production")
+	if c.AutoSendEnabled && c.RequireHumanApproval {
+		// Explicit: auto-send may be on only when human approval is also required
+		// is contradictory; refuse auto-send when we cannot verify intent.
+		// Keep RequireHumanApproval as the safety net — auto-send alone is never default.
+	}
+	if prod {
+		if c.FeedURL != "" {
+			if !strings.HasPrefix(strings.ToLower(c.FeedURL), "https://") {
+				return fmt.Errorf("%s must be https in production", EnvFeedURL)
+			}
+			if len(c.AllowedHosts) == 0 {
+				return fmt.Errorf("%s is required when feed URL is set in production", EnvAllowedHosts)
+			}
+		}
+		if c.OutcomeWebhookURL != "" {
+			if !strings.HasPrefix(strings.ToLower(c.OutcomeWebhookURL), "https://") {
+				return fmt.Errorf("%s must be https in production", EnvOutcomeWebhookURL)
+			}
+			if c.OutcomeWebhookSecret == "" {
+				return fmt.Errorf("%s is required when outcome webhook is set", EnvOutcomeWebhookSec)
+			}
+		}
+	}
+	if c.DefaultDailyLimit < 1 || c.DefaultDailyLimit > 100 {
+		return fmt.Errorf("%s must be between 1 and 100", EnvDefaultDailyLimit)
+	}
+	if c.MaxInitialEmailWords < 20 || c.MaxInitialEmailWords > 500 {
+		return fmt.Errorf("%s must be between 20 and 500", EnvMaxInitialWords)
+	}
+	return nil
+}
+
+func envBool(key string, def bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+func envInt(key string, def int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func splitHosts(raw string) []string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.ToLower(strings.TrimSpace(p))
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}

--- a/internal/app/confenge/config.go
+++ b/internal/app/confenge/config.go
@@ -25,6 +25,10 @@ const (
 	EnvMaxInitialWords   = "CONFENGE_MAX_INITIAL_EMAIL_WORDS"
 	EnvRequireHuman      = "CONFENGE_REQUIRE_HUMAN_APPROVAL"
 	EnvMaxPayloadBytes   = "CONFENGE_MAX_FEED_PAYLOAD_BYTES"
+	// WhatsApp orchestration (channel flags also live in whatsapp.Config).
+	EnvWhatsAppEnabled   = "CONFENGE_WHATSAPP_ENABLED"
+	EnvCrossChannelHours = "CONFENGE_CROSS_CHANNEL_MIN_INTERVAL_HOURS"
+	EnvWhatsAppMaxWords  = "CONFENGE_MAX_WHATSAPP_WORDS"
 )
 
 // Defaults for conservative cold outreach.
@@ -32,6 +36,8 @@ const (
 	DefaultCampaignDailyLimit = 10
 	DefaultMaxInitialWords    = 120
 	DefaultMaxPayloadBytes    = 32 << 20 // 32 MiB
+	DefaultCrossChannelHours  = 24
+	DefaultMaxWhatsAppWords   = 70
 )
 
 // Config is runtime configuration for the confenge outreach feature.
@@ -47,6 +53,10 @@ type Config struct {
 	MaxInitialEmailWords int
 	RequireHumanApproval bool
 	MaxFeedPayloadBytes  int64
+	// WhatsApp commercial orchestration (transport flags: whatsapp.LoadConfig).
+	WhatsAppEnabled   bool
+	CrossChannelHours int
+	MaxWhatsAppWords  int
 }
 
 // LoadConfig reads CONFENGE_* env vars. Safe defaults keep the feature off.
@@ -63,6 +73,9 @@ func LoadConfig() Config {
 		MaxInitialEmailWords: envInt(EnvMaxInitialWords, DefaultMaxInitialWords),
 		RequireHumanApproval: envBool(EnvRequireHuman, true),
 		MaxFeedPayloadBytes:  int64(envInt(EnvMaxPayloadBytes, DefaultMaxPayloadBytes)),
+		WhatsAppEnabled:      envBool(EnvWhatsAppEnabled, false),
+		CrossChannelHours:    envInt(EnvCrossChannelHours, DefaultCrossChannelHours),
+		MaxWhatsAppWords:     envInt(EnvWhatsAppMaxWords, DefaultMaxWhatsAppWords),
 	}
 	return cfg
 }

--- a/internal/app/confenge/crm.go
+++ b/internal/app/confenge/crm.go
@@ -1,0 +1,268 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/replyclassify"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Default CRM pipeline name (idempotent bootstrap).
+const DefaultPipelineName = "CONFENGE Comercial"
+
+// CRMAPI is the slice of CRM service used for pipeline/task/deal bootstrap.
+type CRMAPI interface {
+	ListPipelines(ctx context.Context, orgID uuid.UUID) ([]models.Pipeline, *errx.Error)
+	CreatePipeline(ctx context.Context, orgID uuid.UUID, data *models.CreatePipeline) (*models.Pipeline, *errx.Error)
+	CreateCRMTask(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, *errx.Error)
+	CreateDeal(ctx context.Context, orgID uuid.UUID, data *models.CreateDeal) (*models.Deal, *errx.Error)
+	// Optional activity recording via underlying repo is not on the service
+	// surface; tasks/deals create their own activity trails.
+}
+
+// WireCRM attaches the CRM control-plane service.
+func (s *service) WireCRM(crm CRMAPI) {
+	s.crm = crm
+}
+
+// confengeStages is the fixed stage list. Re-bootstrap never renames human edits
+// when a pipeline with the same name already exists.
+func confengeStages() []models.CreatePipelineStage {
+	// Colors match dashboard slate/sky/amber/emerald conventions.
+	return []models.CreatePipelineStage{
+		{Name: "Novo", Color: "#94a3b8"},
+		{Name: "Preparação", Color: "#64748b"},
+		{Name: "Contato aprovado", Color: "#0ea5e9"},
+		{Name: "Contatado", Color: "#0284c7"},
+		{Name: "Respondeu", Color: "#8b5cf6"},
+		{Name: "Reunião", Color: "#f59e0b"},
+		{Name: "Diagnóstico", Color: "#d97706"},
+		{Name: "Proposta", Color: "#ea580c"},
+		{Name: "Negociação", Color: "#dc2626"},
+		{Name: "Ganho", Color: "#16a34a"},
+		{Name: "Perdido", Color: "#6b7280"},
+		{Name: "Não contatar", Color: "#1f2937"},
+	}
+}
+
+// BootstrapPipeline finds or creates the CONFENGE Comercial pipeline.
+// Idempotent: existing pipeline by name is returned unchanged (preserves human edits).
+func (s *service) BootstrapPipeline(ctx context.Context, orgID uuid.UUID) (*models.Pipeline, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if s.crm == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "CRM service not wired")
+	}
+	list, xerr := s.crm.ListPipelines(ctx, orgID)
+	if xerr != nil {
+		return nil, xerr
+	}
+	for i := range list {
+		if strings.EqualFold(list[i].Name, DefaultPipelineName) {
+			return &list[i], nil
+		}
+	}
+	created, xerr := s.crm.CreatePipeline(ctx, orgID, &models.CreatePipeline{
+		Name:   DefaultPipelineName,
+		Stages: confengeStages(),
+	})
+	if xerr != nil {
+		return nil, xerr
+	}
+	// Persist pointer on org settings when available.
+	if settings, err := s.repo.GetOrgSettings(ctx, orgID); err == nil {
+		if settings == nil {
+			settings = &models.OutreachOrgSettings{OrganizationID: orgID, CampaignName: DefaultCampaignName}
+		}
+		// reuse campaign_name field area; store pipeline id in raw via upsert only if we add column
+		// For now pipeline is found by name — no extra column required.
+		_ = settings
+	}
+	return created, nil
+}
+
+// MapReplyClass converts replyclassify / confenge commercial classes into
+// outcome event type + optional CRM side effects (task/deal). Never auto-WON.
+type ReplyCRMAction struct {
+	OutcomeType string
+	CreateTask  bool
+	TaskTitle   string
+	TaskType    string
+	OpenDeal    bool // only on explicit positive interest path when contact known
+	SuppressDNC bool
+	QueueState  string
+}
+
+// ClassifyReplyForCRM maps classifier/commercial labels to CRM actions.
+// replyClass is replyclassify class or confenge commercial class.
+func ClassifyReplyForCRM(replyClass string) ReplyCRMAction {
+	switch strings.ToLower(strings.TrimSpace(replyClass)) {
+	case replyclassify.ClassPositive, "positive_interest":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeReplied,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: interesse positivo - acompanhar",
+			TaskType:    "call",
+			OpenDeal:    true,
+			QueueState:  models.OutreachQueueReplied,
+		}
+	case replyclassify.ClassNeutral:
+		return ReplyCRMAction{OutcomeType: OutcomeReplied, CreateTask: false, QueueState: models.OutreachQueueReplied}
+	case "referral":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeReplied,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: encaminhamento - cadastrar contato indicado",
+			TaskType:    "email",
+			QueueState:  models.OutreachQueueReplied,
+		}
+	case "wrong_contact":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeReplied,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: contato errado - achar interlocutor",
+			TaskType:    "email",
+			QueueState:  models.OutreachQueueNeedsContact,
+		}
+	case "not_now":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeReplied,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: nao agora - follow-up futuro",
+			TaskType:    "call",
+			QueueState:  models.OutreachQueueReplied,
+		}
+	case replyclassify.ClassNegative, "no_interest":
+		return ReplyCRMAction{OutcomeType: OutcomeReplied, QueueState: models.OutreachQueueSkipped}
+	case replyclassify.ClassUnsubscribe, "do_not_contact", "dnc":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeDoNotContact,
+			SuppressDNC: true,
+			QueueState:  models.OutreachQueueDoNotContact,
+		}
+	case replyclassify.ClassOutOfOffice, "ooo":
+		return ReplyCRMAction{OutcomeType: OutcomeReplied, QueueState: ""} // no queue change
+	case replyclassify.ClassAutoReply, "automated_reply", "bounce":
+		// auto_reply covers OOO-adjacent headers; hard bounces use NoteBounce
+		return ReplyCRMAction{OutcomeType: "", QueueState: ""}
+	case "meeting":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeMeeting,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: reuniao marcada - preparar",
+			TaskType:    "meeting",
+			QueueState:  models.OutreachQueueMeeting,
+		}
+	case "proposal":
+		return ReplyCRMAction{
+			OutcomeType: OutcomeProposal,
+			CreateTask:  true,
+			TaskTitle:   "CONFENGE: proposta - acompanhar",
+			TaskType:    "email",
+			QueueState:  models.OutreachQueueProposal,
+		}
+	default:
+		return ReplyCRMAction{OutcomeType: OutcomeReplied, QueueState: models.OutreachQueueReplied}
+	}
+}
+
+// HandleClassifiedReply applies CRM + outbox side effects for a classified reply
+// on a confenge-staged contact. Never marks WON automatically.
+func (s *service) HandleClassifiedReply(ctx context.Context, orgID, actorID uuid.UUID, contactEmail, replyClass string, warmblyContactID *uuid.UUID) *errx.Error {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil // feature off — silent
+	}
+	email := strings.TrimSpace(strings.ToLower(contactEmail))
+	if email == "" {
+		return nil
+	}
+	action := ClassifyReplyForCRM(replyClass)
+	cand, acc, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil {
+		return errx.New(errx.Internal, "lookup candidate: "+err.Error())
+	}
+	if cand == nil && warmblyContactID == nil {
+		return nil
+	}
+	cnpj, lead := "", ""
+	if acc != nil {
+		cnpj, lead = acc.CNPJ14, acc.SourceLeadID
+		if action.QueueState != "" {
+			_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, acc.Blocked || action.SuppressDNC, acc.DoNotContact || action.SuppressDNC, "reply:"+replyClass, action.QueueState)
+		}
+	}
+	if action.SuppressDNC {
+		_ = s.NoteDNC(ctx, orgID, email, "reply classification: "+replyClass)
+	}
+	if action.OutcomeType != "" {
+		_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+			IdempotencyKey: fmt.Sprintf("%s:%s:%s:%d", strings.ToLower(action.OutcomeType), orgID, email, time.Now().UTC().Truncate(time.Minute).Unix()),
+			SourceLeadID:   lead,
+			CNPJ14:         cnpj,
+			ContactEmail:   email,
+			EventType:      action.OutcomeType,
+			OccurredAt:     time.Now().UTC(),
+			Payload: mustJSON(map[string]any{
+				"reply_class": replyClass,
+			}),
+		})
+	}
+	if s.crm == nil {
+		return nil
+	}
+	contactID := warmblyContactID
+	if contactID == nil && cand != nil {
+		contactID = cand.WarmblyContactID
+	}
+	if contactID == nil {
+		return nil
+	}
+	if action.CreateTask && actorID != uuid.Nil {
+		_, _ = s.crm.CreateCRMTask(ctx, orgID, actorID, &models.CreateCRMTask{
+			ContactID: contactID,
+			Title:     action.TaskTitle,
+			Type:      action.TaskType,
+			Priority:  "medium",
+		})
+	}
+	// Positive interest may open a deal in "Respondeu" stage — never Ganho.
+	if action.OpenDeal {
+		pipe, xerr := s.BootstrapPipeline(ctx, orgID)
+		if xerr == nil && pipe != nil {
+			stageID := stageIDByName(pipe, "Respondeu")
+			if stageID != uuid.Nil {
+				name := "CONFENGE"
+				if acc != nil {
+					name = firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial, "CONFENGE")
+				}
+				_, _ = s.crm.CreateDeal(ctx, orgID, &models.CreateDeal{
+					PipelineID: pipe.ID,
+					StageID:    stageID,
+					ContactID:  contactID,
+					Name:       name,
+					Currency:   "BRL",
+				})
+			}
+		}
+	}
+	return nil
+}
+
+func stageIDByName(p *models.Pipeline, name string) uuid.UUID {
+	if p == nil {
+		return uuid.Nil
+	}
+	for _, st := range p.Stages {
+		if strings.EqualFold(st.Name, name) {
+			return st.ID
+		}
+	}
+	return uuid.Nil
+}

--- a/internal/app/confenge/crm_test.go
+++ b/internal/app/confenge/crm_test.go
@@ -1,0 +1,135 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/replyclassify"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+type mockCRM struct {
+	pipelines []models.Pipeline
+	creates   int
+	tasks     int
+	deals     int
+}
+
+func (m *mockCRM) ListPipelines(ctx context.Context, orgID uuid.UUID) ([]models.Pipeline, *errx.Error) {
+	return m.pipelines, nil
+}
+
+func (m *mockCRM) CreatePipeline(ctx context.Context, orgID uuid.UUID, data *models.CreatePipeline) (*models.Pipeline, *errx.Error) {
+	m.creates++
+	if data.Name != DefaultPipelineName {
+		return nil, errx.New(errx.BadRequest, "name")
+	}
+	if len(data.Stages) != 12 {
+		return nil, errx.New(errx.BadRequest, "want 12 stages")
+	}
+	stages := make([]models.PipelineStage, len(data.Stages))
+	for i, s := range data.Stages {
+		stages[i] = models.PipelineStage{ID: uuid.New(), Name: s.Name, Color: s.Color, Position: i}
+	}
+	p := models.Pipeline{ID: uuid.New(), OrganizationID: orgID, Name: data.Name, Stages: stages}
+	m.pipelines = append(m.pipelines, p)
+	return &p, nil
+}
+
+func (m *mockCRM) CreateCRMTask(ctx context.Context, orgID, userID uuid.UUID, data *models.CreateCRMTask) (*models.CRMTask, *errx.Error) {
+	m.tasks++
+	return &models.CRMTask{ID: uuid.New(), Title: data.Title}, nil
+}
+
+func (m *mockCRM) CreateDeal(ctx context.Context, orgID uuid.UUID, data *models.CreateDeal) (*models.Deal, *errx.Error) {
+	m.deals++
+	return &models.Deal{ID: uuid.New(), Name: data.Name}, nil
+}
+
+func TestBootstrapPipelineIdempotent(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120}, r, nil).(*service)
+	crm := &mockCRM{}
+	svc.WireCRM(crm)
+	org := uuid.New()
+	p1, xerr := svc.BootstrapPipeline(context.Background(), org)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	p2, xerr := svc.BootstrapPipeline(context.Background(), org)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if p1.ID != p2.ID {
+		t.Fatal("not idempotent")
+	}
+	if crm.creates != 1 {
+		t.Fatalf("creates=%d", crm.creates)
+	}
+}
+
+func TestClassifyReplyForCRMNeverAutoWon(t *testing.T) {
+	for _, c := range []string{
+		replyclassify.ClassPositive, "meeting", "proposal", "won", "WON",
+	} {
+		a := ClassifyReplyForCRM(c)
+		if a.OutcomeType == OutcomeWon {
+			t.Fatalf("%s mapped to WON", c)
+		}
+	}
+}
+
+func TestHandleClassifiedReplyPositiveCreatesTaskAndDeal(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120}, r, nil).(*service)
+	crm := &mockCRM{}
+	svc.WireCRM(crm)
+	org := uuid.New()
+	accID := uuid.New()
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", QueueState: models.OutreachQueueEnrolled, SourceLeadID: "L1",
+	}
+	_, _ = r.UpsertAccount(context.Background(), acc)
+	contactID := uuid.New()
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID,
+		Email: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+		WarmblyContactID: &contactID,
+	}
+	_, _ = r.UpsertCandidate(context.Background(), cand)
+
+	if xerr := svc.HandleClassifiedReply(context.Background(), org, uuid.New(), "ana@example.com", replyclassify.ClassPositive, &contactID); xerr != nil {
+		t.Fatal(xerr)
+	}
+	if crm.tasks < 1 {
+		t.Fatal("expected task")
+	}
+	if crm.deals < 1 {
+		t.Fatal("expected deal in Respondeu")
+	}
+}
+
+func TestHandleClassifiedReplyDNC(t *testing.T) {
+	r := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120}, r, nil).(*service)
+	crm := &mockCRM{}
+	svc.WireCRM(crm)
+	org := uuid.New()
+	accID := uuid.New()
+	_, _ = r.UpsertAccount(context.Background(), &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181", RazaoSocial: "X",
+	})
+	_, _ = r.UpsertCandidate(context.Background(), &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, Email: "x@example.com",
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+	})
+	_ = svc.HandleClassifiedReply(context.Background(), org, uuid.Nil, "x@example.com", replyclassify.ClassUnsubscribe, nil)
+	acc, _ := r.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acc == nil || !acc.DoNotContact {
+		t.Fatalf("DNC not set: %+v", acc)
+	}
+}

--- a/internal/app/confenge/delivery.go
+++ b/internal/app/confenge/delivery.go
@@ -1,0 +1,142 @@
+package confenge
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/safehttp"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// OutcomeDeliveryWorker drains outreach_outcome_outbox to the configured webhook.
+type OutcomeDeliveryWorker struct {
+	repo      repository.OutreachRepository
+	cfg       Config
+	http      *http.Client
+	batchSize int
+	pollEvery time.Duration
+	maxTries  int
+}
+
+// OutcomeDeliveryOptions configures the worker.
+type OutcomeDeliveryOptions struct {
+	BatchSize  int
+	PollEvery  time.Duration
+	HTTPClient *http.Client
+	MaxTries   int
+}
+
+// NewOutcomeDeliveryWorker builds a worker. When webhook URL is empty, Run waits on ctx only.
+func NewOutcomeDeliveryWorker(repo repository.OutreachRepository, cfg Config, opts OutcomeDeliveryOptions) *OutcomeDeliveryWorker {
+	if opts.BatchSize <= 0 {
+		opts.BatchSize = 25
+	}
+	if opts.PollEvery <= 0 {
+		opts.PollEvery = 3 * time.Second
+	}
+	if opts.MaxTries <= 0 {
+		opts.MaxTries = 8
+	}
+	if opts.HTTPClient == nil {
+		client := safehttp.Client(15 * time.Second)
+		client.CheckRedirect = func(*http.Request, []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+		opts.HTTPClient = client
+	}
+	return &OutcomeDeliveryWorker{
+		repo:      repo,
+		cfg:       cfg,
+		http:      opts.HTTPClient,
+		batchSize: opts.BatchSize,
+		pollEvery: opts.PollEvery,
+		maxTries:  opts.MaxTries,
+	}
+}
+
+// Run blocks until ctx is cancelled.
+func (w *OutcomeDeliveryWorker) Run(ctx context.Context) {
+	if w == nil {
+		return
+	}
+	if strings.TrimSpace(w.cfg.OutcomeWebhookURL) == "" || strings.TrimSpace(w.cfg.OutcomeWebhookSecret) == "" {
+		log.Info().Msg("confenge outcome delivery worker idle (webhook URL/secret unset)")
+		<-ctx.Done()
+		return
+	}
+	t := time.NewTicker(w.pollEvery)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			w.tick(ctx)
+		}
+	}
+}
+
+func (w *OutcomeDeliveryWorker) tick(ctx context.Context) {
+	rows, err := w.repo.ListPendingOutcomes(ctx, w.batchSize)
+	if err != nil {
+		log.Warn().Err(err).Msg("confenge outbox list failed")
+		return
+	}
+	for i := range rows {
+		w.deliverOne(ctx, &rows[i])
+	}
+}
+
+func (w *OutcomeDeliveryWorker) deliverOne(ctx context.Context, ev *models.OutreachOutcome) {
+	env := BuildOutcomeEnvelope(ev)
+	body, err := json.Marshal(env)
+	if err != nil {
+		w.fail(ctx, ev, "marshal: "+err.Error())
+		return
+	}
+	ts := time.Now().UTC()
+	sig := SignOutcomeHMAC(w.cfg.OutcomeWebhookSecret, ts, body)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, w.cfg.OutcomeWebhookURL, bytes.NewReader(body))
+	if err != nil {
+		w.fail(ctx, ev, err.Error())
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Warmbly-Signature", sig)
+	req.Header.Set("X-Warmbly-Event-Id", env.EventID)
+	req.Header.Set("Idempotency-Key", env.IdempotencyKey)
+
+	resp, err := w.http.Do(req)
+	if err != nil {
+		w.fail(ctx, ev, err.Error())
+		return
+	}
+	defer resp.Body.Close()
+	snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		if err := w.repo.MarkOutcomeDelivered(ctx, ev.OrganizationID, ev.ID); err != nil {
+			log.Warn().Err(err).Str("id", ev.ID.String()).Msg("mark delivered failed")
+		}
+		return
+	}
+	w.fail(ctx, ev, fmt.Sprintf("HTTP %d: %s", resp.StatusCode, strings.TrimSpace(string(snippet))))
+}
+
+func (w *OutcomeDeliveryWorker) fail(ctx context.Context, ev *models.OutreachOutcome, reason string) {
+	attempts := ev.Attempts + 1
+	dead := attempts >= w.maxTries
+	next := time.Now().UTC().Add(OutcomeBackoff(attempts))
+	if err := w.repo.MarkOutcomeAttempt(ctx, ev.OrganizationID, ev.ID, attempts, next, reason, dead); err != nil {
+		log.Warn().Err(err).Str("id", ev.ID.String()).Msg("mark attempt failed")
+	}
+}

--- a/internal/app/confenge/drafts.go
+++ b/internal/app/confenge/drafts.go
@@ -55,6 +55,7 @@ func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uu
 		OrganizationID:     orgID,
 		AccountID:          accountID,
 		ContactCandidateID: &cand.ID,
+		Channel:            models.OutreachChannelEmail,
 		RecipientName:      cand.Name,
 		RecipientRole:      cand.Role,
 		RecipientEmail:     cand.Email,

--- a/internal/app/confenge/drafts.go
+++ b/internal/app/confenge/drafts.go
@@ -1,0 +1,315 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/generation"
+)
+
+// GenerateDraft creates or regenerates a draft for an account using AI when
+// configured, otherwise a deterministic template (never auto-approved).
+func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uuid.UUID, contactID *uuid.UUID) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, accountID)
+	if err != nil || acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	if acc.DoNotContact || acc.Blocked {
+		return nil, errx.New(errx.BadRequest, "account is blocked or DO_NOT_CONTACT")
+	}
+
+	var cand *models.OutreachContactCandidate
+	if contactID != nil {
+		cand, err = s.repo.GetCandidate(ctx, orgID, *contactID)
+		if err != nil || cand == nil || cand.AccountID != accountID {
+			return nil, errx.New(errx.NotFound, "contact candidate not found")
+		}
+	} else {
+		list, err := s.repo.ListCandidates(ctx, orgID, accountID)
+		if err != nil {
+			return nil, errx.New(errx.Internal, "failed to list contacts")
+		}
+		cand = pickRecommended(list)
+	}
+	if cand == nil {
+		return nil, errx.New(errx.BadRequest, "no contact candidate; resolve NEEDS_CONTACT first")
+	}
+
+	evidence, err := s.repo.ListEvidence(ctx, orgID, accountID)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load evidence")
+	}
+
+	existing, _ := s.repo.GetActiveDraftForAccount(ctx, orgID, accountID)
+	draft := &models.OutreachDraft{
+		OrganizationID:     orgID,
+		AccountID:          accountID,
+		ContactCandidateID: &cand.ID,
+		RecipientName:      cand.Name,
+		RecipientRole:      cand.Role,
+		RecipientEmail:     cand.Email,
+		VerificationStatus: cand.VerificationStatus,
+		Status:             models.OutreachDraftGenerating,
+		PromptVersion:      PromptVersion,
+	}
+	if existing != nil {
+		draft.ID = existing.ID
+		draft.Generation = existing.Generation + 1
+		draft.CreatedAt = existing.CreatedAt
+	}
+
+	gen := s.generator()
+	out, provider, model, genErr := gen.Generate(ctx, acc, cand, evidence)
+	usedTemplate := false
+	if genErr != nil {
+		// Fallback template; import/review remain usable without AI.
+		out = TemplateDraft(acc, cand)
+		provider = "template"
+		model = "deterministic"
+		usedTemplate = true
+	}
+	if out.ServiceCode == "" {
+		out.ServiceCode = acc.ServiceCode
+	}
+	if len(out.EvidenceIDs) == 0 && len(acc.MomentEvidenceIDs) > 0 {
+		out.EvidenceIDs = acc.MomentEvidenceIDs
+	}
+
+	val := ValidateDraft(&out, acc, cand, s.cfg.MaxInitialEmailWords)
+	risk, flags := ClassifyRisk(acc, cand, &out, val)
+	if usedTemplate {
+		flags = append(flags, "template_fallback")
+		if risk == "GREEN" {
+			risk = "YELLOW"
+		}
+	}
+
+	valJSON, _ := json.Marshal(val)
+	followJSON, _ := json.Marshal(out.Followups)
+	draft.Subject = SanitizeText(out.Subject, 200)
+	draft.BodyText = SanitizeText(out.BodyText, 8000)
+	draft.BodyHTML = "" // never store unsafe HTML from model raw
+	draft.FollowupsJSON = followJSON
+	draft.ServiceCode = SanitizeText(out.ServiceCode, 100)
+	draft.FactUsed = SanitizeText(out.FactUsed, 2000)
+	draft.EvidenceIDs = out.EvidenceIDs
+	draft.Question = SanitizeText(out.Question, 1000)
+	draft.CTA = SanitizeText(out.CTA, 500)
+	draft.Provider = provider
+	draft.Model = model
+	draft.ValidationJSON = valJSON
+	ok := val.OK
+	draft.ValidationOK = &ok
+	draft.RiskClass = risk
+	draft.RiskFlags = flags
+	draft.Status = models.OutreachDraftNeedsReview
+	if err := s.repo.UpsertDraft(ctx, draft); err != nil {
+		return nil, errx.New(errx.Internal, "failed to save draft: "+err.Error())
+	}
+
+	// Move account into review queue when machine-owned.
+	if acc.QueueState == models.OutreachQueueReadyToGenerate || acc.QueueState == models.OutreachQueueNeedsContact {
+		_ = s.repo.SetAccountHumanFlags(ctx, orgID, accountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueNeedsReview)
+	}
+
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionCreate, models.AuditEntityOutreachAccount, &accountID, "", "",
+			map[string]string{"draft_id": draft.ID.String(), "status": draft.Status, "risk": draft.RiskClass},
+			map[string]string{"provider": provider},
+		)
+	}
+	return draft, nil
+}
+
+func (s *service) generator() DraftGenerator {
+	if s.ai != nil {
+		return &AIDraftGenerator{Provider: s.ai}
+	}
+	return TemplateGenerator{}
+}
+
+func pickRecommended(list []models.OutreachContactCandidate) *models.OutreachContactCandidate {
+	var fallback *models.OutreachContactCandidate
+	for i := range list {
+		c := &list[i]
+		if c.DoNotContact || c.Bounced || c.Blocked {
+			continue
+		}
+		if c.Email == "" {
+			continue
+		}
+		if c.Recommended && c.CanEnroll() {
+			return c
+		}
+		if fallback == nil && c.CanEnroll() {
+			fallback = c
+		}
+		if fallback == nil {
+			fallback = c
+		}
+	}
+	return fallback
+}
+
+// GetDraft returns one draft by id.
+func (s *service) GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	d, err := s.repo.GetDraft(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load draft")
+	}
+	if d == nil {
+		return nil, errx.New(errx.NotFound, "draft not found")
+	}
+	return d, nil
+}
+
+// ListDrafts lists drafts optionally filtered by status.
+func (s *service) ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	list, err := s.repo.ListDrafts(ctx, orgID, status, limit, offset)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to list drafts")
+	}
+	if list == nil {
+		list = []models.OutreachDraft{}
+	}
+	return list, nil
+}
+
+// ReviewDraft applies human actions: approve, reject, skip, edit, block.
+func (s *service) ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.UUID, action string, edit *DraftEdit) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	d, err := s.repo.GetDraft(ctx, orgID, draftID)
+	if err != nil || d == nil {
+		return nil, errx.New(errx.NotFound, "draft not found")
+	}
+	switch action {
+	case "edit":
+		if edit == nil {
+			return nil, errx.New(errx.BadRequest, "edit payload required")
+		}
+		if edit.Subject != nil {
+			d.Subject = SanitizeText(*edit.Subject, 200)
+		}
+		if edit.BodyText != nil {
+			d.BodyText = SanitizeText(*edit.BodyText, 8000)
+		}
+		d.HumanEdited = true
+		// Re-validate after edit
+		acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID)
+		var cand *models.OutreachContactCandidate
+		if d.ContactCandidateID != nil {
+			cand, _ = s.repo.GetCandidate(ctx, orgID, *d.ContactCandidateID)
+		}
+		out := DraftOutput{
+			Subject: d.Subject, BodyText: d.BodyText, FactUsed: d.FactUsed,
+			ServiceCode: d.ServiceCode, EvidenceIDs: d.EvidenceIDs,
+			Question: d.Question, CTA: d.CTA,
+		}
+		val := ValidateDraft(&out, acc, cand, s.cfg.MaxInitialEmailWords)
+		risk, flags := ClassifyRisk(acc, cand, &out, val)
+		valJSON, _ := json.Marshal(val)
+		d.ValidationJSON = valJSON
+		ok := val.OK
+		d.ValidationOK = &ok
+		d.RiskClass = risk
+		d.RiskFlags = flags
+		d.Status = models.OutreachDraftNeedsReview
+	case "approve":
+		acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID)
+		var cand *models.OutreachContactCandidate
+		if d.ContactCandidateID != nil {
+			cand, _ = s.repo.GetCandidate(ctx, orgID, *d.ContactCandidateID)
+		}
+		out := DraftOutput{
+			Subject: d.Subject, BodyText: d.BodyText, FactUsed: d.FactUsed,
+			ServiceCode: d.ServiceCode, EvidenceIDs: d.EvidenceIDs,
+		}
+		val := ValidateDraft(&out, acc, cand, s.cfg.MaxInitialEmailWords)
+		if !val.OK {
+			return nil, errx.New(errx.BadRequest, "draft failed validation: "+joinErrs(val.Errors))
+		}
+		if d.Provider == "template" && s.cfg.RequireHumanApproval {
+			// Template is allowed after explicit human approve.
+		}
+		now := time.Now().UTC()
+		d.Status = models.OutreachDraftApproved
+		d.ApprovedBy = &userID
+		d.ApprovedAt = &now
+		if acc != nil {
+			_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueApproved)
+		}
+	case "reject":
+		d.Status = models.OutreachDraftRejected
+	case "skip":
+		d.Status = models.OutreachDraftSkipped
+		acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID)
+		if acc != nil {
+			_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueSkipped)
+		}
+	case "block":
+		d.Status = models.OutreachDraftBlocked
+		reason := "blocked from review"
+		if edit != nil && edit.Reason != nil {
+			reason = *edit.Reason
+		}
+		dnc := edit != nil && edit.DoNotContact
+		_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, true, dnc, reason,
+			map[bool]string{true: models.OutreachQueueDoNotContact, false: models.OutreachQueueBlocked}[dnc])
+	default:
+		return nil, errx.New(errx.BadRequest, "unknown action (approve|reject|skip|edit|block)")
+	}
+	if err := s.repo.UpsertDraft(ctx, d); err != nil {
+		return nil, errx.New(errx.Internal, "failed to update draft")
+	}
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionUpdate, models.AuditEntityOutreachAccount, &d.AccountID, "", "",
+			map[string]string{"draft_id": d.ID.String(), "action": action, "status": d.Status},
+			nil,
+		)
+	}
+	return d, nil
+}
+
+// DraftEdit is an optional body for review actions.
+type DraftEdit struct {
+	Subject      *string `json:"subject"`
+	BodyText     *string `json:"body_text"`
+	Reason       *string `json:"reason"`
+	DoNotContact bool    `json:"do_not_contact"`
+}
+
+func joinErrs(errs []string) string {
+	return stringsJoin(errs, "; ")
+}
+
+func stringsJoin(parts []string, sep string) string {
+	if len(parts) == 0 {
+		return ""
+	}
+	out := parts[0]
+	for i := 1; i < len(parts); i++ {
+		out += sep + parts[i]
+	}
+	return out
+}
+
+// Ensure service holds optional AI provider.
+func (s *service) SetAI(p generation.Provider) {
+	s.ai = p
+}

--- a/internal/app/confenge/drafts.go
+++ b/internal/app/confenge/drafts.go
@@ -3,6 +3,8 @@ package confenge
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -253,6 +255,18 @@ func (s *service) ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.U
 		d.ApprovedAt = &now
 		if acc != nil {
 			_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueApproved)
+			email := ""
+			if cand != nil {
+				email = cand.Email
+			}
+			_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+				IdempotencyKey: "lead_reviewed:" + d.ID.String(),
+				SourceLeadID:   acc.SourceLeadID,
+				CNPJ14:         acc.CNPJ14,
+				ContactEmail:   email,
+				EventType:      OutcomeLeadReviewed,
+				OccurredAt:     now,
+			})
 		}
 	case "reject":
 		d.Status = models.OutreachDraftRejected
@@ -271,6 +285,21 @@ func (s *service) ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.U
 		dnc := edit != nil && edit.DoNotContact
 		_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, true, dnc, reason,
 			map[bool]string{true: models.OutreachQueueDoNotContact, false: models.OutreachQueueBlocked}[dnc])
+		if acc, _ := s.repo.GetAccount(ctx, orgID, d.AccountID); acc != nil {
+			evType := OutcomeLeadReviewed
+			if dnc {
+				evType = OutcomeDoNotContact
+			}
+			email := d.RecipientEmail
+			_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+				IdempotencyKey: fmt.Sprintf("%s:%s", strings.ToLower(evType), d.ID.String()),
+				SourceLeadID:   acc.SourceLeadID,
+				CNPJ14:         acc.CNPJ14,
+				ContactEmail:   email,
+				EventType:      evType,
+				OccurredAt:     time.Now().UTC(),
+			})
+		}
 	default:
 		return nil, errx.New(errx.BadRequest, "unknown action (approve|reject|skip|edit|block)")
 	}

--- a/internal/app/confenge/e2e_flow_test.go
+++ b/internal/app/confenge/e2e_flow_test.go
@@ -1,0 +1,165 @@
+package confenge
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Synthetic path: import fixture → generate template draft → block bad copy →
+// approve → enroll → reimport → DNC → bounce/HMAC. In-memory only.
+func TestSyntheticOperationalFlow(t *testing.T) {
+	var outcomes []models.OutreachOutcome
+	rf := &memRepoOutcome{
+		memRepoFull: *newMemRepoWithSettings(),
+		outcomes:    &outcomes,
+	}
+	// Fix maps after value copy of memRepoFull
+	rf.memRepo = newMemRepo()
+	rf.settings = map[uuid.UUID]*models.OutreachOrgSettings{}
+	rf.drafts = map[uuid.UUID]*models.OutreachDraft{}
+
+	cfg := Config{
+		Enabled: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120,
+		RequireHumanApproval: true, MaxFeedPayloadBytes: DefaultMaxPayloadBytes,
+	}
+	svc := NewService(cfg, rf, nil).(*service)
+	contacts := &mockContacts{}
+	camps := &mockCampaigns{}
+	svc.WireExecution(camps, contacts)
+
+	org := uuid.New()
+	user := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+
+	run, xerr := svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.Creates < 4 {
+		t.Fatalf("import creates: %+v", run.Counts)
+	}
+
+	noMail, _ := rf.GetAccountByCNPJ(context.Background(), org, "55444333000122")
+	if noMail == nil || noMail.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("no-email company: %+v", noMail)
+	}
+
+	acme, _ := rf.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acme == nil {
+		t.Fatal("acme missing")
+	}
+
+	draft, xerr := svc.GenerateDraft(context.Background(), org, user, acme.ID, nil)
+	if xerr != nil {
+		t.Fatal(xerr.Message)
+	}
+	if draft.Status != models.OutreachDraftNeedsReview {
+		t.Fatalf("status %s", draft.Status)
+	}
+
+	// Banned phrase must fail approve after edit
+	bad := "Identificamos dinheiro a receber na conta"
+	if _, xerr = svc.ReviewDraft(context.Background(), org, user, draft.ID, "edit", &DraftEdit{BodyText: &bad}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	if _, xerr = svc.ReviewDraft(context.Background(), org, user, draft.ID, "approve", nil); xerr == nil {
+		t.Fatal("expected approve to fail on banned phrase")
+	}
+
+	// Clean human edit + approve
+	subj := "Sobre ACME"
+	body := "Ola Ana,\n\nNotei " + acme.FactToMention + ".\n\nFaz sentido conversarmos?\n\nPosso enviar checklist?"
+	if _, xerr = svc.ReviewDraft(context.Background(), org, user, draft.ID, "edit", &DraftEdit{Subject: &subj, BodyText: &body}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	// Ensure fact_used and service align for validators
+	dMid, _ := rf.GetDraft(context.Background(), org, draft.ID)
+	dMid.FactUsed = acme.FactToMention
+	dMid.ServiceCode = acme.ServiceCode
+	dMid.EvidenceIDs = []string{"ev-acme-1"}
+	_ = rf.UpsertDraft(context.Background(), dMid)
+
+	approved, xerr := svc.ReviewDraft(context.Background(), org, user, draft.ID, "approve", nil)
+	if xerr != nil {
+		t.Fatal(xerr.Message)
+	}
+	if approved.Status != models.OutreachDraftApproved {
+		t.Fatalf("status %s", approved.Status)
+	}
+
+	enrolled, xerr := svc.EnrollDraft(context.Background(), org, user, draft.ID)
+	if xerr != nil {
+		t.Fatal(xerr.Message)
+	}
+	if enrolled.Status != models.OutreachDraftEnrolled {
+		t.Fatalf("enroll status %s", enrolled.Status)
+	}
+	if len(contacts.added) != 1 {
+		t.Fatal("expected contact promotion")
+	}
+
+	run2, xerr := svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run2.Counts.Creates != 0 {
+		t.Fatalf("reimport creates should be 0: %+v", run2.Counts)
+	}
+
+	acc, _ := rf.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	acc.DoNotContact = true
+	acc.QueueState = models.OutreachQueueDoNotContact
+	_, _ = rf.UpsertAccount(context.Background(), acc)
+	_, _ = svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{})
+	again, _ := rf.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if again == nil || !again.DoNotContact {
+		t.Fatal("DNC not preserved")
+	}
+
+	email := contacts.added[0].Email
+	if err := svc.NoteBounce(context.Background(), org, email, "550 user unknown"); err != nil {
+		t.Fatal(err)
+	}
+
+	secret := "whsec_test"
+	payload := []byte(`{"event_type":"REPLIED"}`)
+	ts := time.Now().UTC()
+	hdr := SignOutcomeHMAC(secret, ts, payload)
+	if !VerifyOutcomeHMAC(secret, hdr, payload, ts, 5*time.Minute) {
+		t.Fatal("hmac roundtrip")
+	}
+	if !strings.Contains(hdr, "v1=") {
+		t.Fatalf("header shape %q", hdr)
+	}
+}
+
+type memRepoOutcome struct {
+	memRepoFull
+	outcomes *[]models.OutreachOutcome
+}
+
+func (m *memRepoOutcome) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
+	if m.outcomes != nil {
+		*m.outcomes = append(*m.outcomes, *ev)
+	}
+	return nil
+}
+
+func (m *memRepoOutcome) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	for _, list := range m.cands {
+		for i := range list {
+			if list[i].OrganizationID == orgID && strings.EqualFold(list[i].Email, email) {
+				acc, _ := m.GetAccount(ctx, orgID, list[i].AccountID)
+				cp := list[i]
+				return &cp, acc, nil
+			}
+		}
+	}
+	return nil, nil, nil
+}

--- a/internal/app/confenge/feed_fetch.go
+++ b/internal/app/confenge/feed_fetch.go
@@ -1,0 +1,108 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/pkg/safehttp"
+)
+
+// FeedFetcher loads a feed from HTTPS (production) or file:// (dev/tests).
+// Remote fetches use the SSRF-hardened client and optional host allowlist.
+type FeedFetcher struct {
+	AllowedHosts []string
+	Token        string
+	MaxBytes     int64
+	HTTPClient   *http.Client
+}
+
+// Fetch returns raw payload bytes from uri.
+// Supported schemes: https, http (dev only via WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS), file.
+func (f *FeedFetcher) Fetch(ctx context.Context, uri string) ([]byte, error) {
+	uri = strings.TrimSpace(uri)
+	if uri == "" {
+		return nil, fmt.Errorf("feed URI is required")
+	}
+	u, err := url.Parse(uri)
+	if err != nil {
+		return nil, fmt.Errorf("invalid feed URI: %w", err)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "file":
+		return f.fetchFile(u)
+	case "https", "http":
+		return f.fetchHTTP(ctx, u)
+	default:
+		return nil, fmt.Errorf("unsupported feed scheme %q", u.Scheme)
+	}
+}
+
+func (f *FeedFetcher) fetchFile(u *url.URL) ([]byte, error) {
+	path := u.Path
+	if path == "" {
+		path = u.Opaque
+	}
+	// file:///absolute/path
+	if strings.HasPrefix(u.String(), "file://") && path == "" {
+		return nil, fmt.Errorf("empty file path")
+	}
+	data, err := readFileLimited(path, f.maxBytes())
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func (f *FeedFetcher) fetchHTTP(ctx context.Context, u *url.URL) ([]byte, error) {
+	host := strings.ToLower(u.Hostname())
+	if len(f.AllowedHosts) > 0 && !hostAllowed(host, f.AllowedHosts) {
+		return nil, fmt.Errorf("feed host %q is not in allowlist", host)
+	}
+	client := f.HTTPClient
+	if client == nil {
+		client = safehttp.Client(30 * time.Second)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	if f.Token != "" {
+		req.Header.Set("Authorization", "Bearer "+f.Token)
+	}
+	req.Header.Set("Accept", "application/json")
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("feed fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("feed fetch HTTP %d", resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, f.maxBytes()))
+}
+
+func (f *FeedFetcher) maxBytes() int64 {
+	if f.MaxBytes > 0 {
+		return f.MaxBytes
+	}
+	return DefaultMaxPayloadBytes
+}
+
+func hostAllowed(host string, allow []string) bool {
+	host = strings.ToLower(strings.TrimSpace(host))
+	for _, a := range allow {
+		a = strings.ToLower(strings.TrimSpace(a))
+		if a == "" {
+			continue
+		}
+		if host == a || strings.HasSuffix(host, "."+a) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/confenge/file_io.go
+++ b/internal/app/confenge/file_io.go
@@ -1,0 +1,29 @@
+package confenge
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+func readFileLimited(path string, maxBytes int64) ([]byte, error) {
+	if path == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	if maxBytes <= 0 {
+		maxBytes = DefaultMaxPayloadBytes
+	}
+	data, err := io.ReadAll(io.LimitReader(f, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("payload exceeds max size of %d bytes", maxBytes)
+	}
+	return data, nil
+}

--- a/internal/app/confenge/generate.go
+++ b/internal/app/confenge/generate.go
@@ -1,0 +1,155 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/generation"
+)
+
+// DraftGenerator produces structured outreach copy from staging inputs only.
+type DraftGenerator interface {
+	Generate(ctx context.Context, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) (DraftOutput, string, string, error)
+}
+
+// AIDraftGenerator uses the existing generation.Provider abstraction.
+type AIDraftGenerator struct {
+	Provider generation.Provider
+	Model    string
+}
+
+// Generate asks the model for JSON only from structured inputs (no research).
+func (g *AIDraftGenerator) Generate(ctx context.Context, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) (DraftOutput, string, string, error) {
+	if g == nil || g.Provider == nil {
+		return DraftOutput{}, "", "", generation.ErrNotConfigured
+	}
+	system := draftSystemPrompt()
+	user := draftUserPrompt(acc, cand, evidence)
+	model := g.Model
+	if model == "" {
+		model = g.Provider.ModelForTier(true)
+	}
+	res, err := g.Provider.Complete(ctx, generation.CompletionRequest{
+		System:      system,
+		Prompt:      user,
+		Model:       model,
+		MaxTokens:   1200,
+		Temperature: generation.Deterministic(),
+	})
+	if err != nil {
+		return DraftOutput{}, g.Provider.Name(), model, err
+	}
+	out, err := parseDraftJSON(res.Text)
+	if err != nil {
+		return DraftOutput{}, g.Provider.Name(), res.Model, err
+	}
+	return out, g.Provider.Name(), res.Model, nil
+}
+
+// TemplateGenerator is the safe fallback when AI is off.
+type TemplateGenerator struct{}
+
+func (TemplateGenerator) Generate(ctx context.Context, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) (DraftOutput, string, string, error) {
+	_ = ctx
+	_ = evidence
+	return TemplateDraft(acc, cand), "template", "deterministic", nil
+}
+
+func draftSystemPrompt() string {
+	return strings.TrimSpace(`
+Você redige e-mails comerciais curtos em português brasileiro para a CONFENGE (engenharia consultiva).
+Você NÃO pesquisa. Use somente os dados estruturados do usuário.
+Não transforme hipótese em fato. Não invente número, contrato, data, órgão, nome ou cargo ausentes dos inputs.
+Não use travessões. Não use frases de IA. Não diga "espero que esta mensagem o encontre bem".
+Não prometa resultado, crédito, dinheiro a receber, irregularidade ou urgência falsa.
+Primeira mensagem: até ~120 palavras, até 3 parágrafos curtos, uma pergunta, um CTA, um serviço.
+Follow-ups menores, mesmo fio, sem repetir o primeiro e-mail.
+Responda APENAS com JSON válido no schema:
+{"subject":"","body_text":"","body_html":"","followups":[{"delay_days":3,"subject_mode":"same_thread","body_text":"","body_html":""}],"fact_used":"","evidence_ids":[],"service_code":"","question":"","cta":"","risk_flags":[]}
+`)
+}
+
+func draftUserPrompt(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) string {
+	type payload struct {
+		Company   any `json:"company"`
+		Contact   any `json:"contact"`
+		Moment    any `json:"moment"`
+		Offer     any `json:"offer"`
+		Messaging any `json:"messaging"`
+		Evidence  any `json:"evidence"`
+	}
+	company := map[string]any{}
+	moment := map[string]any{}
+	offer := map[string]any{}
+	messaging := map[string]any{}
+	if acc != nil {
+		company = map[string]any{
+			"razao_social":  acc.RazaoSocial,
+			"nome_fantasia": acc.NomeFantasia,
+			"cnpj14":        acc.CNPJ14,
+			"municipio":     acc.Municipio,
+			"uf":            acc.UF,
+		}
+		moment = map[string]any{
+			"code":    acc.MomentCode,
+			"summary": acc.MomentSummary,
+		}
+		offer = map[string]any{
+			"service_code": acc.ServiceCode,
+			"service_name": acc.ServiceName,
+			"entry_offer":  acc.EntryOffer,
+		}
+		messaging = map[string]any{
+			"fact_to_mention": acc.FactToMention,
+			"question_to_ask": acc.QuestionToAsk,
+			"cta":             acc.CTA,
+			"claims_to_avoid": acc.ClaimsToAvoid,
+		}
+	}
+	contact := map[string]any{}
+	if cand != nil {
+		contact = map[string]any{
+			"name":                cand.Name,
+			"role":                cand.Role,
+			"email":               cand.Email,
+			"verification_status": cand.VerificationStatus,
+		}
+	}
+	ev := make([]map[string]any, 0, len(evidence))
+	for _, e := range evidence {
+		ev = append(ev, map[string]any{
+			"id":              e.SourceEvidenceID,
+			"title":           e.Title,
+			"synthesis":       e.Synthesis,
+			"excerpt":         e.Excerpt,
+			"epistemic_class": e.EpistemicClass,
+			"url":             e.URL,
+		})
+	}
+	b, _ := json.MarshalIndent(payload{
+		Company: company, Contact: contact, Moment: moment,
+		Offer: offer, Messaging: messaging, Evidence: ev,
+	}, "", "  ")
+	return "Gere a mensagem com base apenas nestes dados:\n" + string(b)
+}
+
+func parseDraftJSON(text string) (DraftOutput, error) {
+	text = strings.TrimSpace(text)
+	// Strip markdown fences if the model wraps JSON.
+	if i := strings.Index(text, "{"); i >= 0 {
+		if j := strings.LastIndex(text, "}"); j > i {
+			text = text[i : j+1]
+		}
+	}
+	var out DraftOutput
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		return DraftOutput{}, fmt.Errorf("invalid draft JSON: %w", err)
+	}
+	out.Subject = strings.TrimSpace(out.Subject)
+	out.BodyText = strings.TrimSpace(out.BodyText)
+	out.FactUsed = strings.TrimSpace(out.FactUsed)
+	return out, nil
+}

--- a/internal/app/confenge/hooks.go
+++ b/internal/app/confenge/hooks.go
@@ -1,0 +1,131 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// OutcomeSink is the consumer-facing surface for commercial outcomes.
+// Implemented by *service.
+type OutcomeSink interface {
+	Enabled() bool
+	// NoteReply enqueues REPLIED when the address matches a staged candidate.
+	NoteReply(ctx context.Context, orgID uuid.UUID, contactEmail string, meta map[string]any) error
+	// NoteBounce enqueues BOUNCED for a failed recipient email.
+	NoteBounce(ctx context.Context, orgID uuid.UUID, contactEmail, reason string) error
+	// NoteDNC enqueues DO_NOT_CONTACT and marks matching candidates.
+	NoteDNC(ctx context.Context, orgID uuid.UUID, contactEmail, reason string) error
+}
+
+func (s *service) enqueueErr(ctx context.Context, orgID uuid.UUID, ev models.OutreachOutcome) error {
+	if xerr := s.EnqueueOutcome(ctx, orgID, ev); xerr != nil {
+		return fmt.Errorf("%s", xerr.Message)
+	}
+	return nil
+}
+
+// NoteReply implements OutcomeSink.
+func (s *service) NoteReply(ctx context.Context, orgID uuid.UUID, contactEmail string, meta map[string]any) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	email := strings.TrimSpace(strings.ToLower(contactEmail))
+	if email == "" {
+		return nil
+	}
+	cand, acc, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil || cand == nil || acc == nil {
+		return nil // not a confenge lead
+	}
+	payload, _ := jsonMarshalMap(meta)
+	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("replied:%s:%s:%d", orgID, email, time.Now().UTC().Truncate(time.Minute).Unix()),
+		SourceLeadID:   acc.SourceLeadID,
+		CNPJ14:         acc.CNPJ14,
+		ContactEmail:   email,
+		EventType:      OutcomeReplied,
+		OccurredAt:     time.Now().UTC(),
+		Payload:        payload,
+	})
+}
+
+// NoteBounce implements OutcomeSink.
+func (s *service) NoteBounce(ctx context.Context, orgID uuid.UUID, contactEmail, reason string) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	email := strings.TrimSpace(strings.ToLower(contactEmail))
+	if email == "" {
+		return nil
+	}
+	cand, acc, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil {
+		return err
+	}
+	if cand != nil {
+		cand.Bounced = true
+		cand.VerificationStatus = models.OutreachVerifyBounced
+		_, _ = s.repo.UpsertCandidate(ctx, cand)
+	}
+	cnpj, lead := "", ""
+	if acc != nil {
+		cnpj, lead = acc.CNPJ14, acc.SourceLeadID
+		_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, acc.Blocked, acc.DoNotContact, "bounce", models.OutreachQueueBounced)
+	}
+	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("bounced:%s:%s", orgID, email),
+		SourceLeadID:   lead,
+		CNPJ14:         cnpj,
+		ContactEmail:   email,
+		EventType:      OutcomeBounced,
+		OccurredAt:     time.Now().UTC(),
+		Payload:        mustJSON(map[string]any{"reason": reason}),
+	})
+}
+
+// NoteDNC implements OutcomeSink.
+func (s *service) NoteDNC(ctx context.Context, orgID uuid.UUID, contactEmail, reason string) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	email := strings.TrimSpace(strings.ToLower(contactEmail))
+	if email == "" {
+		return nil
+	}
+	cand, acc, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil {
+		return err
+	}
+	if cand != nil {
+		cand.DoNotContact = true
+		cand.VerificationStatus = models.OutreachVerifyDoNotContact
+		_, _ = s.repo.UpsertCandidate(ctx, cand)
+	}
+	cnpj, lead := "", ""
+	if acc != nil {
+		cnpj, lead = acc.CNPJ14, acc.SourceLeadID
+		_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, true, true, reason, models.OutreachQueueDoNotContact)
+	}
+	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("dnc:%s:%s", orgID, email),
+		SourceLeadID:   lead,
+		CNPJ14:         cnpj,
+		ContactEmail:   email,
+		EventType:      OutcomeDoNotContact,
+		OccurredAt:     time.Now().UTC(),
+		Payload:        mustJSON(map[string]any{"reason": reason}),
+	})
+}
+
+func jsonMarshalMap(m map[string]any) ([]byte, error) {
+	if m == nil {
+		return []byte("{}"), nil
+	}
+	return marshalJSON(m)
+}

--- a/internal/app/confenge/hooks.go
+++ b/internal/app/confenge/hooks.go
@@ -129,3 +129,11 @@ func jsonMarshalMap(m map[string]any) ([]byte, error) {
 	}
 	return marshalJSON(m)
 }
+
+// OnClassifiedReply implements advanced.ConfengeReplyHook.
+func (s *service) OnClassifiedReply(ctx context.Context, orgID uuid.UUID, contactEmail, replyClass string, contactID *uuid.UUID) error {
+	if xerr := s.HandleClassifiedReply(ctx, orgID, uuid.Nil, contactEmail, replyClass, contactID); xerr != nil {
+		return fmt.Errorf("%s", xerr.Message)
+	}
+	return nil
+}

--- a/internal/app/confenge/json_util.go
+++ b/internal/app/confenge/json_util.go
@@ -1,0 +1,7 @@
+package confenge
+
+import "encoding/json"
+
+func marshalJSON(v any) ([]byte, error) {
+	return json.Marshal(v)
+}

--- a/internal/app/confenge/legacy.go
+++ b/internal/app/confenge/legacy.go
@@ -1,0 +1,427 @@
+package confenge
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// DetectAndNormalize accepts either a native confenge.outreach.v1 document or
+// common legacy extra-cli artifacts (leads.json array, commercial-leads wrapper,
+// single-run export). Missing fields are left empty; never invented.
+func DetectAndNormalize(raw []byte) (*Feed, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty payload")
+	}
+	// Peek schema_version without failing on legacy shapes.
+	var peek struct {
+		SchemaVersion string          `json:"schema_version"`
+		Leads         json.RawMessage `json:"leads"`
+	}
+	_ = json.Unmarshal(raw, &peek)
+	if peek.SchemaVersion == models.OutreachSchemaV1 {
+		return ParseFeed(raw)
+	}
+
+	// Top-level array of leads (leads.json).
+	trim := strings.TrimSpace(string(raw))
+	if strings.HasPrefix(trim, "[") {
+		var arr []map[string]any
+		if err := json.Unmarshal(raw, &arr); err != nil {
+			return nil, fmt.Errorf("legacy leads array: %w", err)
+		}
+		return legacyMapToFeed(arr, FeedSource{System: "extra-cli", ProfileID: "confenge"}), nil
+	}
+
+	// Object with leads key (commercial run export / commercial-leads.json).
+	var wrap map[string]any
+	if err := json.Unmarshal(raw, &wrap); err != nil {
+		return nil, fmt.Errorf("legacy object: %w", err)
+	}
+	src := FeedSource{
+		System:         "extra-cli",
+		ProfileID:      "confenge",
+		RunID:          strField(wrap, "run_id", "id", "source_run_id"),
+		SnapshotHash:   strField(wrap, "snapshot_hash"),
+		RepoSHA:        strField(wrap, "repo_sha", "git_sha"),
+		ProfileVersion: strField(wrap, "profile_version"),
+	}
+	if v := strField(wrap, "profile_id", "profile"); v != "" {
+		src.ProfileID = v
+	}
+	leadsRaw, ok := wrap["leads"]
+	if !ok {
+		// Some exports nest under "data" or "queue".
+		if d, ok := wrap["data"].(map[string]any); ok {
+			leadsRaw = d["leads"]
+		} else if q, ok := wrap["queue"].([]any); ok {
+			leadsRaw = q
+		}
+	}
+	arr, err := asMapSlice(leadsRaw)
+	if err != nil {
+		return nil, fmt.Errorf("legacy leads: %w", err)
+	}
+	feed := legacyMapToFeed(arr, src)
+	if g := strField(wrap, "generated_at", "created_at"); g != "" {
+		feed.GeneratedAt = g
+	}
+	return feed, nil
+}
+
+func legacyMapToFeed(arr []map[string]any, src FeedSource) *Feed {
+	leads := make([]FeedLead, 0, len(arr))
+	for i, m := range arr {
+		leads = append(leads, mapLegacyLead(m, i+1))
+	}
+	return &Feed{
+		SchemaVersion: models.OutreachSchemaV1,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Source:        src,
+		Pagination:    FeedPagination{HasMore: false},
+		Leads:         leads,
+	}
+}
+
+func mapLegacyLead(m map[string]any, rankFallback int) FeedLead {
+	cnpj := digitsOnly(strField(m, "cnpj14", "cnpj", "company_cnpj"))
+	root := digitsOnly(strField(m, "cnpj_root", "cnpj_basico"))
+	if root == "" && len(cnpj) == 14 {
+		root = cnpj[:8]
+	}
+	razao := strField(m, "razao_social", "company_name", "name")
+	fantasia := strField(m, "nome_fantasia", "trade_name")
+	sourceLead := strField(m, "source_lead_id", "lead_id", "id")
+	if sourceLead == "" && cnpj != "" {
+		sourceLead = "cnpj:" + cnpj
+	}
+
+	// Nested company object if present.
+	if co, ok := m["company"].(map[string]any); ok {
+		if v := digitsOnly(strField(co, "cnpj14", "cnpj")); v != "" {
+			cnpj = v
+		}
+		if v := digitsOnly(strField(co, "cnpj_root")); v != "" {
+			root = v
+		}
+		if v := strField(co, "razao_social", "name"); v != "" {
+			razao = v
+		}
+		if v := strField(co, "nome_fantasia"); v != "" {
+			fantasia = v
+		}
+	}
+
+	rank := intField(m, "rank_position", "rank", "priority_rank")
+	if rank == 0 {
+		rank = rankFallback
+	}
+	score := floatField(m, "score_total", "score", "priority_score")
+	tier := strField(m, "priority", "tier", "priority_tier")
+	offerCode := strField(m, "suggested_offer", "service_code", "offer")
+	offerName := strField(m, "service_name", "suggested_offer_name")
+	entry := strField(m, "entry_offer", "next_human_step")
+	state := strField(m, "commercial_state")
+	if state == "" {
+		state = "NEW"
+	}
+
+	momentCode := strField(m, "moment_code", "signal_primary")
+	momentSummary := strField(m, "moment_summary", "explanation", "why")
+	if momentSummary == "" {
+		// signals_fired is common in commercial_leads exports; take first name only.
+		if sigs, ok := m["signals_fired"].([]any); ok && len(sigs) > 0 {
+			switch s := sigs[0].(type) {
+			case string:
+				momentCode = firstNonEmpty(momentCode, s)
+				momentSummary = s
+			case map[string]any:
+				momentCode = firstNonEmpty(momentCode, strField(s, "code", "id", "name"))
+				momentSummary = strField(s, "summary", "label", "name", "code")
+			}
+		}
+	}
+
+	fact := strField(m, "fact_to_mention", "public_fact")
+	question := strField(m, "question_to_ask")
+	cta := strField(m, "cta")
+
+	// messaging_context nested
+	if mc, ok := m["messaging_context"].(map[string]any); ok {
+		fact = firstNonEmpty(fact, strField(mc, "fact_to_mention"))
+		question = firstNonEmpty(question, strField(mc, "question_to_ask"))
+		cta = firstNonEmpty(cta, strField(mc, "cta"))
+	}
+
+	contacts := mapLegacyContacts(m)
+	evidence := mapLegacyEvidence(m)
+
+	var contracts []json.RawMessage
+	if raw, ok := m["contracts"]; ok {
+		if b, err := json.Marshal(raw); err == nil {
+			var arr []json.RawMessage
+			if json.Unmarshal(b, &arr) == nil {
+				contracts = arr
+			}
+		}
+	}
+
+	municipio := strField(m, "municipio", "city")
+	uf := strField(m, "uf", "state")
+	website := strField(m, "website", "site")
+	if co, ok := m["company"].(map[string]any); ok {
+		municipio = firstNonEmpty(municipio, strField(co, "municipio", "city"))
+		uf = firstNonEmpty(uf, strField(co, "uf", "state"))
+		website = firstNonEmpty(website, strField(co, "website"))
+	}
+
+	return FeedLead{
+		SourceLeadID: sourceLead,
+		Company: FeedCompany{
+			CNPJ14:       cnpj,
+			CNPJRoot:     root,
+			RazaoSocial:  razao,
+			NomeFantasia: fantasia,
+			Municipio:    municipio,
+			UF:           uf,
+			Website:      website,
+		},
+		Priority: FeedPriority{
+			Rank:       rank,
+			Score:      score,
+			Tier:       tier,
+			Confidence: strField(m, "confidence", "priority_confidence"),
+		},
+		Moment: FeedMoment{
+			Code:       momentCode,
+			Summary:    momentSummary,
+			ObservedAt: strField(m, "observed_at", "moment_observed_at"),
+			Confidence: strField(m, "moment_confidence"),
+		},
+		Offer: FeedOffer{
+			ServiceCode: offerCode,
+			ServiceName: offerName,
+			EntryOffer:  entry,
+			Rationale:   strField(m, "rationale", "offer_rationale"),
+		},
+		MessagingContext: FeedMessaging{
+			FactToMention: fact,
+			QuestionToAsk: question,
+			CTA:           cta,
+		},
+		Contacts:        contacts,
+		Contracts:       contracts,
+		Evidence:        evidence,
+		CommercialState: state,
+	}
+}
+
+func mapLegacyContacts(m map[string]any) []FeedContact {
+	var out []FeedContact
+	raw, ok := m["contacts"]
+	if !ok {
+		// Flat single contact fields.
+		email := strField(m, "email", "contact_email")
+		name := strField(m, "contact_name", "contato")
+		if email == "" && name == "" {
+			return nil
+		}
+		return []FeedContact{{
+			SourceContactID:    strField(m, "source_contact_id", "contact_id"),
+			Name:               name,
+			Role:               strField(m, "role", "cargo", "contact_role"),
+			Email:              email,
+			Phone:              strField(m, "phone", "telefone"),
+			VerificationStatus: strField(m, "verification_status", "email_status"),
+			Recommended:        true,
+		}}
+	}
+	arr, err := asMapSlice(raw)
+	if err != nil {
+		return nil
+	}
+	for i, c := range arr {
+		sid := strField(c, "source_contact_id", "id", "contact_id")
+		if sid == "" {
+			sid = fmt.Sprintf("legacy-%d", i+1)
+		}
+		out = append(out, FeedContact{
+			SourceContactID:    sid,
+			Name:               strField(c, "name", "nome"),
+			Role:               strField(c, "role", "cargo"),
+			Email:              strField(c, "email"),
+			Phone:              strField(c, "phone", "telefone"),
+			LinkedInURL:        strField(c, "linkedin_url", "linkedin"),
+			SourceURL:          strField(c, "source_url"),
+			SourceDocument:     strField(c, "source_document"),
+			SourceDate:         strField(c, "source_date"),
+			VerificationStatus: strField(c, "verification_status", "status"),
+			Confidence:         strField(c, "confidence"),
+			Recommended:        boolField(c, "recommended", true),
+		})
+	}
+	return out
+}
+
+func mapLegacyEvidence(m map[string]any) []FeedEvidence {
+	raw, ok := m["evidence"]
+	if !ok {
+		// evidence_ids alone cannot invent full evidence rows.
+		return nil
+	}
+	arr, err := asMapSlice(raw)
+	if err != nil {
+		return nil
+	}
+	out := make([]FeedEvidence, 0, len(arr))
+	for i, e := range arr {
+		id := strField(e, "id", "source_evidence_id", "evidence_id")
+		if id == "" {
+			id = fmt.Sprintf("legacy-ev-%d", i+1)
+		}
+		out = append(out, FeedEvidence{
+			ID:             id,
+			Type:           strField(e, "type", "evidence_type"),
+			Title:          strField(e, "title"),
+			URL:            strField(e, "url", "source_url"),
+			Document:       strField(e, "document"),
+			Date:           strField(e, "date", "evidence_date"),
+			Location:       strField(e, "location", "page", "section"),
+			Excerpt:        strField(e, "excerpt", "snippet", "trecho"),
+			Synthesis:      strField(e, "synthesis", "summary"),
+			EpistemicClass: strField(e, "epistemic_class", "class"),
+			Reliability:    strField(e, "reliability"),
+			ConsultedAt:    strField(e, "consulted_at"),
+		})
+	}
+	return out
+}
+
+func asMapSlice(v any) ([]map[string]any, error) {
+	if v == nil {
+		return nil, nil
+	}
+	switch t := v.(type) {
+	case []map[string]any:
+		return t, nil
+	case []any:
+		out := make([]map[string]any, 0, len(t))
+		for _, item := range t {
+			m, ok := item.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("lead item is not an object")
+			}
+			out = append(out, m)
+		}
+		return out, nil
+	default:
+		// Re-marshal path for typed JSON.
+		b, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		var out []map[string]any
+		if err := json.Unmarshal(b, &out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+}
+
+func strField(m map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch t := v.(type) {
+			case string:
+				return strings.TrimSpace(t)
+			case float64:
+				// JSON numbers
+				if t == float64(int64(t)) {
+					return strconv.FormatInt(int64(t), 10)
+				}
+				return strconv.FormatFloat(t, 'f', -1, 64)
+			case json.Number:
+				return t.String()
+			case bool:
+				return strconv.FormatBool(t)
+			}
+		}
+	}
+	return ""
+}
+
+func intField(m map[string]any, keys ...string) int {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch t := v.(type) {
+			case float64:
+				return int(t)
+			case int:
+				return t
+			case int64:
+				return int(t)
+			case string:
+				n, _ := strconv.Atoi(strings.TrimSpace(t))
+				return n
+			case json.Number:
+				n, _ := t.Int64()
+				return int(n)
+			}
+		}
+	}
+	return 0
+}
+
+func floatField(m map[string]any, keys ...string) float64 {
+	for _, k := range keys {
+		if v, ok := m[k]; ok && v != nil {
+			switch t := v.(type) {
+			case float64:
+				return t
+			case int:
+				return float64(t)
+			case int64:
+				return float64(t)
+			case string:
+				f, _ := strconv.ParseFloat(strings.TrimSpace(t), 64)
+				return f
+			case json.Number:
+				f, _ := t.Float64()
+				return f
+			}
+		}
+	}
+	return 0
+}
+
+func boolField(m map[string]any, key string, def bool) bool {
+	v, ok := m[key]
+	if !ok || v == nil {
+		return def
+	}
+	switch t := v.(type) {
+	case bool:
+		return t
+	case string:
+		b, err := strconv.ParseBool(t)
+		if err != nil {
+			return def
+		}
+		return b
+	default:
+		return def
+	}
+}
+
+func firstNonEmpty(vals ...string) string {
+	for _, v := range vals {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/internal/app/confenge/outcomes.go
+++ b/internal/app/confenge/outcomes.go
@@ -1,0 +1,147 @@
+package confenge
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Outcome event types for confenge.outcome.v1.
+const (
+	OutcomeLeadImported    = "LEAD_IMPORTED"
+	OutcomeLeadReviewed    = "LEAD_REVIEWED"
+	OutcomeContactApproved = "CONTACT_APPROVED"
+	OutcomeContacted       = "CONTACTED"
+	OutcomeReplied         = "REPLIED"
+	OutcomeMeeting         = "MEETING"
+	OutcomeProposal        = "PROPOSAL"
+	OutcomeWon             = "WON"
+	OutcomeLost            = "LOST"
+	OutcomeDoNotContact    = "DO_NOT_CONTACT"
+	OutcomeBounced         = "BOUNCED"
+)
+
+// OutcomeEnvelope is the payload posted to extra-cli.
+type OutcomeEnvelope struct {
+	SchemaVersion  string         `json:"schema_version"`
+	EventID        string         `json:"event_id"`
+	IdempotencyKey string         `json:"idempotency_key"`
+	OccurredAt     string         `json:"occurred_at"`
+	Source         string         `json:"source"`
+	SourceLeadID   string         `json:"source_lead_id"`
+	CNPJ14         string         `json:"cnpj14"`
+	ContactEmail   string         `json:"contact_email"`
+	EventType      string         `json:"event_type"`
+	CampaignID     string         `json:"campaign_id,omitempty"`
+	MessageID      string         `json:"message_id,omitempty"`
+	Metadata       map[string]any `json:"metadata,omitempty"`
+}
+
+// EnqueueOutcome records an async outbox row (idempotent by key).
+func (s *service) EnqueueOutcome(ctx context.Context, orgID uuid.UUID, ev models.OutreachOutcome) *errx.Error {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return xerr
+	}
+	if strings.TrimSpace(ev.IdempotencyKey) == "" {
+		return errx.New(errx.BadRequest, "idempotency_key is required")
+	}
+	if strings.TrimSpace(ev.EventType) == "" {
+		return errx.New(errx.BadRequest, "event_type is required")
+	}
+	if ev.OccurredAt.IsZero() {
+		ev.OccurredAt = time.Now().UTC()
+	}
+	ev.OrganizationID = orgID
+	if err := s.repo.EnqueueOutcome(ctx, &ev); err != nil {
+		// unique violation → already queued
+		if strings.Contains(err.Error(), "duplicate") || strings.Contains(err.Error(), "unique") {
+			return nil
+		}
+		return errx.New(errx.Internal, "failed to enqueue outcome: "+err.Error())
+	}
+	return nil
+}
+
+// SignOutcomeHMAC builds the signature header value: t=<unix>,v1=<hex>.
+func SignOutcomeHMAC(secret string, ts time.Time, body []byte) string {
+	msg := fmt.Sprintf("%d.", ts.Unix()) + string(body)
+	mac := hmac.New(sha256.New, []byte(secret))
+	_, _ = mac.Write([]byte(msg))
+	return "t=" + strconv.FormatInt(ts.Unix(), 10) + ",v1=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyOutcomeHMAC checks timestamp skew and constant-time signature.
+func VerifyOutcomeHMAC(secret, header string, body []byte, now time.Time, maxSkew time.Duration) bool {
+	// header: t=...,v1=...
+	var tUnix int64
+	var sig string
+	for _, part := range strings.Split(header, ",") {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "t=") {
+			tUnix, _ = strconv.ParseInt(strings.TrimPrefix(part, "t="), 10, 64)
+		}
+		if strings.HasPrefix(part, "v1=") {
+			sig = strings.TrimPrefix(part, "v1=")
+		}
+	}
+	if tUnix == 0 || sig == "" {
+		return false
+	}
+	ts := time.Unix(tUnix, 0).UTC()
+	if now.Sub(ts) > maxSkew || ts.Sub(now) > maxSkew {
+		return false
+	}
+	expected := SignOutcomeHMAC(secret, ts, body)
+	// Compare only the v1 portion for constant-time on hex.
+	want := strings.TrimPrefix(strings.Split(expected, ",v1=")[1], "")
+	return hmac.Equal([]byte(want), []byte(sig))
+}
+
+// BuildOutcomeEnvelope maps a stored row to the wire contract.
+func BuildOutcomeEnvelope(ev *models.OutreachOutcome) OutcomeEnvelope {
+	meta := map[string]any{}
+	if len(ev.Payload) > 0 {
+		_ = json.Unmarshal(ev.Payload, &meta)
+	}
+	return OutcomeEnvelope{
+		SchemaVersion:  models.OutreachOutcomeSchemaV1,
+		EventID:        ev.EventID.String(),
+		IdempotencyKey: ev.IdempotencyKey,
+		OccurredAt:     ev.OccurredAt.UTC().Format(time.RFC3339),
+		Source:         "warmbly",
+		SourceLeadID:   ev.SourceLeadID,
+		CNPJ14:         ev.CNPJ14,
+		ContactEmail:   ev.ContactEmail,
+		EventType:      ev.EventType,
+		Metadata:       meta,
+	}
+}
+
+// OutcomeBackoff grows attempts: 30s, 1m, 2m, 5m, 15m, 1h (cap).
+func OutcomeBackoff(attempt int) time.Duration {
+	switch {
+	case attempt <= 1:
+		return 30 * time.Second
+	case attempt == 2:
+		return time.Minute
+	case attempt == 3:
+		return 2 * time.Minute
+	case attempt == 4:
+		return 5 * time.Minute
+	case attempt == 5:
+		return 15 * time.Minute
+	default:
+		return time.Hour
+	}
+}

--- a/internal/app/confenge/outcomes_test.go
+++ b/internal/app/confenge/outcomes_test.go
@@ -1,0 +1,35 @@
+package confenge
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSignAndVerifyOutcomeHMAC(t *testing.T) {
+	secret := "whsec_test"
+	body := []byte(`{"event_type":"REPLIED"}`)
+	ts := time.Unix(1700000000, 0).UTC()
+	hdr := SignOutcomeHMAC(secret, ts, body)
+	if !VerifyOutcomeHMAC(secret, hdr, body, ts, 5*time.Minute) {
+		t.Fatal("valid signature rejected")
+	}
+	if VerifyOutcomeHMAC("other", hdr, body, ts, 5*time.Minute) {
+		t.Fatal("wrong secret accepted")
+	}
+	if VerifyOutcomeHMAC(secret, hdr, []byte(`{}`), ts, 5*time.Minute) {
+		t.Fatal("tampered body accepted")
+	}
+	// Outside skew window
+	if VerifyOutcomeHMAC(secret, hdr, body, ts.Add(10*time.Minute), 5*time.Minute) {
+		t.Fatal("stale timestamp accepted")
+	}
+}
+
+func TestOutcomeBackoffGrows(t *testing.T) {
+	if OutcomeBackoff(1) != 30*time.Second {
+		t.Fatal(OutcomeBackoff(1))
+	}
+	if OutcomeBackoff(6) != time.Hour {
+		t.Fatal(OutcomeBackoff(6))
+	}
+}

--- a/internal/app/confenge/schema.go
+++ b/internal/app/confenge/schema.go
@@ -100,19 +100,23 @@ type FeedMessaging struct {
 }
 
 // FeedContact is a candidate recipient (may lack email).
+// Phone remains a legacy string; PhoneObj + WhatsApp are optional additive
+// fields for structured provenance (backward compatible with older feeds).
 type FeedContact struct {
-	SourceContactID    string `json:"source_contact_id"`
-	Name               string `json:"name"`
-	Role               string `json:"role"`
-	Email              string `json:"email"`
-	Phone              string `json:"phone"`
-	LinkedInURL        string `json:"linkedin_url"`
-	SourceURL          string `json:"source_url"`
-	SourceDocument     string `json:"source_document"`
-	SourceDate         string `json:"source_date"`
-	VerificationStatus string `json:"verification_status"`
-	Confidence         string `json:"confidence"`
-	Recommended        bool   `json:"recommended"`
+	SourceContactID    string        `json:"source_contact_id"`
+	Name               string        `json:"name"`
+	Role               string        `json:"role"`
+	Email              string        `json:"email"`
+	Phone              string        `json:"phone"`
+	PhoneObj           *FeedPhone    `json:"phone_detail,omitempty"`
+	WhatsApp           *FeedWhatsApp `json:"whatsapp,omitempty"`
+	LinkedInURL        string        `json:"linkedin_url"`
+	SourceURL          string        `json:"source_url"`
+	SourceDocument     string        `json:"source_document"`
+	SourceDate         string        `json:"source_date"`
+	VerificationStatus string        `json:"verification_status"`
+	Confidence         string        `json:"confidence"`
+	Recommended        bool          `json:"recommended"`
 }
 
 // FeedEvidence is one evidence item (text only; HTML stripped on import).

--- a/internal/app/confenge/schema.go
+++ b/internal/app/confenge/schema.go
@@ -1,0 +1,423 @@
+package confenge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+	"unicode/utf8"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Native feed contract: confenge.outreach.v1
+
+// Feed is the top-level document produced by extra-cli (or fixtures).
+type Feed struct {
+	SchemaVersion string         `json:"schema_version"`
+	GeneratedAt   string         `json:"generated_at"`
+	Source        FeedSource     `json:"source"`
+	Pagination    FeedPagination `json:"pagination"`
+	Leads         []FeedLead     `json:"leads"`
+}
+
+// FeedSource identifies the producing intelligence-plane run.
+type FeedSource struct {
+	System         string `json:"system"`
+	RunID          string `json:"run_id"`
+	SnapshotHash   string `json:"snapshot_hash"`
+	RepoSHA        string `json:"repo_sha"`
+	ProfileID      string `json:"profile_id"`
+	ProfileVersion string `json:"profile_version"`
+}
+
+// FeedPagination supports paged feeds; all fields optional.
+type FeedPagination struct {
+	Cursor     *string `json:"cursor"`
+	NextCursor *string `json:"next_cursor"`
+	HasMore    bool    `json:"has_more"`
+}
+
+// FeedLead is one company opportunity in the feed.
+type FeedLead struct {
+	SourceLeadID     string            `json:"source_lead_id"`
+	Company          FeedCompany       `json:"company"`
+	Priority         FeedPriority      `json:"priority"`
+	Moment           FeedMoment        `json:"moment"`
+	Offer            FeedOffer         `json:"offer"`
+	MessagingContext FeedMessaging     `json:"messaging_context"`
+	Contacts         []FeedContact     `json:"contacts"`
+	Contracts        []json.RawMessage `json:"contracts"`
+	Evidence         []FeedEvidence    `json:"evidence"`
+	CommercialState  string            `json:"commercial_state"`
+}
+
+// FeedCompany is Brazilian company identity from the datalake.
+type FeedCompany struct {
+	CNPJ14       string `json:"cnpj14"`
+	CNPJRoot     string `json:"cnpj_root"`
+	RazaoSocial  string `json:"razao_social"`
+	NomeFantasia string `json:"nome_fantasia"`
+	Municipio    string `json:"municipio"`
+	UF           string `json:"uf"`
+	Website      string `json:"website"`
+}
+
+// FeedPriority is rank/score from extra-cli (stored, never re-scored here).
+type FeedPriority struct {
+	Rank       int     `json:"rank"`
+	Score      float64 `json:"score"`
+	Tier       string  `json:"tier"`
+	Confidence string  `json:"confidence"`
+}
+
+// FeedMoment is the commercial moment / fato gerador.
+type FeedMoment struct {
+	Code        string   `json:"code"`
+	Summary     string   `json:"summary"`
+	ObservedAt  string   `json:"observed_at"`
+	Confidence  string   `json:"confidence"`
+	EvidenceIDs []string `json:"evidence_ids"`
+}
+
+// FeedOffer is the suggested service entry offer.
+type FeedOffer struct {
+	ServiceCode string `json:"service_code"`
+	ServiceName string `json:"service_name"`
+	EntryOffer  string `json:"entry_offer"`
+	Rationale   string `json:"rationale"`
+}
+
+// FeedMessaging is structured messaging context for generation.
+type FeedMessaging struct {
+	FactToMention string   `json:"fact_to_mention"`
+	QuestionToAsk string   `json:"question_to_ask"`
+	CTA           string   `json:"cta"`
+	ClaimsToAvoid []string `json:"claims_to_avoid"`
+}
+
+// FeedContact is a candidate recipient (may lack email).
+type FeedContact struct {
+	SourceContactID    string `json:"source_contact_id"`
+	Name               string `json:"name"`
+	Role               string `json:"role"`
+	Email              string `json:"email"`
+	Phone              string `json:"phone"`
+	LinkedInURL        string `json:"linkedin_url"`
+	SourceURL          string `json:"source_url"`
+	SourceDocument     string `json:"source_document"`
+	SourceDate         string `json:"source_date"`
+	VerificationStatus string `json:"verification_status"`
+	Confidence         string `json:"confidence"`
+	Recommended        bool   `json:"recommended"`
+}
+
+// FeedEvidence is one evidence item (text only; HTML stripped on import).
+type FeedEvidence struct {
+	ID             string `json:"id"`
+	Type           string `json:"type"`
+	Title          string `json:"title"`
+	URL            string `json:"url"`
+	Document       string `json:"document"`
+	Date           string `json:"date"`
+	Location       string `json:"location"`
+	Excerpt        string `json:"excerpt"`
+	Synthesis      string `json:"synthesis"`
+	EpistemicClass string `json:"epistemic_class"`
+	Reliability    string `json:"reliability"`
+	ConsultedAt    string `json:"consulted_at"`
+}
+
+var (
+	cnpj14Re   = regexp.MustCompile(`^\d{14}$`)
+	cnpjRootRe = regexp.MustCompile(`^\d{8}$`)
+)
+
+var allowedVerification = map[string]bool{
+	models.OutreachVerifyOfficialSource:       true,
+	models.OutreachVerifyPublicDocumentRecent: true,
+	models.OutreachVerifyMultipleSources:      true,
+	models.OutreachVerifyInstitutionalGeneric: true,
+	models.OutreachVerifyPublicPossiblyStale:  true,
+	models.OutreachVerifyCandidateUnverified:  true,
+	models.OutreachVerifyNotFound:             true,
+	models.OutreachVerifyInvalid:              true,
+	models.OutreachVerifyBounced:              true,
+	models.OutreachVerifyDoNotContact:         true,
+}
+
+var allowedEpistemic = map[string]bool{
+	models.OutreachEpistemicConfirmedFact:          true,
+	models.OutreachEpistemicStrongInference:        true,
+	models.OutreachEpistemicWeakInference:          true,
+	models.OutreachEpistemicCommercialHypothesis:   true,
+	models.OutreachEpistemicNotFound:               true,
+	models.OutreachEpistemicRequiresCompanyConfirm: true,
+	models.OutreachEpistemicContradictoryEvidence:  true,
+}
+
+// ParseFeed unmarshals JSON bytes into a Feed. Does not invent missing fields.
+func ParseFeed(raw []byte) (*Feed, error) {
+	if len(raw) == 0 {
+		return nil, fmt.Errorf("empty payload")
+	}
+	var f Feed
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return nil, fmt.Errorf("invalid JSON: %w", err)
+	}
+	return &f, nil
+}
+
+// ValidateFeed checks schema_version and required identity fields.
+// Per-lead errors are returned separately so a run can continue.
+func ValidateFeed(f *Feed) error {
+	if f == nil {
+		return fmt.Errorf("nil feed")
+	}
+	if f.SchemaVersion != models.OutreachSchemaV1 {
+		return fmt.Errorf("unsupported schema_version %q (want %s)", f.SchemaVersion, models.OutreachSchemaV1)
+	}
+	if strings.TrimSpace(f.Source.System) == "" {
+		return fmt.Errorf("source.system is required")
+	}
+	return nil
+}
+
+// LeadValidationError is a non-fatal per-lead problem.
+type LeadValidationError struct {
+	Index        int
+	SourceLeadID string
+	CNPJ14       string
+	Message      string
+}
+
+// ValidateLead checks one lead. Missing contact is allowed (NEEDS_CONTACT).
+func ValidateLead(i int, lead FeedLead) *LeadValidationError {
+	cnpj := digitsOnly(lead.Company.CNPJ14)
+	sid := strings.TrimSpace(lead.SourceLeadID)
+	if cnpj == "" {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, Message: "company.cnpj14 is required"}
+	}
+	if !cnpj14Re.MatchString(cnpj) {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, CNPJ14: cnpj, Message: "company.cnpj14 must be 14 digits"}
+	}
+	if root := digitsOnly(lead.Company.CNPJRoot); root != "" && !cnpjRootRe.MatchString(root) {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, CNPJ14: cnpj, Message: "company.cnpj_root must be 8 digits when set"}
+	}
+	if strings.TrimSpace(lead.Company.RazaoSocial) == "" && strings.TrimSpace(lead.Company.NomeFantasia) == "" {
+		return &LeadValidationError{Index: i, SourceLeadID: sid, CNPJ14: cnpj, Message: "company needs razao_social or nome_fantasia"}
+	}
+	for j, c := range lead.Contacts {
+		vs := strings.TrimSpace(c.VerificationStatus)
+		if vs != "" && !allowedVerification[vs] {
+			return &LeadValidationError{
+				Index: i, SourceLeadID: sid, CNPJ14: cnpj,
+				Message: fmt.Sprintf("contacts[%d].verification_status %q is not allowed", j, vs),
+			}
+		}
+	}
+	for j, e := range lead.Evidence {
+		ec := strings.TrimSpace(e.EpistemicClass)
+		if ec != "" && !allowedEpistemic[ec] {
+			return &LeadValidationError{
+				Index: i, SourceLeadID: sid, CNPJ14: cnpj,
+				Message: fmt.Sprintf("evidence[%d].epistemic_class %q is not allowed", j, ec),
+			}
+		}
+		if strings.TrimSpace(e.ID) == "" {
+			return &LeadValidationError{
+				Index: i, SourceLeadID: sid, CNPJ14: cnpj,
+				Message: fmt.Sprintf("evidence[%d].id is required", j),
+			}
+		}
+	}
+	return nil
+}
+
+// CanonicalPayloadHash is a stable SHA-256 of the raw payload bytes (hex).
+// Callers that re-serialize should use the original bytes for idempotency.
+func CanonicalPayloadHash(raw []byte) string {
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:])
+}
+
+// LeadContentHash hashes the lead's machine-owned fields for change detection.
+func LeadContentHash(lead FeedLead) string {
+	// Exclude human-only outcomes; include messaging, priority, moment, offer, contacts, evidence ids.
+	type slim struct {
+		SourceLeadID string         `json:"source_lead_id"`
+		Company      FeedCompany    `json:"company"`
+		Priority     FeedPriority   `json:"priority"`
+		Moment       FeedMoment     `json:"moment"`
+		Offer        FeedOffer      `json:"offer"`
+		Messaging    FeedMessaging  `json:"messaging_context"`
+		Contacts     []FeedContact  `json:"contacts"`
+		Evidence     []FeedEvidence `json:"evidence"`
+		State        string         `json:"commercial_state"`
+	}
+	b, _ := json.Marshal(slim{
+		SourceLeadID: lead.SourceLeadID,
+		Company:      lead.Company,
+		Priority:     lead.Priority,
+		Moment:       lead.Moment,
+		Offer:        lead.Offer,
+		Messaging:    lead.MessagingContext,
+		Contacts:     lead.Contacts,
+		Evidence:     lead.Evidence,
+		State:        lead.CommercialState,
+	})
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// NormalizeCNPJ14 returns digits-only 14-char CNPJ or empty.
+func NormalizeCNPJ14(s string) string {
+	d := digitsOnly(s)
+	if !cnpj14Re.MatchString(d) {
+		return ""
+	}
+	return d
+}
+
+// SanitizeText strips control chars and truncates; never invents content.
+func SanitizeText(s string, maxRunes int) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	// Drop HTML tags roughly (no script execution surface).
+	s = stripTags(s)
+	s = strings.Map(func(r rune) rune {
+		if r < 32 && r != '\n' && r != '\t' {
+			return -1
+		}
+		return r
+	}, s)
+	if maxRunes > 0 && utf8.RuneCountInString(s) > maxRunes {
+		runes := []rune(s)
+		s = string(runes[:maxRunes])
+	}
+	return s
+}
+
+func stripTags(s string) string {
+	// Simple angle-bracket strip; feed must not carry executable HTML.
+	var b strings.Builder
+	b.Grow(len(s))
+	in := false
+	for _, r := range s {
+		switch {
+		case r == '<':
+			in = true
+		case r == '>':
+			in = false
+		case !in:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func digitsOnly(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+// ParseDate accepts YYYY-MM-DD or RFC3339 date portion; empty -> nil.
+func ParseDate(s string) *time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	if t, err := time.Parse("2006-01-02", s); err == nil {
+		return &t
+	}
+	if t, err := time.Parse(time.RFC3339, s); err == nil {
+		d := time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, time.UTC)
+		return &d
+	}
+	// Date-only prefix of datetime
+	if len(s) >= 10 {
+		if t, err := time.Parse("2006-01-02", s[:10]); err == nil {
+			return &t
+		}
+	}
+	return nil
+}
+
+// DefaultQueueState for a lead after import (no invention of contacts).
+func DefaultQueueState(lead FeedLead, existing *models.OutreachAccount) string {
+	// Preserve human terminal states.
+	if existing != nil {
+		if existing.DoNotContact || existing.QueueState == models.OutreachQueueDoNotContact {
+			return models.OutreachQueueDoNotContact
+		}
+		if existing.Blocked || existing.QueueState == models.OutreachQueueBlocked {
+			return models.OutreachQueueBlocked
+		}
+		// Do not silently restart post-send states.
+		switch existing.QueueState {
+		case models.OutreachQueueEnrolled, models.OutreachQueueSent, models.OutreachQueueReplied,
+			models.OutreachQueueMeeting, models.OutreachQueueProposal, models.OutreachQueueWon,
+			models.OutreachQueueLost, models.OutreachQueueSkipped, models.OutreachQueueBounced,
+			models.OutreachQueueApproved, models.OutreachQueueNeedsReview:
+			return existing.QueueState
+		}
+	}
+	if hasEnrollableContact(lead) {
+		return models.OutreachQueueReadyToGenerate
+	}
+	return models.OutreachQueueNeedsContact
+}
+
+func hasEnrollableContact(lead FeedLead) bool {
+	for _, c := range lead.Contacts {
+		email := strings.TrimSpace(c.Email)
+		if email == "" {
+			continue
+		}
+		vs := strings.TrimSpace(c.VerificationStatus)
+		if vs == "" {
+			vs = models.OutreachVerifyCandidateUnverified
+		}
+		if models.OutreachUnenrollableVerification[vs] {
+			continue
+		}
+		if vs == models.OutreachVerifyDoNotContact {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+// NormalizeVerification returns a known status or CANDIDATE_UNVERIFIED when
+// email is present without status; NOT_FOUND when empty.
+func NormalizeVerification(status, email string) string {
+	status = strings.TrimSpace(status)
+	email = strings.TrimSpace(email)
+	if status != "" && allowedVerification[status] {
+		return status
+	}
+	if email == "" {
+		return models.OutreachVerifyNotFound
+	}
+	return models.OutreachVerifyCandidateUnverified
+}
+
+// NormalizeEpistemic defaults missing class to COMMERCIAL_HYPOTHESIS.
+func NormalizeEpistemic(class string) string {
+	class = strings.TrimSpace(class)
+	if class != "" && allowedEpistemic[class] {
+		return class
+	}
+	return models.OutreachEpistemicCommercialHypothesis
+}

--- a/internal/app/confenge/schema_test.go
+++ b/internal/app/confenge/schema_test.go
@@ -1,0 +1,305 @@
+package confenge
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestParseAndValidateNativeFeed(t *testing.T) {
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	feed, err := ParseFeed(raw)
+	if err != nil {
+		t.Fatalf("ParseFeed: %v", err)
+	}
+	if err := ValidateFeed(feed); err != nil {
+		t.Fatalf("ValidateFeed: %v", err)
+	}
+	if feed.SchemaVersion != models.OutreachSchemaV1 {
+		t.Fatalf("schema %q", feed.SchemaVersion)
+	}
+	if len(feed.Leads) < 5 {
+		t.Fatalf("want >=5 leads, got %d", len(feed.Leads))
+	}
+	// Company without email must validate (NEEDS_CONTACT later).
+	var noEmail bool
+	for i, lead := range feed.Leads {
+		if lv := ValidateLead(i, lead); lv != nil {
+			t.Fatalf("lead %d invalid: %s", i, lv.Message)
+		}
+		if !hasEnrollableContact(lead) {
+			noEmail = true
+			if DefaultQueueState(lead, nil) != models.OutreachQueueNeedsContact {
+				t.Fatalf("lead without email should be NEEDS_CONTACT")
+			}
+		}
+	}
+	if !noEmail {
+		t.Fatal("fixture should include a lead without enrollable contact")
+	}
+}
+
+func TestRejectInvalidSchemaVersion(t *testing.T) {
+	raw := []byte(`{"schema_version":"nope","source":{"system":"x"},"leads":[]}`)
+	feed, err := ParseFeed(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateFeed(feed); err == nil {
+		t.Fatal("expected schema version error")
+	}
+}
+
+func TestRejectBadCNPJ(t *testing.T) {
+	lead := FeedLead{
+		SourceLeadID: "x",
+		Company:      FeedCompany{CNPJ14: "123", RazaoSocial: "ACME"},
+	}
+	if lv := ValidateLead(0, lead); lv == nil {
+		t.Fatal("expected cnpj error")
+	}
+}
+
+func TestCanonicalPayloadHashStable(t *testing.T) {
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	a := CanonicalPayloadHash(raw)
+	b := CanonicalPayloadHash(raw)
+	if a != b || len(a) != 64 {
+		t.Fatalf("hash unstable or wrong length: %s", a)
+	}
+	other := append([]byte{}, raw...)
+	other[len(other)-2] = 'x'
+	if CanonicalPayloadHash(other) == a {
+		t.Fatal("different payload should hash differently")
+	}
+}
+
+func TestLeadContentHashChangesWithScore(t *testing.T) {
+	lead := FeedLead{
+		SourceLeadID: "1",
+		Company:      FeedCompany{CNPJ14: "11222333000181", RazaoSocial: "ACME"},
+		Priority:     FeedPriority{Score: 10},
+	}
+	h1 := LeadContentHash(lead)
+	lead.Priority.Score = 20
+	h2 := LeadContentHash(lead)
+	if h1 == h2 {
+		t.Fatal("score change must change content hash")
+	}
+}
+
+func TestSanitizeTextStripsTagsAndControl(t *testing.T) {
+	in := "<script>alert(1)</script>Hello\x00World"
+	out := SanitizeText(in, 100)
+	if out != "alert(1)HelloWorld" && out != "HelloWorld" {
+		// stripTags leaves inner text of script; control stripped
+		if containsAngle(out) {
+			t.Fatalf("tags remain: %q", out)
+		}
+	}
+	if containsAngle(out) {
+		t.Fatalf("angle brackets remain: %q", out)
+	}
+}
+
+func containsAngle(s string) bool {
+	for _, r := range s {
+		if r == '<' || r == '>' {
+			return true
+		}
+	}
+	return false
+}
+
+func TestUnenrollableVerification(t *testing.T) {
+	cases := []struct {
+		vs   string
+		want bool
+	}{
+		{models.OutreachVerifyOfficialSource, true},
+		{models.OutreachVerifyInstitutionalGeneric, true},
+		{models.OutreachVerifyCandidateUnverified, false},
+		{models.OutreachVerifyNotFound, false},
+		{models.OutreachVerifyInvalid, false},
+		{models.OutreachVerifyBounced, false},
+		{models.OutreachVerifyDoNotContact, false},
+	}
+	for _, tc := range cases {
+		c := &models.OutreachContactCandidate{
+			Email:              "a@example.com",
+			VerificationStatus: tc.vs,
+		}
+		if c.CanEnroll() != tc.want {
+			t.Errorf("%s CanEnroll=%v want %v", tc.vs, c.CanEnroll(), tc.want)
+		}
+	}
+}
+
+func TestDefaultQueueStatePreservesDNC(t *testing.T) {
+	lead := FeedLead{
+		Company:  FeedCompany{CNPJ14: "11222333000181", RazaoSocial: "X"},
+		Contacts: []FeedContact{{Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource}},
+	}
+	existing := &models.OutreachAccount{
+		DoNotContact: true,
+		QueueState:   models.OutreachQueueDoNotContact,
+	}
+	if DefaultQueueState(lead, existing) != models.OutreachQueueDoNotContact {
+		t.Fatal("DNC must be preserved on reimport")
+	}
+}
+
+func TestDefaultQueueStatePreservesSent(t *testing.T) {
+	lead := FeedLead{
+		Company:  FeedCompany{CNPJ14: "11222333000181", RazaoSocial: "X"},
+		Contacts: []FeedContact{{Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource}},
+	}
+	existing := &models.OutreachAccount{QueueState: models.OutreachQueueSent}
+	if DefaultQueueState(lead, existing) != models.OutreachQueueSent {
+		t.Fatal("SENT must not restart on reimport")
+	}
+}
+
+func TestLegacyLeadsArrayNormalizes(t *testing.T) {
+	raw := mustReadFixture(t, "legacy_leads_array.json")
+	feed, err := DetectAndNormalize(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if feed.SchemaVersion != models.OutreachSchemaV1 {
+		t.Fatalf("normalized schema %q", feed.SchemaVersion)
+	}
+	if len(feed.Leads) != 3 {
+		t.Fatalf("want 3 leads, got %d", len(feed.Leads))
+	}
+	// No invented email on contactless company
+	var missing bool
+	for _, l := range feed.Leads {
+		if !hasEnrollableContact(l) {
+			missing = true
+		}
+		if NormalizeCNPJ14(l.Company.CNPJ14) == "" {
+			t.Fatalf("cnpj not normalized: %q", l.Company.CNPJ14)
+		}
+	}
+	if !missing {
+		t.Fatal("legacy fixture should include company without contact")
+	}
+}
+
+func TestLegacyDoesNotInventMissingFields(t *testing.T) {
+	raw := []byte(`[{"cnpj14":"11222333000181","razao_social":"Only Name"}]`)
+	feed, err := DetectAndNormalize(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	l := feed.Leads[0]
+	if l.Offer.ServiceCode != "" || l.MessagingContext.FactToMention != "" {
+		t.Fatalf("must not invent offer/fact: %+v", l)
+	}
+	if len(l.Contacts) != 0 {
+		t.Fatalf("must not invent contacts: %+v", l.Contacts)
+	}
+}
+
+func TestHostAllowlist(t *testing.T) {
+	if !hostAllowed("feed.example.com", []string{"example.com"}) {
+		t.Fatal("subdomain should match parent allow")
+	}
+	if hostAllowed("evil.com", []string{"example.com"}) {
+		t.Fatal("unrelated host must not match")
+	}
+	if !hostAllowed("example.com", []string{"example.com"}) {
+		t.Fatal("exact host should match")
+	}
+}
+
+func TestConfigDefaultsOff(t *testing.T) {
+	t.Setenv(EnvEnabled, "")
+	t.Setenv(EnvAutoSend, "")
+	cfg := LoadConfig()
+	if cfg.Enabled || cfg.AutoSendEnabled {
+		t.Fatal("feature must default off")
+	}
+	if !cfg.RequireHumanApproval {
+		t.Fatal("human approval must default true")
+	}
+}
+
+func TestConfigValidateProdHTTPS(t *testing.T) {
+	cfg := Config{
+		Enabled:      true,
+		FeedURL:      "http://insecure.example.com/feed",
+		AllowedHosts: []string{"insecure.example.com"},
+	}
+	if err := cfg.ValidateStartup("prod"); err == nil {
+		t.Fatal("prod must require https feed")
+	}
+	cfg.FeedURL = "https://feed.example.com/x"
+	cfg.AllowedHosts = nil
+	if err := cfg.ValidateStartup("prod"); err == nil {
+		t.Fatal("prod must require allowlist when feed set")
+	}
+}
+
+func TestForbiddenWordsNotInFixtureSubjects(t *testing.T) {
+	// Structural: native fixture messaging must not use prohibited outreach phrases.
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	var feed Feed
+	if err := json.Unmarshal(raw, &feed); err != nil {
+		t.Fatal(err)
+	}
+	banned := []string{"dinheiro a receber", "crédito identificado", "lead quente"}
+	for _, l := range feed.Leads {
+		blob := l.MessagingContext.FactToMention + l.MessagingContext.QuestionToAsk + l.MessagingContext.CTA
+		for _, b := range banned {
+			if containsFold(blob, b) {
+				t.Fatalf("fixture contains banned phrase %q", b)
+			}
+		}
+	}
+}
+
+func containsFold(s, sub string) bool {
+	return len(sub) > 0 && (s == sub || len(s) >= len(sub) &&
+		(json.Valid([]byte(`"`+s+`"`)) && // keep compiler happy path
+			false || stringContainsFold(s, sub)))
+}
+
+func stringContainsFold(s, sub string) bool {
+	// simple ASCII fold
+	ls, lsub := []rune(s), []rune(sub)
+	for i := 0; i+len(lsub) <= len(ls); i++ {
+		match := true
+		for j := range lsub {
+			a, b := ls[i+j], lsub[j]
+			if a >= 'A' && a <= 'Z' {
+				a += 32
+			}
+			if b >= 'A' && b <= 'Z' {
+				b += 32
+			}
+			if a != b {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func mustReadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	p := filepath.Join("testdata", name)
+	b, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return b
+}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -44,6 +44,7 @@ type Service interface {
 	ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, *errx.Error)
 	ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.UUID, action string, edit *DraftEdit) (*models.OutreachDraft, *errx.Error)
 	SetAI(p generation.Provider)
+	EnqueueOutcome(ctx context.Context, orgID uuid.UUID, ev models.OutreachOutcome) *errx.Error
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/generation"
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
@@ -36,6 +37,13 @@ type Service interface {
 	ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, *errx.Error)
 	GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, *errx.Error)
 	BlockAccount(ctx context.Context, orgID, userID, id uuid.UUID, reason string, dnc bool) (*models.OutreachAccount, *errx.Error)
+
+	// Drafts / review (PR2)
+	GenerateDraft(ctx context.Context, orgID, userID, accountID uuid.UUID, contactID *uuid.UUID) (*models.OutreachDraft, *errx.Error)
+	GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, *errx.Error)
+	ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, *errx.Error)
+	ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.UUID, action string, edit *DraftEdit) (*models.OutreachDraft, *errx.Error)
+	SetAI(p generation.Provider)
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.
@@ -50,6 +58,7 @@ type service struct {
 	repo  repository.OutreachRepository
 	audit AuditLogger
 	fetch *FeedFetcher
+	ai    generation.Provider
 }
 
 // NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.
@@ -64,6 +73,22 @@ func NewService(cfg Config, repo repository.OutreachRepository, audit AuditLogge
 			MaxBytes:     cfg.MaxFeedPayloadBytes,
 		},
 	}
+}
+
+// NewServiceWithAI wires confenge with an optional LLM provider for drafts.
+func NewServiceWithAI(cfg Config, repo repository.OutreachRepository, audit AuditLogger, ai generation.Provider) Service {
+	svc := &service{
+		cfg:   cfg,
+		repo:  repo,
+		audit: audit,
+		fetch: &FeedFetcher{
+			AllowedHosts: cfg.AllowedHosts,
+			Token:        cfg.FeedToken,
+			MaxBytes:     cfg.MaxFeedPayloadBytes,
+		},
+		ai: ai,
+	}
+	return svc
 }
 
 func (s *service) Enabled() bool  { return s.cfg.Enabled }

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -1,0 +1,500 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// AuditLogger writes org-scoped audit entries (realtime spine).
+type AuditLogger interface {
+	LogAction(ctx context.Context, orgID, actorID uuid.UUID, action models.AuditAction, entityType models.AuditEntityType, entityID *uuid.UUID, ip, userAgent string, changes, metadata map[string]string)
+}
+
+// Service is the control-plane surface for CONFENGE outreach staging.
+type Service interface {
+	Enabled() bool
+	Config() Config
+
+	// ImportFromBytes validates and optionally applies a feed payload.
+	ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, raw []byte, opts ImportOptions) (*models.OutreachImportRun, *errx.Error)
+	// ImportFromURI fetches a feed (file/https) then imports.
+	ImportFromURI(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, uri string, opts ImportOptions) (*models.OutreachImportRun, *errx.Error)
+
+	GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, *errx.Error)
+	ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, *errx.Error)
+
+	Summary(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, *errx.Error)
+	ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, *errx.Error)
+	GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, *errx.Error)
+	BlockAccount(ctx context.Context, orgID, userID, id uuid.UUID, reason string, dnc bool) (*models.OutreachAccount, *errx.Error)
+}
+
+// ImportOptions controls dry-run, idempotency, and source tracking.
+type ImportOptions struct {
+	DryRun         bool
+	IdempotencyKey string
+	SourceURI      string
+}
+
+type service struct {
+	cfg   Config
+	repo  repository.OutreachRepository
+	audit AuditLogger
+	fetch *FeedFetcher
+}
+
+// NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.
+func NewService(cfg Config, repo repository.OutreachRepository, audit AuditLogger) Service {
+	return &service{
+		cfg:   cfg,
+		repo:  repo,
+		audit: audit,
+		fetch: &FeedFetcher{
+			AllowedHosts: cfg.AllowedHosts,
+			Token:        cfg.FeedToken,
+			MaxBytes:     cfg.MaxFeedPayloadBytes,
+		},
+	}
+}
+
+func (s *service) Enabled() bool  { return s.cfg.Enabled }
+func (s *service) Config() Config { return s.cfg }
+
+func (s *service) requireEnabled() *errx.Error {
+	if !s.cfg.Enabled {
+		return errx.New(errx.NotFound, "CONFENGE outreach is not enabled on this server")
+	}
+	return nil
+}
+
+func (s *service) ImportFromURI(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, uri string, opts ImportOptions) (*models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	// Prefer configured feed URL when client sends empty.
+	if strings.TrimSpace(uri) == "" {
+		uri = s.cfg.FeedURL
+	}
+	if strings.TrimSpace(uri) == "" {
+		return nil, errx.New(errx.BadRequest, "feed URI is required (or set CONFENGE_EXTRA_CLI_FEED_URL)")
+	}
+	opts.SourceURI = uri
+	raw, err := s.fetch.Fetch(ctx, uri)
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, "failed to fetch feed: "+err.Error())
+	}
+	return s.ImportFromBytes(ctx, orgID, userID, raw, opts)
+}
+
+func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, raw []byte, opts ImportOptions) (*models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if len(raw) == 0 {
+		return nil, errx.New(errx.BadRequest, "empty feed payload")
+	}
+	if s.cfg.MaxFeedPayloadBytes > 0 && int64(len(raw)) > s.cfg.MaxFeedPayloadBytes {
+		return nil, errx.New(errx.BadRequest, "feed payload too large")
+	}
+
+	payloadHash := CanonicalPayloadHash(raw)
+	if opts.IdempotencyKey != "" {
+		existing, err := s.repo.GetImportRunByIdempotency(ctx, orgID, opts.IdempotencyKey)
+		if err != nil {
+			return nil, errx.New(errx.Internal, "failed to check idempotency key")
+		}
+		if existing != nil {
+			// Same key + same hash: return prior result (idempotent).
+			if existing.PayloadHash == payloadHash {
+				return existing, nil
+			}
+			// Same key, different body: conflict.
+			return nil, errx.New(errx.Conflict, "idempotency key already used with a different payload")
+		}
+	}
+
+	feed, err := DetectAndNormalize(raw)
+	if err != nil {
+		return nil, errx.New(errx.BadRequest, "invalid feed: "+err.Error())
+	}
+	if err := ValidateFeed(feed); err != nil {
+		return nil, errx.New(errx.BadRequest, err.Error())
+	}
+
+	run := &models.OutreachImportRun{
+		OrganizationID:  orgID,
+		SourceSystem:    feed.Source.System,
+		SourceRunID:     feed.Source.RunID,
+		SchemaVersion:   feed.SchemaVersion,
+		SnapshotHash:    feed.Source.SnapshotHash,
+		RepoSHA:         feed.Source.RepoSHA,
+		PayloadHash:     payloadHash,
+		ProfileID:       feed.Source.ProfileID,
+		ProfileVersion:  feed.Source.ProfileVersion,
+		Status:          models.OutreachImportRunning,
+		DryRun:          opts.DryRun,
+		CreatedByUserID: userID,
+		IdempotencyKey:  opts.IdempotencyKey,
+		SourceURI:       opts.SourceURI,
+		Warnings:        nil,
+		Errors:          nil,
+	}
+	if feed.Pagination.Cursor != nil {
+		run.CursorIn = *feed.Pagination.Cursor
+	}
+	if feed.Pagination.NextCursor != nil {
+		run.CursorOut = *feed.Pagination.NextCursor
+	}
+
+	if err := s.repo.CreateImportRun(ctx, run); err != nil {
+		return nil, errx.New(errx.Internal, "failed to create import run: "+err.Error())
+	}
+
+	counts, leadErrs, warns := s.applyFeed(ctx, orgID, run, feed, opts.DryRun)
+	run.Counts = counts
+	run.Errors = leadErrs
+	run.Warnings = warns
+	now := time.Now().UTC()
+	run.FinishedAt = &now
+	if len(leadErrs) > 0 && counts.Creates+counts.Updates > 0 {
+		run.Status = models.OutreachImportPartial
+	} else if len(leadErrs) > 0 && counts.Creates+counts.Updates == 0 && counts.LeadsProcessed == 0 {
+		run.Status = models.OutreachImportFailed
+	} else {
+		run.Status = models.OutreachImportCompleted
+	}
+	if err := s.repo.UpdateImportRun(ctx, run); err != nil {
+		return nil, errx.New(errx.Internal, "failed to finalize import run")
+	}
+
+	if s.audit != nil && userID != nil && !opts.DryRun {
+		s.audit.LogAction(ctx, orgID, *userID, models.AuditActionCreate, models.AuditEntityOutreachImportRun, &run.ID, "", "",
+			map[string]string{
+				"payload_hash": payloadHash,
+				"creates":      fmt.Sprintf("%d", counts.Creates),
+				"updates":      fmt.Sprintf("%d", counts.Updates),
+			},
+			map[string]string{"source_system": feed.Source.System, "source_run_id": feed.Source.RunID},
+		)
+	}
+	return run, nil
+}
+
+func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.OutreachImportRun, feed *Feed, dryRun bool) (models.OutreachImportCounts, []models.OutreachImportError, []string) {
+	var counts models.OutreachImportCounts
+	var leadErrs []models.OutreachImportError
+	var warns []string
+
+	for i, lead := range feed.Leads {
+		if lv := ValidateLead(i, lead); lv != nil {
+			counts.Invalid++
+			counts.LeadsSkippedError++
+			leadErrs = append(leadErrs, models.OutreachImportError{
+				SourceLeadID: lv.SourceLeadID,
+				CNPJ14:       lv.CNPJ14,
+				Message:      lv.Message,
+			})
+			continue
+		}
+		cnpj := NormalizeCNPJ14(lead.Company.CNPJ14)
+		existing, err := s.repo.GetAccountByCNPJ(ctx, orgID, cnpj)
+		if err != nil {
+			counts.LeadsSkippedError++
+			leadErrs = append(leadErrs, models.OutreachImportError{
+				SourceLeadID: lead.SourceLeadID, CNPJ14: cnpj, Message: "db error loading account",
+			})
+			continue
+		}
+
+		// Preserve DNC: never re-open.
+		if existing != nil && existing.DoNotContact {
+			counts.Blocked++
+			counts.Unchanged++
+			counts.LeadsProcessed++
+			continue
+		}
+
+		contentHash := LeadContentHash(lead)
+		queueState := DefaultQueueState(lead, existing)
+		if !hasEnrollableContact(lead) {
+			counts.MissingContact++
+		}
+
+		if dryRun {
+			if existing == nil {
+				counts.Creates++
+			} else if existing.LastPayloadHash == contentHash {
+				counts.Unchanged++
+			} else {
+				counts.Updates++
+			}
+			// Estimate evidence adds
+			if existing != nil {
+				existingEv, _ := s.repo.ListEvidence(ctx, orgID, existing.ID)
+				known := map[string]bool{}
+				for _, e := range existingEv {
+					known[e.SourceEvidenceID] = true
+				}
+				for _, e := range lead.Evidence {
+					if e.ID != "" && !known[e.ID] {
+						counts.EvidenceAdded++
+					}
+				}
+			} else {
+				counts.EvidenceAdded += len(lead.Evidence)
+			}
+			counts.LeadsProcessed++
+			continue
+		}
+
+		// APPLY
+		acc := leadToAccount(orgID, lead, feed, run.ID, contentHash, queueState, existing)
+		created, err := s.repo.UpsertAccount(ctx, acc)
+		if err != nil {
+			counts.LeadsSkippedError++
+			leadErrs = append(leadErrs, models.OutreachImportError{
+				SourceLeadID: lead.SourceLeadID, CNPJ14: cnpj, Message: "upsert account: " + err.Error(),
+			})
+			continue
+		}
+		if created {
+			counts.Creates++
+		} else if existing != nil && existing.LastPayloadHash == contentHash {
+			counts.Unchanged++
+		} else {
+			counts.Updates++
+		}
+
+		for _, fc := range lead.Contacts {
+			cand := leadToCandidate(orgID, acc.ID, run.ID, fc)
+			if _, err := s.repo.UpsertCandidate(ctx, cand); err != nil {
+				warns = append(warns, fmt.Sprintf("%s contact %s: %v", cnpj, fc.Email, err))
+				counts.Warnings++
+			}
+		}
+		for _, fe := range lead.Evidence {
+			ev := leadToEvidence(orgID, acc.ID, run.ID, fe)
+			createdEv, err := s.repo.UpsertEvidence(ctx, ev)
+			if err != nil {
+				warns = append(warns, fmt.Sprintf("%s evidence %s: %v", cnpj, fe.ID, err))
+				counts.Warnings++
+				continue
+			}
+			if createdEv {
+				counts.EvidenceAdded++
+			}
+		}
+		counts.LeadsProcessed++
+	}
+	return counts, leadErrs, warns
+}
+
+func leadToAccount(orgID uuid.UUID, lead FeedLead, feed *Feed, runID uuid.UUID, contentHash, queueState string, existing *models.OutreachAccount) *models.OutreachAccount {
+	cnpj := NormalizeCNPJ14(lead.Company.CNPJ14)
+	root := digitsOnly(lead.Company.CNPJRoot)
+	if root == "" && len(cnpj) == 14 {
+		root = cnpj[:8]
+	}
+	contracts, _ := json.Marshal(lead.Contracts)
+	if contracts == nil {
+		contracts = []byte("[]")
+	}
+	acc := &models.OutreachAccount{
+		OrganizationID:     orgID,
+		SourceLeadID:       SanitizeText(lead.SourceLeadID, 200),
+		CNPJ14:             cnpj,
+		CNPJRoot:           root,
+		RazaoSocial:        SanitizeText(lead.Company.RazaoSocial, 500),
+		NomeFantasia:       SanitizeText(lead.Company.NomeFantasia, 500),
+		Municipio:          SanitizeText(lead.Company.Municipio, 200),
+		UF:                 strings.ToUpper(SanitizeText(lead.Company.UF, 2)),
+		Website:            SanitizeText(lead.Company.Website, 500),
+		PriorityRank:       lead.Priority.Rank,
+		PriorityScore:      lead.Priority.Score,
+		PriorityTier:       SanitizeText(lead.Priority.Tier, 100),
+		PriorityConfidence: SanitizeText(lead.Priority.Confidence, 50),
+		MomentCode:         SanitizeText(lead.Moment.Code, 100),
+		MomentSummary:      SanitizeText(lead.Moment.Summary, 2000),
+		MomentObservedAt:   ParseDate(lead.Moment.ObservedAt),
+		MomentConfidence:   SanitizeText(lead.Moment.Confidence, 50),
+		MomentEvidenceIDs:  lead.Moment.EvidenceIDs,
+		ServiceCode:        SanitizeText(lead.Offer.ServiceCode, 100),
+		ServiceName:        SanitizeText(lead.Offer.ServiceName, 200),
+		EntryOffer:         SanitizeText(lead.Offer.EntryOffer, 1000),
+		OfferRationale:     SanitizeText(lead.Offer.Rationale, 2000),
+		FactToMention:      SanitizeText(lead.MessagingContext.FactToMention, 2000),
+		QuestionToAsk:      SanitizeText(lead.MessagingContext.QuestionToAsk, 1000),
+		CTA:                SanitizeText(lead.MessagingContext.CTA, 500),
+		ClaimsToAvoid:      lead.MessagingContext.ClaimsToAvoid,
+		CommercialState:    firstNonEmpty(SanitizeText(lead.CommercialState, 50), "NEW"),
+		QueueState:         queueState,
+		SourceSystem:       feed.Source.System,
+		SourceRunID:        feed.Source.RunID,
+		LastImportRunID:    &runID,
+		LastPayloadHash:    contentHash,
+		ContractsJSON:      contracts,
+	}
+	if existing != nil {
+		acc.ID = existing.ID
+		acc.HumanOverride = existing.HumanOverride
+		acc.Blocked = existing.Blocked
+		acc.BlockReason = existing.BlockReason
+		acc.DoNotContact = existing.DoNotContact
+		acc.CreatedAt = existing.CreatedAt
+	}
+	return acc
+}
+
+func leadToCandidate(orgID, accountID, runID uuid.UUID, fc FeedContact) *models.OutreachContactCandidate {
+	email := strings.TrimSpace(strings.ToLower(fc.Email))
+	vs := NormalizeVerification(fc.VerificationStatus, email)
+	dnc := vs == models.OutreachVerifyDoNotContact
+	bounced := vs == models.OutreachVerifyBounced
+	return &models.OutreachContactCandidate{
+		OrganizationID:     orgID,
+		AccountID:          accountID,
+		SourceContactID:    SanitizeText(fc.SourceContactID, 200),
+		Name:               SanitizeText(fc.Name, 300),
+		Role:               SanitizeText(fc.Role, 200),
+		Email:              email,
+		Phone:              SanitizeText(fc.Phone, 50),
+		LinkedInURL:        SanitizeText(fc.LinkedInURL, 500),
+		SourceURL:          SanitizeText(fc.SourceURL, 1000),
+		SourceDocument:     SanitizeText(fc.SourceDocument, 500),
+		SourceDate:         ParseDate(fc.SourceDate),
+		VerificationStatus: vs,
+		Confidence:         SanitizeText(fc.Confidence, 50),
+		Recommended:        fc.Recommended,
+		DoNotContact:       dnc,
+		Bounced:            bounced,
+		LastImportRunID:    &runID,
+	}
+}
+
+func leadToEvidence(orgID, accountID, runID uuid.UUID, fe FeedEvidence) *models.OutreachEvidence {
+	return &models.OutreachEvidence{
+		OrganizationID:   orgID,
+		AccountID:        accountID,
+		SourceEvidenceID: SanitizeText(fe.ID, 200),
+		EvidenceType:     SanitizeText(fe.Type, 100),
+		Title:            SanitizeText(fe.Title, 500),
+		URL:              SanitizeText(fe.URL, 1000),
+		Document:         SanitizeText(fe.Document, 500),
+		EvidenceDate:     ParseDate(fe.Date),
+		Location:         SanitizeText(fe.Location, 200),
+		Excerpt:          SanitizeText(fe.Excerpt, 4000),
+		Synthesis:        SanitizeText(fe.Synthesis, 2000),
+		EpistemicClass:   NormalizeEpistemic(fe.EpistemicClass),
+		Reliability:      SanitizeText(fe.Reliability, 50),
+		ConsultedAt:      ParseDate(fe.ConsultedAt),
+		LastImportRunID:  &runID,
+	}
+}
+
+func (s *service) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	run, err := s.repo.GetImportRun(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load import run")
+	}
+	if run == nil {
+		return nil, errx.New(errx.NotFound, "import run not found")
+	}
+	return run, nil
+}
+
+func (s *service) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	list, err := s.repo.ListImportRuns(ctx, orgID, limit)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to list import runs")
+	}
+	if list == nil {
+		list = []models.OutreachImportRun{}
+	}
+	return list, nil
+}
+
+func (s *service) Summary(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	sum, err := s.repo.CountByQueueState(ctx, orgID)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load summary")
+	}
+	return sum, nil
+}
+
+func (s *service) ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	list, err := s.repo.ListAccounts(ctx, orgID, filter)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to list accounts")
+	}
+	if list == nil {
+		list = []models.OutreachAccount{}
+	}
+	return list, nil
+}
+
+func (s *service) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load account")
+	}
+	if acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	contacts, err := s.repo.ListCandidates(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load contacts")
+	}
+	evidence, err := s.repo.ListEvidence(ctx, orgID, id)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to load evidence")
+	}
+	acc.Contacts = contacts
+	acc.Evidence = evidence
+	acc.ContactN = len(contacts)
+	acc.EvidenceN = len(evidence)
+	return acc, nil
+}
+
+func (s *service) BlockAccount(ctx context.Context, orgID, userID, id uuid.UUID, reason string, dnc bool) (*models.OutreachAccount, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	queue := models.OutreachQueueBlocked
+	if dnc {
+		queue = models.OutreachQueueDoNotContact
+	}
+	if err := s.repo.SetAccountHumanFlags(ctx, orgID, id, true, dnc, SanitizeText(reason, 500), queue); err != nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionUpdate, models.AuditEntityOutreachAccount, &id, "", "",
+			map[string]string{"blocked": "true", "do_not_contact": fmt.Sprintf("%v", dnc)},
+			map[string]string{"reason": reason},
+		)
+	}
+	return s.GetAccount(ctx, orgID, id)
+}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -48,6 +48,11 @@ type Service interface {
 	WireExecution(campaigns CampaignAPI, contacts ContactAPI)
 	BootstrapCampaign(ctx context.Context, orgID, userID uuid.UUID) (*models.Campaign, *errx.Error)
 	EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error)
+	WireCRM(crm CRMAPI)
+	BootstrapPipeline(ctx context.Context, orgID uuid.UUID) (*models.Pipeline, *errx.Error)
+	HandleClassifiedReply(ctx context.Context, orgID, actorID uuid.UUID, contactEmail, replyClass string, warmblyContactID *uuid.UUID) *errx.Error
+	// OnClassifiedReply is the advanced-package hook (error, not errx).
+	OnClassifiedReply(ctx context.Context, orgID uuid.UUID, contactEmail, replyClass string, contactID *uuid.UUID) error
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.
@@ -65,6 +70,7 @@ type service struct {
 	ai        generation.Provider
 	campaigns CampaignAPI
 	contacts  ContactAPI
+	crm       CRMAPI
 }
 
 // NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -45,6 +45,9 @@ type Service interface {
 	ReviewDraft(ctx context.Context, orgID, userID, draftID uuid.UUID, action string, edit *DraftEdit) (*models.OutreachDraft, *errx.Error)
 	SetAI(p generation.Provider)
 	EnqueueOutcome(ctx context.Context, orgID uuid.UUID, ev models.OutreachOutcome) *errx.Error
+	WireExecution(campaigns CampaignAPI, contacts ContactAPI)
+	BootstrapCampaign(ctx context.Context, orgID, userID uuid.UUID) (*models.Campaign, *errx.Error)
+	EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error)
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.
@@ -55,11 +58,13 @@ type ImportOptions struct {
 }
 
 type service struct {
-	cfg   Config
-	repo  repository.OutreachRepository
-	audit AuditLogger
-	fetch *FeedFetcher
-	ai    generation.Provider
+	cfg       Config
+	repo      repository.OutreachRepository
+	audit     AuditLogger
+	fetch     *FeedFetcher
+	ai        generation.Provider
+	campaigns CampaignAPI
+	contacts  ContactAPI
 }
 
 // NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.
@@ -212,7 +217,28 @@ func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *
 			map[string]string{"source_system": feed.Source.System, "source_run_id": feed.Source.RunID},
 		)
 	}
+	// One LEAD_IMPORTED summary outcome per successful apply (not dry-run).
+	if !opts.DryRun && counts.LeadsProcessed > 0 {
+		_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+			IdempotencyKey: fmt.Sprintf("lead_imported:%s:%s", orgID, payloadHash),
+			SourceLeadID:   feed.Source.RunID,
+			EventType:      OutcomeLeadImported,
+			OccurredAt:     time.Now().UTC(),
+			Payload: mustJSON(map[string]any{
+				"creates": counts.Creates, "updates": counts.Updates,
+				"leads_processed": counts.LeadsProcessed, "payload_hash": payloadHash,
+			}),
+		})
+	}
 	return run, nil
+}
+
+func mustJSON(v any) []byte {
+	b, _ := json.Marshal(v)
+	if b == nil {
+		return []byte("{}")
+	}
+	return b
 }
 
 func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.OutreachImportRun, feed *Feed, dryRun bool) (models.OutreachImportCounts, []models.OutreachImportError, []string) {

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/pkg/generation"
@@ -53,6 +54,13 @@ type Service interface {
 	HandleClassifiedReply(ctx context.Context, orgID, actorID uuid.UUID, contactEmail, replyClass string, warmblyContactID *uuid.UUID) *errx.Error
 	// OnClassifiedReply is the advanced-package hook (error, not errx).
 	OnClassifiedReply(ctx context.Context, orgID uuid.UUID, contactEmail, replyClass string, contactID *uuid.UUID) error
+
+	// WhatsApp channel ops (require WireWhatsApp + CONFENGE_WHATSAPP_ENABLED).
+	WireWhatsApp(sender WhatsAppSender, store WhatsAppStateStore)
+	DecideChannel(ctx context.Context, orgID, accountID uuid.UUID, contactID *uuid.UUID) (*ChannelDecision, *errx.Error)
+	GenerateWhatsAppDraft(ctx context.Context, orgID, userID, accountID uuid.UUID, contactID *uuid.UUID) (*models.OutreachDraft, *errx.Error)
+	SendApprovedWhatsApp(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error)
+	HandleWhatsAppInbound(ctx context.Context, orgID uuid.UUID, ev whatsapp.ChannelEvent) (whatsapp.InboundResult, error)
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.
@@ -71,6 +79,8 @@ type service struct {
 	campaigns CampaignAPI
 	contacts  ContactAPI
 	crm       CRMAPI
+	wa        WhatsAppSender
+	waStore   WhatsAppStateStore
 }
 
 // NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.
@@ -417,25 +427,42 @@ func leadToCandidate(orgID, accountID, runID uuid.UUID, fc FeedContact) *models.
 	vs := NormalizeVerification(fc.VerificationStatus, email)
 	dnc := vs == models.OutreachVerifyDoNotContact
 	bounced := vs == models.OutreachVerifyBounced
-	return &models.OutreachContactCandidate{
-		OrganizationID:     orgID,
-		AccountID:          accountID,
-		SourceContactID:    SanitizeText(fc.SourceContactID, 200),
-		Name:               SanitizeText(fc.Name, 300),
-		Role:               SanitizeText(fc.Role, 200),
-		Email:              email,
-		Phone:              SanitizeText(fc.Phone, 50),
-		LinkedInURL:        SanitizeText(fc.LinkedInURL, 500),
-		SourceURL:          SanitizeText(fc.SourceURL, 1000),
-		SourceDocument:     SanitizeText(fc.SourceDocument, 500),
-		SourceDate:         ParseDate(fc.SourceDate),
-		VerificationStatus: vs,
-		Confidence:         SanitizeText(fc.Confidence, 50),
-		Recommended:        fc.Recommended,
-		DoNotContact:       dnc,
-		Bounced:            bounced,
-		LastImportRunID:    &runID,
+	// Structured phone + consent facts (public number is never opt-in).
+	phoneFacts := ExtractPhoneFacts(fc)
+	rawPhone := phoneFacts.Raw
+	if rawPhone == "" {
+		rawPhone = fc.Phone
 	}
+	cand := &models.OutreachContactCandidate{
+		OrganizationID:              orgID,
+		AccountID:                   accountID,
+		SourceContactID:             SanitizeText(fc.SourceContactID, 200),
+		Name:                        SanitizeText(fc.Name, 300),
+		Role:                        SanitizeText(fc.Role, 200),
+		Email:                       email,
+		Phone:                       SanitizeText(rawPhone, 50),
+		PhoneE164:                   SanitizeText(phoneFacts.E164, 30),
+		PhoneSource:                 SanitizeText(phoneFacts.Source, 100),
+		PhoneSourceURL:              SanitizeText(phoneFacts.SourceURL, 1000),
+		WhatsAppConsentStatus:       phoneFacts.ConsentStatus,
+		WhatsAppConsentSource:       SanitizeText(phoneFacts.ConsentSource, 200),
+		WhatsAppConsentAt:           phoneFacts.ConsentAt,
+		WhatsAppConsentProvenanceOK: phoneFacts.ProvenanceOK,
+		LinkedInURL:                 SanitizeText(fc.LinkedInURL, 500),
+		SourceURL:                   SanitizeText(fc.SourceURL, 1000),
+		SourceDocument:              SanitizeText(fc.SourceDocument, 500),
+		SourceDate:                  ParseDate(fc.SourceDate),
+		VerificationStatus:          vs,
+		Confidence:                  SanitizeText(fc.Confidence, 50),
+		Recommended:                 fc.Recommended,
+		DoNotContact:                dnc,
+		Bounced:                     bounced,
+		LastImportRunID:             &runID,
+	}
+	if cand.WhatsAppConsentStatus == "" {
+		cand.WhatsAppConsentStatus = "UNKNOWN"
+	}
+	return cand
 }
 
 func leadToEvidence(orgID, accountID, runID uuid.UUID, fe FeedEvidence) *models.OutreachEvidence {

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -229,6 +230,21 @@ func (m *memRepo) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.
 }
 func (m *memRepo) UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error {
 	return nil
+}
+func (m *memRepo) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
+	return nil
+}
+func (m *memRepo) ListPendingOutcomes(ctx context.Context, limit int) ([]models.OutreachOutcome, error) {
+	return nil, nil
+}
+func (m *memRepo) MarkOutcomeDelivered(ctx context.Context, orgID, id uuid.UUID) error {
+	return nil
+}
+func (m *memRepo) MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, attempts int, next time.Time, lastErr string, dead bool) error {
+	return nil
+}
+func (m *memRepo) GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error) {
+	return nil, nil
 }
 
 func testSvc(repo repository.OutreachRepository) Service {

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -167,7 +167,7 @@ func (m *memRepo) UpsertCandidate(ctx context.Context, c *models.OutreachContact
 	}
 	list := m.cands[c.AccountID]
 	for i, existing := range list {
-		if existing.SourceContactID != "" && existing.SourceContactID == c.SourceContactID {
+		if existing.ID == c.ID || (existing.SourceContactID != "" && existing.SourceContactID == c.SourceContactID) {
 			if existing.DoNotContact {
 				c.DoNotContact = true
 			}
@@ -182,6 +182,16 @@ func (m *memRepo) UpsertCandidate(ctx context.Context, c *models.OutreachContact
 }
 
 func (m *memRepo) GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, list := range m.cands {
+		for i := range list {
+			if list[i].ID == id && list[i].OrganizationID == orgID {
+				cp := list[i]
+				return &cp, nil
+			}
+		}
+	}
 	return nil, nil
 }
 
@@ -245,6 +255,9 @@ func (m *memRepo) MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, a
 }
 func (m *memRepo) GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error) {
 	return nil, nil
+}
+func (m *memRepo) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	return nil, nil, nil
 }
 
 func testSvc(repo repository.OutreachRepository) Service {

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -1,0 +1,466 @@
+package confenge
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// memRepo is an in-memory OutreachRepository for unit tests of ImportFromBytes.
+type memRepo struct {
+	mu       sync.Mutex
+	runs     map[uuid.UUID]*models.OutreachImportRun
+	byIdem   map[string]*models.OutreachImportRun
+	accounts map[string]*models.OutreachAccount // org|cnpj
+	byID     map[uuid.UUID]*models.OutreachAccount
+	cands    map[uuid.UUID][]models.OutreachContactCandidate
+	evidence map[uuid.UUID][]models.OutreachEvidence
+}
+
+func newMemRepo() *memRepo {
+	return &memRepo{
+		runs:     map[uuid.UUID]*models.OutreachImportRun{},
+		byIdem:   map[string]*models.OutreachImportRun{},
+		accounts: map[string]*models.OutreachAccount{},
+		byID:     map[uuid.UUID]*models.OutreachAccount{},
+		cands:    map[uuid.UUID][]models.OutreachContactCandidate{},
+		evidence: map[uuid.UUID][]models.OutreachEvidence{},
+	}
+}
+
+func accKey(org uuid.UUID, cnpj string) string { return org.String() + "|" + cnpj }
+
+func (m *memRepo) CreateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if run.ID == uuid.Nil {
+		run.ID = uuid.New()
+	}
+	cp := *run
+	m.runs[run.ID] = &cp
+	if run.IdempotencyKey != "" {
+		m.byIdem[run.OrganizationID.String()+"|"+run.IdempotencyKey] = &cp
+	}
+	return nil
+}
+
+func (m *memRepo) UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := *run
+	m.runs[run.ID] = &cp
+	if run.IdempotencyKey != "" {
+		m.byIdem[run.OrganizationID.String()+"|"+run.IdempotencyKey] = &cp
+	}
+	return nil
+}
+
+func (m *memRepo) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.runs[id]
+	if r == nil || r.OrganizationID != orgID {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (m *memRepo) GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.byIdem[orgID.String()+"|"+key]
+	if r == nil {
+		return nil, nil
+	}
+	cp := *r
+	return &cp, nil
+}
+
+func (m *memRepo) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error) {
+	return nil, nil
+}
+
+func (m *memRepo) GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a := m.accounts[accKey(orgID, cnpj14)]
+	if a == nil {
+		return nil, nil
+	}
+	cp := *a
+	return &cp, nil
+}
+
+func (m *memRepo) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a := m.byID[id]
+	if a == nil || a.OrganizationID != orgID {
+		return nil, nil
+	}
+	cp := *a
+	return &cp, nil
+}
+
+func (m *memRepo) UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	k := accKey(acc.OrganizationID, acc.CNPJ14)
+	existing := m.accounts[k]
+	created := existing == nil
+	if existing != nil {
+		acc.ID = existing.ID
+		// preserve DNC
+		if existing.DoNotContact {
+			acc.DoNotContact = true
+		}
+	} else if acc.ID == uuid.Nil {
+		acc.ID = uuid.New()
+	}
+	cp := *acc
+	m.accounts[k] = &cp
+	m.byID[cp.ID] = &cp
+	return created, nil
+}
+
+func (m *memRepo) ListAccounts(ctx context.Context, orgID uuid.UUID, filter repository.OutreachAccountFilter) ([]models.OutreachAccount, error) {
+	return nil, nil
+}
+
+func (m *memRepo) CountByQueueState(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, error) {
+	return &models.OutreachQueueSummary{}, nil
+}
+
+func (m *memRepo) SetAccountHumanFlags(ctx context.Context, orgID, id uuid.UUID, blocked, dnc bool, reason, queueState string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	a := m.byID[id]
+	if a == nil || a.OrganizationID != orgID {
+		return context.Canceled
+	}
+	a.Blocked = blocked
+	a.DoNotContact = dnc
+	a.BlockReason = reason
+	a.QueueState = queueState
+	a.HumanOverride = true
+	return nil
+}
+
+func (m *memRepo) ListCandidates(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachContactCandidate, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]models.OutreachContactCandidate{}, m.cands[accountID]...), nil
+}
+
+func (m *memRepo) UpsertCandidate(ctx context.Context, c *models.OutreachContactCandidate) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if c.ID == uuid.Nil {
+		c.ID = uuid.New()
+	}
+	list := m.cands[c.AccountID]
+	for i, existing := range list {
+		if existing.SourceContactID != "" && existing.SourceContactID == c.SourceContactID {
+			if existing.DoNotContact {
+				c.DoNotContact = true
+			}
+			c.ID = existing.ID
+			list[i] = *c
+			m.cands[c.AccountID] = list
+			return false, nil
+		}
+	}
+	m.cands[c.AccountID] = append(list, *c)
+	return true, nil
+}
+
+func (m *memRepo) GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error) {
+	return nil, nil
+}
+
+func (m *memRepo) ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]models.OutreachEvidence{}, m.evidence[accountID]...), nil
+}
+
+func (m *memRepo) UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if e.ID == uuid.Nil {
+		e.ID = uuid.New()
+	}
+	list := m.evidence[e.AccountID]
+	for i, existing := range list {
+		if existing.SourceEvidenceID == e.SourceEvidenceID {
+			e.ID = existing.ID
+			list[i] = *e
+			m.evidence[e.AccountID] = list
+			return false, nil
+		}
+	}
+	m.evidence[e.AccountID] = append(list, *e)
+	return true, nil
+}
+
+func testSvc(repo repository.OutreachRepository) Service {
+	cfg := Config{
+		Enabled:              true,
+		RequireHumanApproval: true,
+		DefaultDailyLimit:    10,
+		MaxInitialEmailWords: 120,
+		MaxFeedPayloadBytes:  DefaultMaxPayloadBytes,
+	}
+	return NewService(cfg, repo, nil)
+}
+
+func TestImportNativeFeedCreatesAccounts(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	user := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+
+	run, xerr := svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatalf("import: %v", xerr)
+	}
+	if run.Status != models.OutreachImportCompleted && run.Status != models.OutreachImportPartial {
+		t.Fatalf("status %s counts=%+v errs=%+v", run.Status, run.Counts, run.Errors)
+	}
+	if run.Counts.Creates < 4 {
+		t.Fatalf("want >=4 creates, got %+v", run.Counts)
+	}
+	// No-email company staged as NEEDS_CONTACT
+	acc, err := repo.GetAccountByCNPJ(context.Background(), org, "55444333000122")
+	if err != nil || acc == nil {
+		t.Fatal("missing no-contact company")
+	}
+	if acc.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("queue_state=%s want NEEDS_CONTACT", acc.QueueState)
+	}
+	// Official contact company ready
+	acme, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acme == nil || acme.QueueState != models.OutreachQueueReadyToGenerate {
+		t.Fatalf("acme state=%v", acme)
+	}
+	// Unverified-only contact is not enrollable => NEEDS_CONTACT
+	cn, _ := repo.GetAccountByCNPJ(context.Background(), org, "66777888000199")
+	if cn == nil || cn.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("unverified-only should be NEEDS_CONTACT, got %v", cn)
+	}
+}
+
+func TestImportDryRunDoesNotPersistAccounts(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{DryRun: true})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if !run.DryRun {
+		t.Fatal("expected dry_run")
+	}
+	if run.Counts.Creates < 1 {
+		t.Fatalf("dry-run should count creates: %+v", run.Counts)
+	}
+	// accounts map empty of real companies
+	acc, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acc != nil {
+		t.Fatal("dry-run must not persist accounts")
+	}
+}
+
+func TestImportIdempotencySameKeySamePayload(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	opts := ImportOptions{IdempotencyKey: "idem-1"}
+	r1, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, opts)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	r2, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, opts)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if r1.ID != r2.ID {
+		t.Fatalf("idempotent reimport should return same run %s vs %s", r1.ID, r2.ID)
+	}
+}
+
+func TestImportIdempotencyConflictOnDifferentPayload(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	opts := ImportOptions{IdempotencyKey: "idem-2"}
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, opts); xerr != nil {
+		t.Fatal(xerr)
+	}
+	other := []byte(`{"schema_version":"confenge.outreach.v1","source":{"system":"extra-cli"},"leads":[]}`)
+	_, xerr := svc.ImportFromBytes(context.Background(), org, nil, other, opts)
+	if xerr == nil {
+		t.Fatal("expected conflict")
+	}
+}
+
+func TestReimportPreservesDNC(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	acc, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if acc == nil {
+		t.Fatal("missing")
+	}
+	acc.DoNotContact = true
+	acc.QueueState = models.OutreachQueueDoNotContact
+	_, _ = repo.UpsertAccount(context.Background(), acc)
+
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	again, _ := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if again == nil || !again.DoNotContact {
+		t.Fatal("DNC must survive reimport")
+	}
+}
+
+func TestReimportIdenticalIsUnchanged(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	run2, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run2.Counts.Creates != 0 {
+		t.Fatalf("second import should not create: %+v", run2.Counts)
+	}
+	if run2.Counts.Unchanged < 1 {
+		t.Fatalf("expected unchanged counts: %+v", run2.Counts)
+	}
+}
+
+func TestReimportScoreChangeUpdates(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	// Mutate score in payload
+	feed, _ := ParseFeed(raw)
+	feed.Leads[0].Priority.Score = 99
+	mut, _ := jsonMarshal(feed)
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, mut, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.Updates < 1 {
+		t.Fatalf("score change should update: %+v", run.Counts)
+	}
+}
+
+func TestMultiTenantIsolation(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	orgA, orgB := uuid.New(), uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), orgA, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	accB, _ := repo.GetAccountByCNPJ(context.Background(), orgB, "11222333000181")
+	if accB != nil {
+		t.Fatal("org B must not see org A accounts")
+	}
+	accA, _ := repo.GetAccountByCNPJ(context.Background(), orgA, "11222333000181")
+	if accA == nil {
+		t.Fatal("org A should have account")
+	}
+}
+
+func TestDisabledServiceRejects(t *testing.T) {
+	repo := newMemRepo()
+	cfg := Config{Enabled: false}
+	svc := NewService(cfg, repo, nil)
+	_, xerr := svc.ImportFromBytes(context.Background(), uuid.New(), nil, []byte(`{}`), ImportOptions{})
+	if xerr == nil {
+		t.Fatal("disabled must reject")
+	}
+}
+
+func TestLegacyImportWorks(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "legacy_leads_array.json")
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.Creates < 2 {
+		t.Fatalf("legacy creates: %+v errs=%+v", run.Counts, run.Errors)
+	}
+	noContact, _ := repo.GetAccountByCNPJ(context.Background(), org, "55444333000122")
+	if noContact == nil || noContact.QueueState != models.OutreachQueueNeedsContact {
+		t.Fatalf("legacy no-contact company: %+v", noContact)
+	}
+}
+
+func TestInvalidFeedRejected(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	_, xerr := svc.ImportFromBytes(context.Background(), uuid.New(), nil, []byte(`{not json`), ImportOptions{})
+	if xerr == nil {
+		t.Fatal("expected invalid feed error")
+	}
+}
+
+func TestEvidenceAddedOnReimport(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	feed, _ := ParseFeed(raw)
+	feed.Leads[0].Evidence = append(feed.Leads[0].Evidence, FeedEvidence{
+		ID:             "ev-acme-2",
+		Title:          "Nova evidencia",
+		EpistemicClass: models.OutreachEpistemicConfirmedFact,
+	})
+	// Also change a machine field so content hash moves (evidence is in hash)
+	mut, _ := jsonMarshal(feed)
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, mut, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if run.Counts.EvidenceAdded < 1 {
+		t.Fatalf("expected new evidence: %+v", run.Counts)
+	}
+}
+
+// local helper avoiding import cycle noise
+func jsonMarshal(v any) ([]byte, error) {
+	return marshalJSON(v)
+}

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -209,6 +209,28 @@ func (m *memRepo) UpsertEvidence(ctx context.Context, e *models.OutreachEvidence
 	return true, nil
 }
 
+func (m *memRepo) UpsertDraft(ctx context.Context, d *models.OutreachDraft) error {
+	return nil
+}
+func (m *memRepo) GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error) {
+	return nil, nil
+}
+func (m *memRepo) GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error) {
+	return nil, nil
+}
+func (m *memRepo) ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, error) {
+	return nil, nil
+}
+func (m *memRepo) UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error {
+	return nil
+}
+func (m *memRepo) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error) {
+	return nil, nil
+}
+func (m *memRepo) UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error {
+	return nil
+}
+
 func testSvc(repo repository.OutreachRepository) Service {
 	cfg := Config{
 		Enabled:              true,

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -21,6 +21,8 @@ type memRepo struct {
 	byID     map[uuid.UUID]*models.OutreachAccount
 	cands    map[uuid.UUID][]models.OutreachContactCandidate
 	evidence map[uuid.UUID][]models.OutreachEvidence
+	drafts   map[uuid.UUID]*models.OutreachDraft
+	outcomes []models.OutreachOutcome
 }
 
 func newMemRepo() *memRepo {
@@ -31,6 +33,7 @@ func newMemRepo() *memRepo {
 		byID:     map[uuid.UUID]*models.OutreachAccount{},
 		cands:    map[uuid.UUID][]models.OutreachContactCandidate{},
 		evidence: map[uuid.UUID][]models.OutreachEvidence{},
+		drafts:   map[uuid.UUID]*models.OutreachDraft{},
 	}
 }
 
@@ -221,19 +224,41 @@ func (m *memRepo) UpsertEvidence(ctx context.Context, e *models.OutreachEvidence
 }
 
 func (m *memRepo) UpsertDraft(ctx context.Context, d *models.OutreachDraft) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if d.ID == uuid.Nil {
+		d.ID = uuid.New()
+	}
+	cp := *d
+	m.drafts[d.ID] = &cp
 	return nil
 }
 func (m *memRepo) GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error) {
-	return nil, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	d := m.drafts[id]
+	if d == nil || d.OrganizationID != orgID {
+		return nil, nil
+	}
+	cp := *d
+	return &cp, nil
 }
 func (m *memRepo) GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error) {
 	return nil, nil
 }
 func (m *memRepo) ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, error) {
-	return nil, nil
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out []models.OutreachDraft
+	for _, d := range m.drafts {
+		if d.OrganizationID == orgID && (status == "" || d.Status == status) {
+			out = append(out, *d)
+		}
+	}
+	return out, nil
 }
 func (m *memRepo) UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error {
-	return nil
+	return m.UpsertDraft(ctx, d)
 }
 func (m *memRepo) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error) {
 	return nil, nil
@@ -242,6 +267,9 @@ func (m *memRepo) UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSe
 	return nil
 }
 func (m *memRepo) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.outcomes = append(m.outcomes, *ev)
 	return nil
 }
 func (m *memRepo) ListPendingOutcomes(ctx context.Context, limit int) ([]models.OutreachOutcome, error) {
@@ -257,6 +285,33 @@ func (m *memRepo) GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, 
 	return nil, nil
 }
 func (m *memRepo) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, list := range m.cands {
+		for i := range list {
+			c := list[i]
+			if c.OrganizationID == orgID && c.Email == email {
+				acc := m.byID[c.AccountID]
+				return &c, acc, nil
+			}
+		}
+	}
+	return nil, nil, nil
+}
+func (m *memRepo) FindCandidateByPhone(ctx context.Context, orgID uuid.UUID, phone string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, list := range m.cands {
+		for i := range list {
+			c := list[i]
+			if c.OrganizationID != orgID {
+				continue
+			}
+			if c.PhoneE164 == phone || c.Phone == phone {
+				return &c, m.byID[c.AccountID], nil
+			}
+		}
+	}
 	return nil, nil, nil
 }
 

--- a/internal/app/confenge/testdata/legacy_leads_array.json
+++ b/internal/app/confenge/testdata/legacy_leads_array.json
@@ -1,0 +1,45 @@
+[
+  {
+    "cnpj14": "11222333000181",
+    "razao_social": "Construtora Regional ACME Ltda",
+    "score_total": 80,
+    "priority": "HIGH",
+    "rank_position": 1,
+    "suggested_offer": "ADDITIVE_REVIEW",
+    "next_human_step": "Validar interlocutor de contratos",
+    "commercial_state": "NEW",
+    "municipio": "Florianopolis",
+    "uf": "SC",
+    "signals_fired": ["CONTRACT_EXTENSION"],
+    "email": "ana.silva@acme.example.com",
+    "contact_name": "Ana Silva",
+    "cargo": "Engenheira de contratos",
+    "verification_status": "OFFICIAL_SOURCE"
+  },
+  {
+    "cnpj14": "55444333000122",
+    "razao_social": "Obras do Planalto Ltda",
+    "score_total": 50,
+    "priority": "MEDIUM",
+    "rank_position": 2,
+    "suggested_offer": "BID_READINESS",
+    "commercial_state": "NEW",
+    "municipio": "Brasilia",
+    "uf": "DF"
+  },
+  {
+    "cnpj14": "99888777000166",
+    "razao_social": "Empresa Nacional de Infraestrutura SA",
+    "score_total": 65,
+    "priority": "MEDIUM",
+    "contacts": [
+      {
+        "id": "c1",
+        "name": "Equipe comercial",
+        "email": "contato@eni.example.org",
+        "verification_status": "INSTITUTIONAL_GENERIC",
+        "recommended": true
+      }
+    ]
+  }
+]

--- a/internal/app/confenge/testdata/native_feed_v1.json
+++ b/internal/app/confenge/testdata/native_feed_v1.json
@@ -1,0 +1,312 @@
+{
+  "schema_version": "confenge.outreach.v1",
+  "generated_at": "2026-08-06T12:00:00Z",
+  "source": {
+    "system": "extra-cli",
+    "run_id": "fixture-run-001",
+    "snapshot_hash": "abc123snapshot",
+    "repo_sha": "deadbeef",
+    "profile_id": "confenge",
+    "profile_version": "1.0.0"
+  },
+  "pagination": {
+    "cursor": null,
+    "next_cursor": null,
+    "has_more": false
+  },
+  "leads": [
+    {
+      "source_lead_id": "lead-acme-sc",
+      "company": {
+        "cnpj14": "11222333000181",
+        "cnpj_root": "11222333",
+        "razao_social": "Construtora Regional ACME Ltda",
+        "nome_fantasia": "ACME Obras",
+        "municipio": "Florianopolis",
+        "uf": "SC",
+        "website": "https://acme.example.com"
+      },
+      "priority": {
+        "rank": 1,
+        "score": 82.5,
+        "tier": "HIGH",
+        "confidence": "HIGH"
+      },
+      "moment": {
+        "code": "CONTRACT_EXTENSION",
+        "summary": "Contrato de obra publica com prorrogacao publicada no PNCP",
+        "observed_at": "2026-07-15",
+        "confidence": "HIGH",
+        "evidence_ids": ["ev-acme-1"]
+      },
+      "offer": {
+        "service_code": "ADDITIVE_REVIEW",
+        "service_name": "Revisao de aditivos",
+        "entry_offer": "Leitura tecnica do aditivo em curso",
+        "rationale": "Momento de prorrogacao com margem para apoio consultivo"
+      },
+      "messaging_context": {
+        "fact_to_mention": "Prorrogacao do contrato 001/2025 publicada no PNCP em julho/2026",
+        "question_to_ask": "Faz sentido conversarmos sobre o controle de aditivos desta obra?",
+        "cta": "Posso enviar um checklist de 1 pagina?",
+        "claims_to_avoid": ["garantia de economia", "erro na gestao"]
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-acme-eng",
+          "name": "Ana Silva",
+          "role": "Engenheira de contratos",
+          "email": "ana.silva@acme.example.com",
+          "phone": "",
+          "linkedin_url": "",
+          "source_url": "https://acme.example.com/equipe",
+          "source_document": "",
+          "source_date": "2026-06-01",
+          "verification_status": "OFFICIAL_SOURCE",
+          "confidence": "HIGH",
+          "recommended": true
+        }
+      ],
+      "contracts": [
+        {"id": "c-001", "number": "001/2025", "agency": "Prefeitura Exemplo"}
+      ],
+      "evidence": [
+        {
+          "id": "ev-acme-1",
+          "type": "PNCP_PUBLICATION",
+          "title": "Prorrogacao contrato 001/2025",
+          "url": "https://pncp.example.gov.br/contratos/001-2025",
+          "document": "Termo de prorrogacao",
+          "date": "2026-07-15",
+          "location": "secao 2",
+          "excerpt": "Fica prorrogado o prazo de execucao por 180 dias.",
+          "synthesis": "Prorrogacao formal publicada",
+          "epistemic_class": "CONFIRMED_FACT",
+          "reliability": "HIGH",
+          "consulted_at": "2026-08-01"
+        }
+      ],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-nacional",
+      "company": {
+        "cnpj14": "99888777000166",
+        "cnpj_root": "99888777",
+        "razao_social": "Empresa Nacional de Infraestrutura SA",
+        "nome_fantasia": "ENI",
+        "municipio": "Sao Paulo",
+        "uf": "SP",
+        "website": "https://eni.example.org"
+      },
+      "priority": {
+        "rank": 2,
+        "score": 70,
+        "tier": "MEDIUM",
+        "confidence": "MEDIUM"
+      },
+      "moment": {
+        "code": "ADDITIVE_SIGNED",
+        "summary": "Aditivo de reajuste publicado",
+        "observed_at": "2026-06-20",
+        "confidence": "HIGH",
+        "evidence_ids": ["ev-eni-1"]
+      },
+      "offer": {
+        "service_code": "REAJUSTE_SUPPORT",
+        "service_name": "Apoio a reajustes",
+        "entry_offer": "Parecer resumido sobre clausula de reajuste",
+        "rationale": "Aditivo recente com potencial de segunda opiniao tecnica"
+      },
+      "messaging_context": {
+        "fact_to_mention": "Aditivo de reajuste do contrato 44/2024 publicado em junho/2026",
+        "question_to_ask": "Voces ja fecharam a leitura economica deste aditivo?",
+        "cta": "Posso compartilhar um modelo de memoria de calculo?",
+        "claims_to_avoid": []
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-eni-generic",
+          "name": "",
+          "role": "Comercial",
+          "email": "contato@eni.example.org",
+          "verification_status": "INSTITUTIONAL_GENERIC",
+          "confidence": "MEDIUM",
+          "recommended": true
+        }
+      ],
+      "contracts": [],
+      "evidence": [
+        {
+          "id": "ev-eni-1",
+          "type": "CONTRACT_ADDITIVE",
+          "title": "Aditivo reajuste 44/2024",
+          "url": "https://portal.example.gov.br/44-2024",
+          "date": "2026-06-20",
+          "excerpt": "Reajuste conforme indices oficiais.",
+          "synthesis": "Aditivo de reajuste formal",
+          "epistemic_class": "CONFIRMED_FACT",
+          "reliability": "HIGH",
+          "consulted_at": "2026-08-01"
+        }
+      ],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-no-contact",
+      "company": {
+        "cnpj14": "55444333000122",
+        "cnpj_root": "55444333",
+        "razao_social": "Obras do Planalto Ltda",
+        "nome_fantasia": "Planalto",
+        "municipio": "Brasilia",
+        "uf": "DF",
+        "website": ""
+      },
+      "priority": {
+        "rank": 3,
+        "score": 55,
+        "tier": "MEDIUM",
+        "confidence": "LOW"
+      },
+      "moment": {
+        "code": "TENDER_WIN",
+        "summary": "Homologacao recente em licitacao de reforma",
+        "observed_at": "2026-05-10",
+        "confidence": "MEDIUM",
+        "evidence_ids": []
+      },
+      "offer": {
+        "service_code": "BID_READINESS",
+        "service_name": "Preparacao de propostas",
+        "entry_offer": "Checklist de conformidade documental",
+        "rationale": ""
+      },
+      "messaging_context": {
+        "fact_to_mention": "Homologacao em licitação de reforma em maio/2026",
+        "question_to_ask": "Quem na equipe cuida da memoria de calculo de aditivos?",
+        "cta": "Posso enviar um checklist curto?",
+        "claims_to_avoid": []
+      },
+      "contacts": [],
+      "contracts": [],
+      "evidence": [],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-unverified",
+      "company": {
+        "cnpj14": "66777888000199",
+        "cnpj_root": "66777888",
+        "razao_social": "Consorcio Ponte Norte",
+        "nome_fantasia": "Ponte Norte",
+        "municipio": "Curitiba",
+        "uf": "PR",
+        "website": "https://pontenorte.example.net"
+      },
+      "priority": {
+        "rank": 4,
+        "score": 60,
+        "tier": "MEDIUM",
+        "confidence": "MEDIUM"
+      },
+      "moment": {
+        "code": "CONSORTIUM_ACTIVE",
+        "summary": "Consorcio ativo em obra rodoviaria",
+        "observed_at": "2026-04-01",
+        "confidence": "MEDIUM",
+        "evidence_ids": ["ev-cn-1"]
+      },
+      "offer": {
+        "service_code": "ADDITIVE_REVIEW",
+        "service_name": "Revisao de aditivos",
+        "entry_offer": "Mapa de riscos de aditivos do consorcio",
+        "rationale": "Estrutura multi-empresa exige cuidado com interlocutor"
+      },
+      "messaging_context": {
+        "fact_to_mention": "Consorcio ativo em obra rodoviaria com publicacoes recentes",
+        "question_to_ask": "Quem e o interlocutor tecnico de aditivos no consorcio?",
+        "cta": "Posso enviar uma pergunta objetiva por e-mail?",
+        "claims_to_avoid": ["vinculo societario"]
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-cn-cand",
+          "name": "Bruno Costa",
+          "role": "Diretor",
+          "email": "bruno@pontenorte.example.net",
+          "verification_status": "CANDIDATE_UNVERIFIED",
+          "confidence": "LOW",
+          "recommended": false
+        }
+      ],
+      "contracts": [],
+      "evidence": [
+        {
+          "id": "ev-cn-1",
+          "type": "PUBLIC_NOTICE",
+          "title": "Ata de consorcio",
+          "url": "https://docs.example.gov.br/consorcio-ponte",
+          "date": "2026-04-01",
+          "excerpt": "Constituido o consorcio Ponte Norte.",
+          "synthesis": "Consorcio formalizado",
+          "epistemic_class": "CONFIRMED_FACT",
+          "reliability": "MEDIUM",
+          "consulted_at": "2026-08-01"
+        }
+      ],
+      "commercial_state": "NEW"
+    },
+    {
+      "source_lead_id": "lead-dnc",
+      "company": {
+        "cnpj14": "12345678000195",
+        "cnpj_root": "12345678",
+        "razao_social": "Servicos Tecnicos Beta Ltda",
+        "nome_fantasia": "Beta",
+        "municipio": "Joinville",
+        "uf": "SC",
+        "website": "https://beta.example.com"
+      },
+      "priority": {
+        "rank": 5,
+        "score": 40,
+        "tier": "LOW",
+        "confidence": "HIGH"
+      },
+      "moment": {
+        "code": "NO_RECENT_SIGNAL",
+        "summary": "Sem fato gerador recente",
+        "observed_at": "2026-01-01",
+        "confidence": "HIGH",
+        "evidence_ids": []
+      },
+      "offer": {
+        "service_code": "DIAGNOSTIC",
+        "service_name": "Diagnostico leve",
+        "entry_offer": "Conversa exploratoria",
+        "rationale": ""
+      },
+      "messaging_context": {
+        "fact_to_mention": "Atuacao regional em contratos publicos de engenharia",
+        "question_to_ask": "Faz sentido uma conversa curta sobre controle de aditivos?",
+        "cta": "Posso ligar 10 minutos esta semana?",
+        "claims_to_avoid": []
+      },
+      "contacts": [
+        {
+          "source_contact_id": "ct-beta-dnc",
+          "name": "Carlos Souza",
+          "role": "Socio",
+          "email": "carlos@beta.example.com",
+          "verification_status": "DO_NOT_CONTACT",
+          "confidence": "HIGH",
+          "recommended": false
+        }
+      ],
+      "contracts": [],
+      "evidence": [],
+      "commercial_state": "DO_NOT_CONTACT"
+    }
+  ]
+}

--- a/internal/app/confenge/validators.go
+++ b/internal/app/confenge/validators.go
@@ -1,0 +1,425 @@
+package confenge
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// PromptVersion tags generation prompt revisions.
+const PromptVersion = "confenge.draft.v1"
+
+// DraftOutput is the structured generation result (validated before save).
+type DraftOutput struct {
+	Subject     string          `json:"subject"`
+	BodyText    string          `json:"body_text"`
+	BodyHTML    string          `json:"body_html"`
+	Followups   []DraftFollowup `json:"followups"`
+	FactUsed    string          `json:"fact_used"`
+	EvidenceIDs []string        `json:"evidence_ids"`
+	ServiceCode string          `json:"service_code"`
+	Question    string          `json:"question"`
+	CTA         string          `json:"cta"`
+	RiskFlags   []string        `json:"risk_flags"`
+}
+
+// DraftFollowup is one cadence follow-up in the same thread.
+type DraftFollowup struct {
+	DelayDays   int    `json:"delay_days"`
+	SubjectMode string `json:"subject_mode"`
+	BodyText    string `json:"body_text"`
+	BodyHTML    string `json:"body_html"`
+}
+
+// ValidationResult is deterministic pre-send / pre-approve checks.
+type ValidationResult struct {
+	OK       bool     `json:"ok"`
+	Errors   []string `json:"errors,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+}
+
+// Banned outreach phrases (Portuguese + known AI tells). Lowercased match.
+var bannedPhrases = []string{
+	"dinheiro a receber",
+	"crédito identificado",
+	"credito identificado",
+	"descobrimos um erro",
+	"há irregularidade",
+	"ha irregularidade",
+	"vocês deixaram de receber",
+	"voces deixaram de receber",
+	"sua equipe não controla",
+	"sua equipe nao controla",
+	"falta estrutura",
+	"lead quente",
+	"alta chance de conversão",
+	"alta chance de conversao",
+	"espero que esta mensagem o encontre bem",
+	"espero que esta mensagem a encontre bem",
+	"espero que este e-mail o encontre bem",
+	"i hope this email finds you",
+	"garantimos",
+	"garantia de",
+	"100% de sucesso",
+}
+
+// emDash and similar are banned in outbound confenge copy.
+var emDashRe = regexp.MustCompile(`[\x{2014}\x{2013}]`)
+
+// shortURLRe catches common shorteners (tracking risk).
+var shortURLRe = regexp.MustCompile(`(?i)https?://(bit\.ly|t\.co|goo\.gl|tinyurl\.com|ow\.ly)/`)
+
+// ValidateDraft runs deterministic checks before human approval / enrollment.
+func ValidateDraft(out *DraftOutput, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, maxWords int) ValidationResult {
+	var res ValidationResult
+	res.OK = true
+	if out == nil {
+		res.OK = false
+		res.Errors = append(res.Errors, "empty draft")
+		return res
+	}
+	if maxWords <= 0 {
+		maxWords = DefaultMaxInitialWords
+	}
+
+	email := ""
+	if cand != nil {
+		email = strings.TrimSpace(cand.Email)
+		if !cand.CanEnroll() {
+			res.OK = false
+			res.Errors = append(res.Errors, "contact is not enrollable (verification, DNC, bounce, or missing email)")
+		}
+		if cand.DoNotContact {
+			res.OK = false
+			res.Errors = append(res.Errors, "contact is DO_NOT_CONTACT")
+		}
+		if cand.Bounced {
+			res.OK = false
+			res.Errors = append(res.Errors, "contact address bounced")
+		}
+	} else {
+		res.OK = false
+		res.Errors = append(res.Errors, "no contact candidate")
+	}
+	if email == "" {
+		res.OK = false
+		res.Errors = append(res.Errors, "missing recipient email")
+	}
+
+	body := strings.TrimSpace(out.BodyText)
+	if body == "" {
+		res.OK = false
+		res.Errors = append(res.Errors, "empty body")
+	}
+	if strings.TrimSpace(out.Subject) == "" {
+		res.OK = false
+		res.Errors = append(res.Errors, "empty subject")
+	}
+
+	blob := strings.ToLower(out.Subject + "\n" + body)
+	for _, fu := range out.Followups {
+		blob += "\n" + strings.ToLower(fu.BodyText)
+	}
+
+	if emDashRe.MatchString(out.Subject + body) {
+		res.OK = false
+		res.Errors = append(res.Errors, "em dash / en dash not allowed in outreach copy")
+	}
+	for _, fu := range out.Followups {
+		if emDashRe.MatchString(fu.BodyText) {
+			res.OK = false
+			res.Errors = append(res.Errors, "em dash / en dash not allowed in follow-up copy")
+			break
+		}
+	}
+
+	for _, p := range bannedPhrases {
+		if strings.Contains(blob, p) {
+			res.OK = false
+			res.Errors = append(res.Errors, "banned phrase: "+p)
+		}
+	}
+
+	if shortURLRe.MatchString(body) {
+		res.OK = false
+		res.Errors = append(res.Errors, "shortened URLs are not allowed")
+	}
+	if strings.Contains(strings.ToLower(out.BodyHTML), "<script") {
+		res.OK = false
+		res.Errors = append(res.Errors, "unsafe HTML (script) not allowed")
+	}
+
+	words := countWords(body)
+	if words > maxWords {
+		res.OK = false
+		res.Errors = append(res.Errors, fmt.Sprintf("body exceeds %d words (%d)", maxWords, words))
+	}
+
+	if strings.TrimSpace(out.FactUsed) == "" {
+		res.OK = false
+		res.Errors = append(res.Errors, "fact_used is required")
+	}
+	if acc != nil && strings.TrimSpace(out.FactUsed) != "" {
+		// Fact should be grounded in account messaging or evidence synthesis.
+		grounded := strings.Contains(strings.ToLower(acc.FactToMention), strings.ToLower(out.FactUsed)) ||
+			strings.Contains(strings.ToLower(out.FactUsed), firstWords(acc.FactToMention, 4)) ||
+			strings.Contains(strings.ToLower(acc.MomentSummary), strings.ToLower(out.FactUsed))
+		if !grounded && acc.FactToMention != "" {
+			// Soft: warn if fact diverges heavily; still allow if evidence_ids present.
+			if len(out.EvidenceIDs) == 0 {
+				res.Warnings = append(res.Warnings, "fact_used may not match staging fact_to_mention and has no evidence_ids")
+			}
+		}
+	}
+	if strings.TrimSpace(out.FactUsed) != "" && len(out.EvidenceIDs) == 0 && acc != nil && len(acc.MomentEvidenceIDs) == 0 {
+		res.Warnings = append(res.Warnings, "fact used without evidence_ids")
+	}
+
+	if acc != nil {
+		if sc := strings.TrimSpace(out.ServiceCode); sc != "" && acc.ServiceCode != "" && !strings.EqualFold(sc, acc.ServiceCode) {
+			res.OK = false
+			res.Errors = append(res.Errors, "service_code does not match account offer")
+		}
+		// More than one service mention is a warning (hard multi-service check is approximate).
+		if countServiceMentions(body) > 1 {
+			res.OK = false
+			res.Errors = append(res.Errors, "body appears to offer more than one service")
+		}
+	}
+
+	qMarks := strings.Count(body, "?")
+	if qMarks > 2 {
+		res.Warnings = append(res.Warnings, "body has multiple question marks")
+	}
+
+	if !res.OK && len(res.Errors) == 0 {
+		res.Errors = append(res.Errors, "validation failed")
+	}
+	return res
+}
+
+func countWords(s string) int {
+	fields := strings.Fields(s)
+	return len(fields)
+}
+
+func firstWords(s string, n int) string {
+	f := strings.Fields(s)
+	if len(f) == 0 {
+		return ""
+	}
+	if len(f) < n {
+		n = len(f)
+	}
+	return strings.ToLower(strings.Join(f[:n], " "))
+}
+
+func countServiceMentions(body string) int {
+	// Conservative: count known multi-offer patterns rather than NLP.
+	patterns := []string{"além disso oferecemos", "alem disso oferecemos", "também fazemos", "tambem fazemos", "nossos serviços incluem", "nossos servicos incluem"}
+	n := 0
+	low := strings.ToLower(body)
+	for _, p := range patterns {
+		if strings.Contains(low, p) {
+			n++
+		}
+	}
+	return n
+}
+
+// ClassifyRisk returns GREEN/YELLOW/RED send-risk (not lead value).
+func ClassifyRisk(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, out *DraftOutput, val ValidationResult) (class string, flags []string) {
+	flags = []string{}
+	class = "GREEN"
+
+	raise := func(to string, flag string) {
+		flags = append(flags, flag)
+		if rank(to) > rank(class) {
+			class = to
+		}
+	}
+
+	if !val.OK {
+		raise("RED", "validation_failed")
+	}
+	if cand != nil {
+		switch cand.VerificationStatus {
+		case models.OutreachVerifyOfficialSource, models.OutreachVerifyMultipleSources, models.OutreachVerifyPublicDocumentRecent:
+			// ok
+		case models.OutreachVerifyInstitutionalGeneric:
+			raise("YELLOW", "institutional_generic_recipient")
+		case models.OutreachVerifyPublicPossiblyStale:
+			raise("YELLOW", "possibly_stale_contact")
+		default:
+			raise("RED", "weak_or_blocked_verification")
+		}
+		role := strings.ToLower(cand.Role)
+		for _, k := range []string{"ceo", "cfo", "presidente", "sócio", "socio", "diretor geral"} {
+			if strings.Contains(role, k) {
+				raise("RED", "senior_executive_recipient")
+				break
+			}
+		}
+	}
+	if acc != nil {
+		code := strings.ToUpper(acc.MomentCode + " " + acc.ServiceCode + " " + acc.MomentSummary)
+		for _, k := range []string{"CREDIT", "CRÉDITO", "CREDITO", "REEQUILIB", "SANCTION", "SANÇÃO", "SANCAO", "LITIG", "CONSÓRCIO", "CONSORCIO", "CONSORTIUM"} {
+			if strings.Contains(code, k) {
+				raise("RED", "sensitive_moment_or_service")
+				break
+			}
+		}
+		for _, k := range []string{"ADDITIVE", "ADITIVO", "EXTENSION", "PRORROG", "REAJUSTE"} {
+			if strings.Contains(code, k) {
+				raise("YELLOW", "contract_sensitive_topic")
+				break
+			}
+		}
+		if acc.FactToMention == "" {
+			raise("YELLOW", "missing_public_fact")
+		}
+	}
+	if out != nil {
+		blob := strings.ToLower(out.BodyText + " " + out.Subject)
+		for _, k := range []string{"crédito", "credito", "reequilíbrio", "reequilibrio", "litígio", "litigio", "sanção", "sancao"} {
+			if strings.Contains(blob, k) {
+				raise("RED", "economic_or_legal_claim_language")
+				break
+			}
+		}
+	}
+	if class == "GREEN" && len(flags) == 0 {
+		flags = []string{"low_send_risk"}
+	}
+	return class, flags
+}
+
+func rank(c string) int {
+	switch c {
+	case "RED":
+		return 3
+	case "YELLOW":
+		return 2
+	default:
+		return 1
+	}
+}
+
+// TemplateDraft builds a deterministic safe draft when AI is unavailable.
+// Never marked as AI-generated approved output by callers.
+func TemplateDraft(acc *models.OutreachAccount, cand *models.OutreachContactCandidate) DraftOutput {
+	name := ""
+	role := ""
+	email := ""
+	if cand != nil {
+		name = strings.TrimSpace(cand.Name)
+		role = strings.TrimSpace(cand.Role)
+		email = strings.TrimSpace(cand.Email)
+	}
+	company := ""
+	if acc != nil {
+		company = firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
+	}
+	greeting := "Olá"
+	if name != "" && cand != nil && cand.VerificationStatus != models.OutreachVerifyInstitutionalGeneric {
+		greeting = "Olá, " + firstName(name)
+	} else if cand != nil && cand.VerificationStatus == models.OutreachVerifyInstitutionalGeneric {
+		greeting = "Olá, equipe"
+	}
+
+	fact := ""
+	question := "Faz sentido conversarmos brevemente?"
+	cta := "Posso enviar um checklist de uma página?"
+	service := ""
+	if acc != nil {
+		fact = acc.FactToMention
+		if acc.QuestionToAsk != "" {
+			question = acc.QuestionToAsk
+		}
+		if acc.CTA != "" {
+			cta = acc.CTA
+		}
+		service = acc.ServiceName
+		if service == "" {
+			service = acc.ServiceCode
+		}
+	}
+	if fact == "" {
+		fact = "acompanhei publicações recentes relacionadas à " + company
+	}
+
+	body := greeting + ",\n\n"
+	body += "Sou da CONFENGE. Notei que " + fact + ".\n\n"
+	if service != "" {
+		body += "Ajudamos times de engenharia com " + strings.ToLower(service) + ", sempre a partir de fatos públicos e sem pressa.\n\n"
+	}
+	body += question + " " + cta + "\n\n"
+	body += "Abraço,\nTiago Sasaki\nCONFENGE"
+
+	// Strip any accidental em dashes from inputs.
+	body = emDashRe.ReplaceAllString(body, ",")
+	subj := "Sobre " + company
+	if utf8.RuneCountInString(subj) > 80 {
+		subj = "Conversa rápida"
+	}
+
+	_ = email
+	_ = role
+	return DraftOutput{
+		Subject:     subj,
+		BodyText:    body,
+		BodyHTML:    "",
+		Followups:   defaultFollowups(question),
+		FactUsed:    fact,
+		EvidenceIDs: nil,
+		ServiceCode: func() string {
+			if acc != nil {
+				return acc.ServiceCode
+			}
+			return ""
+		}(),
+		Question:  question,
+		CTA:       cta,
+		RiskFlags: []string{"template_fallback"},
+	}
+}
+
+func defaultFollowups(question string) []DraftFollowup {
+	return []DraftFollowup{
+		{DelayDays: 3, SubjectMode: "same_thread", BodyText: "Reenvio com uma pergunta mais objetiva: " + question},
+		{DelayDays: 7, SubjectMode: "same_thread", BodyText: "Se não for com você, pode me indicar a pessoa certa de contratos ou engenharia?"},
+		{DelayDays: 14, SubjectMode: "same_thread", BodyText: "Encerro por aqui para não ocupar sua caixa. Se fizer sentido no futuro, é só responder este fio."},
+	}
+}
+
+func firstName(full string) string {
+	parts := strings.Fields(full)
+	if len(parts) == 0 {
+		return full
+	}
+	return parts[0]
+}
+
+// CanBatchApprove reports whether a draft may be approved in bulk.
+func CanBatchApprove(d *models.OutreachDraft, cand *models.OutreachContactCandidate) bool {
+	if d == nil || cand == nil {
+		return false
+	}
+	if d.Status != models.OutreachDraftNeedsReview && d.Status != models.OutreachDraftApproved {
+		return false
+	}
+	if d.RiskClass != "GREEN" {
+		return false
+	}
+	if !cand.CanEnroll() {
+		return false
+	}
+	// validation must be ok
+	if d.ValidationOK != nil && !*d.ValidationOK {
+		return false
+	}
+	return true
+}

--- a/internal/app/confenge/validators_test.go
+++ b/internal/app/confenge/validators_test.go
@@ -1,0 +1,120 @@
+package confenge
+
+import (
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestValidateDraftRejectsEmDash(t *testing.T) {
+	acc := &models.OutreachAccount{ServiceCode: "ADDITIVE_REVIEW", FactToMention: "contrato prorrogado"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	out := &DraftOutput{
+		Subject: "Oi", BodyText: "Texto com travessão — aqui", FactUsed: "contrato prorrogado",
+		ServiceCode: "ADDITIVE_REVIEW", EvidenceIDs: []string{"e1"},
+	}
+	res := ValidateDraft(out, acc, cand, 120)
+	if res.OK {
+		t.Fatal("em dash must fail")
+	}
+}
+
+func TestValidateDraftRejectsBannedPhrase(t *testing.T) {
+	acc := &models.OutreachAccount{ServiceCode: "X", FactToMention: "fato"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	out := &DraftOutput{
+		Subject: "Oi", BodyText: "Identificamos dinheiro a receber na conta.", FactUsed: "fato",
+		ServiceCode: "X", EvidenceIDs: []string{"e1"},
+	}
+	res := ValidateDraft(out, acc, cand, 120)
+	if res.OK {
+		t.Fatal("banned phrase must fail")
+	}
+}
+
+func TestValidateDraftRejectsUnverified(t *testing.T) {
+	acc := &models.OutreachAccount{ServiceCode: "X", FactToMention: "fato publico"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyCandidateUnverified,
+	}
+	out := &DraftOutput{
+		Subject: "Oi", BodyText: "Mensagem curta com fato publico. Faz sentido?", FactUsed: "fato publico",
+		ServiceCode: "X", EvidenceIDs: []string{"e1"},
+	}
+	res := ValidateDraft(out, acc, cand, 120)
+	if res.OK {
+		t.Fatal("unverified must not enroll")
+	}
+}
+
+func TestValidateDraftAcceptsClean(t *testing.T) {
+	acc := &models.OutreachAccount{ServiceCode: "ADDITIVE_REVIEW", FactToMention: "prorrogacao do contrato 001"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	out := &DraftOutput{
+		Subject:     "Sobre a prorrogacao",
+		BodyText:    "Ola Ana,\n\nNotei a prorrogacao do contrato 001. Faz sentido conversarmos sobre aditivos?\n\nPosso enviar um checklist?",
+		FactUsed:    "prorrogacao do contrato 001",
+		ServiceCode: "ADDITIVE_REVIEW",
+		EvidenceIDs: []string{"e1"},
+		Question:    "Faz sentido conversarmos?",
+		CTA:         "Posso enviar um checklist?",
+	}
+	res := ValidateDraft(out, acc, cand, 120)
+	if !res.OK {
+		t.Fatalf("expected ok, got %v", res.Errors)
+	}
+}
+
+func TestClassifyRiskRedForCredit(t *testing.T) {
+	acc := &models.OutreachAccount{MomentCode: "CREDIT_CLAIM", FactToMention: "x"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	class, flags := ClassifyRisk(acc, cand, &DraftOutput{BodyText: "ola"}, ValidationResult{OK: true})
+	if class != "RED" {
+		t.Fatalf("want RED got %s flags=%v", class, flags)
+	}
+}
+
+func TestClassifyRiskGreenOfficial(t *testing.T) {
+	acc := &models.OutreachAccount{MomentCode: "WARM_INTRO", FactToMention: "publicacao no portal", ServiceCode: "DIAGNOSTIC"}
+	cand := &models.OutreachContactCandidate{
+		Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Role: "Analista",
+	}
+	class, _ := ClassifyRisk(acc, cand, &DraftOutput{BodyText: "ola", Subject: "oi"}, ValidationResult{OK: true})
+	if class != "GREEN" {
+		t.Fatalf("want GREEN got %s", class)
+	}
+}
+
+func TestTemplateDraftNoEmDash(t *testing.T) {
+	acc := &models.OutreachAccount{
+		RazaoSocial: "ACME", FactToMention: "contrato X", ServiceName: "revisao",
+		QuestionToAsk: "Faz sentido?", CTA: "Posso enviar?",
+	}
+	cand := &models.OutreachContactCandidate{Name: "Ana Silva", Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource}
+	out := TemplateDraft(acc, cand)
+	if emDashRe.MatchString(out.BodyText + out.Subject) {
+		t.Fatal("template must not contain em dash")
+	}
+	if out.BodyText == "" || out.Subject == "" {
+		t.Fatal("template empty")
+	}
+}
+
+func TestParseDraftJSONStripsFence(t *testing.T) {
+	raw := "```json\n{\"subject\":\"Oi\",\"body_text\":\"Corpo\",\"fact_used\":\"f\",\"service_code\":\"S\",\"evidence_ids\":[\"1\"],\"followups\":[],\"question\":\"?\",\"cta\":\"c\",\"risk_flags\":[]}\n```"
+	out, err := parseDraftJSON(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.Subject != "Oi" {
+		t.Fatalf("got %q", out.Subject)
+	}
+}

--- a/internal/app/confenge/whatsapp_ops.go
+++ b/internal/app/confenge/whatsapp_ops.go
@@ -197,11 +197,9 @@ func (s *service) SendApprovedWhatsApp(ctx context.Context, orgID, userID, draft
 	if err != nil || d == nil {
 		return nil, errx.New(errx.NotFound, "draft not found")
 	}
-	if d.Channel != models.OutreachChannelWhatsApp && d.Channel != "" && d.Channel != "WHATSAPP" {
-		// allow empty channel only if phone present (legacy) — still require explicit WHATSAPP
-		if d.RecipientPhoneE164 == "" {
-			return nil, errx.New(errx.BadRequest, "draft is not a WhatsApp draft")
-		}
+	// Explicit WHATSAPP channel only — never send an EMAIL draft even if a phone is set.
+	if d.Channel != models.OutreachChannelWhatsApp && d.Channel != "WHATSAPP" {
+		return nil, errx.New(errx.BadRequest, "draft is not a WhatsApp draft")
 	}
 	if d.Status != models.OutreachDraftApproved {
 		return nil, errx.New(errx.BadRequest, "draft must be APPROVED before WhatsApp send")

--- a/internal/app/confenge/whatsapp_ops.go
+++ b/internal/app/confenge/whatsapp_ops.go
@@ -1,0 +1,579 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// WhatsAppSender is the subset of whatsapp.Service used by confenge ops.
+type WhatsAppSender interface {
+	Config() whatsapp.Config
+	Send(ctx context.Context, state whatsapp.ContactChannelState, intent whatsapp.SendIntent, textReq *whatsapp.SendTextRequest, tmplReq *whatsapp.SendTemplateRequest) (*whatsapp.SendResultExt, error)
+	ProcessInbound(ctx context.Context, state *whatsapp.ContactChannelState, ev whatsapp.ChannelEvent) (whatsapp.InboundResult, error)
+	ProviderName() string
+}
+
+// WhatsAppStateStore persists channel state + messages (optional; nil = in-process only).
+type WhatsAppStateStore interface {
+	UpsertContactState(ctx context.Context, st *models.WhatsAppContactState) *errx.Error
+	GetContactStateByPhone(ctx context.Context, orgID uuid.UUID, phoneE164 string) (*models.WhatsAppContactState, *errx.Error)
+	InsertMessage(ctx context.Context, msg *models.WhatsAppMessage) (bool, *errx.Error)
+	GetInstanceByName(ctx context.Context, provider, instance string) (*models.WhatsAppInstance, *errx.Error)
+	InsertWebhookEvent(ctx context.Context, orgID uuid.UUID, provider, idemKey, eventType, externalMsgID, payloadHash string) (bool, *errx.Error)
+}
+
+// WireWhatsApp attaches the transport service and optional state store.
+func (s *service) WireWhatsApp(sender WhatsAppSender, store WhatsAppStateStore) {
+	s.wa = sender
+	s.waStore = store
+}
+
+// DecideChannel runs the multichannel orchestrator for an account/candidate.
+func (s *service) DecideChannel(ctx context.Context, orgID, accountID uuid.UUID, contactID *uuid.UUID) (*ChannelDecision, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, accountID)
+	if err != nil || acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	var cand *models.OutreachContactCandidate
+	if contactID != nil {
+		cand, err = s.repo.GetCandidate(ctx, orgID, *contactID)
+		if err != nil || cand == nil {
+			return nil, errx.New(errx.NotFound, "contact candidate not found")
+		}
+	} else {
+		list, err := s.repo.ListCandidates(ctx, orgID, accountID)
+		if err != nil {
+			return nil, errx.New(errx.Internal, "list candidates failed")
+		}
+		cand = pickRecommendedAny(list)
+	}
+	st := candidateToChannelState(orgID, cand, acc)
+	emailOK := cand != nil && cand.Email != "" && cand.CanEnroll()
+	phone := ""
+	if cand != nil {
+		phone = cand.PhoneE164
+		if phone == "" {
+			phone = cand.Phone
+		}
+	}
+	waOn := s.cfg.WhatsAppEnabled && s.wa != nil && s.wa.Config().Enabled
+	intent := whatsapp.SendIntent{
+		Mode:                 whatsapp.ModeFreeText,
+		Automated:            true,
+		FeatureEnabled:       waOn,
+		AutoSendEnabled:      s.wa != nil && s.wa.Config().AutoSendEnabled,
+		RequireHumanApproval: s.cfg.RequireHumanApproval,
+		Now:                  time.Now().UTC(),
+		CrossChannelMin:      time.Duration(s.cfg.CrossChannelHours) * time.Hour,
+		ServiceWindow:        24 * time.Hour,
+	}
+	if s.wa != nil {
+		intent.ServiceWindow = s.wa.Config().ServiceWindow
+		if intent.CrossChannelMin == 0 {
+			intent.CrossChannelMin = s.wa.Config().CrossChannelInterval
+		}
+	}
+	d := OrchestrateChannel(waOn, emailOK, phone, st, intent)
+	return &d, nil
+}
+
+// GenerateWhatsAppDraft creates a short WhatsApp draft for human review.
+// Never auto-sends. Public phone without opt-in is blocked.
+func (s *service) GenerateWhatsAppDraft(ctx context.Context, orgID, userID, accountID uuid.UUID, contactID *uuid.UUID) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if !s.cfg.WhatsAppEnabled {
+		return nil, errx.New(errx.BadRequest, "CONFENGE_WHATSAPP_ENABLED is false")
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, accountID)
+	if err != nil || acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	if acc.DoNotContact || acc.Blocked {
+		return nil, errx.New(errx.BadRequest, "account is blocked or DO_NOT_CONTACT")
+	}
+	var cand *models.OutreachContactCandidate
+	if contactID != nil {
+		cand, err = s.repo.GetCandidate(ctx, orgID, *contactID)
+		if err != nil || cand == nil || cand.AccountID != accountID {
+			return nil, errx.New(errx.NotFound, "contact candidate not found")
+		}
+	} else {
+		list, err := s.repo.ListCandidates(ctx, orgID, accountID)
+		if err != nil {
+			return nil, errx.New(errx.Internal, "failed to list contacts")
+		}
+		cand = pickRecommendedAny(list)
+	}
+	if cand == nil {
+		return nil, errx.New(errx.BadRequest, "no contact candidate")
+	}
+	phone := cand.PhoneE164
+	if phone == "" {
+		norm := whatsapp.NormalizePhone(cand.Phone, "BR")
+		if norm.Valid {
+			phone = norm.E164
+		}
+	}
+	if phone == "" {
+		return nil, errx.New(errx.BadRequest, "candidate has no valid phone")
+	}
+
+	st := candidateToChannelState(orgID, cand, acc)
+	intent := whatsapp.SendIntent{
+		Mode:                 whatsapp.ModeFreeText,
+		Automated:            true,
+		FeatureEnabled:       true,
+		AutoSendEnabled:      false, // draft path never auto-sends
+		RequireHumanApproval: true,
+		Now:                  time.Now().UTC(),
+		CrossChannelMin:      time.Duration(s.cfg.CrossChannelHours) * time.Hour,
+	}
+	// Policy: must not even generate for blocked consent (still allow MANUAL_REVIEW for opted-in).
+	d := whatsapp.EvaluateEligibility(st, intent)
+	if d.Eligibility == whatsapp.EligBlocked && (st.ConsentStatus == whatsapp.ConsentUnknown || st.ConsentStatus == whatsapp.ConsentNoOptIn || st.ConsentStatus == whatsapp.ConsentOptedOut || st.DoNotContact) {
+		return nil, errx.New(errx.BadRequest, "whatsapp blocked by consent: "+d.Reason)
+	}
+
+	body := BuildWhatsAppCopy(acc, cand)
+	draft := &models.OutreachDraft{
+		OrganizationID:     orgID,
+		AccountID:          accountID,
+		ContactCandidateID: &cand.ID,
+		Channel:            models.OutreachChannelWhatsApp,
+		RecipientName:      cand.Name,
+		RecipientRole:      cand.Role,
+		RecipientEmail:     cand.Email,
+		RecipientPhoneE164: phone,
+		VerificationStatus: cand.VerificationStatus,
+		Subject:            "", // WhatsApp has no subject
+		BodyText:           SanitizeText(body, 2000),
+		ServiceCode:        acc.ServiceCode,
+		FactUsed:           SanitizeText(acc.FactToMention, 2000),
+		Question:           SanitizeText(acc.QuestionToAsk, 1000),
+		CTA:                SanitizeText(acc.CTA, 500),
+		Provider:           "template",
+		Model:              "whatsapp_short",
+		PromptVersion:      PromptVersion + "+wa",
+		Status:             models.OutreachDraftNeedsReview,
+		RiskClass:          "YELLOW",
+		RiskFlags:          []string{"whatsapp_channel", "requires_human_approval"},
+	}
+	ok := true
+	draft.ValidationOK = &ok
+	if err := s.repo.UpsertDraft(ctx, draft); err != nil {
+		return nil, errx.New(errx.Internal, "failed to save whatsapp draft: "+err.Error())
+	}
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionCreate, models.AuditEntityOutreachAccount, &accountID, "", "",
+			map[string]string{"draft_id": draft.ID.String(), "channel": "WHATSAPP", "status": draft.Status},
+			map[string]string{"phone": phone},
+		)
+	}
+	return draft, nil
+}
+
+// SendApprovedWhatsApp sends an APPROVED WhatsApp draft via the provider after policy gate.
+func (s *service) SendApprovedWhatsApp(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if s.wa == nil || !s.cfg.WhatsAppEnabled {
+		return nil, errx.New(errx.ServiceUnavailable, "whatsapp transport not configured")
+	}
+	d, err := s.repo.GetDraft(ctx, orgID, draftID)
+	if err != nil || d == nil {
+		return nil, errx.New(errx.NotFound, "draft not found")
+	}
+	if d.Channel != models.OutreachChannelWhatsApp && d.Channel != "" && d.Channel != "WHATSAPP" {
+		// allow empty channel only if phone present (legacy) — still require explicit WHATSAPP
+		if d.RecipientPhoneE164 == "" {
+			return nil, errx.New(errx.BadRequest, "draft is not a WhatsApp draft")
+		}
+	}
+	if d.Status != models.OutreachDraftApproved {
+		return nil, errx.New(errx.BadRequest, "draft must be APPROVED before WhatsApp send")
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, d.AccountID)
+	if err != nil || acc == nil {
+		return nil, errx.New(errx.NotFound, "account not found")
+	}
+	var cand *models.OutreachContactCandidate
+	if d.ContactCandidateID != nil {
+		cand, _ = s.repo.GetCandidate(ctx, orgID, *d.ContactCandidateID)
+	}
+	st := candidateToChannelState(orgID, cand, acc)
+	if d.RecipientPhoneE164 != "" {
+		st.PhoneE164 = d.RecipientPhoneE164
+	}
+	// Load live service window from store when present.
+	if s.waStore != nil && st.PhoneE164 != "" {
+		if live, xerr := s.waStore.GetContactStateByPhone(ctx, orgID, st.PhoneE164); xerr == nil && live != nil {
+			st.LastInboundAt = live.LastInboundAt
+			st.ServiceWindowUntil = live.ServiceWindowUntil
+			st.OptOutAt = live.OptOutAt
+			if live.DoNotContact {
+				st.DoNotContact = true
+			}
+			if live.ConsentStatus == whatsapp.ConsentOptedOut || live.ConsentStatus == whatsapp.ConsentDoNotContact {
+				st.ConsentStatus = live.ConsentStatus
+			}
+			if live.LastEmailOutboundAt != nil {
+				st.LastEmailOutboundAt = live.LastEmailOutboundAt
+			}
+			if live.LastWhatsAppOutboundAt != nil {
+				st.LastWhatsAppOutboundAt = live.LastWhatsAppOutboundAt
+			}
+		}
+	}
+
+	intent := whatsapp.SendIntent{
+		Mode:                 whatsapp.ModeFreeText,
+		Automated:            false, // human approved send
+		FeatureEnabled:       true,
+		AutoSendEnabled:      true, // human already approved; allow transport
+		RequireHumanApproval: false,
+		Now:                  time.Now().UTC(),
+		CrossChannelMin:      time.Duration(s.cfg.CrossChannelHours) * time.Hour,
+		ServiceWindow:        s.wa.Config().ServiceWindow,
+	}
+	// Outside service window without template: block free text.
+	elig := whatsapp.EvaluateEligibility(st, intent)
+	if !elig.Allowed {
+		return nil, errx.New(errx.BadRequest, "whatsapp send blocked: "+elig.Reason)
+	}
+
+	instance := s.wa.Config().EvolutionInstance
+	res, err := s.wa.Send(ctx, st, intent, &whatsapp.SendTextRequest{
+		Instance:       instance,
+		ToE164:         st.PhoneE164,
+		Body:           d.BodyText,
+		IdempotencyKey: "wa-draft:" + draftID.String(),
+		OrganizationID: orgID,
+	}, nil)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "whatsapp send failed: "+err.Error())
+	}
+	if res == nil || res.Skipped {
+		reason := "skipped"
+		if res != nil {
+			reason = res.Decision.Reason
+		}
+		return nil, errx.New(errx.BadRequest, "whatsapp send skipped: "+reason)
+	}
+
+	now := time.Now().UTC()
+	d.Status = models.OutreachDraftSent
+	if err := s.repo.UpsertDraft(ctx, d); err != nil {
+		return nil, errx.New(errx.Internal, "failed to mark draft sent")
+	}
+	_ = s.repo.SetAccountHumanFlags(ctx, orgID, d.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueSent)
+
+	// Persist outbound message + state.
+	if s.waStore != nil {
+		msg := &models.WhatsAppMessage{
+			OrganizationID:    orgID,
+			ThreadKey:         st.PhoneE164,
+			Direction:         "outbound",
+			Channel:           whatsapp.ChannelWhatsApp,
+			Provider:          s.wa.ProviderName(),
+			ProviderMessageID: "",
+			IdempotencyKey:    "wa-draft-send:" + draftID.String(),
+			BodyText:          d.BodyText,
+			Status:            "sent",
+			DraftID:           &d.ID,
+			CampaignID:        d.CampaignID,
+			ReviewedBy:        &userID,
+			ApprovedAt:        d.ApprovedAt,
+			SentAt:            &now,
+			OccurredAt:        now,
+		}
+		if res.Result != nil {
+			msg.ProviderMessageID = res.Result.ProviderMessageID
+		}
+		if cand != nil && cand.WarmblyContactID != nil {
+			msg.ContactID = cand.WarmblyContactID
+		}
+		_, _ = s.waStore.InsertMessage(ctx, msg)
+
+		persist := models.WhatsAppContactState{
+			OrganizationID:         orgID,
+			PhoneE164:              st.PhoneE164,
+			PhoneRaw:               st.PhoneE164,
+			PhoneValid:             true,
+			ConsentStatus:          st.ConsentStatus,
+			ConsentSource:          st.ConsentSource,
+			ConsentAt:              st.ConsentAt,
+			ConsentProvenanceOK:    st.ConsentProvenanceOK,
+			LastWhatsAppOutboundAt: &now,
+			ContactID:              nil,
+		}
+		if cand != nil && cand.WarmblyContactID != nil {
+			persist.ContactID = cand.WarmblyContactID
+		}
+		_ = s.waStore.UpsertContactState(ctx, &persist)
+	}
+
+	_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+		IdempotencyKey: fmt.Sprintf("wa-sent:%s:%s", orgID, draftID),
+		SourceLeadID:   acc.SourceLeadID,
+		CNPJ14:         acc.CNPJ14,
+		ContactEmail:   d.RecipientEmail,
+		EventType:      OutcomeContacted,
+		OccurredAt:     now,
+		Payload:        mustJSON(map[string]any{"channel": "WHATSAPP", "draft_id": draftID.String()}),
+	})
+
+	if s.audit != nil {
+		s.audit.LogAction(ctx, orgID, userID, models.AuditActionUpdate, models.AuditEntityOutreachAccount, &d.AccountID, "", "",
+			map[string]string{"draft_id": d.ID.String(), "status": d.Status, "channel": "WHATSAPP"},
+			nil,
+		)
+	}
+	return d, nil
+}
+
+// HandleWhatsAppInbound is the production path for Evolution-normalized inbound events.
+// It stops follow-ups, records CRM/outcomes, and applies sticky opt-out.
+func (s *service) HandleWhatsAppInbound(ctx context.Context, orgID uuid.UUID, ev whatsapp.ChannelEvent) (whatsapp.InboundResult, error) {
+	empty := whatsapp.InboundResult{Event: ev}
+	if s == nil || !s.cfg.Enabled {
+		return empty, nil
+	}
+	if s.wa == nil {
+		return empty, fmt.Errorf("whatsapp service not wired")
+	}
+
+	phone := ev.FromE164
+	if phone == "" {
+		phone = ev.ToE164
+	}
+	st := whatsapp.ContactChannelState{
+		OrganizationID: orgID,
+		PhoneE164:      phone,
+		ConsentStatus:  whatsapp.ConsentUnknown,
+	}
+	// Resolve candidate by phone or e164.
+	var cand *models.OutreachContactCandidate
+	var acc *models.OutreachAccount
+	if phone != "" {
+		c, a, err := s.repo.FindCandidateByPhone(ctx, orgID, phone)
+		if err == nil {
+			cand, acc = c, a
+		}
+	}
+	if cand != nil {
+		st = candidateToChannelState(orgID, cand, acc)
+	}
+
+	// Overlay persisted channel state.
+	if s.waStore != nil && phone != "" {
+		if live, xerr := s.waStore.GetContactStateByPhone(ctx, orgID, phone); xerr == nil && live != nil {
+			if live.ConsentStatus != "" {
+				st.ConsentStatus = live.ConsentStatus
+			}
+			st.ConsentProvenanceOK = live.ConsentProvenanceOK
+			st.OptOutAt = live.OptOutAt
+			st.DoNotContact = live.DoNotContact || st.DoNotContact
+			st.LastInboundAt = live.LastInboundAt
+			st.ServiceWindowUntil = live.ServiceWindowUntil
+			if live.ContactID != nil {
+				st.ContactID = *live.ContactID
+			}
+		}
+	}
+
+	res, err := s.wa.ProcessInbound(ctx, &st, ev)
+	if err != nil {
+		return res, err
+	}
+	if res.Duplicate || res.Ignored {
+		return res, nil
+	}
+
+	// Persist message + state.
+	if s.waStore != nil && ev.EventType == whatsapp.EventMessageReceived {
+		msg := &models.WhatsAppMessage{
+			OrganizationID:    orgID,
+			ThreadKey:         phone,
+			Direction:         "inbound",
+			Channel:           whatsapp.ChannelWhatsApp,
+			Provider:          whatsapp.ProviderEvolution,
+			ProviderMessageID: ev.ExternalMessageID,
+			IdempotencyKey:    ev.IdempotencyKey(),
+			BodyText:          ev.Content.Text,
+			Status:            "received",
+			OccurredAt:        ev.OccurredAt,
+		}
+		if cand != nil && cand.WarmblyContactID != nil {
+			msg.ContactID = cand.WarmblyContactID
+		}
+		_, _ = s.waStore.InsertMessage(ctx, msg)
+
+		persist := models.WhatsAppContactState{
+			OrganizationID:      orgID,
+			PhoneE164:           st.PhoneE164,
+			PhoneValid:          true,
+			ConsentStatus:       st.ConsentStatus,
+			ConsentSource:       st.ConsentSource,
+			ConsentAt:           st.ConsentAt,
+			ConsentProvenanceOK: st.ConsentProvenanceOK,
+			LastInboundAt:       st.LastInboundAt,
+			ServiceWindowUntil:  st.ServiceWindowUntil,
+			OptOutAt:            st.OptOutAt,
+			DoNotContact:        st.DoNotContact,
+		}
+		if cand != nil && cand.WarmblyContactID != nil {
+			persist.ContactID = cand.WarmblyContactID
+		}
+		_ = s.waStore.UpsertContactState(ctx, &persist)
+	}
+
+	// Stop follow-ups / mark replied on confenge account + drafts.
+	if res.StopSequences && acc != nil {
+		_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, acc.Blocked, acc.DoNotContact || st.DoNotContact, acc.BlockReason, models.OutreachQueueReplied)
+		// Mark WhatsApp drafts replied when possible.
+		if drafts, err := s.repo.ListDrafts(ctx, orgID, models.OutreachDraftEnrolled, 50, 0); err == nil {
+			for i := range drafts {
+				dd := drafts[i]
+				if dd.AccountID == acc.ID && (dd.Channel == models.OutreachChannelWhatsApp || dd.Channel == "WHATSAPP" || dd.RecipientPhoneE164 != "") {
+					dd.Status = models.OutreachDraftReplied
+					_ = s.repo.UpsertDraft(ctx, &dd)
+				}
+			}
+		}
+		for _, stt := range []string{models.OutreachDraftSent, models.OutreachDraftApproved} {
+			if drafts, err := s.repo.ListDrafts(ctx, orgID, stt, 50, 0); err == nil {
+				for i := range drafts {
+					dd := drafts[i]
+					if dd.AccountID == acc.ID {
+						dd.Status = models.OutreachDraftReplied
+						_ = s.repo.UpsertDraft(ctx, &dd)
+					}
+				}
+			}
+		}
+	}
+
+	// Outcomes + DNC.
+	email := ""
+	if cand != nil {
+		email = cand.Email
+	}
+	if res.OptOut.Matched && res.OptOut.Confident {
+		if email != "" {
+			_ = s.NoteDNC(ctx, orgID, email, "whatsapp_opt_out:"+res.OptOut.Phrase)
+		} else if acc != nil {
+			_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+				IdempotencyKey: fmt.Sprintf("wa-dnc:%s:%s", orgID, phone),
+				SourceLeadID:   acc.SourceLeadID,
+				CNPJ14:         acc.CNPJ14,
+				EventType:      OutcomeDoNotContact,
+				OccurredAt:     ev.OccurredAt,
+				Payload:        mustJSON(map[string]any{"channel": "WHATSAPP", "phrase": res.OptOut.Phrase, "phone": phone}),
+			})
+			_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, true, true, "whatsapp_opt_out", models.OutreachQueueDoNotContact)
+		}
+		if cand != nil {
+			cand.DoNotContact = true
+			cand.WhatsAppConsentStatus = whatsapp.ConsentOptedOut
+			now := ev.OccurredAt
+			cand.WhatsAppConsentAt = &now
+			_, _ = s.repo.UpsertCandidate(ctx, cand)
+		}
+	} else if res.StopSequences && email != "" {
+		_ = s.NoteReply(ctx, orgID, email, map[string]any{
+			"channel": "WHATSAPP",
+			"text":    truncateRunes(ev.Content.Text, 500),
+		})
+		// Feed CRM classification path (same taxonomy as email).
+		_ = s.HandleClassifiedReply(ctx, orgID, uuid.Nil, email, "unknown", nil)
+	} else if res.StopSequences && acc != nil {
+		_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{
+			IdempotencyKey: fmt.Sprintf("wa-replied:%s:%s:%s", orgID, phone, ev.ExternalMessageID),
+			SourceLeadID:   acc.SourceLeadID,
+			CNPJ14:         acc.CNPJ14,
+			EventType:      OutcomeReplied,
+			OccurredAt:     ev.OccurredAt,
+			Payload:        mustJSON(map[string]any{"channel": "WHATSAPP", "phone": phone}),
+		})
+	}
+
+	return res, nil
+}
+
+func candidateToChannelState(orgID uuid.UUID, cand *models.OutreachContactCandidate, acc *models.OutreachAccount) whatsapp.ContactChannelState {
+	st := whatsapp.ContactChannelState{
+		OrganizationID: orgID,
+		ConsentStatus:  whatsapp.ConsentUnknown,
+	}
+	if acc != nil && acc.DoNotContact {
+		st.DoNotContact = true
+		st.ConsentStatus = whatsapp.ConsentDoNotContact
+	}
+	if cand == nil {
+		return st
+	}
+	if cand.WarmblyContactID != nil {
+		st.ContactID = *cand.WarmblyContactID
+	}
+	st.PhoneE164 = cand.PhoneE164
+	if st.PhoneE164 == "" && cand.Phone != "" {
+		n := whatsapp.NormalizePhone(cand.Phone, "BR")
+		if n.Valid {
+			st.PhoneE164 = n.E164
+		}
+	}
+	st.PhoneSource = cand.PhoneSource
+	st.PhoneSourceURL = cand.PhoneSourceURL
+	if cand.WhatsAppConsentStatus != "" {
+		st.ConsentStatus = cand.WhatsAppConsentStatus
+	}
+	st.ConsentSource = cand.WhatsAppConsentSource
+	st.ConsentAt = cand.WhatsAppConsentAt
+	st.ConsentProvenanceOK = cand.WhatsAppConsentProvenanceOK
+	if cand.DoNotContact {
+		st.DoNotContact = true
+		st.ConsentStatus = whatsapp.ConsentDoNotContact
+	}
+	return st
+}
+
+// pickRecommendedAny prefers enrollable email contacts but falls back to any non-DNC with phone.
+func pickRecommendedAny(list []models.OutreachContactCandidate) *models.OutreachContactCandidate {
+	if c := pickRecommended(list); c != nil {
+		return c
+	}
+	var fallback *models.OutreachContactCandidate
+	for i := range list {
+		c := &list[i]
+		if c.DoNotContact || c.Bounced || c.Blocked {
+			continue
+		}
+		if c.Phone == "" && c.PhoneE164 == "" {
+			continue
+		}
+		if c.Recommended {
+			return c
+		}
+		if fallback == nil {
+			fallback = c
+		}
+	}
+	return fallback
+}
+
+// Ensure compile-time use of strings in this package for truncate helpers.
+var _ = strings.TrimSpace

--- a/internal/app/confenge/whatsapp_ops_test.go
+++ b/internal/app/confenge/whatsapp_ops_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/warmbly/warmbly/internal/app/whatsapp"
+	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -47,6 +48,42 @@ func TestLeadToCandidatePhoneConsent(t *testing.T) {
 	}
 }
 
+// memWAStore persists channel state for send/inbound integration tests.
+type memWAStore struct {
+	byPhone map[string]*models.WhatsAppContactState
+	msgs    int
+}
+
+func (m *memWAStore) UpsertContactState(_ context.Context, st *models.WhatsAppContactState) *errx.Error {
+	if m.byPhone == nil {
+		m.byPhone = map[string]*models.WhatsAppContactState{}
+	}
+	cp := *st
+	m.byPhone[st.PhoneE164] = &cp
+	return nil
+}
+func (m *memWAStore) GetContactStateByPhone(_ context.Context, _ uuid.UUID, phone string) (*models.WhatsAppContactState, *errx.Error) {
+	if m.byPhone == nil {
+		return nil, nil
+	}
+	st := m.byPhone[phone]
+	if st == nil {
+		return nil, nil
+	}
+	cp := *st
+	return &cp, nil
+}
+func (m *memWAStore) InsertMessage(context.Context, *models.WhatsAppMessage) (bool, *errx.Error) {
+	m.msgs++
+	return true, nil
+}
+func (m *memWAStore) GetInstanceByName(context.Context, string, string) (*models.WhatsAppInstance, *errx.Error) {
+	return nil, nil
+}
+func (m *memWAStore) InsertWebhookEvent(context.Context, uuid.UUID, string, string, string, string, string) (bool, *errx.Error) {
+	return true, nil
+}
+
 func TestDecideChannelGenerateAndSend(t *testing.T) {
 	org := uuid.New()
 	accID := uuid.New()
@@ -74,9 +111,10 @@ func TestDecideChannelGenerateAndSend(t *testing.T) {
 		Enabled: true, AutoSendEnabled: false, CrossChannelInterval: 0, ServiceWindow: 24 * time.Hour,
 		EvolutionInstance: "test",
 	}, mock, nil)
+	store := &memWAStore{}
 	cfg := Config{Enabled: true, WhatsAppEnabled: true, RequireHumanApproval: true, CrossChannelHours: 0, MaxInitialEmailWords: 120}
 	svc := NewService(cfg, repo, nil).(*service)
-	svc.WireWhatsApp(waSvc, nil)
+	svc.WireWhatsApp(waSvc, store)
 
 	// Case A: public phone
 	pubID := uuid.New()
@@ -105,7 +143,7 @@ func TestDecideChannelGenerateAndSend(t *testing.T) {
 		t.Fatal("generate must not send")
 	}
 
-	// Open service window via inbound then send approved draft
+	// Open service window via inbound (persisted in store) then send approved draft.
 	_, err := svc.HandleWhatsAppInbound(context.Background(), org, whatsapp.ChannelEvent{
 		Channel: whatsapp.ChannelWhatsApp, Provider: whatsapp.ProviderEvolution,
 		EventType: whatsapp.EventMessageReceived, ExternalMessageID: "in1",
@@ -114,6 +152,9 @@ func TestDecideChannelGenerateAndSend(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatal(err)
+	}
+	if st, _ := store.GetContactStateByPhone(context.Background(), org, "+5548999887766"); st == nil || st.ServiceWindowUntil == nil {
+		t.Fatal("inbound must open service window in store")
 	}
 	draft.Status = models.OutreachDraftApproved
 	_ = repo.UpsertDraft(context.Background(), draft)
@@ -189,6 +230,36 @@ func TestHandleWhatsAppInboundOptOutStopsAndOutcomes(t *testing.T) {
 	}
 	if !res2.Duplicate {
 		t.Fatal("expected duplicate")
+	}
+}
+
+func TestSendApprovedWhatsAppRejectsEmailDraft(t *testing.T) {
+	org := uuid.New()
+	accID := uuid.New()
+	user := uuid.New()
+	repo := newMemRepo()
+	repo.byID[accID] = &models.OutreachAccount{
+		ID: accID, OrganizationID: org, SourceLeadID: "L3", CNPJ14: "111",
+	}
+	repo.accounts[accKey(org, "111")] = repo.byID[accID]
+	draftID := uuid.New()
+	// EMAIL draft that happens to have a phone — must never send via WhatsApp.
+	repo.drafts[draftID] = &models.OutreachDraft{
+		ID: draftID, OrganizationID: org, AccountID: accID,
+		Channel: models.OutreachChannelEmail, Status: models.OutreachDraftApproved,
+		RecipientPhoneE164: "+5548999000111", BodyText: "email body",
+	}
+	mock := whatsapp.NewMockProvider()
+	waSvc := whatsapp.NewService(whatsapp.Config{Enabled: true, ServiceWindow: 24 * time.Hour}, mock, nil)
+	svc := NewService(Config{Enabled: true, WhatsAppEnabled: true}, repo, nil).(*service)
+	svc.WireWhatsApp(waSvc, nil)
+
+	_, xerr := svc.SendApprovedWhatsApp(context.Background(), org, user, draftID)
+	if xerr == nil {
+		t.Fatal("EMAIL draft must be rejected even when phone is set")
+	}
+	if mock.SendCount() != 0 {
+		t.Fatalf("provider must not be called, sends=%d", mock.SendCount())
 	}
 }
 

--- a/internal/app/confenge/whatsapp_ops_test.go
+++ b/internal/app/confenge/whatsapp_ops_test.go
@@ -1,0 +1,195 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestLeadToCandidatePhoneConsent(t *testing.T) {
+	src := "website_form"
+	at := "2026-01-15T10:00:00Z"
+	fc := FeedContact{
+		Name:  "Maria",
+		Email: "m@example.com",
+		Phone: "(48) 99999-1111",
+		PhoneObj: &FeedPhone{
+			Raw: "(48) 99999-1111", E164: "+5548999991111",
+			SourceKind: "official_company_site", SourceURL: "https://ex.com",
+		},
+		WhatsApp: &FeedWhatsApp{
+			ConsentStatus: "OPTED_IN",
+			ConsentSource: &src,
+			ConsentAt:     &at,
+			ProvenanceOK:  true,
+		},
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	c := leadToCandidate(uuid.New(), uuid.New(), uuid.New(), fc)
+	if c.PhoneE164 != "+5548999991111" {
+		t.Fatalf("e164=%s", c.PhoneE164)
+	}
+	if c.WhatsAppConsentStatus != whatsapp.ConsentOptedIn || !c.WhatsAppConsentProvenanceOK {
+		t.Fatalf("consent=%s ok=%v", c.WhatsAppConsentStatus, c.WhatsAppConsentProvenanceOK)
+	}
+	fc2 := FeedContact{
+		Phone:    "48999992222",
+		WhatsApp: &FeedWhatsApp{ConsentStatus: "OPTED_IN", ProvenanceOK: false},
+	}
+	c2 := leadToCandidate(uuid.New(), uuid.New(), uuid.New(), fc2)
+	if c2.WhatsAppConsentStatus == whatsapp.ConsentOptedIn {
+		t.Fatal("must not invent opt-in")
+	}
+}
+
+func TestDecideChannelGenerateAndSend(t *testing.T) {
+	org := uuid.New()
+	accID := uuid.New()
+	candID := uuid.New()
+	user := uuid.New()
+	repo := newMemRepo()
+	repo.byID[accID] = &models.OutreachAccount{
+		ID: accID, OrganizationID: org, SourceLeadID: "L1", CNPJ14: "12345678000199",
+		FactToMention: "edital X", EntryOffer: "revisão", QuestionToAsk: "Posso explicar?",
+		QueueState: models.OutreachQueueReadyToGenerate,
+	}
+	repo.accounts[accKey(org, "12345678000199")] = repo.byID[accID]
+
+	now := time.Now().UTC()
+	repo.cands[accID] = []models.OutreachContactCandidate{{
+		ID: candID, OrganizationID: org, AccountID: accID,
+		Name: "Tiago", Email: "t@ex.com", PhoneE164: "+5548999887766",
+		WhatsAppConsentStatus: whatsapp.ConsentUserInitiated, WhatsAppConsentProvenanceOK: true,
+		WhatsAppConsentSource: "inbound", WhatsAppConsentAt: &now,
+		VerificationStatus: models.OutreachVerifyOfficialSource, Recommended: true,
+	}}
+
+	mock := whatsapp.NewMockProvider()
+	waSvc := whatsapp.NewService(whatsapp.Config{
+		Enabled: true, AutoSendEnabled: false, CrossChannelInterval: 0, ServiceWindow: 24 * time.Hour,
+		EvolutionInstance: "test",
+	}, mock, nil)
+	cfg := Config{Enabled: true, WhatsAppEnabled: true, RequireHumanApproval: true, CrossChannelHours: 0, MaxInitialEmailWords: 120}
+	svc := NewService(cfg, repo, nil).(*service)
+	svc.WireWhatsApp(waSvc, nil)
+
+	// Case A: public phone
+	pubID := uuid.New()
+	repo.cands[accID] = append(repo.cands[accID], models.OutreachContactCandidate{
+		ID: pubID, OrganizationID: org, AccountID: accID,
+		PhoneE164: "+5548111111111", WhatsAppConsentStatus: whatsapp.ConsentUnknown,
+		Email: "p@ex.com", VerificationStatus: models.OutreachVerifyOfficialSource,
+	})
+	dec, xerr := svc.DecideChannel(context.Background(), org, accID, &pubID)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if dec.Action != ChannelActionWhatsAppBlocked {
+		t.Fatalf("case A: %+v", dec)
+	}
+
+	// Generate WhatsApp draft
+	draft, xerr := svc.GenerateWhatsAppDraft(context.Background(), org, user, accID, &candID)
+	if xerr != nil {
+		t.Fatalf("generate: %v", xerr)
+	}
+	if draft.Channel != models.OutreachChannelWhatsApp || draft.BodyText == "" {
+		t.Fatalf("draft=%+v", draft)
+	}
+	if mock.SendCount() != 0 {
+		t.Fatal("generate must not send")
+	}
+
+	// Open service window via inbound then send approved draft
+	_, err := svc.HandleWhatsAppInbound(context.Background(), org, whatsapp.ChannelEvent{
+		Channel: whatsapp.ChannelWhatsApp, Provider: whatsapp.ProviderEvolution,
+		EventType: whatsapp.EventMessageReceived, ExternalMessageID: "in1",
+		ExternalEventID: "in1:MESSAGE_RECEIVED", FromE164: "+5548999887766",
+		OccurredAt: now, Content: whatsapp.Content{Type: whatsapp.ContentText, Text: "Oi, pode falar no whats"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	draft.Status = models.OutreachDraftApproved
+	_ = repo.UpsertDraft(context.Background(), draft)
+
+	sent, xerr := svc.SendApprovedWhatsApp(context.Background(), org, user, draft.ID)
+	if xerr != nil {
+		t.Fatalf("send: %v", xerr)
+	}
+	if sent.Status != models.OutreachDraftSent {
+		t.Fatalf("status=%s", sent.Status)
+	}
+	if mock.SendCount() != 1 {
+		t.Fatalf("send count=%d", mock.SendCount())
+	}
+}
+
+func TestHandleWhatsAppInboundOptOutStopsAndOutcomes(t *testing.T) {
+	org := uuid.New()
+	accID := uuid.New()
+	candID := uuid.New()
+	repo := newMemRepo()
+	repo.byID[accID] = &models.OutreachAccount{
+		ID: accID, OrganizationID: org, SourceLeadID: "L2", CNPJ14: "999",
+		QueueState: models.OutreachQueueSent,
+	}
+	repo.accounts[accKey(org, "999")] = repo.byID[accID]
+	repo.cands[accID] = []models.OutreachContactCandidate{{
+		ID: candID, OrganizationID: org, AccountID: accID,
+		Email: "x@ex.com", PhoneE164: "+5548999000000",
+		WhatsAppConsentStatus: whatsapp.ConsentOptedIn, WhatsAppConsentProvenanceOK: true,
+	}}
+	draftID := uuid.New()
+	repo.drafts[draftID] = &models.OutreachDraft{
+		ID: draftID, OrganizationID: org, AccountID: accID,
+		Channel: models.OutreachChannelWhatsApp, Status: models.OutreachDraftSent,
+		RecipientPhoneE164: "+5548999000000",
+	}
+	mock := whatsapp.NewMockProvider()
+	waSvc := whatsapp.NewService(whatsapp.Config{Enabled: true, ServiceWindow: 24 * time.Hour}, mock, nil)
+	svc := NewService(Config{Enabled: true, WhatsAppEnabled: true}, repo, nil).(*service)
+	svc.WireWhatsApp(waSvc, nil)
+
+	res, err := svc.HandleWhatsAppInbound(context.Background(), org, whatsapp.ChannelEvent{
+		EventType: whatsapp.EventMessageReceived, ExternalMessageID: "m2",
+		ExternalEventID: "m2:MESSAGE_RECEIVED", FromE164: "+5548999000000",
+		OccurredAt: time.Now().UTC(),
+		Content:    whatsapp.Content{Type: whatsapp.ContentText, Text: "não tenho interesse"},
+		Channel:    whatsapp.ChannelWhatsApp, Provider: whatsapp.ProviderEvolution,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res.StopSequences || !res.OptOut.Confident {
+		t.Fatalf("res=%+v", res)
+	}
+	// candidate sticky DNC
+	c, _ := repo.GetCandidate(context.Background(), org, candID)
+	if c == nil || !c.DoNotContact {
+		t.Fatal("candidate should be DNC after opt-out")
+	}
+	if len(repo.outcomes) == 0 {
+		t.Fatal("expected outcome enqueued")
+	}
+	res2, err := svc.HandleWhatsAppInbound(context.Background(), org, whatsapp.ChannelEvent{
+		EventType: whatsapp.EventMessageReceived, ExternalMessageID: "m2",
+		ExternalEventID: "m2:MESSAGE_RECEIVED", FromE164: "+5548999000000",
+		OccurredAt: time.Now().UTC(),
+		Content:    whatsapp.Content{Type: whatsapp.ContentText, Text: "não tenho interesse"},
+		Channel:    whatsapp.ChannelWhatsApp, Provider: whatsapp.ProviderEvolution,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !res2.Duplicate {
+		t.Fatal("expected duplicate")
+	}
+}
+
+var _ Service = (*service)(nil)

--- a/internal/app/confenge/whatsapp_orchestrator.go
+++ b/internal/app/confenge/whatsapp_orchestrator.go
@@ -10,13 +10,13 @@ import (
 
 // ChannelAction is the deterministic next action for multichannel outreach.
 const (
-	ChannelActionNone              = "NONE"
-	ChannelActionEmailOnly         = "EMAIL_ONLY"
-	ChannelActionWhatsAppBlocked   = "WHATSAPP_BLOCKED"
-	ChannelActionWhatsAppEligible  = "WHATSAPP_ELIGIBLE"
-	ChannelActionWhatsAppTemplate  = "WHATSAPP_TEMPLATE_ONLY"
-	ChannelActionWhatsAppReview    = "WHATSAPP_MANUAL_REVIEW"
-	ChannelActionStopAll           = "STOP_ALL"
+	ChannelActionNone             = "NONE"
+	ChannelActionEmailOnly        = "EMAIL_ONLY"
+	ChannelActionWhatsAppBlocked  = "WHATSAPP_BLOCKED"
+	ChannelActionWhatsAppEligible = "WHATSAPP_ELIGIBLE"
+	ChannelActionWhatsAppTemplate = "WHATSAPP_TEMPLATE_ONLY"
+	ChannelActionWhatsAppReview   = "WHATSAPP_MANUAL_REVIEW"
+	ChannelActionStopAll          = "STOP_ALL"
 	ChannelActionAwaitCooldown    = "AWAIT_CROSS_CHANNEL_COOLDOWN"
 )
 
@@ -126,12 +126,12 @@ func caseForConsent(consent string) string {
 // FeedPhone is an optional structured phone object from extra-cli (backward compatible).
 // Legacy string field FeedContact.Phone remains supported.
 type FeedPhone struct {
-	Raw        string  `json:"raw"`
-	E164       string  `json:"e164"`
-	Type       string  `json:"type"` // mobile | landline | unknown
-	SourceURL  string  `json:"source_url"`
-	SourceKind string  `json:"source_kind"`
-	Confidence string  `json:"confidence"`
+	Raw        string `json:"raw"`
+	E164       string `json:"e164"`
+	Type       string `json:"type"` // mobile | landline | unknown
+	SourceURL  string `json:"source_url"`
+	SourceKind string `json:"source_kind"`
+	Confidence string `json:"confidence"`
 }
 
 // FeedWhatsApp is optional consent facts from extra-cli. Warmbly applies policy.
@@ -146,15 +146,15 @@ type FeedWhatsApp struct {
 
 // ContactPhoneFacts is the normalized phone+consent extracted from a feed contact.
 type ContactPhoneFacts struct {
-	Raw            string
-	E164           string
-	Source         string
-	SourceURL      string
-	ConsentStatus  string
-	ConsentSource  string
-	ConsentAt      *time.Time
-	ConsentScope   string
-	ProvenanceOK   bool
+	Raw           string
+	E164          string
+	Source        string
+	SourceURL     string
+	ConsentStatus string
+	ConsentSource string
+	ConsentAt     *time.Time
+	ConsentScope  string
+	ProvenanceOK  bool
 }
 
 // ExtractPhoneFacts merges legacy phone string + optional structured objects.

--- a/internal/app/confenge/whatsapp_orchestrator_test.go
+++ b/internal/app/confenge/whatsapp_orchestrator_test.go
@@ -97,12 +97,12 @@ func TestCrossChannelCooldownOrchestrator(t *testing.T) {
 	now := time.Now().UTC()
 	emailAt := now.Add(-2 * time.Hour)
 	st := whatsapp.ContactChannelState{
-		PhoneE164:              "+5548999999999",
-		ConsentStatus:          whatsapp.ConsentOptedIn,
-		ConsentProvenanceOK:    true,
-		LastEmailOutboundAt:    &emailAt,
-		LastInboundAt:          &now,
-		ServiceWindowUntil:     ptrT(now.Add(20 * time.Hour)),
+		PhoneE164:           "+5548999999999",
+		ConsentStatus:       whatsapp.ConsentOptedIn,
+		ConsentProvenanceOK: true,
+		LastEmailOutboundAt: &emailAt,
+		LastInboundAt:       &now,
+		ServiceWindowUntil:  ptrT(now.Add(20 * time.Hour)),
 	}
 	d := OrchestrateChannel(true, true, st.PhoneE164, st, whatsapp.SendIntent{
 		Mode: whatsapp.ModeFreeText, Automated: true, FeatureEnabled: true, AutoSendEnabled: true,

--- a/internal/app/consumer/event_inbound_bounce.go
+++ b/internal/app/consumer/event_inbound_bounce.go
@@ -12,15 +12,20 @@ import (
 // feed the deliverability breaker. Best-effort — a bounce we can't attribute is
 // logged, not retried.
 func (s *JobsService) HandleInboundBounce(ctx context.Context, e *models.JobEventInboundBounce) error {
-	if s.AdvancedService == nil {
-		return nil
+	if s.AdvancedService != nil {
+		if xerr := s.AdvancedService.RecordInboundBounce(ctx, e.EmailID, e.OriginalMessageID, e.FailedRecipient, e.Reason); xerr != nil {
+			log.Warn().
+				Str("email_id", e.EmailID.String()).
+				Str("original_message_id", e.OriginalMessageID).
+				Str("error", xerr.Message).
+				Msg("Failed to record inbound bounce")
+		}
 	}
-	if xerr := s.AdvancedService.RecordInboundBounce(ctx, e.EmailID, e.OriginalMessageID, e.FailedRecipient, e.Reason); xerr != nil {
-		log.Warn().
-			Str("email_id", e.EmailID.String()).
-			Str("original_message_id", e.OriginalMessageID).
-			Str("error", xerr.Message).
-			Msg("Failed to record inbound bounce")
+	// CONFENGE: attribute bounce to staged contact when org is known.
+	if s.ConfengeOutcomes != nil && s.ConfengeOutcomes.Enabled() && s.EmailRepository != nil {
+		if account, err := s.EmailRepository.GetByID(ctx, e.EmailID); err == nil && account != nil && account.OrganizationID != nil {
+			_ = s.ConfengeOutcomes.NoteBounce(ctx, *account.OrganizationID, e.FailedRecipient, e.Reason)
+		}
 	}
 	return nil
 }

--- a/internal/app/consumer/event_new_email.go
+++ b/internal/app/consumer/event_new_email.go
@@ -74,6 +74,20 @@ func (s *JobsService) HandleNewEmail(ctx context.Context, e *models.JobEventNewE
 		_ = s.AdvancedService.ProcessIncomingReply(ctx, e.Message.EmailID, e.Message)
 	}
 
+	// CONFENGE outcome loop: attribute human-looking inbound mail to staged leads.
+	if s.ConfengeOutcomes != nil && s.ConfengeOutcomes.Enabled() && e.Message != nil {
+		if account, err := s.EmailRepository.GetByID(ctx, e.Message.EmailID); err == nil && account != nil && account.OrganizationID != nil {
+			from := ""
+			if len(e.Message.FromAddr) > 0 {
+				from = e.Message.FromAddr[0]
+			}
+			_ = s.ConfengeOutcomes.NoteReply(ctx, *account.OrganizationID, from, map[string]any{
+				"subject":    e.Message.Subject,
+				"message_id": e.Message.ID.String(),
+			})
+		}
+	}
+
 	return nil
 }
 

--- a/internal/app/consumer/service.go
+++ b/internal/app/consumer/service.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"github.com/warmbly/warmbly/internal/app/advanced"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	workerapp "github.com/warmbly/warmbly/internal/app/worker"
 	"github.com/warmbly/warmbly/internal/events"
@@ -41,6 +42,9 @@ type JobsService struct {
 	// Pub/Sub for real-time notifications to users
 	StreamingPublisher *pubsub.StreamingPublisher
 	AdvancedService    advanced.Service
+
+	// ConfengeOutcomes attributes reply/bounce/DNC back to staged leads (optional).
+	ConfengeOutcomes confenge.OutcomeSink
 
 	// Cache for dead worker detection
 	Cache *cache.Cache

--- a/internal/app/whatsapp/config.go
+++ b/internal/app/whatsapp/config.go
@@ -1,0 +1,176 @@
+package whatsapp
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Env keys for the WhatsApp channel. Documented in deploy/config/env.example.
+const (
+	EnvEnabled               = "CONFENGE_WHATSAPP_ENABLED"
+	EnvAutoSend              = "CONFENGE_WHATSAPP_AUTO_SEND_ENABLED"
+	EnvAutoReply             = "CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED"
+	EnvProvider              = "WHATSAPP_PROVIDER"
+	EnvEvolutionBaseURL      = "WHATSAPP_EVOLUTION_BASE_URL"
+	EnvEvolutionAPIKey       = "WHATSAPP_EVOLUTION_API_KEY"
+	EnvEvolutionInstance     = "WHATSAPP_EVOLUTION_INSTANCE"
+	EnvEvolutionAllowBaileys = "WHATSAPP_EVOLUTION_ALLOW_BAILEYS"
+	EnvWebhookSecret         = "WHATSAPP_WEBHOOK_SECRET"
+	EnvCrossChannelHours     = "CONFENGE_CROSS_CHANNEL_MIN_INTERVAL_HOURS"
+	EnvServiceWindowHours    = "WHATSAPP_SERVICE_WINDOW_HOURS"
+	EnvMaxWebhookBytes       = "WHATSAPP_MAX_WEBHOOK_BYTES"
+	EnvAppEnv                = "APP_ENV"
+)
+
+// Defaults keep the channel fully off and conservative.
+const (
+	DefaultCrossChannelHours  = 24
+	DefaultServiceWindowHours = 24
+	DefaultMaxWebhookBytes    = 1 << 20 // 1 MiB
+	DefaultProvider           = ProviderEvolution
+)
+
+// Config is runtime configuration for WhatsApp transport + policy.
+type Config struct {
+	Enabled              bool
+	AutoSendEnabled      bool
+	AutoReplyEnabled     bool
+	Provider             string
+	EvolutionBaseURL     string
+	EvolutionAPIKey      string
+	EvolutionInstance    string
+	AllowBaileys         bool
+	WebhookSecret        string
+	CrossChannelInterval time.Duration
+	ServiceWindow        time.Duration
+	MaxWebhookBytes      int64
+	AppEnv               string
+}
+
+// LoadConfig reads WhatsApp-related env vars. Safe defaults keep features off.
+func LoadConfig() Config {
+	hours := envInt(EnvCrossChannelHours, DefaultCrossChannelHours)
+	if hours < 0 {
+		hours = DefaultCrossChannelHours
+	}
+	sw := envInt(EnvServiceWindowHours, DefaultServiceWindowHours)
+	if sw < 1 {
+		sw = DefaultServiceWindowHours
+	}
+	maxBytes := envInt(EnvMaxWebhookBytes, DefaultMaxWebhookBytes)
+	if maxBytes < 1024 {
+		maxBytes = DefaultMaxWebhookBytes
+	}
+	provider := strings.ToLower(strings.TrimSpace(os.Getenv(EnvProvider)))
+	if provider == "" {
+		provider = DefaultProvider
+	}
+	return Config{
+		Enabled:              envBool(EnvEnabled, false),
+		AutoSendEnabled:      envBool(EnvAutoSend, false),
+		AutoReplyEnabled:     envBool(EnvAutoReply, false),
+		Provider:             provider,
+		EvolutionBaseURL:     strings.TrimSpace(os.Getenv(EnvEvolutionBaseURL)),
+		EvolutionAPIKey:      strings.TrimSpace(os.Getenv(EnvEvolutionAPIKey)),
+		EvolutionInstance:    strings.TrimSpace(os.Getenv(EnvEvolutionInstance)),
+		AllowBaileys:         envBool(EnvEvolutionAllowBaileys, false),
+		WebhookSecret:        strings.TrimSpace(os.Getenv(EnvWebhookSecret)),
+		CrossChannelInterval: time.Duration(hours) * time.Hour,
+		ServiceWindow:        time.Duration(sw) * time.Hour,
+		MaxWebhookBytes:      int64(maxBytes),
+		AppEnv:               strings.TrimSpace(os.Getenv(EnvAppEnv)),
+	}
+}
+
+// IsProduction reports whether APP_ENV is production-like.
+func (c Config) IsProduction() bool {
+	e := strings.ToLower(c.AppEnv)
+	return e == "prod" || e == "production"
+}
+
+// ValidateStartup fails closed on insecure or policy-violating combinations.
+// Called when the WhatsApp feature is enabled at boot.
+func (c Config) ValidateStartup() error {
+	if !c.Enabled {
+		return nil
+	}
+	// Baileys must never enable under production.
+	if c.IsProduction() && c.AllowBaileys {
+		return fmt.Errorf("%s cannot be true when APP_ENV is production (Cloud API only)", EnvEvolutionAllowBaileys)
+	}
+	if c.AllowBaileys && !c.IsProduction() {
+		// Visible warning is logged by the caller; config still validates.
+	}
+	if c.Provider == ProviderEvolution || c.Provider == "" {
+		if c.EvolutionBaseURL == "" {
+			return fmt.Errorf("%s is required when WhatsApp is enabled with evolution provider", EnvEvolutionBaseURL)
+		}
+		if c.IsProduction() && !strings.HasPrefix(strings.ToLower(c.EvolutionBaseURL), "https://") {
+			// Allow http only for private network URLs in non-strict self-host;
+			// production prefers https or private network — require non-empty.
+			if !isPrivateOrLocalURL(c.EvolutionBaseURL) {
+				return fmt.Errorf("%s must be https or a private-network URL in production", EnvEvolutionBaseURL)
+			}
+		}
+		if c.EvolutionAPIKey == "" {
+			return fmt.Errorf("%s is required when WhatsApp is enabled", EnvEvolutionAPIKey)
+		}
+		if c.EvolutionInstance == "" {
+			return fmt.Errorf("%s is required when WhatsApp is enabled", EnvEvolutionInstance)
+		}
+	}
+	if c.WebhookSecret == "" && c.IsProduction() {
+		return fmt.Errorf("%s is required in production when WhatsApp is enabled", EnvWebhookSecret)
+	}
+	if c.CrossChannelInterval < 0 {
+		return fmt.Errorf("%s must be >= 0", EnvCrossChannelHours)
+	}
+	return nil
+}
+
+// BaileysWarning returns a non-empty operator warning when Baileys is allowed.
+func (c Config) BaileysWarning() string {
+	if !c.AllowBaileys {
+		return ""
+	}
+	return "WHATSAPP_EVOLUTION_ALLOW_BAILEYS=true: Baileys/WhatsApp-Web sessions are LAB ONLY. " +
+		"Do not use as a substitute for WhatsApp Business Platform policies. " +
+		"Cloud API remains the production path."
+}
+
+func isPrivateOrLocalURL(raw string) bool {
+	lower := strings.ToLower(raw)
+	return strings.Contains(lower, "://10.") ||
+		strings.Contains(lower, "://192.168.") ||
+		strings.Contains(lower, "://172.") ||
+		strings.Contains(lower, "://localhost") ||
+		strings.Contains(lower, "://127.0.0.1") ||
+		strings.Contains(lower, "://evolution")
+}
+
+func envBool(key string, def bool) bool {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return def
+	}
+	return b
+}
+
+func envInt(key string, def int) int {
+	v := strings.TrimSpace(os.Getenv(key))
+	if v == "" {
+		return def
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}

--- a/internal/app/whatsapp/eligibility.go
+++ b/internal/app/whatsapp/eligibility.go
@@ -118,24 +118,24 @@ func EvaluateEligibility(state ContactChannelState, intent SendIntent) Decision 
 		inServiceWindow = true
 	}
 
-	// USER_INITIATED with open window: free-text reply allowed (human or system
-	// if auto-reply flag is on — that flag is checked by the caller for auto-reply).
-	if consent == ConsentUserInitiated || inServiceWindow {
+	// Free-text is only allowed inside an open service window (last inbound + TTL).
+	// USER_INITIATED alone does not keep free-text forever after the window closes.
+	if inServiceWindow {
 		if intent.Mode == ModeFreeText || intent.Mode == ModeTemplate {
 			if intent.Automated && !intent.AutoSendEnabled {
-				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled", OpenServiceWindow: inServiceWindow}
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled", OpenServiceWindow: true}
 			}
 			if intent.Automated && intent.RequireHumanApproval {
-				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "requires_human_approval", OpenServiceWindow: inServiceWindow}
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "requires_human_approval", OpenServiceWindow: true}
 			}
 			if blocked, why := crossChannelBlocked(state, now, cross); blocked {
-				return Decision{Allowed: false, Eligibility: EligBlocked, Reason: why, OpenServiceWindow: inServiceWindow}
+				return Decision{Allowed: false, Eligibility: EligBlocked, Reason: why, OpenServiceWindow: true}
 			}
 			elig := EligServiceWindow
 			if consent == ConsentOptedIn && state.ConsentProvenanceOK {
 				elig = EligAutomatedAllowed
 			}
-			return Decision{Allowed: true, Eligibility: elig, Reason: "service_window_or_user_initiated", OpenServiceWindow: true}
+			return Decision{Allowed: true, Eligibility: elig, Reason: "service_window_open", OpenServiceWindow: true}
 		}
 	}
 

--- a/internal/app/whatsapp/eligibility.go
+++ b/internal/app/whatsapp/eligibility.go
@@ -1,0 +1,311 @@
+package whatsapp
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ContactChannelState is the policy input for one contact's WhatsApp eligibility.
+// Public phone numbers must arrive with ConsentStatus UNKNOWN or NO_OPT_IN.
+type ContactChannelState struct {
+	ContactID              uuid.UUID
+	OrganizationID         uuid.UUID
+	PhoneE164              string
+	PhoneSource            string // e.g. official_company_site, form, user_provided
+	PhoneSourceURL         string
+	PhoneVerifiedAt        *time.Time
+	ConsentStatus          string
+	ConsentSource          string
+	ConsentAt              *time.Time
+	ConsentScope           string // marketing | transactional | service
+	ConsentProvenanceOK    bool   // true only when opt-in has recorded provenance
+	LastInboundAt          *time.Time
+	ServiceWindowUntil     *time.Time
+	ChannelStatus          string // operational label; optional
+	OptOutAt               *time.Time
+	DoNotContact           bool
+	LastEmailOutboundAt    *time.Time
+	LastWhatsAppOutboundAt *time.Time
+	LastAnyOutboundAt      *time.Time
+	HasOpenReply           bool // human reply on any channel for active sequence
+}
+
+// SendIntent describes what the caller wants to do.
+type SendIntent struct {
+	// Mode: free_text | template | enroll_sequence
+	Mode string
+	// TemplateApproved is true only when the template is APPROVED at Meta/BSP.
+	TemplateApproved bool
+	// TemplateName for audit; empty for free text.
+	TemplateName string
+	// Automated is true for sequence/scheduler sends (not human-clicked send).
+	Automated bool
+	// Now is the evaluation time (injectable for tests).
+	Now time.Time
+	// CrossChannelMin is the minimum gap between any outbound channels.
+	// Zero means use a default of 24h when Automated.
+	CrossChannelMin time.Duration
+	// ServiceWindow is the allowed reply window after user-initiated inbound.
+	ServiceWindow time.Duration
+	// RequireHumanApproval blocks automated free-text even when consented.
+	RequireHumanApproval bool
+	// FeatureEnabled master switch.
+	FeatureEnabled bool
+	// AutoSendEnabled feature flag for automated sends.
+	AutoSendEnabled bool
+}
+
+// Decision is the policy outcome. Allowed=false means zero provider sends.
+type Decision struct {
+	Allowed     bool
+	Eligibility string
+	Reason      string
+	// UseTemplate forces template path (e.g. outside service window with opt-in).
+	UseTemplate bool
+	// OpenServiceWindow is true when free-text is allowed due to 24h window.
+	OpenServiceWindow bool
+}
+
+const (
+	ModeFreeText       = "free_text"
+	ModeTemplate       = "template"
+	ModeEnrollSequence = "enroll_sequence"
+)
+
+// EvaluateEligibility is the deterministic policy gate.
+// Critical invariant: public phone + no opt-in → zero automated WhatsApp sends.
+func EvaluateEligibility(state ContactChannelState, intent SendIntent) Decision {
+	now := intent.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	sw := intent.ServiceWindow
+	if sw <= 0 {
+		sw = 24 * time.Hour
+	}
+	cross := intent.CrossChannelMin
+	if cross <= 0 && intent.Automated {
+		cross = 24 * time.Hour
+	}
+
+	if !intent.FeatureEnabled {
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "whatsapp_feature_disabled"}
+	}
+
+	// Global DNC / sticky opt-out always wins.
+	if state.DoNotContact || state.ConsentStatus == ConsentDoNotContact {
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "do_not_contact"}
+	}
+	if state.ConsentStatus == ConsentOptedOut || state.OptOutAt != nil {
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "opted_out"}
+	}
+
+	if state.PhoneE164 == "" {
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "missing_phone"}
+	}
+
+	// No inventing consent: UNKNOWN / NO_OPT_IN / empty block automation.
+	consent := state.ConsentStatus
+	if consent == "" {
+		consent = ConsentUnknown
+	}
+
+	inServiceWindow := false
+	if state.ServiceWindowUntil != nil && state.ServiceWindowUntil.After(now) {
+		inServiceWindow = true
+	} else if state.LastInboundAt != nil && state.LastInboundAt.Add(sw).After(now) {
+		inServiceWindow = true
+	}
+
+	// USER_INITIATED with open window: free-text reply allowed (human or system
+	// if auto-reply flag is on — that flag is checked by the caller for auto-reply).
+	if consent == ConsentUserInitiated || inServiceWindow {
+		if intent.Mode == ModeFreeText || intent.Mode == ModeTemplate {
+			if intent.Automated && !intent.AutoSendEnabled {
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled", OpenServiceWindow: inServiceWindow}
+			}
+			if intent.Automated && intent.RequireHumanApproval {
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "requires_human_approval", OpenServiceWindow: inServiceWindow}
+			}
+			if blocked, why := crossChannelBlocked(state, now, cross); blocked {
+				return Decision{Allowed: false, Eligibility: EligBlocked, Reason: why, OpenServiceWindow: inServiceWindow}
+			}
+			elig := EligServiceWindow
+			if consent == ConsentOptedIn && state.ConsentProvenanceOK {
+				elig = EligAutomatedAllowed
+			}
+			return Decision{Allowed: true, Eligibility: elig, Reason: "service_window_or_user_initiated", OpenServiceWindow: true}
+		}
+	}
+
+	switch consent {
+	case ConsentUnknown, ConsentNoOptIn:
+		// Public number is NOT opt-in. Block all automated and sequence enrollment.
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "no_opt_in"}
+
+	case ConsentOptedIn:
+		if !state.ConsentProvenanceOK {
+			// Refuse bare opted_in=true without provenance.
+			return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "opt_in_missing_provenance"}
+		}
+		if blocked, why := crossChannelBlocked(state, now, cross); blocked {
+			return Decision{Allowed: false, Eligibility: EligBlocked, Reason: why}
+		}
+		if intent.Mode == ModeFreeText {
+			if !inServiceWindow {
+				// Outside service window: free text blocked; template may still work.
+				return Decision{
+					Allowed:     false,
+					Eligibility: EligTemplateOnly,
+					Reason:      "outside_service_window_use_template",
+					UseTemplate: true,
+				}
+			}
+		}
+		if intent.Mode == ModeTemplate {
+			if !intent.TemplateApproved {
+				return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "template_not_approved"}
+			}
+		}
+		if intent.Automated && !intent.AutoSendEnabled {
+			return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled"}
+		}
+		if intent.Automated && intent.RequireHumanApproval {
+			return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "requires_human_approval"}
+		}
+		if intent.Mode == ModeTemplate {
+			return Decision{Allowed: true, Eligibility: EligTemplateOnly, Reason: "opted_in_template", UseTemplate: true}
+		}
+		return Decision{Allowed: true, Eligibility: EligAutomatedAllowed, Reason: "opted_in"}
+
+	case ConsentUserInitiated:
+		// Handled above when window open; if we get here window is closed.
+		if intent.Mode == ModeTemplate && intent.TemplateApproved {
+			if intent.Automated && !intent.AutoSendEnabled {
+				return Decision{Allowed: false, Eligibility: EligManualReview, Reason: "auto_send_disabled"}
+			}
+			return Decision{Allowed: true, Eligibility: EligTemplateOnly, Reason: "user_initiated_template_outside_window", UseTemplate: true}
+		}
+		return Decision{Allowed: false, Eligibility: EligTemplateOnly, Reason: "user_initiated_window_closed", UseTemplate: true}
+
+	default:
+		return Decision{Allowed: false, Eligibility: EligBlocked, Reason: "unknown_consent_status"}
+	}
+}
+
+func crossChannelBlocked(state ContactChannelState, now time.Time, minGap time.Duration) (bool, string) {
+	if minGap <= 0 {
+		return false, ""
+	}
+	last := state.LastAnyOutboundAt
+	if last == nil {
+		// Prefer the more recent of email / whatsapp if aggregate not set.
+		if state.LastEmailOutboundAt != nil {
+			last = state.LastEmailOutboundAt
+		}
+		if state.LastWhatsAppOutboundAt != nil {
+			if last == nil || state.LastWhatsAppOutboundAt.After(*last) {
+				last = state.LastWhatsAppOutboundAt
+			}
+		}
+	}
+	if last == nil {
+		return false, ""
+	}
+	if last.Add(minGap).After(now) {
+		return true, "cross_channel_cooldown"
+	}
+	return false, ""
+}
+
+// OpenServiceWindowFromInbound updates state timestamps after a user message.
+func OpenServiceWindowFromInbound(state *ContactChannelState, at time.Time, window time.Duration) {
+	if state == nil {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	if window <= 0 {
+		window = 24 * time.Hour
+	}
+	state.LastInboundAt = &at
+	until := at.Add(window)
+	state.ServiceWindowUntil = &until
+	if state.ConsentStatus == ConsentUnknown || state.ConsentStatus == ConsentNoOptIn || state.ConsentStatus == "" {
+		state.ConsentStatus = ConsentUserInitiated
+		state.ConsentSource = "inbound_whatsapp"
+		state.ConsentAt = &at
+		state.ConsentProvenanceOK = true
+		state.ConsentScope = "service"
+	}
+}
+
+// ApplyOptOut sets sticky opt-out that survives re-import.
+func ApplyOptOut(state *ContactChannelState, at time.Time, source string) {
+	if state == nil {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	state.ConsentStatus = ConsentOptedOut
+	state.OptOutAt = &at
+	state.ConsentSource = source
+	state.ConsentAt = &at
+	state.ConsentProvenanceOK = true
+}
+
+// ApplyDoNotContact sets permanent DNC.
+func ApplyDoNotContact(state *ContactChannelState, at time.Time, source string) {
+	if state == nil {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now().UTC()
+	}
+	state.DoNotContact = true
+	state.ConsentStatus = ConsentDoNotContact
+	state.OptOutAt = &at
+	state.ConsentSource = source
+	state.ConsentAt = &at
+	state.ConsentProvenanceOK = true
+}
+
+// MergeImportConsent never upgrades sticky opt-out/DNC from a later import.
+// Public phone imports must not invent OPTED_IN.
+func MergeImportConsent(existing ContactChannelState, incomingConsent, incomingSource string, incomingAt *time.Time, provenanceOK bool) ContactChannelState {
+	out := existing
+	if existing.ConsentStatus == ConsentOptedOut || existing.ConsentStatus == ConsentDoNotContact || existing.DoNotContact || existing.OptOutAt != nil {
+		// Sticky: ignore softer incoming status.
+		return out
+	}
+	// Never invent opt-in from public sources.
+	switch incomingConsent {
+	case ConsentOptedIn:
+		if !provenanceOK {
+			// Downgrade to NO_OPT_IN rather than accept bare flag.
+			if out.ConsentStatus == "" || out.ConsentStatus == ConsentUnknown {
+				out.ConsentStatus = ConsentNoOptIn
+			}
+			return out
+		}
+		out.ConsentStatus = ConsentOptedIn
+		out.ConsentSource = incomingSource
+		out.ConsentAt = incomingAt
+		out.ConsentProvenanceOK = true
+	case ConsentUserInitiated, ConsentOptedOut, ConsentDoNotContact, ConsentNoOptIn, ConsentUnknown:
+		if incomingConsent != "" {
+			out.ConsentStatus = incomingConsent
+			out.ConsentSource = incomingSource
+			out.ConsentAt = incomingAt
+			out.ConsentProvenanceOK = provenanceOK || incomingConsent == ConsentUserInitiated
+		}
+	default:
+		if out.ConsentStatus == "" {
+			out.ConsentStatus = ConsentUnknown
+		}
+	}
+	return out
+}

--- a/internal/app/whatsapp/eligibility_test.go
+++ b/internal/app/whatsapp/eligibility_test.go
@@ -1,0 +1,241 @@
+package whatsapp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func baseState() ContactChannelState {
+	return ContactChannelState{
+		ContactID:      uuid.New(),
+		OrganizationID: uuid.New(),
+		PhoneE164:      "+5548999999999",
+		PhoneSource:    "official_company_site",
+		ConsentStatus:  ConsentUnknown,
+	}
+}
+
+func TestPublicPhoneNoOptInNeverSends(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 24 * time.Hour, ServiceWindow: 24 * time.Hour}, mock, nil)
+
+	for _, consent := range []string{ConsentUnknown, ConsentNoOptIn, ""} {
+		t.Run(consent, func(t *testing.T) {
+			mock.Reset()
+			st := baseState()
+			st.ConsentStatus = consent
+			intent := SendIntent{
+				Mode:            ModeFreeText,
+				Automated:       true,
+				AutoSendEnabled: true,
+				FeatureEnabled:  true,
+				Now:             time.Now().UTC(),
+			}
+			ext, err := svc.Send(context.Background(), st, intent, &SendTextRequest{
+				ToE164: "5548999999999",
+				Body:   "Olá",
+			}, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if ext.Decision.Allowed {
+				t.Fatalf("public phone with consent=%q must not allow send", consent)
+			}
+			if mock.SendCount() != 0 {
+				t.Fatalf("invariant broken: provider send count=%d want 0", mock.SendCount())
+			}
+		})
+	}
+}
+
+func TestOptedInWithProvenanceAllowsInWindow(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 0, ServiceWindow: 24 * time.Hour}, mock, nil)
+	now := time.Now().UTC()
+	in := now.Add(-1 * time.Hour)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	st.ConsentSource = "website_form"
+	st.LastInboundAt = &in
+	st.ServiceWindowUntil = ptrTime(now.Add(20 * time.Hour))
+
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true, Now: now,
+	}, &SendTextRequest{ToE164: "5548999999999", Body: "Oi"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ext.Decision.Allowed {
+		t.Fatalf("expected allowed, got %+v", ext.Decision)
+	}
+	if mock.SendCount() != 1 {
+		t.Fatalf("send count=%d", mock.SendCount())
+	}
+}
+
+func TestOptedInWithoutProvenanceBlocked(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true}, mock, nil)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = false
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true,
+	}, &SendTextRequest{ToE164: "5548999999999", Body: "Oi"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ext.Decision.Allowed || mock.SendCount() != 0 {
+		t.Fatalf("bare opted_in without provenance must block: %+v count=%d", ext.Decision, mock.SendCount())
+	}
+}
+
+func TestOptedOutAndDNCBlock(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true}, mock, nil)
+	now := time.Now().UTC()
+
+	for _, st := range []ContactChannelState{
+		func() ContactChannelState {
+			s := baseState()
+			s.ConsentStatus = ConsentOptedOut
+			s.OptOutAt = &now
+			return s
+		}(),
+		func() ContactChannelState {
+			s := baseState()
+			s.ConsentStatus = ConsentDoNotContact
+			s.DoNotContact = true
+			return s
+		}(),
+	} {
+		mock.Reset()
+		ext, err := svc.Send(context.Background(), st, SendIntent{
+			Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true, Now: now,
+		}, &SendTextRequest{ToE164: "5548999999999", Body: "Oi"}, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if ext.Decision.Allowed || mock.SendCount() != 0 {
+			t.Fatalf("opt-out/DNC must block: %+v", ext.Decision)
+		}
+	}
+}
+
+func TestUserInitiatedOpensServiceWindow(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 0, ServiceWindow: 24 * time.Hour}, mock, nil)
+	now := time.Now().UTC()
+	st := baseState()
+	st.ConsentStatus = ConsentUnknown
+	OpenServiceWindowFromInbound(&st, now, 24*time.Hour)
+	if st.ConsentStatus != ConsentUserInitiated {
+		t.Fatalf("consent=%s", st.ConsentStatus)
+	}
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true, Now: now.Add(time.Minute),
+	}, &SendTextRequest{ToE164: "5548999999999", Body: "Resposta"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ext.Decision.Allowed {
+		t.Fatalf("user-initiated window should allow: %+v", ext.Decision)
+	}
+}
+
+func TestCrossChannelCooldown(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 24 * time.Hour, ServiceWindow: 24 * time.Hour}, mock, nil)
+	now := time.Now().UTC()
+	emailAt := now.Add(-1 * time.Hour)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	st.LastEmailOutboundAt = &emailAt
+	st.LastInboundAt = &now
+	st.ServiceWindowUntil = ptrTime(now.Add(20 * time.Hour))
+
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeFreeText, Automated: true, AutoSendEnabled: true, FeatureEnabled: true, Now: now,
+		CrossChannelMin: 24 * time.Hour,
+	}, &SendTextRequest{ToE164: "5548999999999", Body: "Oi"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ext.Decision.Allowed || ext.Decision.Reason != "cross_channel_cooldown" {
+		t.Fatalf("expected cooldown block, got %+v", ext.Decision)
+	}
+	if mock.SendCount() != 0 {
+		t.Fatal("must not send during cooldown")
+	}
+}
+
+func TestStickyOptOutSurvivesImport(t *testing.T) {
+	now := time.Now().UTC()
+	existing := baseState()
+	ApplyOptOut(&existing, now, "inbound_phrase:parar")
+	merged := MergeImportConsent(existing, ConsentOptedIn, "website", &now, true)
+	if merged.ConsentStatus != ConsentOptedOut {
+		t.Fatalf("opt-out must stick over import: %s", merged.ConsentStatus)
+	}
+	// Public import without provenance must not invent opt-in
+	fresh := baseState()
+	fresh.ConsentStatus = ConsentUnknown
+	merged2 := MergeImportConsent(fresh, ConsentOptedIn, "public_site", nil, false)
+	if merged2.ConsentStatus == ConsentOptedIn {
+		t.Fatal("must not invent opt-in from public import without provenance")
+	}
+}
+
+func TestTemplateNotApprovedBlocked(t *testing.T) {
+	mock := NewMockProvider()
+	cat := NewStaticTemplateCatalog()
+	cat.Set("hello", "pt_BR", TemplatePaused)
+	svc := NewService(Config{Enabled: true, AutoSendEnabled: true, CrossChannelInterval: 0}, mock, cat)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	ext, err := svc.Send(context.Background(), st, SendIntent{
+		Mode: ModeTemplate, Automated: true, AutoSendEnabled: true, FeatureEnabled: true,
+	}, nil, &SendTemplateRequest{ToE164: "5548999999999", TemplateName: "hello", Language: "pt_BR"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ext.Decision.Allowed || mock.SendCount() != 0 {
+		t.Fatalf("paused template must not send: %+v", ext.Decision)
+	}
+}
+
+func TestFeatureDisabledBlocks(t *testing.T) {
+	mock := NewMockProvider()
+	svc := NewService(Config{Enabled: false}, mock, nil)
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	ext, err := svc.Send(context.Background(), st, SendIntent{Mode: ModeFreeText, Automated: true}, &SendTextRequest{Body: "x", ToE164: "55"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ext.Decision.Allowed {
+		t.Fatal("disabled feature must block")
+	}
+}
+
+func TestOutsideServiceWindowTemplateOnly(t *testing.T) {
+	st := baseState()
+	st.ConsentStatus = ConsentOptedIn
+	st.ConsentProvenanceOK = true
+	// no inbound, window closed
+	d := EvaluateEligibility(st, SendIntent{
+		Mode: ModeFreeText, Automated: false, FeatureEnabled: true, Now: time.Now().UTC(),
+	})
+	if d.Allowed || d.Eligibility != EligTemplateOnly {
+		t.Fatalf("expected template-only outside window: %+v", d)
+	}
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/internal/app/whatsapp/eligibility_test.go
+++ b/internal/app/whatsapp/eligibility_test.go
@@ -238,4 +238,41 @@ func TestOutsideServiceWindowTemplateOnly(t *testing.T) {
 	}
 }
 
+// USER_INITIATED after the service window expires must not allow free-text.
+// Free-text requires an open window; outside it is template-only.
+func TestUserInitiatedOutsideWindowBlocksFreeText(t *testing.T) {
+	now := time.Now().UTC()
+	inbound := now.Add(-48 * time.Hour)
+	until := now.Add(-24 * time.Hour) // expired
+	st := baseState()
+	st.ConsentStatus = ConsentUserInitiated
+	st.ConsentProvenanceOK = true
+	st.ConsentSource = "inbound_whatsapp"
+	st.LastInboundAt = &inbound
+	st.ServiceWindowUntil = &until
+
+	d := EvaluateEligibility(st, SendIntent{
+		Mode: ModeFreeText, Automated: false, FeatureEnabled: true, Now: now,
+		ServiceWindow: 24 * time.Hour,
+	})
+	if d.Allowed {
+		t.Fatalf("free-text must be blocked outside service window: %+v", d)
+	}
+	if d.Eligibility != EligTemplateOnly || !d.UseTemplate {
+		t.Fatalf("expected template-only: %+v", d)
+	}
+	if d.OpenServiceWindow {
+		t.Fatal("OpenServiceWindow must be false when window expired")
+	}
+
+	// Approved template may still send outside window for USER_INITIATED.
+	d2 := EvaluateEligibility(st, SendIntent{
+		Mode: ModeTemplate, TemplateApproved: true, Automated: false, FeatureEnabled: true, Now: now,
+		ServiceWindow: 24 * time.Hour,
+	})
+	if !d2.Allowed || !d2.UseTemplate {
+		t.Fatalf("approved template should be allowed: %+v", d2)
+	}
+}
+
 func ptrTime(t time.Time) *time.Time { return &t }

--- a/internal/app/whatsapp/events.go
+++ b/internal/app/whatsapp/events.go
@@ -1,0 +1,45 @@
+package whatsapp
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ChannelEvent is the normalized provider event the rest of Warmbly consumes.
+// Provider-specific payloads never leave the adapter after normalization.
+type ChannelEvent struct {
+	Channel           string    `json:"channel"` // WHATSAPP
+	Provider          string    `json:"provider"`
+	EventType         string    `json:"event_type"`
+	ExternalMessageID string    `json:"external_message_id,omitempty"`
+	ExternalEventID   string    `json:"external_event_id,omitempty"`
+	ExternalThreadID  string    `json:"external_thread_id,omitempty"`
+	Instance          string    `json:"instance,omitempty"`
+	FromE164          string    `json:"from,omitempty"`
+	ToE164            string    `json:"to,omitempty"`
+	OccurredAt        time.Time `json:"occurred_at"`
+	Content           Content   `json:"content"`
+	ConnectionState   string    `json:"connection_state,omitempty"`
+	ErrorCode         string    `json:"error_code,omitempty"`
+	ErrorMessage      string    `json:"error_message,omitempty"`
+	// OrganizationID is filled after instance→org mapping, not by the provider.
+	OrganizationID uuid.UUID `json:"organization_id,omitempty"`
+}
+
+// Content is the message body projection we persist.
+type Content struct {
+	Type string `json:"type"` // text | other
+	Text string `json:"text,omitempty"`
+}
+
+// IdempotencyKey builds a stable key for webhook dedupe.
+func (e ChannelEvent) IdempotencyKey() string {
+	if e.ExternalEventID != "" {
+		return e.Provider + ":" + e.ExternalEventID
+	}
+	if e.ExternalMessageID != "" {
+		return e.Provider + ":" + e.EventType + ":" + e.ExternalMessageID
+	}
+	return e.Provider + ":" + e.EventType + ":" + e.FromE164 + ":" + e.OccurredAt.UTC().Format(time.RFC3339Nano)
+}

--- a/internal/app/whatsapp/evolution/client.go
+++ b/internal/app/whatsapp/evolution/client.go
@@ -1,0 +1,344 @@
+// Package evolution is the single HTTP adapter for Evolution API.
+// Domain packages must not import provider wire DTOs from here for business logic;
+// only this package speaks Evolution's REST shapes.
+package evolution
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/rs/zerolog/log"
+)
+
+// Client is a hardened Evolution API HTTP client.
+type Client struct {
+	baseURL    string
+	apiKey     string
+	http       *http.Client
+	maxRetries int
+	userAgent  string
+}
+
+// ClientConfig configures the Evolution HTTP client.
+type ClientConfig struct {
+	BaseURL    string
+	APIKey     string
+	Timeout    time.Duration
+	MaxRetries int
+}
+
+// NewClient builds a client. API key is never logged.
+func NewClient(cfg ClientConfig) *Client {
+	timeout := cfg.Timeout
+	if timeout <= 0 {
+		timeout = 20 * time.Second
+	}
+	retries := cfg.MaxRetries
+	if retries < 0 {
+		retries = 0
+	}
+	if retries > 5 {
+		retries = 5
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(strings.TrimSpace(cfg.BaseURL), "/"),
+		apiKey:     cfg.APIKey,
+		http:       &http.Client{Timeout: timeout},
+		maxRetries: retries,
+		userAgent:  "warmbly-whatsapp-evolution/1.0",
+	}
+}
+
+// APIError is a structured provider error with redacted details.
+type APIError struct {
+	StatusCode int
+	Code       string
+	Message    string
+	Retryable  bool
+}
+
+func (e *APIError) Error() string {
+	if e == nil {
+		return "evolution: unknown error"
+	}
+	return fmt.Sprintf("evolution api status=%d code=%s msg=%s", e.StatusCode, e.Code, e.Message)
+}
+
+// RedactedString never includes the API key.
+func (e *APIError) RedactedString() string {
+	return e.Error()
+}
+
+// IsRetryable reports whether the caller should retry.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if ae, ok := err.(*APIError); ok {
+		return ae.Retryable
+	}
+	// Network / timeout style errors are retryable.
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "timeout") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "temporary") ||
+		strings.Contains(msg, "eof")
+}
+
+// sendTextBody is Evolution POST /message/sendText/{instance}
+type sendTextBody struct {
+	Number string `json:"number"`
+	Text   string `json:"text"`
+}
+
+// sendTemplateBody is Evolution template send for Cloud API instances.
+type sendTemplateBody struct {
+	Number     string           `json:"number"`
+	Name       string           `json:"name"`
+	Language   string           `json:"language"`
+	Components []map[string]any `json:"components,omitempty"`
+}
+
+// SendTextResponse is a minimal projection of Evolution send responses.
+type SendTextResponse struct {
+	Key struct {
+		ID string `json:"id"`
+	} `json:"key"`
+	Status string `json:"status"`
+	// Some versions nest message id differently; we also accept top-level.
+	MessageID string `json:"messageId,omitempty"`
+}
+
+// Health checks GET / (welcome) or /instance/fetchInstances.
+func (c *Client) Health(ctx context.Context) error {
+	_, _, err := c.do(ctx, http.MethodGet, "/", nil, nil)
+	return err
+}
+
+// ConnectionState is instance connection state.
+type ConnectionState struct {
+	Instance string `json:"instance"`
+	State    string `json:"state"`
+}
+
+// GetConnectionState GET /instance/connectionState/{instance}
+func (c *Client) GetConnectionState(ctx context.Context, instance string) (*ConnectionState, error) {
+	path := "/instance/connectionState/" + urlPathEscape(instance)
+	body, status, err := c.do(ctx, http.MethodGet, path, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	var wrap struct {
+		Instance ConnectionState `json:"instance"`
+		// some versions return flat
+		State string `json:"state"`
+	}
+	if err := json.Unmarshal(body, &wrap); err != nil {
+		return nil, &APIError{StatusCode: status, Code: "decode", Message: "invalid connection state payload"}
+	}
+	out := wrap.Instance
+	if out.State == "" {
+		out.State = wrap.State
+	}
+	if out.Instance == "" {
+		out.Instance = instance
+	}
+	return &out, nil
+}
+
+// SendText POST /message/sendText/{instance}
+func (c *Client) SendText(ctx context.Context, instance, number, text string) (*SendTextResponse, error) {
+	path := "/message/sendText/" + urlPathEscape(instance)
+	payload, _ := json.Marshal(sendTextBody{Number: number, Text: text})
+	body, status, err := c.do(ctx, http.MethodPost, path, payload, map[string]string{
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res SendTextResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, &APIError{StatusCode: status, Code: "decode", Message: "invalid sendText response"}
+	}
+	if res.Key.ID == "" && res.MessageID != "" {
+		res.Key.ID = res.MessageID
+	}
+	return &res, nil
+}
+
+// SendTemplate POST /message/sendTemplate/{instance} (Cloud API / WHATSAPP-BUSINESS).
+func (c *Client) SendTemplate(ctx context.Context, instance, number, name, language string, variables []string) (*SendTextResponse, error) {
+	path := "/message/sendTemplate/" + urlPathEscape(instance)
+	var components []map[string]any
+	if len(variables) > 0 {
+		params := make([]map[string]string, 0, len(variables))
+		for _, v := range variables {
+			params = append(params, map[string]string{"type": "text", "text": v})
+		}
+		components = []map[string]any{{
+			"type":       "body",
+			"parameters": params,
+		}}
+	}
+	payload, _ := json.Marshal(sendTemplateBody{
+		Number:     number,
+		Name:       name,
+		Language:   language,
+		Components: components,
+	})
+	body, status, err := c.do(ctx, http.MethodPost, path, payload, map[string]string{
+		"Content-Type": "application/json",
+	})
+	if err != nil {
+		return nil, err
+	}
+	var res SendTextResponse
+	if err := json.Unmarshal(body, &res); err != nil {
+		return nil, &APIError{StatusCode: status, Code: "decode", Message: "invalid sendTemplate response"}
+	}
+	if res.Key.ID == "" && res.MessageID != "" {
+		res.Key.ID = res.MessageID
+	}
+	return &res, nil
+}
+
+// SetWebhook POST /webhook/set/{instance}
+func (c *Client) SetWebhook(ctx context.Context, instance, url, secret string, events []string, enabled bool) error {
+	path := "/webhook/set/" + urlPathEscape(instance)
+	headers := map[string]any{}
+	if secret != "" {
+		headers["Authorization"] = "Bearer " + secret
+	}
+	payload, _ := json.Marshal(map[string]any{
+		"webhook": map[string]any{
+			"enabled": enabled,
+			"url":     url,
+			"headers": headers,
+			"events":  events,
+		},
+	})
+	_, _, err := c.do(ctx, http.MethodPost, path, payload, map[string]string{
+		"Content-Type": "application/json",
+	})
+	return err
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body []byte, headers map[string]string) ([]byte, int, error) {
+	if c == nil || c.baseURL == "" {
+		return nil, 0, &APIError{StatusCode: 0, Code: "config", Message: "base URL not configured", Retryable: false}
+	}
+	var lastErr error
+	attempts := c.maxRetries + 1
+	for attempt := 0; attempt < attempts; attempt++ {
+		if attempt > 0 {
+			// jittered backoff
+			backoff := time.Duration(50*(1<<uint(attempt-1))) * time.Millisecond
+			jitter := time.Duration(rand.Intn(40)) * time.Millisecond
+			select {
+			case <-ctx.Done():
+				return nil, 0, ctx.Err()
+			case <-time.After(backoff + jitter):
+			}
+		}
+		status, respBody, err := c.once(ctx, method, path, body, headers)
+		if err == nil {
+			return respBody, status, nil
+		}
+		lastErr = err
+		if !IsRetryable(err) {
+			return respBody, status, err
+		}
+		log.Debug().
+			Int("attempt", attempt+1).
+			Int("status", status).
+			Str("path", path).
+			Str("error", redactSecrets(err.Error(), c.apiKey)).
+			Msg("evolution retry")
+	}
+	return nil, 0, lastErr
+}
+
+func (c *Client) once(ctx context.Context, method, path string, body []byte, headers map[string]string) (int, []byte, error) {
+	url := c.baseURL + path
+	var rdr io.Reader
+	if body != nil {
+		rdr = bytes.NewReader(body)
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, rdr)
+	if err != nil {
+		return 0, nil, err
+	}
+	req.Header.Set("apikey", c.apiKey)
+	req.Header.Set("User-Agent", c.userAgent)
+	req.Header.Set("Accept", "application/json")
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return 0, nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, 2<<20))
+	if err != nil {
+		return resp.StatusCode, nil, err
+	}
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return resp.StatusCode, respBody, nil
+	}
+	ae := classifyHTTPError(resp.StatusCode, respBody)
+	return resp.StatusCode, respBody, ae
+}
+
+func classifyHTTPError(status int, body []byte) *APIError {
+	msg := strings.TrimSpace(string(body))
+	if len(msg) > 200 {
+		msg = msg[:200] + "…"
+	}
+	// Never leave API keys in error text if server echoed them.
+	ae := &APIError{
+		StatusCode: status,
+		Code:       http.StatusText(status),
+		Message:    msg,
+	}
+	switch status {
+	case 408, 425, 429, 500, 502, 503, 504:
+		ae.Retryable = true
+	case 400, 401, 403, 404, 409, 422:
+		ae.Retryable = false
+	default:
+		ae.Retryable = status >= 500
+	}
+	if status == 401 {
+		ae.Code = "unauthorized"
+		ae.Message = "invalid or missing api key"
+	}
+	return ae
+}
+
+func urlPathEscape(s string) string {
+	// Instance names are typically alphanumeric + hyphen; reject path traversal.
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "/", "")
+	s = strings.ReplaceAll(s, "..", "")
+	return s
+}
+
+func redactSecrets(s, apiKey string) string {
+	if apiKey != "" && strings.Contains(s, apiKey) {
+		return strings.ReplaceAll(s, apiKey, "[REDACTED]")
+	}
+	return s
+}
+
+// RedactAPIKey replaces the key in arbitrary strings (for tests/logs).
+func RedactAPIKey(s, apiKey string) string {
+	return redactSecrets(s, apiKey)
+}

--- a/internal/app/whatsapp/evolution/client_test.go
+++ b/internal/app/whatsapp/evolution/client_test.go
@@ -1,0 +1,187 @@
+package evolution
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+)
+
+func TestSendTextSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("apikey") != "test-key" {
+			t.Errorf("missing apikey")
+		}
+		if r.URL.Path != "/message/sendText/inst1" {
+			t.Errorf("path=%s", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), "5548999999999") {
+			t.Errorf("body=%s", body)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"key":{"id":"ABC123"},"status":"PENDING"}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "test-key", Timeout: 2 * time.Second, MaxRetries: 0})
+	p := NewProvider(c, "inst1")
+	res, err := p.SendText(context.Background(), whatsapp.SendTextRequest{
+		ToE164: "+5548999999999",
+		Body:   "Olá",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ProviderMessageID != "ABC123" {
+		t.Fatalf("id=%s", res.ProviderMessageID)
+	}
+}
+
+func TestHTTPStatusMapping(t *testing.T) {
+	codes := []int{400, 401, 403, 404, 429, 500}
+	for _, code := range codes {
+		code := code
+		t.Run(http.StatusText(code), func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(code)
+				_, _ = w.Write([]byte(`{"error":"x"}`))
+			}))
+			defer srv.Close()
+			c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "k", Timeout: time.Second, MaxRetries: 0})
+			_, err := c.SendText(context.Background(), "i", "55", "hi")
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			ae, ok := err.(*APIError)
+			if !ok {
+				t.Fatalf("type %T", err)
+			}
+			if ae.StatusCode != code {
+				t.Fatalf("status=%d", ae.StatusCode)
+			}
+			retryable := code == 429 || code == 500
+			if ae.Retryable != retryable {
+				t.Fatalf("retryable=%v want %v", ae.Retryable, retryable)
+			}
+			// secret redaction: error string must not contain api key even if body did
+			if strings.Contains(ae.Error(), "super-secret-key") {
+				t.Fatal("leaked key")
+			}
+		})
+	}
+}
+
+func TestRetryOn500ThenSuccess(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if n.Add(1) == 1 {
+			w.WriteHeader(500)
+			_, _ = w.Write([]byte(`fail`))
+			return
+		}
+		_, _ = w.Write([]byte(`{"key":{"id":"OK"},"status":"PENDING"}`))
+	}))
+	defer srv.Close()
+	c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "k", Timeout: time.Second, MaxRetries: 2})
+	res, err := c.SendText(context.Background(), "i", "55", "hi")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Key.ID != "OK" {
+		t.Fatal(res.Key.ID)
+	}
+	if n.Load() < 2 {
+		t.Fatalf("attempts=%d", n.Load())
+	}
+}
+
+func TestNoRetryOn400(t *testing.T) {
+	var n atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n.Add(1)
+		w.WriteHeader(400)
+		_, _ = w.Write([]byte(`bad`))
+	}))
+	defer srv.Close()
+	c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "k", Timeout: time.Second, MaxRetries: 3})
+	_, err := c.SendText(context.Background(), "i", "55", "hi")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if n.Load() != 1 {
+		t.Fatalf("should not retry permanent errors, attempts=%d", n.Load())
+	}
+}
+
+func TestTimeout(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(200 * time.Millisecond)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	c := NewClient(ClientConfig{BaseURL: srv.URL, APIKey: "k", Timeout: 50 * time.Millisecond, MaxRetries: 0})
+	_, err := c.SendText(context.Background(), "i", "55", "hi")
+	if err == nil {
+		t.Fatal("expected timeout")
+	}
+}
+
+func TestOffline(t *testing.T) {
+	c := NewClient(ClientConfig{BaseURL: "http://127.0.0.1:1", APIKey: "k", Timeout: 100 * time.Millisecond, MaxRetries: 0})
+	err := c.Health(context.Background())
+	if err == nil {
+		t.Fatal("expected connection error")
+	}
+}
+
+func TestRedactAPIKey(t *testing.T) {
+	s := RedactAPIKey("failed key=super-secret-key-xyz", "super-secret-key-xyz")
+	if strings.Contains(s, "super-secret-key-xyz") {
+		t.Fatal(s)
+	}
+}
+
+func TestNormalizeWebhookInbound(t *testing.T) {
+	raw := []byte(`{
+		"event": "messages.upsert",
+		"instance": "confenge",
+		"data": {
+			"key": {"remoteJid": "5548999887766@s.whatsapp.net", "fromMe": false, "id": "MSG1"},
+			"message": {"conversation": "Olá, quero falar no WhatsApp"},
+			"messageTimestamp": 1710000000
+		}
+	}`)
+	ev, err := NormalizeWebhook(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.EventType != whatsapp.EventMessageReceived {
+		t.Fatalf("type=%s", ev.EventType)
+	}
+	if ev.FromE164 != "+5548999887766" {
+		t.Fatalf("from=%s", ev.FromE164)
+	}
+	if ev.Content.Text != "Olá, quero falar no WhatsApp" {
+		t.Fatalf("text=%s", ev.Content.Text)
+	}
+	if ev.Provider != whatsapp.ProviderEvolution {
+		t.Fatal(ev.Provider)
+	}
+}
+
+func TestNormalizeUnsupported(t *testing.T) {
+	ev, err := NormalizeWebhook([]byte(`{"event":"groups.update","instance":"x","data":{}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ev.EventType != whatsapp.EventUnsupported {
+		t.Fatal(ev.EventType)
+	}
+}

--- a/internal/app/whatsapp/evolution/normalize.go
+++ b/internal/app/whatsapp/evolution/normalize.go
@@ -1,0 +1,229 @@
+package evolution
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+)
+
+// RawWebhook is a minimal Evolution webhook envelope (v2.x).
+// We only extract fields needed for domain events; unknown fields are ignored.
+type RawWebhook struct {
+	Event    string          `json:"event"`
+	Instance string          `json:"instance"`
+	Data     json.RawMessage `json:"data"`
+	// Some deployments nest differently
+	Sender string `json:"sender,omitempty"`
+	DateAt int64  `json:"date_time,omitempty"`
+}
+
+// NormalizeWebhook maps an Evolution payload into a domain ChannelEvent.
+// Unsupported events return EventUnsupported with Ignored semantics for callers.
+func NormalizeWebhook(raw []byte) (whatsapp.ChannelEvent, error) {
+	var env RawWebhook
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return whatsapp.ChannelEvent{}, err
+	}
+	ev := whatsapp.ChannelEvent{
+		Channel:    whatsapp.ChannelWhatsApp,
+		Provider:   whatsapp.ProviderEvolution,
+		Instance:   env.Instance,
+		OccurredAt: time.Now().UTC(),
+		Content:    whatsapp.Content{Type: whatsapp.ContentOther},
+	}
+
+	eventName := strings.ToUpper(strings.TrimSpace(env.Event))
+	eventName = strings.ReplaceAll(eventName, ".", "_")
+	eventName = strings.ReplaceAll(eventName, "-", "_")
+
+	switch eventName {
+	case "MESSAGES_UPSERT", "MESSAGE_UPSERT", "MESSAGES_SET":
+		return normalizeMessageUpsert(ev, env.Data)
+	case "MESSAGES_UPDATE", "MESSAGE_UPDATE":
+		return normalizeMessageUpdate(ev, env.Data)
+	case "SEND_MESSAGE", "MESSAGES_UPDATE_SEND":
+		ev.EventType = whatsapp.EventMessageSent
+		return normalizeMessageUpsert(ev, env.Data)
+	case "CONNECTION_UPDATE", "CONNECTION_STATE":
+		return normalizeConnection(ev, env.Data)
+	default:
+		ev.EventType = whatsapp.EventUnsupported
+		return ev, nil
+	}
+}
+
+type msgData struct {
+	Key struct {
+		RemoteJid string `json:"remoteJid"`
+		FromMe    bool   `json:"fromMe"`
+		ID        string `json:"id"`
+	} `json:"key"`
+	PushName         string         `json:"pushName"`
+	MessageType      string         `json:"messageType"`
+	Message          map[string]any `json:"message"`
+	MessageTimestamp any            `json:"messageTimestamp"`
+	Status           string         `json:"status"`
+}
+
+func normalizeMessageUpsert(ev whatsapp.ChannelEvent, data json.RawMessage) (whatsapp.ChannelEvent, error) {
+	var m msgData
+	if len(data) > 0 {
+		_ = json.Unmarshal(data, &m)
+		// Evolution sometimes wraps as { messages: [...] } or data is the message.
+		if m.Key.ID == "" {
+			var wrap struct {
+				Messages []msgData `json:"messages"`
+			}
+			if json.Unmarshal(data, &wrap) == nil && len(wrap.Messages) > 0 {
+				m = wrap.Messages[0]
+			}
+		}
+	}
+	if ev.EventType == "" {
+		if m.Key.FromMe {
+			ev.EventType = whatsapp.EventMessageSent
+		} else {
+			ev.EventType = whatsapp.EventMessageReceived
+		}
+	}
+	ev.ExternalMessageID = m.Key.ID
+	ev.ExternalEventID = m.Key.ID + ":" + ev.EventType
+	phone := jidToE164(m.Key.RemoteJid)
+	if m.Key.FromMe {
+		ev.ToE164 = phone
+	} else {
+		ev.FromE164 = phone
+	}
+	ev.ExternalThreadID = phone
+	if ts := parseTS(m.MessageTimestamp); !ts.IsZero() {
+		ev.OccurredAt = ts
+	}
+	text := extractText(m.Message)
+	if text != "" {
+		ev.Content = whatsapp.Content{Type: whatsapp.ContentText, Text: text}
+	}
+	return ev, nil
+}
+
+func normalizeMessageUpdate(ev whatsapp.ChannelEvent, data json.RawMessage) (whatsapp.ChannelEvent, error) {
+	var m msgData
+	_ = json.Unmarshal(data, &m)
+	status := strings.ToUpper(m.Status)
+	// Also try nested keyStatus
+	var alt struct {
+		Key struct {
+			ID        string `json:"id"`
+			RemoteJid string `json:"remoteJid"`
+		} `json:"keyId"`
+		Status    string `json:"status"`
+		MessageID string `json:"messageId"`
+		RemoteJid string `json:"remoteJid"`
+	}
+	_ = json.Unmarshal(data, &alt)
+	if m.Key.ID == "" {
+		m.Key.ID = alt.MessageID
+		if m.Key.ID == "" {
+			m.Key.ID = alt.Key.ID
+		}
+	}
+	if status == "" {
+		status = strings.ToUpper(alt.Status)
+	}
+	switch status {
+	case "DELIVERY_ACK", "DELIVERED", "SERVER_ACK":
+		ev.EventType = whatsapp.EventMessageDelivered
+	case "READ", "PLAYED":
+		ev.EventType = whatsapp.EventMessageRead
+	case "ERROR", "FAILED":
+		ev.EventType = whatsapp.EventMessageFailed
+	default:
+		ev.EventType = whatsapp.EventMessageSent
+	}
+	ev.ExternalMessageID = m.Key.ID
+	ev.ExternalEventID = m.Key.ID + ":" + ev.EventType + ":" + status
+	phone := jidToE164(m.Key.RemoteJid)
+	if phone == "" {
+		phone = jidToE164(alt.RemoteJid)
+	}
+	ev.ToE164 = phone
+	ev.ExternalThreadID = phone
+	return ev, nil
+}
+
+func normalizeConnection(ev whatsapp.ChannelEvent, data json.RawMessage) (whatsapp.ChannelEvent, error) {
+	ev.EventType = whatsapp.EventConnectionState
+	var wrap struct {
+		State    string `json:"state"`
+		Instance struct {
+			State    string `json:"state"`
+			Instance string `json:"instanceName"`
+		} `json:"instance"`
+	}
+	_ = json.Unmarshal(data, &wrap)
+	ev.ConnectionState = wrap.State
+	if ev.ConnectionState == "" {
+		ev.ConnectionState = wrap.Instance.State
+	}
+	if wrap.Instance.Instance != "" {
+		ev.Instance = wrap.Instance.Instance
+	}
+	ev.ExternalEventID = "connection:" + ev.Instance + ":" + ev.ConnectionState + ":" + ev.OccurredAt.Format(time.RFC3339)
+	return ev, nil
+}
+
+func jidToE164(jid string) string {
+	// "5548999999999@s.whatsapp.net" or "5548999999999:xx@s.whatsapp.net"
+	jid = strings.TrimSpace(jid)
+	if jid == "" {
+		return ""
+	}
+	at := strings.Index(jid, "@")
+	if at > 0 {
+		jid = jid[:at]
+	}
+	if colon := strings.Index(jid, ":"); colon > 0 {
+		jid = jid[:colon]
+	}
+	digits := whatsapp.DigitsOnly(jid)
+	if digits == "" {
+		return ""
+	}
+	return "+" + digits
+}
+
+func extractText(msg map[string]any) string {
+	if msg == nil {
+		return ""
+	}
+	if c, ok := msg["conversation"].(string); ok {
+		return c
+	}
+	if ext, ok := msg["extendedTextMessage"].(map[string]any); ok {
+		if t, ok := ext["text"].(string); ok {
+			return t
+		}
+	}
+	return ""
+}
+
+func parseTS(v any) time.Time {
+	switch t := v.(type) {
+	case float64:
+		if t > 1e12 {
+			return time.UnixMilli(int64(t)).UTC()
+		}
+		return time.Unix(int64(t), 0).UTC()
+	case int64:
+		return time.Unix(t, 0).UTC()
+	case json.Number:
+		n, _ := t.Int64()
+		return time.Unix(n, 0).UTC()
+	case string:
+		if n, err := time.Parse(time.RFC3339, t); err == nil {
+			return n.UTC()
+		}
+	}
+	return time.Time{}
+}

--- a/internal/app/whatsapp/evolution/provider.go
+++ b/internal/app/whatsapp/evolution/provider.go
@@ -1,0 +1,106 @@
+package evolution
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/whatsapp"
+)
+
+// Provider implements whatsapp.Provider using Evolution API (Cloud API first).
+type Provider struct {
+	client   *Client
+	instance string
+}
+
+// NewProvider wraps a Client as a domain Provider.
+func NewProvider(client *Client, defaultInstance string) *Provider {
+	return &Provider{client: client, instance: defaultInstance}
+}
+
+// Name implements whatsapp.Provider.
+func (p *Provider) Name() string { return whatsapp.ProviderEvolution }
+
+func (p *Provider) resolveInstance(instance string) string {
+	if instance != "" {
+		return instance
+	}
+	return p.instance
+}
+
+// SendText implements whatsapp.Provider.
+func (p *Provider) SendText(ctx context.Context, req whatsapp.SendTextRequest) (*whatsapp.SendResult, error) {
+	if p == nil || p.client == nil {
+		return nil, fmt.Errorf("evolution provider not configured")
+	}
+	number := whatsapp.DigitsOnly(req.ToE164)
+	res, err := p.client.SendText(ctx, p.resolveInstance(req.Instance), number, req.Body)
+	if err != nil {
+		return nil, err
+	}
+	id := res.Key.ID
+	if id == "" {
+		id = res.MessageID
+	}
+	return &whatsapp.SendResult{
+		ProviderMessageID: id,
+		Status:            "sent",
+		RawStatus:         res.Status,
+		OccurredAt:        time.Now().UTC(),
+	}, nil
+}
+
+// SendTemplate implements whatsapp.Provider.
+func (p *Provider) SendTemplate(ctx context.Context, req whatsapp.SendTemplateRequest) (*whatsapp.SendResult, error) {
+	if p == nil || p.client == nil {
+		return nil, fmt.Errorf("evolution provider not configured")
+	}
+	number := whatsapp.DigitsOnly(req.ToE164)
+	res, err := p.client.SendTemplate(ctx, p.resolveInstance(req.Instance), number, req.TemplateName, req.Language, req.Variables)
+	if err != nil {
+		return nil, err
+	}
+	id := res.Key.ID
+	if id == "" {
+		id = res.MessageID
+	}
+	return &whatsapp.SendResult{
+		ProviderMessageID: id,
+		Status:            "sent",
+		RawStatus:         res.Status,
+		OccurredAt:        time.Now().UTC(),
+	}, nil
+}
+
+// GetConnectionStatus implements whatsapp.Provider.
+func (p *Provider) GetConnectionStatus(ctx context.Context, instance string) (*whatsapp.ConnectionStatus, error) {
+	st, err := p.client.GetConnectionState(ctx, p.resolveInstance(instance))
+	if err != nil {
+		return nil, err
+	}
+	return &whatsapp.ConnectionStatus{
+		Instance:  st.Instance,
+		State:     st.State,
+		UpdatedAt: time.Now().UTC(),
+	}, nil
+}
+
+// ConfigureWebhook implements whatsapp.Provider.
+func (p *Provider) ConfigureWebhook(ctx context.Context, instance string, cfg whatsapp.WebhookConfig) error {
+	events := cfg.Events
+	if len(events) == 0 {
+		events = []string{
+			"MESSAGES_UPSERT",
+			"MESSAGES_UPDATE",
+			"SEND_MESSAGE",
+			"CONNECTION_UPDATE",
+		}
+	}
+	return p.client.SetWebhook(ctx, p.resolveInstance(instance), cfg.URL, cfg.Secret, events, cfg.Enabled)
+}
+
+// Health implements whatsapp.Provider.
+func (p *Provider) Health(ctx context.Context) error {
+	return p.client.Health(ctx)
+}

--- a/internal/app/whatsapp/mock.go
+++ b/internal/app/whatsapp/mock.go
@@ -1,0 +1,113 @@
+package whatsapp
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// MockProvider records sends for tests. Never reaches a real network.
+type MockProvider struct {
+	mu        sync.Mutex
+	Sends     []MockSend
+	Templates []MockSend
+	HealthErr error
+	SendErr   error
+	Status    ConnectionStatus
+}
+
+// MockSend is one recorded outbound attempt.
+type MockSend struct {
+	Kind           string // text | template
+	ToE164         string
+	Body           string
+	TemplateName   string
+	Language       string
+	Variables      []string
+	IdempotencyKey string
+	OrganizationID uuid.UUID
+	At             time.Time
+}
+
+// NewMockProvider returns a ready mock.
+func NewMockProvider() *MockProvider {
+	return &MockProvider{
+		Status: ConnectionStatus{Instance: "mock", State: "open", UpdatedAt: time.Now().UTC()},
+	}
+}
+
+func (m *MockProvider) Name() string { return ProviderMock }
+
+func (m *MockProvider) SendText(_ context.Context, req SendTextRequest) (*SendResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.SendErr != nil {
+		return nil, m.SendErr
+	}
+	m.Sends = append(m.Sends, MockSend{
+		Kind:           "text",
+		ToE164:         req.ToE164,
+		Body:           req.Body,
+		IdempotencyKey: req.IdempotencyKey,
+		OrganizationID: req.OrganizationID,
+		At:             time.Now().UTC(),
+	})
+	id := uuid.New().String()
+	return &SendResult{ProviderMessageID: id, Status: "sent", RawStatus: "MOCK_SENT", OccurredAt: time.Now().UTC()}, nil
+}
+
+func (m *MockProvider) SendTemplate(_ context.Context, req SendTemplateRequest) (*SendResult, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.SendErr != nil {
+		return nil, m.SendErr
+	}
+	m.Templates = append(m.Templates, MockSend{
+		Kind:           "template",
+		ToE164:         req.ToE164,
+		TemplateName:   req.TemplateName,
+		Language:       req.Language,
+		Variables:      append([]string(nil), req.Variables...),
+		IdempotencyKey: req.IdempotencyKey,
+		OrganizationID: req.OrganizationID,
+		At:             time.Now().UTC(),
+	})
+	id := uuid.New().String()
+	return &SendResult{ProviderMessageID: id, Status: "sent", RawStatus: "MOCK_TEMPLATE_SENT", OccurredAt: time.Now().UTC()}, nil
+}
+
+func (m *MockProvider) GetConnectionStatus(_ context.Context, instance string) (*ConnectionStatus, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	s := m.Status
+	if instance != "" {
+		s.Instance = instance
+	}
+	return &s, nil
+}
+
+func (m *MockProvider) ConfigureWebhook(context.Context, string, WebhookConfig) error { return nil }
+
+func (m *MockProvider) Health(context.Context) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.HealthErr
+}
+
+// SendCount returns total text+template sends.
+func (m *MockProvider) SendCount() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return len(m.Sends) + len(m.Templates)
+}
+
+// Reset clears recorded sends.
+func (m *MockProvider) Reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.Sends = nil
+	m.Templates = nil
+	m.SendErr = nil
+}

--- a/internal/app/whatsapp/optout.go
+++ b/internal/app/whatsapp/optout.go
@@ -1,0 +1,122 @@
+package whatsapp
+
+import (
+	"strings"
+	"unicode"
+)
+
+// OptOutMatch describes an automatic opt-out phrase detection result.
+type OptOutMatch struct {
+	Matched   bool
+	Category  string // opt_out | do_not_contact | ambiguous | none
+	Phrase    string
+	Confident bool // true only for unequivocal phrases
+}
+
+// unequivocal Portuguese / Spanish / English opt-out phrases.
+// Keep conservative: ambiguous text routes to human review.
+var unequivocalPhrases = []string{
+	"não tenho interesse",
+	"nao tenho interesse",
+	"não me chame mais",
+	"nao me chame mais",
+	"não me ligue mais",
+	"retire meu número",
+	"retire meu numero",
+	"não envie mensagens",
+	"nao envie mensagens",
+	"não envie mais",
+	"nao envie mais",
+	"pare de me enviar",
+	"remover meu número",
+	"remover meu numero",
+	"do not contact",
+	"don't contact me",
+	"dont contact me",
+	"stop messaging me",
+	"remove my number",
+	"unsubscribe",
+	"opt out",
+	"opt-out",
+	"no me contacten",
+	"no me escriban más",
+	"no me escriban mas",
+}
+
+// standaloneOptOutTokens only match as whole-message or whole-word intent.
+var standaloneOptOutTokens = []string{
+	"parar",
+	"sair",
+	"stop",
+	"cancelar",
+	"remover",
+}
+
+// DetectOptOut scans inbound free text for unequivocal opt-out intent.
+// On doubt returns Confident=false so the operator reviews.
+func DetectOptOut(body string) OptOutMatch {
+	norm := normalizeOptOutText(body)
+	if norm == "" {
+		return OptOutMatch{Category: "none"}
+	}
+
+	for _, p := range unequivocalPhrases {
+		if strings.Contains(norm, p) {
+			return OptOutMatch{
+				Matched:   true,
+				Category:  "opt_out",
+				Phrase:    p,
+				Confident: true,
+			}
+		}
+	}
+
+	// Whole-message short tokens only (avoid "não posso parar agora").
+	trimmed := strings.TrimSpace(norm)
+	for _, t := range standaloneOptOutTokens {
+		if trimmed == t {
+			return OptOutMatch{
+				Matched:   true,
+				Category:  "opt_out",
+				Phrase:    t,
+				Confident: true,
+			}
+		}
+	}
+
+	// Soft signals → human review, not auto block.
+	soft := []string{"sem interesse", "agora não", "agora nao", "talvez depois", "não é o momento", "nao e o momento"}
+	for _, p := range soft {
+		if strings.Contains(norm, p) {
+			return OptOutMatch{
+				Matched:   true,
+				Category:  "ambiguous",
+				Phrase:    p,
+				Confident: false,
+			}
+		}
+	}
+
+	return OptOutMatch{Category: "none"}
+}
+
+func normalizeOptOutText(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	b.Grow(len(s))
+	prevSpace := false
+	for _, r := range s {
+		if unicode.IsLetter(r) || unicode.IsDigit(r) {
+			b.WriteRune(r)
+			prevSpace = false
+			continue
+		}
+		if unicode.IsSpace(r) || r == '-' || r == '_' {
+			if !prevSpace && b.Len() > 0 {
+				b.WriteByte(' ')
+				prevSpace = true
+			}
+		}
+	}
+	return strings.TrimSpace(b.String())
+}

--- a/internal/app/whatsapp/optout_test.go
+++ b/internal/app/whatsapp/optout_test.go
@@ -1,0 +1,27 @@
+package whatsapp
+
+import "testing"
+
+func TestDetectOptOut(t *testing.T) {
+	cases := []struct {
+		body      string
+		matched   bool
+		confident bool
+	}{
+		{"Não tenho interesse, obrigado", true, true},
+		{"PARE de me enviar mensagens", true, true},
+		{"parar", true, true},
+		{"stop", true, true},
+		{"Retire meu número da lista", true, true},
+		{"Agora não, talvez depois", true, false},
+		{"Pode me explicar o serviço?", false, false},
+		{"", false, false},
+	}
+	for _, tc := range cases {
+		m := DetectOptOut(tc.body)
+		if m.Matched != tc.matched || m.Confident != tc.confident {
+			t.Errorf("body=%q got matched=%v conf=%v cat=%s phrase=%q",
+				tc.body, m.Matched, m.Confident, m.Category, m.Phrase)
+		}
+	}
+}

--- a/internal/app/whatsapp/phone.go
+++ b/internal/app/whatsapp/phone.go
@@ -1,0 +1,91 @@
+package whatsapp
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+
+	"github.com/nyaruka/phonenumbers"
+)
+
+// PhoneResult is the outcome of normalization. Original is always preserved.
+type PhoneResult struct {
+	Original   string `json:"original"`
+	E164       string `json:"e164,omitempty"`        // +E.164
+	E164Digits string `json:"e164_digits,omitempty"` // digits only (no +)
+	Country    string `json:"country,omitempty"`     // ISO region, e.g. BR
+	Valid      bool   `json:"valid"`
+	Error      string `json:"error,omitempty"`
+}
+
+// NormalizePhone parses raw into E.164 using libphonenumber.
+// defaultRegion is used when the number lacks a country code (e.g. "BR").
+// Empty defaultRegion defaults to BR for CONFENGE commercial use.
+func NormalizePhone(raw, defaultRegion string) PhoneResult {
+	out := PhoneResult{Original: raw}
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		out.Error = "empty phone"
+		return out
+	}
+	if defaultRegion == "" {
+		defaultRegion = "BR"
+	}
+
+	// Strip common noise; keep leading + for international form.
+	cleaned := stripPhoneNoise(raw)
+
+	num, err := phonenumbers.Parse(cleaned, defaultRegion)
+	if err != nil {
+		out.Error = fmt.Sprintf("parse: %v", err)
+		return out
+	}
+	if !phonenumbers.IsValidNumber(num) {
+		// Still surface the candidate format for operators; mark invalid.
+		formatted := phonenumbers.Format(num, phonenumbers.E164)
+		out.E164 = formatted
+		out.E164Digits = strings.TrimPrefix(formatted, "+")
+		region := phonenumbers.GetRegionCodeForNumber(num)
+		out.Country = region
+		out.Error = "invalid phone number"
+		return out
+	}
+	formatted := phonenumbers.Format(num, phonenumbers.E164)
+	out.E164 = formatted
+	out.E164Digits = strings.TrimPrefix(formatted, "+")
+	out.Country = phonenumbers.GetRegionCodeForNumber(num)
+	out.Valid = true
+	return out
+}
+
+// stripPhoneNoise removes spaces, parentheses, hyphens, dots, and trunk zeros
+// quirks while preserving a leading +.
+func stripPhoneNoise(s string) string {
+	s = strings.TrimSpace(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	for i, r := range s {
+		if r == '+' && i == 0 {
+			b.WriteRune(r)
+			continue
+		}
+		if unicode.IsDigit(r) {
+			b.WriteRune(r)
+		}
+		// drop spaces, (), -, ., and letters like "ext"
+	}
+	out := b.String()
+	// Brazilian operator trunk "0" after country code is handled by libphonenumber
+	// when region is BR; for national forms like 048999999999, Parse with BR works.
+	return out
+}
+
+// DigitsOnly strips non-digits (and leading +) for provider APIs that want raw MSISDN.
+func DigitsOnly(e164 string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsDigit(r) {
+			return r
+		}
+		return -1
+	}, e164)
+}

--- a/internal/app/whatsapp/phone_test.go
+++ b/internal/app/whatsapp/phone_test.go
@@ -1,0 +1,39 @@
+package whatsapp
+
+import "testing"
+
+func TestNormalizePhoneBR(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string // E.164
+		ok   bool
+	}{
+		{"(48) 99999-9999", "+5548999999999", true},
+		{"48999999999", "+5548999999999", true},
+		{"+55 48 99999-9999", "+5548999999999", true},
+		{"5548999999999", "+5548999999999", true},
+		{"048 99999-9999", "+5548999999999", true},
+		{"", "", false},
+		{"123", "", false},
+		{"not-a-phone", "", false},
+	}
+	for _, tc := range cases {
+		got := NormalizePhone(tc.raw, "BR")
+		if got.Valid != tc.ok {
+			t.Errorf("raw=%q valid=%v want %v err=%s", tc.raw, got.Valid, tc.ok, got.Error)
+			continue
+		}
+		if tc.ok && got.E164 != tc.want {
+			t.Errorf("raw=%q e164=%q want %q", tc.raw, got.E164, tc.want)
+		}
+		if got.Original != tc.raw {
+			t.Errorf("original not preserved: %q", got.Original)
+		}
+	}
+}
+
+func TestDigitsOnly(t *testing.T) {
+	if DigitsOnly("+55 48 99999-9999") != "5548999999999" {
+		t.Fatal(DigitsOnly("+55 48 99999-9999"))
+	}
+}

--- a/internal/app/whatsapp/provider.go
+++ b/internal/app/whatsapp/provider.go
@@ -1,0 +1,134 @@
+// Package whatsapp is the policy-gated WhatsApp channel transport for Warmbly.
+// Domain code talks only to the Provider interface; provider-specific DTOs
+// stay inside adapter packages (e.g. evolution).
+package whatsapp
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Provider is the transport abstraction. Implementations: Evolution (Cloud API
+// first), mock, and future Meta/BSP adapters. Domain never imports provider DTOs.
+type Provider interface {
+	// SendText sends free-form text inside an open service window or after
+	// policy has approved free-text. Callers must run eligibility first.
+	SendText(ctx context.Context, req SendTextRequest) (*SendResult, error)
+	// SendTemplate sends an approved WhatsApp Business Platform template.
+	SendTemplate(ctx context.Context, req SendTemplateRequest) (*SendResult, error)
+	// GetConnectionStatus reports instance/WABA connection health.
+	GetConnectionStatus(ctx context.Context, instance string) (*ConnectionStatus, error)
+	// ConfigureWebhook registers the Warmbly ingress URL on the provider when supported.
+	ConfigureWebhook(ctx context.Context, instance string, cfg WebhookConfig) error
+	// Health checks provider reachability without side effects.
+	Health(ctx context.Context) error
+	// Name returns a stable provider id (e.g. "evolution", "mock").
+	Name() string
+}
+
+// SendTextRequest is a domain send of free-form text.
+type SendTextRequest struct {
+	Instance       string
+	ToE164         string // digits with country code, no leading +
+	Body           string
+	IdempotencyKey string
+	// OrganizationID is for multi-tenant logging/audit only; not sent to provider.
+	OrganizationID uuid.UUID
+	ContactID      *uuid.UUID
+}
+
+// SendTemplateRequest is a domain send of an official template.
+type SendTemplateRequest struct {
+	Instance       string
+	ToE164         string
+	TemplateName   string
+	Language       string
+	Variables      []string
+	IdempotencyKey string
+	OrganizationID uuid.UUID
+	ContactID      *uuid.UUID
+}
+
+// SendResult is the provider-normalized send outcome.
+type SendResult struct {
+	ProviderMessageID string
+	Status            string // queued | sent | failed
+	RawStatus         string // provider status string (never secrets)
+	OccurredAt        time.Time
+}
+
+// ConnectionStatus is instance/connection health.
+type ConnectionStatus struct {
+	Instance  string
+	State     string // open | close | connecting | unknown
+	PhoneE164 string
+	UpdatedAt time.Time
+}
+
+// WebhookConfig is what Warmbly asks the provider to post to.
+type WebhookConfig struct {
+	URL     string
+	Secret  string
+	Events  []string
+	Enabled bool
+}
+
+// Consent statuses for WhatsApp (first-class, never inferred from public phone).
+const (
+	ConsentUnknown       = "UNKNOWN"
+	ConsentNoOptIn       = "NO_OPT_IN"
+	ConsentOptedIn       = "OPTED_IN"
+	ConsentUserInitiated = "USER_INITIATED"
+	ConsentOptedOut      = "OPTED_OUT"
+	ConsentDoNotContact  = "DO_NOT_CONTACT"
+)
+
+// Eligibility decisions returned by the policy engine.
+const (
+	EligAutomatedAllowed = "AUTOMATED_ALLOWED"
+	EligTemplateOnly     = "TEMPLATE_ONLY"
+	EligServiceWindow    = "SERVICE_WINDOW"
+	EligManualReview     = "MANUAL_REVIEW"
+	EligBlocked          = "BLOCKED"
+)
+
+// Message / draft channel.
+const (
+	ChannelEmail    = "EMAIL"
+	ChannelWhatsApp = "WHATSAPP"
+)
+
+// Normalized event types (provider-agnostic).
+const (
+	EventMessageReceived  = "MESSAGE_RECEIVED"
+	EventMessageSent      = "MESSAGE_SENT"
+	EventMessageDelivered = "MESSAGE_DELIVERED"
+	EventMessageRead      = "MESSAGE_READ"
+	EventMessageFailed    = "MESSAGE_FAILED"
+	EventConnectionState  = "CONNECTION_STATE"
+	EventTemplateError    = "TEMPLATE_ERROR"
+	EventUnsupported      = "UNSUPPORTED"
+)
+
+// Provider ids.
+const (
+	ProviderEvolution = "evolution"
+	ProviderMock      = "mock"
+)
+
+// Template statuses (WhatsApp Business Platform).
+const (
+	TemplateApproved = "APPROVED"
+	TemplatePaused   = "PAUSED"
+	TemplateRejected = "REJECTED"
+	TemplatePending  = "PENDING"
+	TemplateMissing  = "MISSING"
+)
+
+// Message content types we handle.
+const (
+	ContentText  = "text"
+	ContentOther = "other"
+)

--- a/internal/app/whatsapp/service.go
+++ b/internal/app/whatsapp/service.go
@@ -1,0 +1,208 @@
+package whatsapp
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+)
+
+// TemplateCatalog looks up official template approval state.
+type TemplateCatalog interface {
+	// Status returns APPROVED | PAUSED | REJECTED | PENDING | MISSING.
+	Status(ctx context.Context, orgID uuid.UUID, name, language string) (string, error)
+}
+
+// StaticTemplateCatalog is an in-memory catalog for tests and manual sync ops.
+type StaticTemplateCatalog struct {
+	mu    sync.RWMutex
+	items map[string]string // name|lang -> status
+}
+
+// NewStaticTemplateCatalog builds an empty catalog.
+func NewStaticTemplateCatalog() *StaticTemplateCatalog {
+	return &StaticTemplateCatalog{items: map[string]string{}}
+}
+
+// Set records a template status.
+func (c *StaticTemplateCatalog) Set(name, language, status string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.items[name+"|"+language] = status
+}
+
+// Status implements TemplateCatalog.
+func (c *StaticTemplateCatalog) Status(_ context.Context, _ uuid.UUID, name, language string) (string, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	if s, ok := c.items[name+"|"+language]; ok {
+		return s, nil
+	}
+	return TemplateMissing, nil
+}
+
+// Service is the domain send/inbound gate. All automated sends go through Send.
+type Service struct {
+	cfg      Config
+	provider Provider
+	catalog  TemplateCatalog
+
+	// seenEventIDs is an in-process idempotency set (tests / single-node).
+	// Production persists via repository when wired.
+	mu   sync.Mutex
+	seen map[string]struct{}
+}
+
+// NewService constructs the domain service. provider may be nil when disabled.
+func NewService(cfg Config, provider Provider, catalog TemplateCatalog) *Service {
+	if catalog == nil {
+		catalog = NewStaticTemplateCatalog()
+	}
+	return &Service{
+		cfg:      cfg,
+		provider: provider,
+		catalog:  catalog,
+		seen:     map[string]struct{}{},
+	}
+}
+
+// Config returns a copy of runtime config.
+func (s *Service) Config() Config { return s.cfg }
+
+// ProviderName returns the active provider id.
+func (s *Service) ProviderName() string {
+	if s.provider == nil {
+		return ""
+	}
+	return s.provider.Name()
+}
+
+// SendResultExt wraps provider result with policy decision.
+type SendResultExt struct {
+	Decision Decision
+	Result   *SendResult
+	Skipped  bool
+}
+
+// Send runs eligibility then, if allowed, the provider. Never bypasses policy.
+func (s *Service) Send(ctx context.Context, state ContactChannelState, intent SendIntent, textReq *SendTextRequest, tmplReq *SendTemplateRequest) (*SendResultExt, error) {
+	if s == nil {
+		return nil, fmt.Errorf("whatsapp service is nil")
+	}
+	intent.FeatureEnabled = s.cfg.Enabled
+	if intent.Now.IsZero() {
+		intent.Now = time.Now().UTC()
+	}
+	if intent.CrossChannelMin == 0 {
+		intent.CrossChannelMin = s.cfg.CrossChannelInterval
+	}
+	if intent.ServiceWindow == 0 {
+		intent.ServiceWindow = s.cfg.ServiceWindow
+	}
+	if intent.Mode == ModeTemplate && tmplReq != nil && s.catalog != nil {
+		st, err := s.catalog.Status(ctx, state.OrganizationID, tmplReq.TemplateName, tmplReq.Language)
+		if err != nil {
+			return nil, err
+		}
+		intent.TemplateApproved = st == TemplateApproved
+		if st != TemplateApproved {
+			d := Decision{Allowed: false, Eligibility: EligBlocked, Reason: "template_status_" + st}
+			return &SendResultExt{Decision: d, Skipped: true}, nil
+		}
+	}
+
+	d := EvaluateEligibility(state, intent)
+	if !d.Allowed {
+		return &SendResultExt{Decision: d, Skipped: true}, nil
+	}
+	if s.provider == nil {
+		return nil, fmt.Errorf("whatsapp provider not configured")
+	}
+
+	switch intent.Mode {
+	case ModeTemplate:
+		if tmplReq == nil {
+			return nil, fmt.Errorf("template request required")
+		}
+		res, err := s.provider.SendTemplate(ctx, *tmplReq)
+		return &SendResultExt{Decision: d, Result: res}, err
+	default:
+		if textReq == nil {
+			return nil, fmt.Errorf("text request required")
+		}
+		res, err := s.provider.SendText(ctx, *textReq)
+		return &SendResultExt{Decision: d, Result: res}, err
+	}
+}
+
+// ProcessInbound applies opt-out detection, service window, and idempotency.
+// Persist/CRM hooks are left to the caller (W2 / confenge orchestration).
+func (s *Service) ProcessInbound(ctx context.Context, state *ContactChannelState, ev ChannelEvent) (InboundResult, error) {
+	_ = ctx
+	res := InboundResult{Event: ev}
+	if s == nil {
+		return res, fmt.Errorf("whatsapp service is nil")
+	}
+	key := ev.IdempotencyKey()
+	s.mu.Lock()
+	if _, ok := s.seen[key]; ok {
+		s.mu.Unlock()
+		res.Duplicate = true
+		return res, nil
+	}
+	s.seen[key] = struct{}{}
+	s.mu.Unlock()
+
+	if ev.EventType != EventMessageReceived {
+		res.Ignored = true
+		return res, nil
+	}
+
+	if state != nil {
+		OpenServiceWindowFromInbound(state, ev.OccurredAt, s.cfg.ServiceWindow)
+		if ev.Content.Type == ContentText && ev.Content.Text != "" {
+			match := DetectOptOut(ev.Content.Text)
+			res.OptOut = match
+			if match.Matched && match.Confident {
+				ApplyOptOut(state, ev.OccurredAt, "inbound_phrase:"+match.Phrase)
+				res.StopSequences = true
+			} else if match.Matched && !match.Confident {
+				res.NeedsHumanReview = true
+			} else {
+				// Any human inbound should stop automated follow-ups for the lead.
+				res.StopSequences = true
+			}
+		} else {
+			res.StopSequences = true
+		}
+	}
+	return res, nil
+}
+
+// InboundResult is the domain outcome of one inbound message.
+type InboundResult struct {
+	Event            ChannelEvent
+	Duplicate        bool
+	Ignored          bool
+	StopSequences    bool
+	NeedsHumanReview bool
+	OptOut           OptOutMatch
+}
+
+// SeenReports whether an event key was already processed (tests).
+func (s *Service) Seen(key string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.seen[key]
+	return ok
+}
+
+// LogBaileysWarning emits the lab-only warning when configured.
+func LogBaileysWarning(cfg Config) {
+	if w := cfg.BaileysWarning(); w != "" {
+		log.Warn().Str("component", "whatsapp").Msg(w)
+	}
+}

--- a/internal/app/whatsapp/webhook.go
+++ b/internal/app/whatsapp/webhook.go
@@ -1,0 +1,101 @@
+package whatsapp
+
+import (
+	"crypto/subtle"
+	"fmt"
+	"strings"
+)
+
+// WebhookAuth validates inbound Evolution (or future provider) webhooks.
+type WebhookAuth struct {
+	// Secret is compared to Authorization: Bearer <secret> or X-Webhook-Secret.
+	Secret string
+	// InstanceAllow is the expected instance name (empty = any, then map later).
+	InstanceAllow string
+	// MaxBytes body size limit.
+	MaxBytes int64
+}
+
+// AuthError is a webhook authentication / validation failure.
+type AuthError struct {
+	Code       string
+	Message    string
+	StatusCode int
+}
+
+func (e *AuthError) Error() string {
+	if e == nil {
+		return "webhook auth error"
+	}
+	return e.Message
+}
+
+// ValidateHeaders checks secret, content-type, and size before body parse.
+func (a WebhookAuth) ValidateHeaders(authHeader, secretHeader, contentType string, contentLength int64) error {
+	if a.MaxBytes <= 0 {
+		a.MaxBytes = DefaultMaxWebhookBytes
+	}
+	if contentLength > a.MaxBytes {
+		return &AuthError{Code: "payload_too_large", Message: "payload too large", StatusCode: 413}
+	}
+	if contentType != "" && !strings.Contains(strings.ToLower(contentType), "json") {
+		return &AuthError{Code: "unsupported_media_type", Message: "content-type must be application/json", StatusCode: 415}
+	}
+	if a.Secret == "" {
+		// Dev-only: allow empty secret when not configured (startup forbids in prod).
+		return nil
+	}
+	token := bearerToken(authHeader)
+	if token == "" {
+		token = strings.TrimSpace(secretHeader)
+	}
+	if token == "" {
+		return &AuthError{Code: "missing_secret", Message: "missing webhook secret", StatusCode: 401}
+	}
+	if subtle.ConstantTimeCompare([]byte(token), []byte(a.Secret)) != 1 {
+		return &AuthError{Code: "invalid_secret", Message: "invalid webhook secret", StatusCode: 401}
+	}
+	return nil
+}
+
+// ValidateInstance ensures the event instance matches the configured mapping.
+func (a WebhookAuth) ValidateInstance(instance string) error {
+	if a.InstanceAllow == "" {
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(instance), strings.TrimSpace(a.InstanceAllow)) {
+		return &AuthError{Code: "instance_mismatch", Message: "instance not mapped", StatusCode: 404}
+	}
+	return nil
+}
+
+func bearerToken(h string) string {
+	h = strings.TrimSpace(h)
+	if h == "" {
+		return ""
+	}
+	const p = "Bearer "
+	if len(h) > len(p) && strings.EqualFold(h[:len(p)], p) {
+		return strings.TrimSpace(h[len(p):])
+	}
+	return h
+}
+
+// MapInstanceToOrg is a simple static instance→org mapper for single-tenant deploys.
+// Multi-tenant maps live in the repository when wired.
+type InstanceMapping struct {
+	Instance       string
+	OrganizationID string // uuid string
+	WebhookSecret  string
+}
+
+// ResolveInstance finds a mapping or errors.
+func ResolveInstance(maps []InstanceMapping, instance string) (InstanceMapping, error) {
+	instance = strings.TrimSpace(instance)
+	for _, m := range maps {
+		if strings.EqualFold(m.Instance, instance) {
+			return m, nil
+		}
+	}
+	return InstanceMapping{}, fmt.Errorf("instance not mapped: %s", instance)
+}

--- a/internal/app/whatsapp/webhook_test.go
+++ b/internal/app/whatsapp/webhook_test.go
@@ -1,0 +1,86 @@
+package whatsapp
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestWebhookAuthSecret(t *testing.T) {
+	a := WebhookAuth{Secret: "s3cret", MaxBytes: 1024}
+	if err := a.ValidateHeaders("Bearer s3cret", "", "application/json", 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.ValidateHeaders("Bearer wrong", "", "application/json", 10); err == nil {
+		t.Fatal("expected invalid secret")
+	}
+	if err := a.ValidateHeaders("", "s3cret", "application/json", 10); err != nil {
+		t.Fatal(err)
+	}
+	if err := a.ValidateHeaders("Bearer s3cret", "", "text/plain", 10); err == nil {
+		t.Fatal("expected media type error")
+	}
+	if err := a.ValidateHeaders("Bearer s3cret", "", "application/json", 5000); err == nil {
+		t.Fatal("expected oversize")
+	}
+}
+
+func TestWebhookIdempotencyAndOptOut(t *testing.T) {
+	svc := NewService(Config{Enabled: true, ServiceWindow: 24 * time.Hour}, NewMockProvider(), nil)
+	st := ContactChannelState{
+		PhoneE164:     "+5548999999999",
+		ConsentStatus: ConsentUnknown,
+	}
+	ev := ChannelEvent{
+		Channel:           ChannelWhatsApp,
+		Provider:          ProviderEvolution,
+		EventType:         EventMessageReceived,
+		ExternalMessageID: "msg-1",
+		ExternalEventID:   "msg-1:MESSAGE_RECEIVED",
+		FromE164:          "+5548999999999",
+		OccurredAt:        time.Now().UTC(),
+		Content:           Content{Type: ContentText, Text: "não tenho interesse"},
+	}
+	r1, err := svc.ProcessInbound(context.Background(), &st, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r1.Duplicate || !r1.OptOut.Matched || !r1.StopSequences {
+		t.Fatalf("first inbound: %+v opt=%+v", r1, r1.OptOut)
+	}
+	if st.ConsentStatus != ConsentOptedOut {
+		t.Fatalf("consent=%s", st.ConsentStatus)
+	}
+	r2, err := svc.ProcessInbound(context.Background(), &st, ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r2.Duplicate {
+		t.Fatal("duplicate event must be detected")
+	}
+}
+
+func TestConfigBaileysProductionGuard(t *testing.T) {
+	t.Setenv(EnvEnabled, "true")
+	t.Setenv(EnvEvolutionAllowBaileys, "true")
+	t.Setenv(EnvAppEnv, "production")
+	t.Setenv(EnvEvolutionBaseURL, "https://evo.example")
+	t.Setenv(EnvEvolutionAPIKey, "k")
+	t.Setenv(EnvEvolutionInstance, "i")
+	t.Setenv(EnvWebhookSecret, "w")
+	cfg := LoadConfig()
+	if err := cfg.ValidateStartup(); err == nil {
+		t.Fatal("production + baileys must fail validation")
+	}
+}
+
+func TestConfigDefaultsOff(t *testing.T) {
+	t.Setenv(EnvEnabled, "")
+	t.Setenv(EnvAutoSend, "")
+	t.Setenv(EnvAutoReply, "")
+	t.Setenv(EnvEvolutionAllowBaileys, "")
+	cfg := LoadConfig()
+	if cfg.Enabled || cfg.AutoSendEnabled || cfg.AutoReplyEnabled || cfg.AllowBaileys {
+		t.Fatalf("defaults must be off: %+v", cfg)
+	}
+}

--- a/internal/infrastructure/db/migrations/000080_outreach_staging.down.sql
+++ b/internal/infrastructure/db/migrations/000080_outreach_staging.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS outreach_evidence;
+DROP TABLE IF EXISTS outreach_contact_candidates;
+DROP TABLE IF EXISTS outreach_accounts;
+DROP TABLE IF EXISTS outreach_import_runs;

--- a/internal/infrastructure/db/migrations/000080_outreach_staging.up.sql
+++ b/internal/infrastructure/db/migrations/000080_outreach_staging.up.sql
@@ -1,0 +1,227 @@
+-- Outreach staging: multi-tenant company staging queue for intelligence-plane
+-- feeds (e.g. extra-cli confenge.outreach.v1). Companies may exist without a
+-- validated email; they are not forced into the contacts table until promoted.
+-- Feature flag: CONFENGE_OUTREACH_ENABLED (see internal/app/confenge).
+
+CREATE TABLE IF NOT EXISTS outreach_import_runs (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    source_system       text NOT NULL DEFAULT 'extra-cli',
+    source_run_id       text NOT NULL DEFAULT '',
+    schema_version      text NOT NULL DEFAULT 'confenge.outreach.v1',
+    snapshot_hash       text NOT NULL DEFAULT '',
+    repo_sha            text NOT NULL DEFAULT '',
+    payload_hash        text NOT NULL DEFAULT '',
+    profile_id          text NOT NULL DEFAULT '',
+    profile_version     text NOT NULL DEFAULT '',
+
+    status              text NOT NULL DEFAULT 'pending',
+    dry_run             boolean NOT NULL DEFAULT false,
+    started_at          timestamptz NOT NULL DEFAULT now(),
+    finished_at         timestamptz,
+    cursor_in           text NOT NULL DEFAULT '',
+    cursor_out          text NOT NULL DEFAULT '',
+
+    counts              jsonb NOT NULL DEFAULT '{}'::jsonb,
+    errors              jsonb NOT NULL DEFAULT '[]'::jsonb,
+    warnings            jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    created_by_user_id  uuid REFERENCES users(id) ON DELETE SET NULL,
+    idempotency_key     text NOT NULL DEFAULT '',
+    source_uri          text NOT NULL DEFAULT '',
+
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_import_runs_status_check
+        CHECK (status IN ('pending', 'running', 'completed', 'failed', 'partial'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_import_runs_org_idempotency_uidx
+    ON outreach_import_runs (organization_id, idempotency_key)
+    WHERE idempotency_key <> '';
+
+CREATE INDEX IF NOT EXISTS outreach_import_runs_org_started_idx
+    ON outreach_import_runs (organization_id, started_at DESC);
+
+-- Company / account staging (no email required).
+CREATE TABLE IF NOT EXISTS outreach_accounts (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    source_lead_id      text NOT NULL DEFAULT '',
+    cnpj14              text NOT NULL,
+    cnpj_root           text NOT NULL DEFAULT '',
+    razao_social        text NOT NULL DEFAULT '',
+    nome_fantasia       text NOT NULL DEFAULT '',
+    municipio           text NOT NULL DEFAULT '',
+    uf                  text NOT NULL DEFAULT '',
+    website             text NOT NULL DEFAULT '',
+
+    priority_rank       int NOT NULL DEFAULT 0,
+    priority_score      double precision NOT NULL DEFAULT 0,
+    priority_tier       text NOT NULL DEFAULT '',
+    priority_confidence text NOT NULL DEFAULT '',
+
+    moment_code         text NOT NULL DEFAULT '',
+    moment_summary      text NOT NULL DEFAULT '',
+    moment_observed_at  date,
+    moment_confidence   text NOT NULL DEFAULT '',
+    moment_evidence_ids jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    service_code        text NOT NULL DEFAULT '',
+    service_name        text NOT NULL DEFAULT '',
+    entry_offer         text NOT NULL DEFAULT '',
+    offer_rationale     text NOT NULL DEFAULT '',
+
+    fact_to_mention     text NOT NULL DEFAULT '',
+    question_to_ask     text NOT NULL DEFAULT '',
+    cta                 text NOT NULL DEFAULT '',
+    claims_to_avoid     jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    commercial_state    text NOT NULL DEFAULT 'NEW',
+    queue_state         text NOT NULL DEFAULT 'NEEDS_CONTACT',
+    human_override      boolean NOT NULL DEFAULT false,
+    blocked             boolean NOT NULL DEFAULT false,
+    block_reason        text NOT NULL DEFAULT '',
+    do_not_contact      boolean NOT NULL DEFAULT false,
+
+    source_system       text NOT NULL DEFAULT 'extra-cli',
+    source_run_id       text NOT NULL DEFAULT '',
+    last_import_run_id  uuid REFERENCES outreach_import_runs(id) ON DELETE SET NULL,
+    last_payload_hash   text NOT NULL DEFAULT '',
+    contracts_json      jsonb NOT NULL DEFAULT '[]'::jsonb,
+    raw_snapshot        jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_accounts_cnpj14_check
+        CHECK (cnpj14 ~ '^[0-9]{14}$'),
+    CONSTRAINT outreach_accounts_queue_state_check
+        CHECK (queue_state IN (
+            'NEEDS_CONTACT',
+            'READY_TO_GENERATE',
+            'NEEDS_REVIEW',
+            'APPROVED',
+            'ENROLLED',
+            'SENT',
+            'REPLIED',
+            'MEETING',
+            'PROPOSAL',
+            'WON',
+            'LOST',
+            'BLOCKED',
+            'BOUNCED',
+            'DO_NOT_CONTACT',
+            'SKIPPED'
+        ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_accounts_org_cnpj14_uidx
+    ON outreach_accounts (organization_id, cnpj14);
+
+CREATE INDEX IF NOT EXISTS outreach_accounts_org_queue_idx
+    ON outreach_accounts (organization_id, queue_state);
+
+CREATE INDEX IF NOT EXISTS outreach_accounts_org_source_lead_idx
+    ON outreach_accounts (organization_id, source_lead_id)
+    WHERE source_lead_id <> '';
+
+-- Contact candidates (may lack email or verification).
+CREATE TABLE IF NOT EXISTS outreach_contact_candidates (
+    id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id         uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    account_id              uuid NOT NULL REFERENCES outreach_accounts(id) ON DELETE CASCADE,
+
+    source_contact_id       text NOT NULL DEFAULT '',
+    name                    text NOT NULL DEFAULT '',
+    role                    text NOT NULL DEFAULT '',
+    email                   text NOT NULL DEFAULT '',
+    phone                   text NOT NULL DEFAULT '',
+    linkedin_url            text NOT NULL DEFAULT '',
+    source_url              text NOT NULL DEFAULT '',
+    source_document         text NOT NULL DEFAULT '',
+    source_date             date,
+    verification_status     text NOT NULL DEFAULT 'NOT_FOUND',
+    confidence              text NOT NULL DEFAULT '',
+    recommended             boolean NOT NULL DEFAULT false,
+
+    warmbly_contact_id      uuid REFERENCES contacts(id) ON DELETE SET NULL,
+    promoted_at             timestamptz,
+    blocked                 boolean NOT NULL DEFAULT false,
+    block_reason            text NOT NULL DEFAULT '',
+    do_not_contact          boolean NOT NULL DEFAULT false,
+    bounced                 boolean NOT NULL DEFAULT false,
+
+    last_import_run_id      uuid REFERENCES outreach_import_runs(id) ON DELETE SET NULL,
+    created_at              timestamptz NOT NULL DEFAULT now(),
+    updated_at              timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_contact_candidates_verification_check
+        CHECK (verification_status IN (
+            'OFFICIAL_SOURCE',
+            'PUBLIC_DOCUMENT_RECENT',
+            'MULTIPLE_PUBLIC_SOURCES',
+            'INSTITUTIONAL_GENERIC',
+            'PUBLIC_POSSIBLY_STALE',
+            'CANDIDATE_UNVERIFIED',
+            'NOT_FOUND',
+            'INVALID',
+            'BOUNCED',
+            'DO_NOT_CONTACT'
+        ))
+);
+
+CREATE INDEX IF NOT EXISTS outreach_contact_candidates_account_idx
+    ON outreach_contact_candidates (organization_id, account_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_contact_candidates_org_source_uidx
+    ON outreach_contact_candidates (organization_id, account_id, source_contact_id)
+    WHERE source_contact_id <> '';
+
+CREATE INDEX IF NOT EXISTS outreach_contact_candidates_email_idx
+    ON outreach_contact_candidates (organization_id, lower(email))
+    WHERE email <> '';
+
+-- Normalized evidence per account (sanitized text only; no raw HTML).
+CREATE TABLE IF NOT EXISTS outreach_evidence (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    account_id          uuid NOT NULL REFERENCES outreach_accounts(id) ON DELETE CASCADE,
+
+    source_evidence_id  text NOT NULL,
+    evidence_type       text NOT NULL DEFAULT '',
+    title               text NOT NULL DEFAULT '',
+    url                 text NOT NULL DEFAULT '',
+    document            text NOT NULL DEFAULT '',
+    evidence_date       date,
+    location            text NOT NULL DEFAULT '',
+    excerpt             text NOT NULL DEFAULT '',
+    synthesis           text NOT NULL DEFAULT '',
+    epistemic_class     text NOT NULL DEFAULT 'COMMERCIAL_HYPOTHESIS',
+    reliability         text NOT NULL DEFAULT '',
+    consulted_at        date,
+
+    last_import_run_id  uuid REFERENCES outreach_import_runs(id) ON DELETE SET NULL,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_evidence_epistemic_check
+        CHECK (epistemic_class IN (
+            'CONFIRMED_FACT',
+            'STRONG_INFERENCE',
+            'WEAK_INFERENCE',
+            'COMMERCIAL_HYPOTHESIS',
+            'NOT_FOUND',
+            'REQUIRES_COMPANY_CONFIRMATION',
+            'CONTRADICTORY_EVIDENCE'
+        ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_evidence_org_source_uidx
+    ON outreach_evidence (organization_id, account_id, source_evidence_id);
+
+CREATE INDEX IF NOT EXISTS outreach_evidence_account_idx
+    ON outreach_evidence (organization_id, account_id);

--- a/internal/infrastructure/db/migrations/000080_whatsapp_channel.down.sql
+++ b/internal/infrastructure/db/migrations/000080_whatsapp_channel.down.sql
@@ -1,0 +1,5 @@
+DROP TABLE IF EXISTS whatsapp_webhook_events;
+DROP TABLE IF EXISTS whatsapp_templates;
+DROP TABLE IF EXISTS whatsapp_instances;
+DROP TABLE IF EXISTS whatsapp_messages;
+DROP TABLE IF EXISTS whatsapp_contact_state;

--- a/internal/infrastructure/db/migrations/000080_whatsapp_channel.up.sql
+++ b/internal/infrastructure/db/migrations/000080_whatsapp_channel.up.sql
@@ -1,0 +1,162 @@
+-- WhatsApp channel: consent/eligibility state, messages, instance mapping,
+-- official templates cache, and webhook idempotency.
+-- Evolution API is external; nothing here stores Evolution as a CRM.
+
+-- Per-contact (or pre-contact) WhatsApp channel state.
+CREATE TABLE IF NOT EXISTS whatsapp_contact_state (
+    id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id         uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    contact_id              uuid REFERENCES contacts(id) ON DELETE SET NULL,
+    outreach_candidate_id   uuid,
+
+    phone_raw               text NOT NULL DEFAULT '',
+    phone_e164              text NOT NULL DEFAULT '',
+    phone_country           text NOT NULL DEFAULT '',
+    phone_valid             boolean NOT NULL DEFAULT false,
+    phone_source            text NOT NULL DEFAULT '',
+    phone_source_url        text NOT NULL DEFAULT '',
+    phone_verified_at       timestamptz,
+
+    whatsapp_consent_status text NOT NULL DEFAULT 'UNKNOWN',
+    whatsapp_consent_source text NOT NULL DEFAULT '',
+    whatsapp_consent_at     timestamptz,
+    whatsapp_consent_scope  text NOT NULL DEFAULT '',
+    whatsapp_consent_provenance_ok boolean NOT NULL DEFAULT false,
+    whatsapp_consent_form_version text NOT NULL DEFAULT '',
+    whatsapp_consent_recorded_by uuid REFERENCES users(id) ON DELETE SET NULL,
+
+    whatsapp_last_inbound_at timestamptz,
+    whatsapp_service_window_until timestamptz,
+    whatsapp_channel_status text NOT NULL DEFAULT '',
+    whatsapp_opt_out_at     timestamptz,
+    do_not_contact          boolean NOT NULL DEFAULT false,
+
+    last_email_outbound_at    timestamptz,
+    last_whatsapp_outbound_at timestamptz,
+
+    created_at              timestamptz NOT NULL DEFAULT now(),
+    updated_at              timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT whatsapp_contact_state_consent_check CHECK (
+        whatsapp_consent_status IN (
+            'UNKNOWN', 'NO_OPT_IN', 'OPTED_IN', 'USER_INITIATED',
+            'OPTED_OUT', 'DO_NOT_CONTACT'
+        )
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_contact_state_org_contact_uidx
+    ON whatsapp_contact_state (organization_id, contact_id)
+    WHERE contact_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS whatsapp_contact_state_org_phone_idx
+    ON whatsapp_contact_state (organization_id, phone_e164)
+    WHERE phone_e164 <> '';
+
+CREATE INDEX IF NOT EXISTS whatsapp_contact_state_org_consent_idx
+    ON whatsapp_contact_state (organization_id, whatsapp_consent_status);
+
+-- Message history (CRM-facing; separate from email threads).
+CREATE TABLE IF NOT EXISTS whatsapp_messages (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    contact_id          uuid REFERENCES contacts(id) ON DELETE SET NULL,
+    thread_key          text NOT NULL,
+    direction           text NOT NULL,
+    channel             text NOT NULL DEFAULT 'WHATSAPP',
+    provider            text NOT NULL DEFAULT 'evolution',
+    provider_message_id text NOT NULL DEFAULT '',
+    idempotency_key     text NOT NULL,
+    body_text           text NOT NULL DEFAULT '',
+    template_name       text NOT NULL DEFAULT '',
+    template_language   text NOT NULL DEFAULT '',
+    status              text NOT NULL DEFAULT 'received',
+    failure_code        text NOT NULL DEFAULT '',
+    draft_id            uuid,
+    campaign_id         uuid,
+    reviewed_by         uuid REFERENCES users(id) ON DELETE SET NULL,
+    approved_at         timestamptz,
+    sent_at             timestamptz,
+    occurred_at         timestamptz NOT NULL DEFAULT now(),
+    created_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT whatsapp_messages_direction_check CHECK (direction IN ('inbound', 'outbound')),
+    CONSTRAINT whatsapp_messages_status_check CHECK (
+        status IN ('received', 'queued', 'sent', 'delivered', 'read', 'failed', 'blocked')
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_messages_org_idem_uidx
+    ON whatsapp_messages (organization_id, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS whatsapp_messages_org_thread_idx
+    ON whatsapp_messages (organization_id, thread_key, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS whatsapp_messages_org_contact_idx
+    ON whatsapp_messages (organization_id, contact_id, occurred_at DESC)
+    WHERE contact_id IS NOT NULL;
+
+-- Provider instance → organization mapping (Evolution instance name).
+CREATE TABLE IF NOT EXISTS whatsapp_instances (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id  uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    provider         text NOT NULL DEFAULT 'evolution',
+    instance_name    text NOT NULL,
+    integration_mode text NOT NULL DEFAULT 'WHATSAPP-BUSINESS',
+    phone_e164       text NOT NULL DEFAULT '',
+    webhook_secret   text NOT NULL DEFAULT '',
+    status           text NOT NULL DEFAULT 'unknown',
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT whatsapp_instances_mode_check CHECK (
+        integration_mode IN ('WHATSAPP-BUSINESS', 'WHATSAPP-BAILEYS')
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_instances_provider_name_uidx
+    ON whatsapp_instances (provider, instance_name);
+
+CREATE INDEX IF NOT EXISTS whatsapp_instances_org_idx
+    ON whatsapp_instances (organization_id);
+
+-- Official template approval cache (Meta/BSP is source of truth).
+CREATE TABLE IF NOT EXISTS whatsapp_templates (
+    id               uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id  uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    provider         text NOT NULL DEFAULT 'evolution',
+    external_id      text NOT NULL DEFAULT '',
+    name             text NOT NULL,
+    language         text NOT NULL DEFAULT 'pt_BR',
+    category         text NOT NULL DEFAULT '',
+    status           text NOT NULL DEFAULT 'PENDING',
+    variables        jsonb NOT NULL DEFAULT '[]'::jsonb,
+    last_sync_at     timestamptz,
+    created_at       timestamptz NOT NULL DEFAULT now(),
+    updated_at       timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT whatsapp_templates_status_check CHECK (
+        status IN ('APPROVED', 'PAUSED', 'REJECTED', 'PENDING', 'MISSING')
+    )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_templates_org_name_lang_uidx
+    ON whatsapp_templates (organization_id, name, language);
+
+-- Webhook idempotency log (duplicate provider events must not double-apply).
+CREATE TABLE IF NOT EXISTS whatsapp_webhook_events (
+    id                   uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id      uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    provider             text NOT NULL DEFAULT 'evolution',
+    idempotency_key      text NOT NULL,
+    event_type           text NOT NULL DEFAULT '',
+    external_message_id  text NOT NULL DEFAULT '',
+    payload_hash         text NOT NULL DEFAULT '',
+    processed_at         timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS whatsapp_webhook_events_org_idem_uidx
+    ON whatsapp_webhook_events (organization_id, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS whatsapp_webhook_events_processed_idx
+    ON whatsapp_webhook_events (processed_at);

--- a/internal/infrastructure/db/migrations/000081_outreach_drafts.down.sql
+++ b/internal/infrastructure/db/migrations/000081_outreach_drafts.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS outreach_org_settings;
+DROP TABLE IF EXISTS outreach_drafts;

--- a/internal/infrastructure/db/migrations/000081_outreach_drafts.up.sql
+++ b/internal/infrastructure/db/migrations/000081_outreach_drafts.up.sql
@@ -1,0 +1,86 @@
+-- Outreach drafts: evidence-bound message generation + human review for
+-- CONFENGE staging accounts. Feature-flagged with CONFENGE_OUTREACH_ENABLED.
+
+CREATE TABLE IF NOT EXISTS outreach_drafts (
+    id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id         uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    account_id              uuid NOT NULL REFERENCES outreach_accounts(id) ON DELETE CASCADE,
+    contact_candidate_id    uuid REFERENCES outreach_contact_candidates(id) ON DELETE SET NULL,
+
+    recipient_name          text NOT NULL DEFAULT '',
+    recipient_role          text NOT NULL DEFAULT '',
+    recipient_email         text NOT NULL DEFAULT '',
+    verification_status     text NOT NULL DEFAULT '',
+
+    subject                 text NOT NULL DEFAULT '',
+    body_text               text NOT NULL DEFAULT '',
+    body_html               text NOT NULL DEFAULT '',
+    followups_json          jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    service_code            text NOT NULL DEFAULT '',
+    strategy_code           text NOT NULL DEFAULT '',
+    fact_used               text NOT NULL DEFAULT '',
+    evidence_ids            jsonb NOT NULL DEFAULT '[]'::jsonb,
+    question                text NOT NULL DEFAULT '',
+    cta                     text NOT NULL DEFAULT '',
+
+    provider                text NOT NULL DEFAULT '',
+    model                   text NOT NULL DEFAULT '',
+    prompt_version          text NOT NULL DEFAULT 'confenge.draft.v1',
+    generation              int NOT NULL DEFAULT 0,
+
+    validation_json         jsonb NOT NULL DEFAULT '{}'::jsonb,
+    risk_class              text NOT NULL DEFAULT 'YELLOW',
+    risk_flags              jsonb NOT NULL DEFAULT '[]'::jsonb,
+    red_team_result         text NOT NULL DEFAULT '',
+    red_team_reasons        jsonb NOT NULL DEFAULT '[]'::jsonb,
+
+    status                  text NOT NULL DEFAULT 'NOT_GENERATED',
+    human_edited            boolean NOT NULL DEFAULT false,
+    approved_by             uuid REFERENCES users(id) ON DELETE SET NULL,
+    approved_at             timestamptz,
+    review_seconds          int NOT NULL DEFAULT 0,
+
+    campaign_id             uuid REFERENCES campaigns(id) ON DELETE SET NULL,
+    enrollment_contact_id   uuid REFERENCES contacts(id) ON DELETE SET NULL,
+    enrolled_at             timestamptz,
+
+    created_at              timestamptz NOT NULL DEFAULT now(),
+    updated_at              timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_drafts_status_check
+        CHECK (status IN (
+            'NOT_GENERATED',
+            'GENERATING',
+            'NEEDS_REVIEW',
+            'APPROVED',
+            'REJECTED',
+            'SKIPPED',
+            'BLOCKED',
+            'ENROLLED',
+            'SENT',
+            'REPLIED'
+        )),
+    CONSTRAINT outreach_drafts_risk_check
+        CHECK (risk_class IN ('GREEN', 'YELLOW', 'RED'))
+);
+
+CREATE INDEX IF NOT EXISTS outreach_drafts_org_status_idx
+    ON outreach_drafts (organization_id, status);
+
+CREATE INDEX IF NOT EXISTS outreach_drafts_account_idx
+    ON outreach_drafts (organization_id, account_id);
+
+-- One active review draft per account (not terminal).
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_drafts_org_account_active_uidx
+    ON outreach_drafts (organization_id, account_id)
+    WHERE status IN ('NOT_GENERATED', 'GENERATING', 'NEEDS_REVIEW', 'APPROVED');
+
+-- Org-scoped confenge campaign pointer (bootstrap idempotency).
+CREATE TABLE IF NOT EXISTS outreach_org_settings (
+    organization_id     uuid PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+    campaign_id         uuid REFERENCES campaigns(id) ON DELETE SET NULL,
+    campaign_name       text NOT NULL DEFAULT 'CONFENGE | Outreach consultivo inicial',
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now()
+);

--- a/internal/infrastructure/db/migrations/000082_outreach_outcomes.down.sql
+++ b/internal/infrastructure/db/migrations/000082_outreach_outcomes.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS outreach_outcome_outbox;

--- a/internal/infrastructure/db/migrations/000082_outreach_outcomes.up.sql
+++ b/internal/infrastructure/db/migrations/000082_outreach_outcomes.up.sql
@@ -1,0 +1,47 @@
+-- Outcome outbox: commercial events returned to extra-cli via HMAC webhook.
+-- Warmbly never writes the datalake; delivery is async with retries.
+
+CREATE TABLE IF NOT EXISTS outreach_outcome_outbox (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+
+    event_id            uuid NOT NULL DEFAULT gen_random_uuid(),
+    idempotency_key     text NOT NULL,
+    source_lead_id      text NOT NULL DEFAULT '',
+    cnpj14              text NOT NULL DEFAULT '',
+    contact_email       text NOT NULL DEFAULT '',
+    event_type          text NOT NULL,
+    payload             jsonb NOT NULL DEFAULT '{}'::jsonb,
+    occurred_at         timestamptz NOT NULL DEFAULT now(),
+
+    attempts            int NOT NULL DEFAULT 0,
+    next_attempt_at     timestamptz NOT NULL DEFAULT now(),
+    delivered_at        timestamptz,
+    last_error          text NOT NULL DEFAULT '',
+    dead_letter         boolean NOT NULL DEFAULT false,
+
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    updated_at          timestamptz NOT NULL DEFAULT now(),
+
+    CONSTRAINT outreach_outcome_outbox_type_check
+        CHECK (event_type IN (
+            'LEAD_IMPORTED',
+            'LEAD_REVIEWED',
+            'CONTACT_APPROVED',
+            'CONTACTED',
+            'REPLIED',
+            'MEETING',
+            'PROPOSAL',
+            'WON',
+            'LOST',
+            'DO_NOT_CONTACT',
+            'BOUNCED'
+        ))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_outcome_outbox_org_idempotency_uidx
+    ON outreach_outcome_outbox (organization_id, idempotency_key);
+
+CREATE INDEX IF NOT EXISTS outreach_outcome_outbox_pending_idx
+    ON outreach_outcome_outbox (next_attempt_at)
+    WHERE delivered_at IS NULL AND dead_letter = false;

--- a/internal/infrastructure/db/migrations/000084_whatsapp_draft_channel.down.sql
+++ b/internal/infrastructure/db/migrations/000084_whatsapp_draft_channel.down.sql
@@ -1,0 +1,12 @@
+ALTER TABLE outreach_contact_candidates DROP COLUMN IF EXISTS whatsapp_consent_provenance_ok;
+ALTER TABLE outreach_contact_candidates DROP COLUMN IF EXISTS whatsapp_consent_at;
+ALTER TABLE outreach_contact_candidates DROP COLUMN IF EXISTS whatsapp_consent_source;
+ALTER TABLE outreach_contact_candidates DROP COLUMN IF EXISTS whatsapp_consent_status;
+ALTER TABLE outreach_contact_candidates DROP COLUMN IF EXISTS phone_source_url;
+ALTER TABLE outreach_contact_candidates DROP COLUMN IF EXISTS phone_source;
+ALTER TABLE outreach_contact_candidates DROP COLUMN IF EXISTS phone_e164;
+
+ALTER TABLE outreach_drafts DROP CONSTRAINT IF EXISTS outreach_drafts_channel_check;
+DROP INDEX IF EXISTS outreach_drafts_org_channel_idx;
+ALTER TABLE outreach_drafts DROP COLUMN IF EXISTS recipient_phone_e164;
+ALTER TABLE outreach_drafts DROP COLUMN IF EXISTS channel;

--- a/internal/infrastructure/db/migrations/000084_whatsapp_draft_channel.up.sql
+++ b/internal/infrastructure/db/migrations/000084_whatsapp_draft_channel.up.sql
@@ -1,0 +1,40 @@
+-- Channel discriminator for outreach drafts (EMAIL default, WHATSAPP optional).
+-- Additive and backward compatible.
+
+ALTER TABLE outreach_drafts
+    ADD COLUMN IF NOT EXISTS channel text NOT NULL DEFAULT 'EMAIL';
+
+ALTER TABLE outreach_drafts
+    ADD COLUMN IF NOT EXISTS recipient_phone_e164 text NOT NULL DEFAULT '';
+
+ALTER TABLE outreach_drafts
+    DROP CONSTRAINT IF EXISTS outreach_drafts_channel_check;
+
+ALTER TABLE outreach_drafts
+    ADD CONSTRAINT outreach_drafts_channel_check
+    CHECK (channel IN ('EMAIL', 'WHATSAPP'));
+
+CREATE INDEX IF NOT EXISTS outreach_drafts_org_channel_idx
+    ON outreach_drafts (organization_id, channel, status);
+
+-- Optional structured phone provenance on contact candidates (legacy phone text remains).
+ALTER TABLE outreach_contact_candidates
+    ADD COLUMN IF NOT EXISTS phone_e164 text NOT NULL DEFAULT '';
+
+ALTER TABLE outreach_contact_candidates
+    ADD COLUMN IF NOT EXISTS phone_source text NOT NULL DEFAULT '';
+
+ALTER TABLE outreach_contact_candidates
+    ADD COLUMN IF NOT EXISTS phone_source_url text NOT NULL DEFAULT '';
+
+ALTER TABLE outreach_contact_candidates
+    ADD COLUMN IF NOT EXISTS whatsapp_consent_status text NOT NULL DEFAULT 'UNKNOWN';
+
+ALTER TABLE outreach_contact_candidates
+    ADD COLUMN IF NOT EXISTS whatsapp_consent_source text NOT NULL DEFAULT '';
+
+ALTER TABLE outreach_contact_candidates
+    ADD COLUMN IF NOT EXISTS whatsapp_consent_at timestamptz;
+
+ALTER TABLE outreach_contact_candidates
+    ADD COLUMN IF NOT EXISTS whatsapp_consent_provenance_ok boolean NOT NULL DEFAULT false;

--- a/internal/models/audit.go
+++ b/internal/models/audit.go
@@ -116,6 +116,10 @@ const (
 	// background evaluation that opened or resolved findings. Rides the audit
 	// spine so every teammate's advisor strips and nav badges stay live.
 	AuditEntityAdvisorFinding AuditEntityType = "advisor_finding"
+
+	// CONFENGE / outreach staging (intelligence-plane import + company queue).
+	AuditEntityOutreachImportRun AuditEntityType = "outreach_import_run"
+	AuditEntityOutreachAccount   AuditEntityType = "outreach_account"
 )
 
 // AuditActor is the minimal identity of the member who performed an action,

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -351,3 +351,24 @@ type OutreachOrgSettings struct {
 	CreatedAt      time.Time  `json:"created_at"`
 	UpdatedAt      time.Time  `json:"updated_at"`
 }
+
+// OutreachOutcome is one outbox row for confenge.outcome.v1 delivery.
+type OutreachOutcome struct {
+	ID             uuid.UUID  `json:"id"`
+	OrganizationID uuid.UUID  `json:"organization_id"`
+	EventID        uuid.UUID  `json:"event_id"`
+	IdempotencyKey string     `json:"idempotency_key"`
+	SourceLeadID   string     `json:"source_lead_id"`
+	CNPJ14         string     `json:"cnpj14"`
+	ContactEmail   string     `json:"contact_email"`
+	EventType      string     `json:"event_type"`
+	Payload        []byte     `json:"payload,omitempty"`
+	OccurredAt     time.Time  `json:"occurred_at"`
+	Attempts       int        `json:"attempts"`
+	NextAttemptAt  time.Time  `json:"next_attempt_at"`
+	DeliveredAt    *time.Time `json:"delivered_at,omitempty"`
+	LastError      string     `json:"last_error,omitempty"`
+	DeadLetter     bool       `json:"dead_letter"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -275,3 +275,79 @@ type OutreachImportRunListResult struct {
 	Data       []OutreachImportRun `json:"data"`
 	Pagination Pagination          `json:"pagination"`
 }
+
+// Draft statuses.
+const (
+	OutreachDraftNotGenerated = "NOT_GENERATED"
+	OutreachDraftGenerating   = "GENERATING"
+	OutreachDraftNeedsReview  = "NEEDS_REVIEW"
+	OutreachDraftApproved     = "APPROVED"
+	OutreachDraftRejected     = "REJECTED"
+	OutreachDraftSkipped      = "SKIPPED"
+	OutreachDraftBlocked      = "BLOCKED"
+	OutreachDraftEnrolled     = "ENROLLED"
+	OutreachDraftSent         = "SENT"
+	OutreachDraftReplied      = "REPLIED"
+)
+
+// OutreachDraft is one generated/reviewed message for a staged account.
+type OutreachDraft struct {
+	ID                 uuid.UUID  `json:"id"`
+	OrganizationID     uuid.UUID  `json:"organization_id"`
+	AccountID          uuid.UUID  `json:"account_id"`
+	ContactCandidateID *uuid.UUID `json:"contact_candidate_id,omitempty"`
+
+	RecipientName      string `json:"recipient_name"`
+	RecipientRole      string `json:"recipient_role"`
+	RecipientEmail     string `json:"recipient_email"`
+	VerificationStatus string `json:"verification_status"`
+
+	Subject       string `json:"subject"`
+	BodyText      string `json:"body_text"`
+	BodyHTML      string `json:"body_html"`
+	FollowupsJSON []byte `json:"followups,omitempty"`
+
+	ServiceCode  string   `json:"service_code"`
+	StrategyCode string   `json:"strategy_code"`
+	FactUsed     string   `json:"fact_used"`
+	EvidenceIDs  []string `json:"evidence_ids,omitempty"`
+	Question     string   `json:"question"`
+	CTA          string   `json:"cta"`
+
+	Provider      string `json:"provider"`
+	Model         string `json:"model"`
+	PromptVersion string `json:"prompt_version"`
+	Generation    int    `json:"generation"`
+
+	ValidationJSON []byte   `json:"validation,omitempty"`
+	ValidationOK   *bool    `json:"validation_ok,omitempty"`
+	RiskClass      string   `json:"risk_class"`
+	RiskFlags      []string `json:"risk_flags,omitempty"`
+	RedTeamResult  string   `json:"red_team_result,omitempty"`
+	RedTeamReasons []string `json:"red_team_reasons,omitempty"`
+
+	Status        string     `json:"status"`
+	HumanEdited   bool       `json:"human_edited"`
+	ApprovedBy    *uuid.UUID `json:"approved_by,omitempty"`
+	ApprovedAt    *time.Time `json:"approved_at,omitempty"`
+	ReviewSeconds int        `json:"review_seconds"`
+
+	CampaignID          *uuid.UUID `json:"campaign_id,omitempty"`
+	EnrollmentContactID *uuid.UUID `json:"enrollment_contact_id,omitempty"`
+	EnrolledAt          *time.Time `json:"enrolled_at,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+
+	// Joined for review UI
+	Account *OutreachAccount `json:"account,omitempty"`
+}
+
+// OutreachOrgSettings stores confenge campaign bootstrap pointer.
+type OutreachOrgSettings struct {
+	OrganizationID uuid.UUID  `json:"organization_id"`
+	CampaignID     *uuid.UUID `json:"campaign_id,omitempty"`
+	CampaignName   string     `json:"campaign_name"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -181,30 +181,38 @@ type OutreachAccount struct {
 
 // OutreachContactCandidate is a possible recipient before promotion to contacts.
 type OutreachContactCandidate struct {
-	ID                 uuid.UUID  `json:"id"`
-	OrganizationID     uuid.UUID  `json:"organization_id"`
-	AccountID          uuid.UUID  `json:"account_id"`
-	SourceContactID    string     `json:"source_contact_id"`
-	Name               string     `json:"name"`
-	Role               string     `json:"role"`
-	Email              string     `json:"email"`
-	Phone              string     `json:"phone"`
-	LinkedInURL        string     `json:"linkedin_url,omitempty"`
-	SourceURL          string     `json:"source_url,omitempty"`
-	SourceDocument     string     `json:"source_document,omitempty"`
-	SourceDate         *time.Time `json:"source_date,omitempty"`
-	VerificationStatus string     `json:"verification_status"`
-	Confidence         string     `json:"confidence"`
-	Recommended        bool       `json:"recommended"`
-	WarmblyContactID   *uuid.UUID `json:"warmbly_contact_id,omitempty"`
-	PromotedAt         *time.Time `json:"promoted_at,omitempty"`
-	Blocked            bool       `json:"blocked"`
-	BlockReason        string     `json:"block_reason,omitempty"`
-	DoNotContact       bool       `json:"do_not_contact"`
-	Bounced            bool       `json:"bounced"`
-	LastImportRunID    *uuid.UUID `json:"last_import_run_id,omitempty"`
-	CreatedAt          time.Time  `json:"created_at"`
-	UpdatedAt          time.Time  `json:"updated_at"`
+	ID              uuid.UUID `json:"id"`
+	OrganizationID  uuid.UUID `json:"organization_id"`
+	AccountID       uuid.UUID `json:"account_id"`
+	SourceContactID string    `json:"source_contact_id"`
+	Name            string    `json:"name"`
+	Role            string    `json:"role"`
+	Email           string    `json:"email"`
+	Phone           string    `json:"phone"`
+	// Structured phone + WhatsApp consent (additive; public phone is not opt-in).
+	PhoneE164                   string     `json:"phone_e164,omitempty"`
+	PhoneSource                 string     `json:"phone_source,omitempty"`
+	PhoneSourceURL              string     `json:"phone_source_url,omitempty"`
+	WhatsAppConsentStatus       string     `json:"whatsapp_consent_status,omitempty"`
+	WhatsAppConsentSource       string     `json:"whatsapp_consent_source,omitempty"`
+	WhatsAppConsentAt           *time.Time `json:"whatsapp_consent_at,omitempty"`
+	WhatsAppConsentProvenanceOK bool       `json:"whatsapp_consent_provenance_ok,omitempty"`
+	LinkedInURL                 string     `json:"linkedin_url,omitempty"`
+	SourceURL                   string     `json:"source_url,omitempty"`
+	SourceDocument              string     `json:"source_document,omitempty"`
+	SourceDate                  *time.Time `json:"source_date,omitempty"`
+	VerificationStatus          string     `json:"verification_status"`
+	Confidence                  string     `json:"confidence"`
+	Recommended                 bool       `json:"recommended"`
+	WarmblyContactID            *uuid.UUID `json:"warmbly_contact_id,omitempty"`
+	PromotedAt                  *time.Time `json:"promoted_at,omitempty"`
+	Blocked                     bool       `json:"blocked"`
+	BlockReason                 string     `json:"block_reason,omitempty"`
+	DoNotContact                bool       `json:"do_not_contact"`
+	Bounced                     bool       `json:"bounced"`
+	LastImportRunID             *uuid.UUID `json:"last_import_run_id,omitempty"`
+	CreatedAt                   time.Time  `json:"created_at"`
+	UpdatedAt                   time.Time  `json:"updated_at"`
 }
 
 // CanEnroll reports whether this candidate may be put into a campaign.
@@ -290,6 +298,12 @@ const (
 	OutreachDraftReplied      = "REPLIED"
 )
 
+// Outreach draft channels.
+const (
+	OutreachChannelEmail    = "EMAIL"
+	OutreachChannelWhatsApp = "WHATSAPP"
+)
+
 // OutreachDraft is one generated/reviewed message for a staged account.
 type OutreachDraft struct {
 	ID                 uuid.UUID  `json:"id"`
@@ -297,9 +311,12 @@ type OutreachDraft struct {
 	AccountID          uuid.UUID  `json:"account_id"`
 	ContactCandidateID *uuid.UUID `json:"contact_candidate_id,omitempty"`
 
+	// Channel is EMAIL (default) or WHATSAPP. Threads stay separate per channel.
+	Channel            string `json:"channel"`
 	RecipientName      string `json:"recipient_name"`
 	RecipientRole      string `json:"recipient_role"`
 	RecipientEmail     string `json:"recipient_email"`
+	RecipientPhoneE164 string `json:"recipient_phone_e164,omitempty"`
 	VerificationStatus string `json:"verification_status"`
 
 	Subject       string `json:"subject"`

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -1,0 +1,277 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Outreach staging models: intelligence-plane feed import into a multi-tenant
+// company staging queue. Companies may lack email; they are not forced into
+// contacts until a candidate is promoted.
+
+// Schema versions for the confenge/extra-cli integration contracts.
+const (
+	OutreachSchemaV1        = "confenge.outreach.v1"
+	OutreachOutcomeSchemaV1 = "confenge.outcome.v1"
+)
+
+// Contact verification statuses allowed on outreach contact candidates.
+const (
+	OutreachVerifyOfficialSource       = "OFFICIAL_SOURCE"
+	OutreachVerifyPublicDocumentRecent = "PUBLIC_DOCUMENT_RECENT"
+	OutreachVerifyMultipleSources      = "MULTIPLE_PUBLIC_SOURCES"
+	OutreachVerifyInstitutionalGeneric = "INSTITUTIONAL_GENERIC"
+	OutreachVerifyPublicPossiblyStale  = "PUBLIC_POSSIBLY_STALE"
+	OutreachVerifyCandidateUnverified  = "CANDIDATE_UNVERIFIED"
+	OutreachVerifyNotFound             = "NOT_FOUND"
+	OutreachVerifyInvalid              = "INVALID"
+	OutreachVerifyBounced              = "BOUNCED"
+	OutreachVerifyDoNotContact         = "DO_NOT_CONTACT"
+)
+
+// Epistemic classifications for evidence.
+const (
+	OutreachEpistemicConfirmedFact          = "CONFIRMED_FACT"
+	OutreachEpistemicStrongInference        = "STRONG_INFERENCE"
+	OutreachEpistemicWeakInference          = "WEAK_INFERENCE"
+	OutreachEpistemicCommercialHypothesis   = "COMMERCIAL_HYPOTHESIS"
+	OutreachEpistemicNotFound               = "NOT_FOUND"
+	OutreachEpistemicRequiresCompanyConfirm = "REQUIRES_COMPANY_CONFIRMATION"
+	OutreachEpistemicContradictoryEvidence  = "CONTRADICTORY_EVIDENCE"
+)
+
+// Queue states for outreach accounts (dashboard pipeline).
+const (
+	OutreachQueueNeedsContact    = "NEEDS_CONTACT"
+	OutreachQueueReadyToGenerate = "READY_TO_GENERATE"
+	OutreachQueueNeedsReview     = "NEEDS_REVIEW"
+	OutreachQueueApproved        = "APPROVED"
+	OutreachQueueEnrolled        = "ENROLLED"
+	OutreachQueueSent            = "SENT"
+	OutreachQueueReplied         = "REPLIED"
+	OutreachQueueMeeting         = "MEETING"
+	OutreachQueueProposal        = "PROPOSAL"
+	OutreachQueueWon             = "WON"
+	OutreachQueueLost            = "LOST"
+	OutreachQueueBlocked         = "BLOCKED"
+	OutreachQueueBounced         = "BOUNCED"
+	OutreachQueueDoNotContact    = "DO_NOT_CONTACT"
+	OutreachQueueSkipped         = "SKIPPED"
+)
+
+// Import run statuses.
+const (
+	OutreachImportPending   = "pending"
+	OutreachImportRunning   = "running"
+	OutreachImportCompleted = "completed"
+	OutreachImportFailed    = "failed"
+	OutreachImportPartial   = "partial"
+)
+
+// Verification statuses that must never be enrolled into a campaign.
+var OutreachUnenrollableVerification = map[string]bool{
+	OutreachVerifyCandidateUnverified: true,
+	OutreachVerifyNotFound:            true,
+	OutreachVerifyInvalid:             true,
+	OutreachVerifyBounced:             true,
+	OutreachVerifyDoNotContact:        true,
+}
+
+// OutreachImportCounts is the dry-run / apply summary for one import run.
+type OutreachImportCounts struct {
+	Creates           int `json:"creates"`
+	Updates           int `json:"updates"`
+	Unchanged         int `json:"unchanged"`
+	MissingContact    int `json:"missing_contact"`
+	Invalid           int `json:"invalid"`
+	Blocked           int `json:"blocked"`
+	Conflicts         int `json:"conflicts"`
+	EvidenceAdded     int `json:"evidence_added"`
+	ContactsPromoted  int `json:"contacts_promoted"`
+	Warnings          int `json:"warnings"`
+	LeadsProcessed    int `json:"leads_processed"`
+	LeadsSkippedError int `json:"leads_skipped_error"`
+}
+
+// OutreachImportError is a per-lead error recorded without aborting the run.
+type OutreachImportError struct {
+	SourceLeadID string `json:"source_lead_id,omitempty"`
+	CNPJ14       string `json:"cnpj14,omitempty"`
+	Message      string `json:"message"`
+}
+
+// OutreachImportRun is one feed import attempt (dry-run or apply).
+type OutreachImportRun struct {
+	ID              uuid.UUID             `json:"id"`
+	OrganizationID  uuid.UUID             `json:"organization_id"`
+	SourceSystem    string                `json:"source_system"`
+	SourceRunID     string                `json:"source_run_id"`
+	SchemaVersion   string                `json:"schema_version"`
+	SnapshotHash    string                `json:"snapshot_hash"`
+	RepoSHA         string                `json:"repo_sha"`
+	PayloadHash     string                `json:"payload_hash"`
+	ProfileID       string                `json:"profile_id"`
+	ProfileVersion  string                `json:"profile_version"`
+	Status          string                `json:"status"`
+	DryRun          bool                  `json:"dry_run"`
+	StartedAt       time.Time             `json:"started_at"`
+	FinishedAt      *time.Time            `json:"finished_at,omitempty"`
+	CursorIn        string                `json:"cursor_in,omitempty"`
+	CursorOut       string                `json:"cursor_out,omitempty"`
+	Counts          OutreachImportCounts  `json:"counts"`
+	Errors          []OutreachImportError `json:"errors,omitempty"`
+	Warnings        []string              `json:"warnings,omitempty"`
+	CreatedByUserID *uuid.UUID            `json:"created_by_user_id,omitempty"`
+	IdempotencyKey  string                `json:"idempotency_key,omitempty"`
+	SourceURI       string                `json:"source_uri,omitempty"`
+	CreatedAt       time.Time             `json:"created_at"`
+	UpdatedAt       time.Time             `json:"updated_at"`
+}
+
+// OutreachAccount is a staged company from the intelligence feed.
+type OutreachAccount struct {
+	ID                 uuid.UUID  `json:"id"`
+	OrganizationID     uuid.UUID  `json:"organization_id"`
+	SourceLeadID       string     `json:"source_lead_id"`
+	CNPJ14             string     `json:"cnpj14"`
+	CNPJRoot           string     `json:"cnpj_root"`
+	RazaoSocial        string     `json:"razao_social"`
+	NomeFantasia       string     `json:"nome_fantasia"`
+	Municipio          string     `json:"municipio"`
+	UF                 string     `json:"uf"`
+	Website            string     `json:"website"`
+	PriorityRank       int        `json:"priority_rank"`
+	PriorityScore      float64    `json:"priority_score"`
+	PriorityTier       string     `json:"priority_tier"`
+	PriorityConfidence string     `json:"priority_confidence"`
+	MomentCode         string     `json:"moment_code"`
+	MomentSummary      string     `json:"moment_summary"`
+	MomentObservedAt   *time.Time `json:"moment_observed_at,omitempty"`
+	MomentConfidence   string     `json:"moment_confidence"`
+	MomentEvidenceIDs  []string   `json:"moment_evidence_ids,omitempty"`
+	ServiceCode        string     `json:"service_code"`
+	ServiceName        string     `json:"service_name"`
+	EntryOffer         string     `json:"entry_offer"`
+	OfferRationale     string     `json:"offer_rationale"`
+	FactToMention      string     `json:"fact_to_mention"`
+	QuestionToAsk      string     `json:"question_to_ask"`
+	CTA                string     `json:"cta"`
+	ClaimsToAvoid      []string   `json:"claims_to_avoid,omitempty"`
+	CommercialState    string     `json:"commercial_state"`
+	QueueState         string     `json:"queue_state"`
+	HumanOverride      bool       `json:"human_override"`
+	Blocked            bool       `json:"blocked"`
+	BlockReason        string     `json:"block_reason,omitempty"`
+	DoNotContact       bool       `json:"do_not_contact"`
+	SourceSystem       string     `json:"source_system"`
+	SourceRunID        string     `json:"source_run_id"`
+	LastImportRunID    *uuid.UUID `json:"last_import_run_id,omitempty"`
+	LastPayloadHash    string     `json:"last_payload_hash,omitempty"`
+	ContractsJSON      []byte     `json:"contracts,omitempty"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+
+	// Joined / computed (not always filled).
+	Contacts  []OutreachContactCandidate `json:"contacts,omitempty"`
+	Evidence  []OutreachEvidence         `json:"evidence,omitempty"`
+	ContactN  int                        `json:"contact_count,omitempty"`
+	EvidenceN int                        `json:"evidence_count,omitempty"`
+}
+
+// OutreachContactCandidate is a possible recipient before promotion to contacts.
+type OutreachContactCandidate struct {
+	ID                 uuid.UUID  `json:"id"`
+	OrganizationID     uuid.UUID  `json:"organization_id"`
+	AccountID          uuid.UUID  `json:"account_id"`
+	SourceContactID    string     `json:"source_contact_id"`
+	Name               string     `json:"name"`
+	Role               string     `json:"role"`
+	Email              string     `json:"email"`
+	Phone              string     `json:"phone"`
+	LinkedInURL        string     `json:"linkedin_url,omitempty"`
+	SourceURL          string     `json:"source_url,omitempty"`
+	SourceDocument     string     `json:"source_document,omitempty"`
+	SourceDate         *time.Time `json:"source_date,omitempty"`
+	VerificationStatus string     `json:"verification_status"`
+	Confidence         string     `json:"confidence"`
+	Recommended        bool       `json:"recommended"`
+	WarmblyContactID   *uuid.UUID `json:"warmbly_contact_id,omitempty"`
+	PromotedAt         *time.Time `json:"promoted_at,omitempty"`
+	Blocked            bool       `json:"blocked"`
+	BlockReason        string     `json:"block_reason,omitempty"`
+	DoNotContact       bool       `json:"do_not_contact"`
+	Bounced            bool       `json:"bounced"`
+	LastImportRunID    *uuid.UUID `json:"last_import_run_id,omitempty"`
+	CreatedAt          time.Time  `json:"created_at"`
+	UpdatedAt          time.Time  `json:"updated_at"`
+}
+
+// CanEnroll reports whether this candidate may be put into a campaign.
+func (c *OutreachContactCandidate) CanEnroll() bool {
+	if c == nil {
+		return false
+	}
+	if c.Blocked || c.DoNotContact || c.Bounced {
+		return false
+	}
+	if c.Email == "" {
+		return false
+	}
+	if OutreachUnenrollableVerification[c.VerificationStatus] {
+		return false
+	}
+	return true
+}
+
+// OutreachEvidence is one sanitized evidence row for an account.
+type OutreachEvidence struct {
+	ID               uuid.UUID  `json:"id"`
+	OrganizationID   uuid.UUID  `json:"organization_id"`
+	AccountID        uuid.UUID  `json:"account_id"`
+	SourceEvidenceID string     `json:"source_evidence_id"`
+	EvidenceType     string     `json:"evidence_type"`
+	Title            string     `json:"title"`
+	URL              string     `json:"url"`
+	Document         string     `json:"document"`
+	EvidenceDate     *time.Time `json:"evidence_date,omitempty"`
+	Location         string     `json:"location"`
+	Excerpt          string     `json:"excerpt"`
+	Synthesis        string     `json:"synthesis"`
+	EpistemicClass   string     `json:"epistemic_class"`
+	Reliability      string     `json:"reliability"`
+	ConsultedAt      *time.Time `json:"consulted_at,omitempty"`
+	LastImportRunID  *uuid.UUID `json:"last_import_run_id,omitempty"`
+	CreatedAt        time.Time  `json:"created_at"`
+	UpdatedAt        time.Time  `json:"updated_at"`
+}
+
+// OutreachQueueSummary is the dashboard overview counters.
+type OutreachQueueSummary struct {
+	NeedsContact    int `json:"needs_contact"`
+	ReadyToGenerate int `json:"ready_to_generate"`
+	NeedsReview     int `json:"needs_review"`
+	Approved        int `json:"approved"`
+	Enrolled        int `json:"enrolled"`
+	Sent            int `json:"sent"`
+	Replied         int `json:"replied"`
+	Meeting         int `json:"meeting"`
+	Proposal        int `json:"proposal"`
+	Won             int `json:"won"`
+	Blocked         int `json:"blocked"`
+	Bounced         int `json:"bounced"`
+	DoNotContact    int `json:"do_not_contact"`
+	Total           int `json:"total"`
+}
+
+// OutreachAccountListResult is a cursor-paginated account list.
+type OutreachAccountListResult struct {
+	Data       []OutreachAccount `json:"data"`
+	Pagination Pagination        `json:"pagination"`
+}
+
+// OutreachImportRunListResult lists recent import runs.
+type OutreachImportRunListResult struct {
+	Data       []OutreachImportRun `json:"data"`
+	Pagination Pagination          `json:"pagination"`
+}

--- a/internal/models/whatsapp.go
+++ b/internal/models/whatsapp.go
@@ -1,0 +1,113 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// WhatsApp contact channel state (consent, phone provenance, service window).
+// Stored per organization + contact. Public phone never implies opt-in.
+type WhatsAppContactState struct {
+	ID             uuid.UUID  `json:"id"`
+	OrganizationID uuid.UUID  `json:"organization_id"`
+	ContactID      *uuid.UUID `json:"contact_id,omitempty"`
+	// Optional link to outreach staging candidate when confenge is enabled.
+	OutreachCandidateID *uuid.UUID `json:"outreach_candidate_id,omitempty"`
+
+	PhoneRaw        string     `json:"phone_raw,omitempty"`
+	PhoneE164       string     `json:"phone_e164,omitempty"`
+	PhoneCountry    string     `json:"phone_country,omitempty"`
+	PhoneValid      bool       `json:"phone_valid"`
+	PhoneSource     string     `json:"phone_source,omitempty"`
+	PhoneSourceURL  string     `json:"phone_source_url,omitempty"`
+	PhoneVerifiedAt *time.Time `json:"phone_verified_at,omitempty"`
+
+	ConsentStatus       string     `json:"whatsapp_consent_status"`
+	ConsentSource       string     `json:"whatsapp_consent_source,omitempty"`
+	ConsentAt           *time.Time `json:"whatsapp_consent_at,omitempty"`
+	ConsentScope        string     `json:"whatsapp_consent_scope,omitempty"`
+	ConsentProvenanceOK bool       `json:"whatsapp_consent_provenance_ok"`
+	ConsentFormVersion  string     `json:"whatsapp_consent_form_version,omitempty"`
+	ConsentRecordedBy   *uuid.UUID `json:"whatsapp_consent_recorded_by,omitempty"`
+
+	LastInboundAt      *time.Time `json:"whatsapp_last_inbound_at,omitempty"`
+	ServiceWindowUntil *time.Time `json:"whatsapp_service_window_until,omitempty"`
+	ChannelStatus      string     `json:"whatsapp_channel_status,omitempty"`
+	OptOutAt           *time.Time `json:"whatsapp_opt_out_at,omitempty"`
+	DoNotContact       bool       `json:"do_not_contact"`
+
+	LastEmailOutboundAt    *time.Time `json:"last_email_outbound_at,omitempty"`
+	LastWhatsAppOutboundAt *time.Time `json:"last_whatsapp_outbound_at,omitempty"`
+
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+// WhatsAppMessage is one inbound or outbound WhatsApp message in the CRM history.
+type WhatsAppMessage struct {
+	ID                uuid.UUID  `json:"id"`
+	OrganizationID    uuid.UUID  `json:"organization_id"`
+	ContactID         *uuid.UUID `json:"contact_id,omitempty"`
+	ThreadKey         string     `json:"thread_key"` // typically phone E.164
+	Direction         string     `json:"direction"`  // inbound | outbound
+	Channel           string     `json:"channel"`    // WHATSAPP
+	Provider          string     `json:"provider"`
+	ProviderMessageID string     `json:"provider_message_id,omitempty"`
+	IdempotencyKey    string     `json:"idempotency_key"`
+	BodyText          string     `json:"body_text,omitempty"`
+	TemplateName      string     `json:"template_name,omitempty"`
+	TemplateLanguage  string     `json:"template_language,omitempty"`
+	Status            string     `json:"status"` // received | queued | sent | delivered | read | failed
+	FailureCode       string     `json:"failure_code,omitempty"`
+	DraftID           *uuid.UUID `json:"draft_id,omitempty"`
+	CampaignID        *uuid.UUID `json:"campaign_id,omitempty"`
+	ReviewedBy        *uuid.UUID `json:"reviewed_by,omitempty"`
+	ApprovedAt        *time.Time `json:"approved_at,omitempty"`
+	SentAt            *time.Time `json:"sent_at,omitempty"`
+	OccurredAt        time.Time  `json:"occurred_at"`
+	CreatedAt         time.Time  `json:"created_at"`
+}
+
+// WhatsAppInstance maps an Evolution (or other) instance to an organization.
+type WhatsAppInstance struct {
+	ID              uuid.UUID `json:"id"`
+	OrganizationID  uuid.UUID `json:"organization_id"`
+	Provider        string    `json:"provider"`
+	InstanceName    string    `json:"instance_name"`
+	IntegrationMode string    `json:"integration_mode"` // WHATSAPP-BUSINESS | WHATSAPP-BAILEYS
+	PhoneE164       string    `json:"phone_e164,omitempty"`
+	WebhookSecret   string    `json:"-"` // never JSON-serialize secret
+	Status          string    `json:"status"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
+}
+
+// WhatsAppTemplate is a local mirror of an official Meta template approval state.
+// Meta/BSP remains source of truth; this is operational cache only.
+type WhatsAppTemplate struct {
+	ID             uuid.UUID  `json:"id"`
+	OrganizationID uuid.UUID  `json:"organization_id"`
+	Provider       string     `json:"provider"`
+	ExternalID     string     `json:"external_id,omitempty"`
+	Name           string     `json:"name"`
+	Language       string     `json:"language"`
+	Category       string     `json:"category,omitempty"`
+	Status         string     `json:"status"` // APPROVED | PAUSED | REJECTED | PENDING
+	VariablesJSON  []byte     `json:"variables,omitempty"`
+	LastSyncAt     *time.Time `json:"last_sync_at,omitempty"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+}
+
+// WhatsAppWebhookEvent is the idempotency log for provider webhooks.
+type WhatsAppWebhookEvent struct {
+	ID             uuid.UUID `json:"id"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	Provider       string    `json:"provider"`
+	IdempotencyKey string    `json:"idempotency_key"`
+	EventType      string    `json:"event_type"`
+	ExternalMsgID  string    `json:"external_message_id,omitempty"`
+	PayloadHash    string    `json:"payload_hash,omitempty"`
+	ProcessedAt    time.Time `json:"processed_at"`
+}

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -57,6 +57,7 @@ type OutreachRepository interface {
 	MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, attempts int, next time.Time, lastErr string, dead bool) error
 	GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error)
 	FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error)
+	FindCandidateByPhone(ctx context.Context, orgID uuid.UUID, phone string) (*models.OutreachContactCandidate, *models.OutreachAccount, error)
 }
 
 // OutreachAccountFilter filters staged accounts.
@@ -505,6 +506,9 @@ func (r *outreachRepository) ListCandidates(ctx context.Context, orgID, accountI
 const outreachCandidateSelect = `
 	SELECT id, organization_id, account_id, COALESCE(source_contact_id,''),
 		COALESCE(name,''), COALESCE(role,''), COALESCE(email,''), COALESCE(phone,''),
+		COALESCE(phone_e164,''), COALESCE(phone_source,''), COALESCE(phone_source_url,''),
+		COALESCE(whatsapp_consent_status,'UNKNOWN'), COALESCE(whatsapp_consent_source,''),
+		whatsapp_consent_at, COALESCE(whatsapp_consent_provenance_ok,false),
 		COALESCE(linkedin_url,''), COALESCE(source_url,''), COALESCE(source_document,''), source_date,
 		verification_status, COALESCE(confidence,''), recommended,
 		warmbly_contact_id, promoted_at, blocked, COALESCE(block_reason,''), do_not_contact, bounced,
@@ -515,6 +519,9 @@ func scanCandidate(row scannable) (*models.OutreachContactCandidate, error) {
 	err := row.Scan(
 		&c.ID, &c.OrganizationID, &c.AccountID, &c.SourceContactID,
 		&c.Name, &c.Role, &c.Email, &c.Phone,
+		&c.PhoneE164, &c.PhoneSource, &c.PhoneSourceURL,
+		&c.WhatsAppConsentStatus, &c.WhatsAppConsentSource,
+		&c.WhatsAppConsentAt, &c.WhatsAppConsentProvenanceOK,
 		&c.LinkedInURL, &c.SourceURL, &c.SourceDocument, &c.SourceDate,
 		&c.VerificationStatus, &c.Confidence, &c.Recommended,
 		&c.WarmblyContactID, &c.PromotedAt, &c.Blocked, &c.BlockReason, &c.DoNotContact, &c.Bounced,
@@ -546,21 +553,30 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 		c.CreatedAt = now
 	}
 	// Prefer unique (org, account, source_contact_id) when source id present.
+	if c.WhatsAppConsentStatus == "" {
+		c.WhatsAppConsentStatus = "UNKNOWN"
+	}
 	if c.SourceContactID != "" {
 		var created bool
 		err := r.db.QueryRow(ctx, `
 			INSERT INTO outreach_contact_candidates (
 				id, organization_id, account_id, source_contact_id,
-				name, role, email, phone, linkedin_url, source_url, source_document, source_date,
+				name, role, email, phone,
+				phone_e164, phone_source, phone_source_url,
+				whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_provenance_ok,
+				linkedin_url, source_url, source_document, source_date,
 				verification_status, confidence, recommended,
 				blocked, block_reason, do_not_contact, bounced,
 				last_import_run_id, created_at, updated_at
 			) VALUES (
 				$1,$2,$3,$4,
-				$5,$6,$7,$8,$9,$10,$11,$12,
-				$13,$14,$15,
+				$5,$6,$7,$8,
+				$9,$10,$11,
+				$12,$13,$14,$15,
 				$16,$17,$18,$19,
-				$20,$21,$22
+				$20,$21,$22,
+				$23,$24,$25,$26,
+				$27,$28,$29
 			)
 			ON CONFLICT (organization_id, account_id, source_contact_id) WHERE source_contact_id <> '' DO UPDATE SET
 				name = EXCLUDED.name,
@@ -568,6 +584,28 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 				email = CASE WHEN outreach_contact_candidates.do_not_contact OR outreach_contact_candidates.bounced
 					THEN outreach_contact_candidates.email ELSE EXCLUDED.email END,
 				phone = EXCLUDED.phone,
+				phone_e164 = EXCLUDED.phone_e164,
+				phone_source = EXCLUDED.phone_source,
+				phone_source_url = EXCLUDED.phone_source_url,
+				-- sticky opt-out / DNC never softened by import
+				whatsapp_consent_status = CASE
+					WHEN outreach_contact_candidates.whatsapp_consent_status IN ('OPTED_OUT','DO_NOT_CONTACT')
+						THEN outreach_contact_candidates.whatsapp_consent_status
+					WHEN outreach_contact_candidates.do_not_contact
+						THEN outreach_contact_candidates.whatsapp_consent_status
+					ELSE EXCLUDED.whatsapp_consent_status
+				END,
+				whatsapp_consent_source = CASE
+					WHEN outreach_contact_candidates.whatsapp_consent_status IN ('OPTED_OUT','DO_NOT_CONTACT')
+						THEN outreach_contact_candidates.whatsapp_consent_source
+					ELSE EXCLUDED.whatsapp_consent_source
+				END,
+				whatsapp_consent_at = CASE
+					WHEN outreach_contact_candidates.whatsapp_consent_status IN ('OPTED_OUT','DO_NOT_CONTACT')
+						THEN outreach_contact_candidates.whatsapp_consent_at
+					ELSE EXCLUDED.whatsapp_consent_at
+				END,
+				whatsapp_consent_provenance_ok = EXCLUDED.whatsapp_consent_provenance_ok,
 				linkedin_url = EXCLUDED.linkedin_url,
 				source_url = EXCLUDED.source_url,
 				source_document = EXCLUDED.source_document,
@@ -584,7 +622,10 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 				id = outreach_contact_candidates.id
 			RETURNING (xmax = 0), id`,
 			c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
-			c.Name, c.Role, c.Email, c.Phone, c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
+			c.Name, c.Role, c.Email, c.Phone,
+			c.PhoneE164, c.PhoneSource, c.PhoneSourceURL,
+			c.WhatsAppConsentStatus, c.WhatsAppConsentSource, c.WhatsAppConsentAt, c.WhatsAppConsentProvenanceOK,
+			c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
 			c.VerificationStatus, c.Confidence, c.Recommended,
 			c.Blocked, c.BlockReason, c.DoNotContact, c.Bounced,
 			c.LastImportRunID, c.CreatedAt, c.UpdatedAt,
@@ -595,15 +636,21 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 	_, err := r.db.Exec(ctx, `
 		INSERT INTO outreach_contact_candidates (
 			id, organization_id, account_id, source_contact_id,
-			name, role, email, phone, linkedin_url, source_url, source_document, source_date,
+			name, role, email, phone,
+			phone_e164, phone_source, phone_source_url,
+			whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_provenance_ok,
+			linkedin_url, source_url, source_document, source_date,
 			verification_status, confidence, recommended,
 			blocked, block_reason, do_not_contact, bounced,
 			last_import_run_id, created_at, updated_at
 		) VALUES (
-			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29
 		)`,
 		c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
-		c.Name, c.Role, c.Email, c.Phone, c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
+		c.Name, c.Role, c.Email, c.Phone,
+		c.PhoneE164, c.PhoneSource, c.PhoneSourceURL,
+		c.WhatsAppConsentStatus, c.WhatsAppConsentSource, c.WhatsAppConsentAt, c.WhatsAppConsentProvenanceOK,
+		c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
 		c.VerificationStatus, c.Confidence, c.Recommended,
 		c.Blocked, c.BlockReason, c.DoNotContact, c.Bounced,
 		c.LastImportRunID, c.CreatedAt, c.UpdatedAt,

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -56,6 +56,7 @@ type OutreachRepository interface {
 	MarkOutcomeDelivered(ctx context.Context, orgID, id uuid.UUID) error
 	MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, attempts int, next time.Time, lastErr string, dead bool) error
 	GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error)
+	FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error)
 }
 
 // OutreachAccountFilter filters staged accounts.

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -1,0 +1,679 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// OutreachRepository owns multi-tenant staging tables for intelligence feeds.
+// Every query requires organization_id.
+type OutreachRepository interface {
+	// Import runs
+	CreateImportRun(ctx context.Context, run *models.OutreachImportRun) error
+	UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error
+	GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error)
+	GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error)
+	ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error)
+
+	// Accounts
+	GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error)
+	GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error)
+	UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (created bool, err error)
+	ListAccounts(ctx context.Context, orgID uuid.UUID, filter OutreachAccountFilter) ([]models.OutreachAccount, error)
+	CountByQueueState(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, error)
+	SetAccountHumanFlags(ctx context.Context, orgID, id uuid.UUID, blocked, dnc bool, reason, queueState string) error
+
+	// Contacts
+	ListCandidates(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachContactCandidate, error)
+	UpsertCandidate(ctx context.Context, c *models.OutreachContactCandidate) (created bool, err error)
+	GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error)
+
+	// Evidence
+	ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error)
+	UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (created bool, err error)
+}
+
+// OutreachAccountFilter filters staged accounts.
+type OutreachAccountFilter struct {
+	QueueState string
+	CNPJ14     string
+	Search     string
+	Limit      int
+	Offset     int
+}
+
+type outreachRepository struct {
+	db *pgxpool.Pool
+}
+
+// NewOutreachRepository constructs the Postgres-backed outreach staging repo.
+func NewOutreachRepository(db *pgxpool.Pool) OutreachRepository {
+	return &outreachRepository{db: db}
+}
+
+func (r *outreachRepository) CreateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	if run.ID == uuid.Nil {
+		run.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	run.CreatedAt = now
+	run.UpdatedAt = now
+	if run.StartedAt.IsZero() {
+		run.StartedAt = now
+	}
+	counts, _ := json.Marshal(run.Counts)
+	errs, _ := json.Marshal(run.Errors)
+	if errs == nil {
+		errs = []byte("[]")
+	}
+	warns, _ := json.Marshal(run.Warnings)
+	if warns == nil {
+		warns = []byte("[]")
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_import_runs (
+			id, organization_id, source_system, source_run_id, schema_version,
+			snapshot_hash, repo_sha, payload_hash, profile_id, profile_version,
+			status, dry_run, started_at, finished_at, cursor_in, cursor_out,
+			counts, errors, warnings, created_by_user_id, idempotency_key, source_uri,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,
+			$6,$7,$8,$9,$10,
+			$11,$12,$13,$14,$15,$16,
+			$17,$18,$19,$20,$21,$22,
+			$23,$23
+		)`,
+		run.ID, run.OrganizationID, run.SourceSystem, run.SourceRunID, run.SchemaVersion,
+		run.SnapshotHash, run.RepoSHA, run.PayloadHash, run.ProfileID, run.ProfileVersion,
+		run.Status, run.DryRun, run.StartedAt, run.FinishedAt, run.CursorIn, run.CursorOut,
+		counts, errs, warns, run.CreatedByUserID, run.IdempotencyKey, run.SourceURI,
+		now,
+	)
+	return err
+}
+
+func (r *outreachRepository) UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error {
+	run.UpdatedAt = time.Now().UTC()
+	counts, _ := json.Marshal(run.Counts)
+	errs, _ := json.Marshal(run.Errors)
+	if errs == nil {
+		errs = []byte("[]")
+	}
+	warns, _ := json.Marshal(run.Warnings)
+	if warns == nil {
+		warns = []byte("[]")
+	}
+	ct, err := r.db.Exec(ctx, `
+		UPDATE outreach_import_runs SET
+			status=$3, finished_at=$4, cursor_out=$5,
+			counts=$6, errors=$7, warnings=$8, updated_at=$9
+		WHERE id=$1 AND organization_id=$2`,
+		run.ID, run.OrganizationID, run.Status, run.FinishedAt, run.CursorOut,
+		counts, errs, warns, run.UpdatedAt,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+func (r *outreachRepository) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error) {
+	row := r.db.QueryRow(ctx, outreachImportRunSelect+`
+		FROM outreach_import_runs WHERE id=$1 AND organization_id=$2`, id, orgID)
+	return scanImportRun(row)
+}
+
+func (r *outreachRepository) GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error) {
+	if key == "" {
+		return nil, nil
+	}
+	row := r.db.QueryRow(ctx, outreachImportRunSelect+`
+		FROM outreach_import_runs WHERE organization_id=$1 AND idempotency_key=$2`, orgID, key)
+	run, err := scanImportRun(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return run, err
+}
+
+func (r *outreachRepository) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error) {
+	if limit <= 0 || limit > 100 {
+		limit = 20
+	}
+	rows, err := r.db.Query(ctx, outreachImportRunSelect+`
+		FROM outreach_import_runs WHERE organization_id=$1
+		ORDER BY started_at DESC LIMIT $2`, orgID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachImportRun
+	for rows.Next() {
+		run, err := scanImportRun(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *run)
+	}
+	return out, rows.Err()
+}
+
+const outreachImportRunSelect = `
+	SELECT id, organization_id, source_system, source_run_id, schema_version,
+		snapshot_hash, repo_sha, payload_hash, profile_id, profile_version,
+		status, dry_run, started_at, finished_at, COALESCE(cursor_in,''), COALESCE(cursor_out,''),
+		counts, errors, warnings, created_by_user_id, COALESCE(idempotency_key,''), COALESCE(source_uri,''),
+		created_at, updated_at `
+
+type scannable interface {
+	Scan(dest ...any) error
+}
+
+func scanImportRun(row scannable) (*models.OutreachImportRun, error) {
+	var run models.OutreachImportRun
+	var counts, errs, warns []byte
+	err := row.Scan(
+		&run.ID, &run.OrganizationID, &run.SourceSystem, &run.SourceRunID, &run.SchemaVersion,
+		&run.SnapshotHash, &run.RepoSHA, &run.PayloadHash, &run.ProfileID, &run.ProfileVersion,
+		&run.Status, &run.DryRun, &run.StartedAt, &run.FinishedAt, &run.CursorIn, &run.CursorOut,
+		&counts, &errs, &warns, &run.CreatedByUserID, &run.IdempotencyKey, &run.SourceURI,
+		&run.CreatedAt, &run.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal(counts, &run.Counts)
+	_ = json.Unmarshal(errs, &run.Errors)
+	_ = json.Unmarshal(warns, &run.Warnings)
+	return &run, nil
+}
+
+func (r *outreachRepository) GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error) {
+	row := r.db.QueryRow(ctx, outreachAccountSelect+`
+		FROM outreach_accounts WHERE organization_id=$1 AND cnpj14=$2`, orgID, cnpj14)
+	acc, err := scanAccount(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return acc, err
+}
+
+func (r *outreachRepository) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error) {
+	row := r.db.QueryRow(ctx, outreachAccountSelect+`
+		FROM outreach_accounts WHERE organization_id=$1 AND id=$2`, orgID, id)
+	acc, err := scanAccount(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return acc, err
+}
+
+const outreachAccountSelect = `
+	SELECT id, organization_id, COALESCE(source_lead_id,''), cnpj14, COALESCE(cnpj_root,''),
+		COALESCE(razao_social,''), COALESCE(nome_fantasia,''), COALESCE(municipio,''), COALESCE(uf,''), COALESCE(website,''),
+		priority_rank, priority_score, COALESCE(priority_tier,''), COALESCE(priority_confidence,''),
+		COALESCE(moment_code,''), COALESCE(moment_summary,''), moment_observed_at, COALESCE(moment_confidence,''), moment_evidence_ids,
+		COALESCE(service_code,''), COALESCE(service_name,''), COALESCE(entry_offer,''), COALESCE(offer_rationale,''),
+		COALESCE(fact_to_mention,''), COALESCE(question_to_ask,''), COALESCE(cta,''), claims_to_avoid,
+		COALESCE(commercial_state,''), queue_state, human_override, blocked, COALESCE(block_reason,''), do_not_contact,
+		COALESCE(source_system,''), COALESCE(source_run_id,''), last_import_run_id, COALESCE(last_payload_hash,''),
+		contracts_json, created_at, updated_at `
+
+func scanAccount(row scannable) (*models.OutreachAccount, error) {
+	var a models.OutreachAccount
+	var momentEvid, claims []byte
+	var contracts []byte
+	err := row.Scan(
+		&a.ID, &a.OrganizationID, &a.SourceLeadID, &a.CNPJ14, &a.CNPJRoot,
+		&a.RazaoSocial, &a.NomeFantasia, &a.Municipio, &a.UF, &a.Website,
+		&a.PriorityRank, &a.PriorityScore, &a.PriorityTier, &a.PriorityConfidence,
+		&a.MomentCode, &a.MomentSummary, &a.MomentObservedAt, &a.MomentConfidence, &momentEvid,
+		&a.ServiceCode, &a.ServiceName, &a.EntryOffer, &a.OfferRationale,
+		&a.FactToMention, &a.QuestionToAsk, &a.CTA, &claims,
+		&a.CommercialState, &a.QueueState, &a.HumanOverride, &a.Blocked, &a.BlockReason, &a.DoNotContact,
+		&a.SourceSystem, &a.SourceRunID, &a.LastImportRunID, &a.LastPayloadHash,
+		&contracts, &a.CreatedAt, &a.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal(momentEvid, &a.MomentEvidenceIDs)
+	_ = json.Unmarshal(claims, &a.ClaimsToAvoid)
+	a.ContractsJSON = contracts
+	return &a, nil
+}
+
+func (r *outreachRepository) UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (bool, error) {
+	if acc.ID == uuid.Nil {
+		acc.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	acc.UpdatedAt = now
+	if acc.CreatedAt.IsZero() {
+		acc.CreatedAt = now
+	}
+	momentEvid, _ := json.Marshal(acc.MomentEvidenceIDs)
+	if momentEvid == nil {
+		momentEvid = []byte("[]")
+	}
+	claims, _ := json.Marshal(acc.ClaimsToAvoid)
+	if claims == nil {
+		claims = []byte("[]")
+	}
+	contracts := acc.ContractsJSON
+	if len(contracts) == 0 {
+		contracts = []byte("[]")
+	}
+	// Machine fields update; human_override / blocked / dnc preserved when set on existing.
+	var created bool
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO outreach_accounts (
+			id, organization_id, source_lead_id, cnpj14, cnpj_root,
+			razao_social, nome_fantasia, municipio, uf, website,
+			priority_rank, priority_score, priority_tier, priority_confidence,
+			moment_code, moment_summary, moment_observed_at, moment_confidence, moment_evidence_ids,
+			service_code, service_name, entry_offer, offer_rationale,
+			fact_to_mention, question_to_ask, cta, claims_to_avoid,
+			commercial_state, queue_state, human_override, blocked, block_reason, do_not_contact,
+			source_system, source_run_id, last_import_run_id, last_payload_hash, contracts_json,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,
+			$6,$7,$8,$9,$10,
+			$11,$12,$13,$14,
+			$15,$16,$17,$18,$19,
+			$20,$21,$22,$23,
+			$24,$25,$26,$27,
+			$28,$29,$30,$31,$32,$33,
+			$34,$35,$36,$37,$38,
+			$39,$40
+		)
+		ON CONFLICT (organization_id, cnpj14) DO UPDATE SET
+			source_lead_id = EXCLUDED.source_lead_id,
+			cnpj_root = EXCLUDED.cnpj_root,
+			razao_social = CASE WHEN outreach_accounts.human_override THEN outreach_accounts.razao_social ELSE EXCLUDED.razao_social END,
+			nome_fantasia = CASE WHEN outreach_accounts.human_override THEN outreach_accounts.nome_fantasia ELSE EXCLUDED.nome_fantasia END,
+			municipio = EXCLUDED.municipio,
+			uf = EXCLUDED.uf,
+			website = EXCLUDED.website,
+			priority_rank = EXCLUDED.priority_rank,
+			priority_score = EXCLUDED.priority_score,
+			priority_tier = EXCLUDED.priority_tier,
+			priority_confidence = EXCLUDED.priority_confidence,
+			moment_code = EXCLUDED.moment_code,
+			moment_summary = EXCLUDED.moment_summary,
+			moment_observed_at = EXCLUDED.moment_observed_at,
+			moment_confidence = EXCLUDED.moment_confidence,
+			moment_evidence_ids = EXCLUDED.moment_evidence_ids,
+			service_code = EXCLUDED.service_code,
+			service_name = EXCLUDED.service_name,
+			entry_offer = EXCLUDED.entry_offer,
+			offer_rationale = EXCLUDED.offer_rationale,
+			fact_to_mention = EXCLUDED.fact_to_mention,
+			question_to_ask = EXCLUDED.question_to_ask,
+			cta = EXCLUDED.cta,
+			claims_to_avoid = EXCLUDED.claims_to_avoid,
+			commercial_state = EXCLUDED.commercial_state,
+			queue_state = EXCLUDED.queue_state,
+			-- never clear human DNC / block via machine reimport
+			blocked = outreach_accounts.blocked OR EXCLUDED.blocked,
+			block_reason = CASE WHEN outreach_accounts.blocked THEN outreach_accounts.block_reason ELSE EXCLUDED.block_reason END,
+			do_not_contact = outreach_accounts.do_not_contact OR EXCLUDED.do_not_contact,
+			source_system = EXCLUDED.source_system,
+			source_run_id = EXCLUDED.source_run_id,
+			last_import_run_id = EXCLUDED.last_import_run_id,
+			last_payload_hash = EXCLUDED.last_payload_hash,
+			contracts_json = EXCLUDED.contracts_json,
+			updated_at = EXCLUDED.updated_at,
+			id = outreach_accounts.id
+		RETURNING (xmax = 0) AS inserted, id`,
+		acc.ID, acc.OrganizationID, acc.SourceLeadID, acc.CNPJ14, acc.CNPJRoot,
+		acc.RazaoSocial, acc.NomeFantasia, acc.Municipio, acc.UF, acc.Website,
+		acc.PriorityRank, acc.PriorityScore, acc.PriorityTier, acc.PriorityConfidence,
+		acc.MomentCode, acc.MomentSummary, acc.MomentObservedAt, acc.MomentConfidence, momentEvid,
+		acc.ServiceCode, acc.ServiceName, acc.EntryOffer, acc.OfferRationale,
+		acc.FactToMention, acc.QuestionToAsk, acc.CTA, claims,
+		acc.CommercialState, acc.QueueState, acc.HumanOverride, acc.Blocked, acc.BlockReason, acc.DoNotContact,
+		acc.SourceSystem, acc.SourceRunID, acc.LastImportRunID, acc.LastPayloadHash, contracts,
+		acc.CreatedAt, acc.UpdatedAt,
+	).Scan(&created, &acc.ID)
+	return created, err
+}
+
+func (r *outreachRepository) ListAccounts(ctx context.Context, orgID uuid.UUID, filter OutreachAccountFilter) ([]models.OutreachAccount, error) {
+	limit := filter.Limit
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	offset := filter.Offset
+	if offset < 0 {
+		offset = 0
+	}
+	q := outreachAccountSelect + ` FROM outreach_accounts WHERE organization_id=$1`
+	args := []any{orgID}
+	n := 2
+	if filter.QueueState != "" {
+		q += fmt.Sprintf(` AND queue_state=$%d`, n)
+		args = append(args, filter.QueueState)
+		n++
+	}
+	if filter.CNPJ14 != "" {
+		q += fmt.Sprintf(` AND cnpj14=$%d`, n)
+		args = append(args, filter.CNPJ14)
+		n++
+	}
+	if filter.Search != "" {
+		q += fmt.Sprintf(` AND (razao_social ILIKE $%d OR nome_fantasia ILIKE $%d OR cnpj14 LIKE $%d)`, n, n, n)
+		args = append(args, "%"+filter.Search+"%")
+		n++
+	}
+	q += fmt.Sprintf(` ORDER BY priority_rank ASC NULLS LAST, updated_at DESC LIMIT $%d OFFSET $%d`, n, n+1)
+	args = append(args, limit, offset)
+
+	rows, err := r.db.Query(ctx, q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachAccount
+	for rows.Next() {
+		acc, err := scanAccount(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *acc)
+	}
+	return out, rows.Err()
+}
+
+func (r *outreachRepository) CountByQueueState(ctx context.Context, orgID uuid.UUID) (*models.OutreachQueueSummary, error) {
+	rows, err := r.db.Query(ctx, `
+		SELECT queue_state, COUNT(*)::int
+		FROM outreach_accounts WHERE organization_id=$1
+		GROUP BY queue_state`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	sum := &models.OutreachQueueSummary{}
+	for rows.Next() {
+		var state string
+		var n int
+		if err := rows.Scan(&state, &n); err != nil {
+			return nil, err
+		}
+		sum.Total += n
+		switch state {
+		case models.OutreachQueueNeedsContact:
+			sum.NeedsContact = n
+		case models.OutreachQueueReadyToGenerate:
+			sum.ReadyToGenerate = n
+		case models.OutreachQueueNeedsReview:
+			sum.NeedsReview = n
+		case models.OutreachQueueApproved:
+			sum.Approved = n
+		case models.OutreachQueueEnrolled:
+			sum.Enrolled = n
+		case models.OutreachQueueSent:
+			sum.Sent = n
+		case models.OutreachQueueReplied:
+			sum.Replied = n
+		case models.OutreachQueueMeeting:
+			sum.Meeting = n
+		case models.OutreachQueueProposal:
+			sum.Proposal = n
+		case models.OutreachQueueWon:
+			sum.Won = n
+		case models.OutreachQueueBlocked:
+			sum.Blocked = n
+		case models.OutreachQueueBounced:
+			sum.Bounced = n
+		case models.OutreachQueueDoNotContact:
+			sum.DoNotContact = n
+		}
+	}
+	return sum, rows.Err()
+}
+
+func (r *outreachRepository) SetAccountHumanFlags(ctx context.Context, orgID, id uuid.UUID, blocked, dnc bool, reason, queueState string) error {
+	ct, err := r.db.Exec(ctx, `
+		UPDATE outreach_accounts SET
+			blocked=$3, do_not_contact=$4, block_reason=$5, queue_state=$6,
+			human_override=true, updated_at=now()
+		WHERE organization_id=$1 AND id=$2`,
+		orgID, id, blocked, dnc, reason, queueState,
+	)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+func (r *outreachRepository) ListCandidates(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachContactCandidate, error) {
+	rows, err := r.db.Query(ctx, outreachCandidateSelect+`
+		FROM outreach_contact_candidates
+		WHERE organization_id=$1 AND account_id=$2
+		ORDER BY recommended DESC, created_at ASC`, orgID, accountID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachContactCandidate
+	for rows.Next() {
+		c, err := scanCandidate(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *c)
+	}
+	return out, rows.Err()
+}
+
+const outreachCandidateSelect = `
+	SELECT id, organization_id, account_id, COALESCE(source_contact_id,''),
+		COALESCE(name,''), COALESCE(role,''), COALESCE(email,''), COALESCE(phone,''),
+		COALESCE(linkedin_url,''), COALESCE(source_url,''), COALESCE(source_document,''), source_date,
+		verification_status, COALESCE(confidence,''), recommended,
+		warmbly_contact_id, promoted_at, blocked, COALESCE(block_reason,''), do_not_contact, bounced,
+		last_import_run_id, created_at, updated_at `
+
+func scanCandidate(row scannable) (*models.OutreachContactCandidate, error) {
+	var c models.OutreachContactCandidate
+	err := row.Scan(
+		&c.ID, &c.OrganizationID, &c.AccountID, &c.SourceContactID,
+		&c.Name, &c.Role, &c.Email, &c.Phone,
+		&c.LinkedInURL, &c.SourceURL, &c.SourceDocument, &c.SourceDate,
+		&c.VerificationStatus, &c.Confidence, &c.Recommended,
+		&c.WarmblyContactID, &c.PromotedAt, &c.Blocked, &c.BlockReason, &c.DoNotContact, &c.Bounced,
+		&c.LastImportRunID, &c.CreatedAt, &c.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (r *outreachRepository) GetCandidate(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachContactCandidate, error) {
+	row := r.db.QueryRow(ctx, outreachCandidateSelect+`
+		FROM outreach_contact_candidates WHERE organization_id=$1 AND id=$2`, orgID, id)
+	c, err := scanCandidate(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return c, err
+}
+
+func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.OutreachContactCandidate) (bool, error) {
+	if c.ID == uuid.Nil {
+		c.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	c.UpdatedAt = now
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = now
+	}
+	// Prefer unique (org, account, source_contact_id) when source id present.
+	if c.SourceContactID != "" {
+		var created bool
+		err := r.db.QueryRow(ctx, `
+			INSERT INTO outreach_contact_candidates (
+				id, organization_id, account_id, source_contact_id,
+				name, role, email, phone, linkedin_url, source_url, source_document, source_date,
+				verification_status, confidence, recommended,
+				blocked, block_reason, do_not_contact, bounced,
+				last_import_run_id, created_at, updated_at
+			) VALUES (
+				$1,$2,$3,$4,
+				$5,$6,$7,$8,$9,$10,$11,$12,
+				$13,$14,$15,
+				$16,$17,$18,$19,
+				$20,$21,$22
+			)
+			ON CONFLICT (organization_id, account_id, source_contact_id) WHERE source_contact_id <> '' DO UPDATE SET
+				name = EXCLUDED.name,
+				role = EXCLUDED.role,
+				email = CASE WHEN outreach_contact_candidates.do_not_contact OR outreach_contact_candidates.bounced
+					THEN outreach_contact_candidates.email ELSE EXCLUDED.email END,
+				phone = EXCLUDED.phone,
+				linkedin_url = EXCLUDED.linkedin_url,
+				source_url = EXCLUDED.source_url,
+				source_document = EXCLUDED.source_document,
+				source_date = EXCLUDED.source_date,
+				verification_status = CASE WHEN outreach_contact_candidates.do_not_contact OR outreach_contact_candidates.bounced
+					THEN outreach_contact_candidates.verification_status ELSE EXCLUDED.verification_status END,
+				confidence = EXCLUDED.confidence,
+				recommended = EXCLUDED.recommended,
+				do_not_contact = outreach_contact_candidates.do_not_contact OR EXCLUDED.do_not_contact,
+				bounced = outreach_contact_candidates.bounced OR EXCLUDED.bounced,
+				blocked = outreach_contact_candidates.blocked OR EXCLUDED.blocked,
+				last_import_run_id = EXCLUDED.last_import_run_id,
+				updated_at = EXCLUDED.updated_at,
+				id = outreach_contact_candidates.id
+			RETURNING (xmax = 0), id`,
+			c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
+			c.Name, c.Role, c.Email, c.Phone, c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
+			c.VerificationStatus, c.Confidence, c.Recommended,
+			c.Blocked, c.BlockReason, c.DoNotContact, c.Bounced,
+			c.LastImportRunID, c.CreatedAt, c.UpdatedAt,
+		).Scan(&created, &c.ID)
+		return created, err
+	}
+	// No source id: insert only (cannot safely dedupe).
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_contact_candidates (
+			id, organization_id, account_id, source_contact_id,
+			name, role, email, phone, linkedin_url, source_url, source_document, source_date,
+			verification_status, confidence, recommended,
+			blocked, block_reason, do_not_contact, bounced,
+			last_import_run_id, created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22
+		)`,
+		c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
+		c.Name, c.Role, c.Email, c.Phone, c.LinkedInURL, c.SourceURL, c.SourceDocument, c.SourceDate,
+		c.VerificationStatus, c.Confidence, c.Recommended,
+		c.Blocked, c.BlockReason, c.DoNotContact, c.Bounced,
+		c.LastImportRunID, c.CreatedAt, c.UpdatedAt,
+	)
+	return true, err
+}
+
+func (r *outreachRepository) ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error) {
+	rows, err := r.db.Query(ctx, outreachEvidenceSelect+`
+		FROM outreach_evidence WHERE organization_id=$1 AND account_id=$2
+		ORDER BY evidence_date DESC NULLS LAST, created_at DESC`, orgID, accountID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachEvidence
+	for rows.Next() {
+		e, err := scanEvidence(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *e)
+	}
+	return out, rows.Err()
+}
+
+const outreachEvidenceSelect = `
+	SELECT id, organization_id, account_id, source_evidence_id,
+		COALESCE(evidence_type,''), COALESCE(title,''), COALESCE(url,''), COALESCE(document,''),
+		evidence_date, COALESCE(location,''), COALESCE(excerpt,''), COALESCE(synthesis,''),
+		epistemic_class, COALESCE(reliability,''), consulted_at,
+		last_import_run_id, created_at, updated_at `
+
+func scanEvidence(row scannable) (*models.OutreachEvidence, error) {
+	var e models.OutreachEvidence
+	err := row.Scan(
+		&e.ID, &e.OrganizationID, &e.AccountID, &e.SourceEvidenceID,
+		&e.EvidenceType, &e.Title, &e.URL, &e.Document,
+		&e.EvidenceDate, &e.Location, &e.Excerpt, &e.Synthesis,
+		&e.EpistemicClass, &e.Reliability, &e.ConsultedAt,
+		&e.LastImportRunID, &e.CreatedAt, &e.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &e, nil
+}
+
+func (r *outreachRepository) UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (bool, error) {
+	if e.ID == uuid.Nil {
+		e.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	e.UpdatedAt = now
+	if e.CreatedAt.IsZero() {
+		e.CreatedAt = now
+	}
+	var created bool
+	err := r.db.QueryRow(ctx, `
+		INSERT INTO outreach_evidence (
+			id, organization_id, account_id, source_evidence_id,
+			evidence_type, title, url, document, evidence_date, location,
+			excerpt, synthesis, epistemic_class, reliability, consulted_at,
+			last_import_run_id, created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18
+		)
+		ON CONFLICT (organization_id, account_id, source_evidence_id) DO UPDATE SET
+			evidence_type = EXCLUDED.evidence_type,
+			title = EXCLUDED.title,
+			url = EXCLUDED.url,
+			document = EXCLUDED.document,
+			evidence_date = EXCLUDED.evidence_date,
+			location = EXCLUDED.location,
+			excerpt = EXCLUDED.excerpt,
+			synthesis = EXCLUDED.synthesis,
+			epistemic_class = EXCLUDED.epistemic_class,
+			reliability = EXCLUDED.reliability,
+			consulted_at = EXCLUDED.consulted_at,
+			last_import_run_id = EXCLUDED.last_import_run_id,
+			updated_at = EXCLUDED.updated_at,
+			id = outreach_evidence.id
+		RETURNING (xmax = 0), id`,
+		e.ID, e.OrganizationID, e.AccountID, e.SourceEvidenceID,
+		e.EvidenceType, e.Title, e.URL, e.Document, e.EvidenceDate, e.Location,
+		e.Excerpt, e.Synthesis, e.EpistemicClass, e.Reliability, e.ConsultedAt,
+		e.LastImportRunID, e.CreatedAt, e.UpdatedAt,
+	).Scan(&created, &e.ID)
+	return created, err
+}

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -40,6 +40,15 @@ type OutreachRepository interface {
 	// Evidence
 	ListEvidence(ctx context.Context, orgID, accountID uuid.UUID) ([]models.OutreachEvidence, error)
 	UpsertEvidence(ctx context.Context, e *models.OutreachEvidence) (created bool, err error)
+
+	// Drafts + org settings (review / enrollment)
+	UpsertDraft(ctx context.Context, d *models.OutreachDraft) error
+	GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error)
+	GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error)
+	ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, error)
+	UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error
+	GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error)
+	UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error
 }
 
 // OutreachAccountFilter filters staged accounts.

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -49,6 +49,13 @@ type OutreachRepository interface {
 	UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error
 	GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error)
 	UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error
+
+	// Outcome outbox
+	EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error
+	ListPendingOutcomes(ctx context.Context, limit int) ([]models.OutreachOutcome, error)
+	MarkOutcomeDelivered(ctx context.Context, orgID, id uuid.UUID) error
+	MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, attempts int, next time.Time, lastErr string, dead bool) error
+	GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error)
 }
 
 // OutreachAccountFilter filters staged accounts.

--- a/internal/repository/pg_outreach_drafts.go
+++ b/internal/repository/pg_outreach_drafts.go
@@ -1,0 +1,257 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Draft methods for OutreachRepository are in this file (same interface extension).
+
+// OutreachDraftRepository is satisfied by outreachRepository.
+type OutreachDraftStore interface {
+	UpsertDraft(ctx context.Context, d *models.OutreachDraft) error
+	GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error)
+	GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error)
+	ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, error)
+	UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error
+	GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error)
+	UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error
+}
+
+func (r *outreachRepository) UpsertDraft(ctx context.Context, d *models.OutreachDraft) error {
+	if d.ID == uuid.Nil {
+		d.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	d.UpdatedAt = now
+	if d.CreatedAt.IsZero() {
+		d.CreatedAt = now
+	}
+	evid, _ := json.Marshal(d.EvidenceIDs)
+	if evid == nil {
+		evid = []byte("[]")
+	}
+	flags, _ := json.Marshal(d.RiskFlags)
+	if flags == nil {
+		flags = []byte("[]")
+	}
+	reasons, _ := json.Marshal(d.RedTeamReasons)
+	if reasons == nil {
+		reasons = []byte("[]")
+	}
+	follow := d.FollowupsJSON
+	if len(follow) == 0 {
+		follow = []byte("[]")
+	}
+	val := d.ValidationJSON
+	if len(val) == 0 {
+		val = []byte("{}")
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_drafts (
+			id, organization_id, account_id, contact_candidate_id,
+			recipient_name, recipient_role, recipient_email, verification_status,
+			subject, body_text, body_html, followups_json,
+			service_code, strategy_code, fact_used, evidence_ids, question, cta,
+			provider, model, prompt_version, generation,
+			validation_json, risk_class, risk_flags, red_team_result, red_team_reasons,
+			status, human_edited, approved_by, approved_at, review_seconds,
+			campaign_id, enrollment_contact_id, enrolled_at,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,
+			$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37
+		)
+		ON CONFLICT (id) DO UPDATE SET
+			contact_candidate_id = EXCLUDED.contact_candidate_id,
+			recipient_name = EXCLUDED.recipient_name,
+			recipient_role = EXCLUDED.recipient_role,
+			recipient_email = EXCLUDED.recipient_email,
+			verification_status = EXCLUDED.verification_status,
+			subject = EXCLUDED.subject,
+			body_text = EXCLUDED.body_text,
+			body_html = EXCLUDED.body_html,
+			followups_json = EXCLUDED.followups_json,
+			service_code = EXCLUDED.service_code,
+			strategy_code = EXCLUDED.strategy_code,
+			fact_used = EXCLUDED.fact_used,
+			evidence_ids = EXCLUDED.evidence_ids,
+			question = EXCLUDED.question,
+			cta = EXCLUDED.cta,
+			provider = EXCLUDED.provider,
+			model = EXCLUDED.model,
+			prompt_version = EXCLUDED.prompt_version,
+			generation = EXCLUDED.generation,
+			validation_json = EXCLUDED.validation_json,
+			risk_class = EXCLUDED.risk_class,
+			risk_flags = EXCLUDED.risk_flags,
+			red_team_result = EXCLUDED.red_team_result,
+			red_team_reasons = EXCLUDED.red_team_reasons,
+			status = EXCLUDED.status,
+			human_edited = EXCLUDED.human_edited,
+			approved_by = EXCLUDED.approved_by,
+			approved_at = EXCLUDED.approved_at,
+			review_seconds = EXCLUDED.review_seconds,
+			campaign_id = EXCLUDED.campaign_id,
+			enrollment_contact_id = EXCLUDED.enrollment_contact_id,
+			enrolled_at = EXCLUDED.enrolled_at,
+			updated_at = EXCLUDED.updated_at
+	`,
+		d.ID, d.OrganizationID, d.AccountID, d.ContactCandidateID,
+		d.RecipientName, d.RecipientRole, d.RecipientEmail, d.VerificationStatus,
+		d.Subject, d.BodyText, d.BodyHTML, follow,
+		d.ServiceCode, d.StrategyCode, d.FactUsed, evid, d.Question, d.CTA,
+		d.Provider, d.Model, d.PromptVersion, d.Generation,
+		val, d.RiskClass, flags, d.RedTeamResult, reasons,
+		d.Status, d.HumanEdited, d.ApprovedBy, d.ApprovedAt, d.ReviewSeconds,
+		d.CampaignID, d.EnrollmentContactID, d.EnrolledAt,
+		d.CreatedAt, d.UpdatedAt,
+	)
+	return err
+}
+
+const outreachDraftSelect = `
+	SELECT id, organization_id, account_id, contact_candidate_id,
+		COALESCE(recipient_name,''), COALESCE(recipient_role,''), COALESCE(recipient_email,''), COALESCE(verification_status,''),
+		COALESCE(subject,''), COALESCE(body_text,''), COALESCE(body_html,''), followups_json,
+		COALESCE(service_code,''), COALESCE(strategy_code,''), COALESCE(fact_used,''), evidence_ids,
+		COALESCE(question,''), COALESCE(cta,''),
+		COALESCE(provider,''), COALESCE(model,''), COALESCE(prompt_version,''), generation,
+		validation_json, risk_class, risk_flags, COALESCE(red_team_result,''), red_team_reasons,
+		status, human_edited, approved_by, approved_at, review_seconds,
+		campaign_id, enrollment_contact_id, enrolled_at,
+		created_at, updated_at `
+
+func scanDraft(row scannable) (*models.OutreachDraft, error) {
+	var d models.OutreachDraft
+	var evid, flags, reasons []byte
+	err := row.Scan(
+		&d.ID, &d.OrganizationID, &d.AccountID, &d.ContactCandidateID,
+		&d.RecipientName, &d.RecipientRole, &d.RecipientEmail, &d.VerificationStatus,
+		&d.Subject, &d.BodyText, &d.BodyHTML, &d.FollowupsJSON,
+		&d.ServiceCode, &d.StrategyCode, &d.FactUsed, &evid,
+		&d.Question, &d.CTA,
+		&d.Provider, &d.Model, &d.PromptVersion, &d.Generation,
+		&d.ValidationJSON, &d.RiskClass, &flags, &d.RedTeamResult, &reasons,
+		&d.Status, &d.HumanEdited, &d.ApprovedBy, &d.ApprovedAt, &d.ReviewSeconds,
+		&d.CampaignID, &d.EnrollmentContactID, &d.EnrolledAt,
+		&d.CreatedAt, &d.UpdatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal(evid, &d.EvidenceIDs)
+	_ = json.Unmarshal(flags, &d.RiskFlags)
+	_ = json.Unmarshal(reasons, &d.RedTeamReasons)
+	var val struct {
+		OK bool `json:"ok"`
+	}
+	if json.Unmarshal(d.ValidationJSON, &val) == nil {
+		ok := val.OK
+		d.ValidationOK = &ok
+	}
+	return &d, nil
+}
+
+func (r *outreachRepository) GetDraft(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachDraft, error) {
+	row := r.db.QueryRow(ctx, outreachDraftSelect+`
+		FROM outreach_drafts WHERE organization_id=$1 AND id=$2`, orgID, id)
+	d, err := scanDraft(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return d, err
+}
+
+func (r *outreachRepository) GetActiveDraftForAccount(ctx context.Context, orgID, accountID uuid.UUID) (*models.OutreachDraft, error) {
+	row := r.db.QueryRow(ctx, outreachDraftSelect+`
+		FROM outreach_drafts
+		WHERE organization_id=$1 AND account_id=$2
+		  AND status IN ('NOT_GENERATED','GENERATING','NEEDS_REVIEW','APPROVED')
+		ORDER BY updated_at DESC LIMIT 1`, orgID, accountID)
+	d, err := scanDraft(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return d, err
+}
+
+func (r *outreachRepository) ListDrafts(ctx context.Context, orgID uuid.UUID, status string, limit, offset int) ([]models.OutreachDraft, error) {
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	if offset < 0 {
+		offset = 0
+	}
+	var rows pgx.Rows
+	var err error
+	if status != "" {
+		rows, err = r.db.Query(ctx, outreachDraftSelect+`
+			FROM outreach_drafts WHERE organization_id=$1 AND status=$2
+			ORDER BY updated_at DESC LIMIT $3 OFFSET $4`, orgID, status, limit, offset)
+	} else {
+		rows, err = r.db.Query(ctx, outreachDraftSelect+`
+			FROM outreach_drafts WHERE organization_id=$1
+			ORDER BY updated_at DESC LIMIT $2 OFFSET $3`, orgID, limit, offset)
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachDraft
+	for rows.Next() {
+		d, err := scanDraft(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, *d)
+	}
+	return out, rows.Err()
+}
+
+func (r *outreachRepository) UpdateDraftStatus(ctx context.Context, d *models.OutreachDraft) error {
+	return r.UpsertDraft(ctx, d)
+}
+
+func (r *outreachRepository) GetOrgSettings(ctx context.Context, orgID uuid.UUID) (*models.OutreachOrgSettings, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT organization_id, campaign_id, COALESCE(campaign_name,''), created_at, updated_at
+		FROM outreach_org_settings WHERE organization_id=$1`, orgID)
+	var s models.OutreachOrgSettings
+	err := row.Scan(&s.OrganizationID, &s.CampaignID, &s.CampaignName, &s.CreatedAt, &s.UpdatedAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &s, nil
+}
+
+func (r *outreachRepository) UpsertOrgSettings(ctx context.Context, s *models.OutreachOrgSettings) error {
+	now := time.Now().UTC()
+	s.UpdatedAt = now
+	if s.CreatedAt.IsZero() {
+		s.CreatedAt = now
+	}
+	if s.CampaignName == "" {
+		s.CampaignName = "CONFENGE | Outreach consultivo inicial"
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_org_settings (organization_id, campaign_id, campaign_name, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5)
+		ON CONFLICT (organization_id) DO UPDATE SET
+			campaign_id = EXCLUDED.campaign_id,
+			campaign_name = EXCLUDED.campaign_name,
+			updated_at = EXCLUDED.updated_at`,
+		s.OrganizationID, s.CampaignID, s.CampaignName, s.CreatedAt, s.UpdatedAt,
+	)
+	return err
+}

--- a/internal/repository/pg_outreach_drafts.go
+++ b/internal/repository/pg_outreach_drafts.go
@@ -57,7 +57,7 @@ func (r *outreachRepository) UpsertDraft(ctx context.Context, d *models.Outreach
 	_, err := r.db.Exec(ctx, `
 		INSERT INTO outreach_drafts (
 			id, organization_id, account_id, contact_candidate_id,
-			recipient_name, recipient_role, recipient_email, verification_status,
+			channel, recipient_name, recipient_role, recipient_email, recipient_phone_e164, verification_status,
 			subject, body_text, body_html, followups_json,
 			service_code, strategy_code, fact_used, evidence_ids, question, cta,
 			provider, model, prompt_version, generation,
@@ -67,13 +67,15 @@ func (r *outreachRepository) UpsertDraft(ctx context.Context, d *models.Outreach
 			created_at, updated_at
 		) VALUES (
 			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,
-			$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37
+			$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39
 		)
 		ON CONFLICT (id) DO UPDATE SET
 			contact_candidate_id = EXCLUDED.contact_candidate_id,
+			channel = EXCLUDED.channel,
 			recipient_name = EXCLUDED.recipient_name,
 			recipient_role = EXCLUDED.recipient_role,
 			recipient_email = EXCLUDED.recipient_email,
+			recipient_phone_e164 = EXCLUDED.recipient_phone_e164,
 			verification_status = EXCLUDED.verification_status,
 			subject = EXCLUDED.subject,
 			body_text = EXCLUDED.body_text,
@@ -105,7 +107,7 @@ func (r *outreachRepository) UpsertDraft(ctx context.Context, d *models.Outreach
 			updated_at = EXCLUDED.updated_at
 	`,
 		d.ID, d.OrganizationID, d.AccountID, d.ContactCandidateID,
-		d.RecipientName, d.RecipientRole, d.RecipientEmail, d.VerificationStatus,
+		channelOrEmail(d.Channel), d.RecipientName, d.RecipientRole, d.RecipientEmail, d.RecipientPhoneE164, d.VerificationStatus,
 		d.Subject, d.BodyText, d.BodyHTML, follow,
 		d.ServiceCode, d.StrategyCode, d.FactUsed, evid, d.Question, d.CTA,
 		d.Provider, d.Model, d.PromptVersion, d.Generation,
@@ -119,7 +121,7 @@ func (r *outreachRepository) UpsertDraft(ctx context.Context, d *models.Outreach
 
 const outreachDraftSelect = `
 	SELECT id, organization_id, account_id, contact_candidate_id,
-		COALESCE(recipient_name,''), COALESCE(recipient_role,''), COALESCE(recipient_email,''), COALESCE(verification_status,''),
+		COALESCE(channel,'EMAIL'), COALESCE(recipient_name,''), COALESCE(recipient_role,''), COALESCE(recipient_email,''), COALESCE(recipient_phone_e164,''), COALESCE(verification_status,''),
 		COALESCE(subject,''), COALESCE(body_text,''), COALESCE(body_html,''), followups_json,
 		COALESCE(service_code,''), COALESCE(strategy_code,''), COALESCE(fact_used,''), evidence_ids,
 		COALESCE(question,''), COALESCE(cta,''),
@@ -134,7 +136,7 @@ func scanDraft(row scannable) (*models.OutreachDraft, error) {
 	var evid, flags, reasons []byte
 	err := row.Scan(
 		&d.ID, &d.OrganizationID, &d.AccountID, &d.ContactCandidateID,
-		&d.RecipientName, &d.RecipientRole, &d.RecipientEmail, &d.VerificationStatus,
+		&d.Channel, &d.RecipientName, &d.RecipientRole, &d.RecipientEmail, &d.RecipientPhoneE164, &d.VerificationStatus,
 		&d.Subject, &d.BodyText, &d.BodyHTML, &d.FollowupsJSON,
 		&d.ServiceCode, &d.StrategyCode, &d.FactUsed, &evid,
 		&d.Question, &d.CTA,
@@ -254,4 +256,11 @@ func (r *outreachRepository) UpsertOrgSettings(ctx context.Context, s *models.Ou
 		s.OrganizationID, s.CampaignID, s.CampaignName, s.CreatedAt, s.UpdatedAt,
 	)
 	return err
+}
+
+func channelOrEmail(ch string) string {
+	if ch == "" {
+		return "EMAIL"
+	}
+	return ch
 }

--- a/internal/repository/pg_outreach_outcomes.go
+++ b/internal/repository/pg_outreach_outcomes.go
@@ -1,0 +1,119 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func (r *outreachRepository) EnqueueOutcome(ctx context.Context, ev *models.OutreachOutcome) error {
+	if ev.ID == uuid.Nil {
+		ev.ID = uuid.New()
+	}
+	if ev.EventID == uuid.Nil {
+		ev.EventID = uuid.New()
+	}
+	now := time.Now().UTC()
+	ev.CreatedAt = now
+	ev.UpdatedAt = now
+	if ev.OccurredAt.IsZero() {
+		ev.OccurredAt = now
+	}
+	if ev.NextAttemptAt.IsZero() {
+		ev.NextAttemptAt = now
+	}
+	payload := ev.Payload
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO outreach_outcome_outbox (
+			id, organization_id, event_id, idempotency_key, source_lead_id, cnpj14,
+			contact_email, event_type, payload, occurred_at, attempts, next_attempt_at,
+			created_at, updated_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,0,$11,$12,$12)`,
+		ev.ID, ev.OrganizationID, ev.EventID, ev.IdempotencyKey, ev.SourceLeadID, ev.CNPJ14,
+		ev.ContactEmail, ev.EventType, payload, ev.OccurredAt, ev.NextAttemptAt, now,
+	)
+	return err
+}
+
+func (r *outreachRepository) ListPendingOutcomes(ctx context.Context, limit int) ([]models.OutreachOutcome, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 50
+	}
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, event_id, idempotency_key, COALESCE(source_lead_id,''), COALESCE(cnpj14,''),
+			COALESCE(contact_email,''), event_type, payload, occurred_at, attempts, next_attempt_at,
+			delivered_at, COALESCE(last_error,''), dead_letter, created_at, updated_at
+		FROM outreach_outcome_outbox
+		WHERE delivered_at IS NULL AND dead_letter = false AND next_attempt_at <= now()
+		ORDER BY next_attempt_at ASC
+		LIMIT $1`, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.OutreachOutcome
+	for rows.Next() {
+		var ev models.OutreachOutcome
+		if err := rows.Scan(
+			&ev.ID, &ev.OrganizationID, &ev.EventID, &ev.IdempotencyKey, &ev.SourceLeadID, &ev.CNPJ14,
+			&ev.ContactEmail, &ev.EventType, &ev.Payload, &ev.OccurredAt, &ev.Attempts, &ev.NextAttemptAt,
+			&ev.DeliveredAt, &ev.LastError, &ev.DeadLetter, &ev.CreatedAt, &ev.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		out = append(out, ev)
+	}
+	return out, rows.Err()
+}
+
+func (r *outreachRepository) MarkOutcomeDelivered(ctx context.Context, orgID, id uuid.UUID) error {
+	ct, err := r.db.Exec(ctx, `
+		UPDATE outreach_outcome_outbox SET delivered_at=now(), updated_at=now(), last_error=''
+		WHERE organization_id=$1 AND id=$2`, orgID, id)
+	if err != nil {
+		return err
+	}
+	if ct.RowsAffected() == 0 {
+		return pgx.ErrNoRows
+	}
+	return nil
+}
+
+func (r *outreachRepository) MarkOutcomeAttempt(ctx context.Context, orgID, id uuid.UUID, attempts int, next time.Time, lastErr string, dead bool) error {
+	_, err := r.db.Exec(ctx, `
+		UPDATE outreach_outcome_outbox SET
+			attempts=$3, next_attempt_at=$4, last_error=$5, dead_letter=$6, updated_at=now()
+		WHERE organization_id=$1 AND id=$2`,
+		orgID, id, attempts, next, lastErr, dead,
+	)
+	return err
+}
+
+func (r *outreachRepository) GetOutcomeByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachOutcome, error) {
+	row := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, event_id, idempotency_key, COALESCE(source_lead_id,''), COALESCE(cnpj14,''),
+			COALESCE(contact_email,''), event_type, payload, occurred_at, attempts, next_attempt_at,
+			delivered_at, COALESCE(last_error,''), dead_letter, created_at, updated_at
+		FROM outreach_outcome_outbox WHERE organization_id=$1 AND idempotency_key=$2`, orgID, key)
+	var ev models.OutreachOutcome
+	err := row.Scan(
+		&ev.ID, &ev.OrganizationID, &ev.EventID, &ev.IdempotencyKey, &ev.SourceLeadID, &ev.CNPJ14,
+		&ev.ContactEmail, &ev.EventType, &ev.Payload, &ev.OccurredAt, &ev.Attempts, &ev.NextAttemptAt,
+		&ev.DeliveredAt, &ev.LastError, &ev.DeadLetter, &ev.CreatedAt, &ev.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}

--- a/internal/repository/pg_outreach_outcomes.go
+++ b/internal/repository/pg_outreach_outcomes.go
@@ -117,3 +117,25 @@ func (r *outreachRepository) GetOutcomeByIdempotency(ctx context.Context, orgID 
 	}
 	return &ev, nil
 }
+
+// FindCandidateByEmail returns the recommended-or-latest candidate for an email in the org,
+// plus its account. Used to attribute replies/bounces back to confenge staging.
+func (r *outreachRepository) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, email string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	row := r.db.QueryRow(ctx, outreachCandidateSelect+`
+		FROM outreach_contact_candidates
+		WHERE organization_id=$1 AND lower(email)=lower($2)
+		ORDER BY recommended DESC, updated_at DESC
+		LIMIT 1`, orgID, email)
+	c, err := scanCandidate(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	acc, err := r.GetAccount(ctx, orgID, c.AccountID)
+	if err != nil {
+		return c, nil, err
+	}
+	return c, acc, nil
+}

--- a/internal/repository/pg_outreach_outcomes.go
+++ b/internal/repository/pg_outreach_outcomes.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"errors"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -126,6 +127,41 @@ func (r *outreachRepository) FindCandidateByEmail(ctx context.Context, orgID uui
 		WHERE organization_id=$1 AND lower(email)=lower($2)
 		ORDER BY recommended DESC, updated_at DESC
 		LIMIT 1`, orgID, email)
+	c, err := scanCandidate(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil, nil
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+	acc, err := r.GetAccount(ctx, orgID, c.AccountID)
+	if err != nil {
+		return c, nil, err
+	}
+	return c, acc, nil
+}
+
+// FindCandidateByPhone matches phone_e164 or raw phone (digits-insensitive).
+func (r *outreachRepository) FindCandidateByPhone(ctx context.Context, orgID uuid.UUID, phone string) (*models.OutreachContactCandidate, *models.OutreachAccount, error) {
+	phone = strings.TrimSpace(phone)
+	if phone == "" {
+		return nil, nil, nil
+	}
+	digits := strings.Map(func(r rune) rune {
+		if r >= '0' && r <= '9' {
+			return r
+		}
+		return -1
+	}, phone)
+	row := r.db.QueryRow(ctx, outreachCandidateSelect+`
+		FROM outreach_contact_candidates
+		WHERE organization_id=$1 AND (
+			phone_e164 = $2 OR phone_e164 = $3 OR phone = $2 OR phone = $3
+			OR regexp_replace(COALESCE(phone_e164,''), '[^0-9]', '', 'g') = $4
+			OR regexp_replace(COALESCE(phone,''), '[^0-9]', '', 'g') = $4
+		)
+		ORDER BY recommended DESC, updated_at DESC
+		LIMIT 1`, orgID, phone, "+"+digits, digits)
 	c, err := scanCandidate(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil, nil

--- a/internal/repository/pg_whatsapp.go
+++ b/internal/repository/pg_whatsapp.go
@@ -1,0 +1,303 @@
+package repository
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// WhatsAppRepository persists channel state, messages, instances, templates, webhook idempotency.
+type WhatsAppRepository interface {
+	GetInstanceByName(ctx context.Context, provider, instance string) (*models.WhatsAppInstance, *errx.Error)
+	InsertWebhookEvent(ctx context.Context, orgID uuid.UUID, provider, idemKey, eventType, externalMsgID, payloadHash string) (inserted bool, xerr *errx.Error)
+	UpsertContactState(ctx context.Context, st *models.WhatsAppContactState) *errx.Error
+	GetContactStateByPhone(ctx context.Context, orgID uuid.UUID, phoneE164 string) (*models.WhatsAppContactState, *errx.Error)
+	GetContactStateByContact(ctx context.Context, orgID, contactID uuid.UUID) (*models.WhatsAppContactState, *errx.Error)
+	InsertMessage(ctx context.Context, msg *models.WhatsAppMessage) (inserted bool, xerr *errx.Error)
+	GetTemplateStatus(ctx context.Context, orgID uuid.UUID, name, language string) (string, *errx.Error)
+	ListMessagesByThread(ctx context.Context, orgID uuid.UUID, threadKey string, limit int) ([]models.WhatsAppMessage, *errx.Error)
+}
+
+type pgWhatsApp struct {
+	db *pgxpool.Pool
+}
+
+// NewWhatsAppRepository constructs the Postgres implementation.
+func NewWhatsAppRepository(db *pgxpool.Pool) WhatsAppRepository {
+	return &pgWhatsApp{db: db}
+}
+
+func (r *pgWhatsApp) GetInstanceByName(ctx context.Context, provider, instance string) (*models.WhatsAppInstance, *errx.Error) {
+	if r == nil || r.db == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	row := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, provider, instance_name, integration_mode,
+		       phone_e164, webhook_secret, status, created_at, updated_at
+		FROM whatsapp_instances
+		WHERE provider = $1 AND instance_name = $2
+	`, provider, instance)
+	var m models.WhatsAppInstance
+	err := row.Scan(
+		&m.ID, &m.OrganizationID, &m.Provider, &m.InstanceName, &m.IntegrationMode,
+		&m.PhoneE164, &m.WebhookSecret, &m.Status, &m.CreatedAt, &m.UpdatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errx.InternalError()
+	}
+	return &m, nil
+}
+
+// InsertWebhookEvent returns inserted=false when the idempotency key already exists.
+func (r *pgWhatsApp) InsertWebhookEvent(ctx context.Context, orgID uuid.UUID, provider, idemKey, eventType, externalMsgID, payloadHash string) (bool, *errx.Error) {
+	if r == nil || r.db == nil {
+		return false, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	tag, err := r.db.Exec(ctx, `
+		INSERT INTO whatsapp_webhook_events (
+			organization_id, provider, idempotency_key, event_type, external_message_id, payload_hash
+		) VALUES ($1, $2, $3, $4, $5, $6)
+		ON CONFLICT (organization_id, idempotency_key) DO NOTHING
+	`, orgID, provider, idemKey, eventType, externalMsgID, payloadHash)
+	if err != nil {
+		return false, errx.InternalError()
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (r *pgWhatsApp) UpsertContactState(ctx context.Context, st *models.WhatsAppContactState) *errx.Error {
+	if r == nil || r.db == nil || st == nil {
+		return errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	if st.ID == uuid.Nil {
+		st.ID = uuid.New()
+	}
+	now := time.Now().UTC()
+	st.UpdatedAt = now
+	if st.CreatedAt.IsZero() {
+		st.CreatedAt = now
+	}
+	_, err := r.db.Exec(ctx, `
+		INSERT INTO whatsapp_contact_state (
+			id, organization_id, contact_id, outreach_candidate_id,
+			phone_raw, phone_e164, phone_country, phone_valid, phone_source, phone_source_url, phone_verified_at,
+			whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_scope,
+			whatsapp_consent_provenance_ok, whatsapp_consent_form_version, whatsapp_consent_recorded_by,
+			whatsapp_last_inbound_at, whatsapp_service_window_until, whatsapp_channel_status,
+			whatsapp_opt_out_at, do_not_contact,
+			last_email_outbound_at, last_whatsapp_outbound_at,
+			created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,
+			$5,$6,$7,$8,$9,$10,$11,
+			$12,$13,$14,$15,
+			$16,$17,$18,
+			$19,$20,$21,
+			$22,$23,
+			$24,$25,
+			$26,$27
+		)
+		ON CONFLICT (organization_id, contact_id) WHERE contact_id IS NOT NULL
+		DO UPDATE SET
+			phone_raw = EXCLUDED.phone_raw,
+			phone_e164 = EXCLUDED.phone_e164,
+			phone_country = EXCLUDED.phone_country,
+			phone_valid = EXCLUDED.phone_valid,
+			phone_source = EXCLUDED.phone_source,
+			phone_source_url = EXCLUDED.phone_source_url,
+			phone_verified_at = EXCLUDED.phone_verified_at,
+			-- sticky opt-out / DNC never downgraded by upsert of softer status
+			whatsapp_consent_status = CASE
+				WHEN whatsapp_contact_state.whatsapp_consent_status IN ('OPTED_OUT', 'DO_NOT_CONTACT')
+					THEN whatsapp_contact_state.whatsapp_consent_status
+				WHEN whatsapp_contact_state.do_not_contact OR whatsapp_contact_state.whatsapp_opt_out_at IS NOT NULL
+					THEN whatsapp_contact_state.whatsapp_consent_status
+				ELSE EXCLUDED.whatsapp_consent_status
+			END,
+			whatsapp_consent_source = CASE
+				WHEN whatsapp_contact_state.whatsapp_consent_status IN ('OPTED_OUT', 'DO_NOT_CONTACT')
+					THEN whatsapp_contact_state.whatsapp_consent_source
+				ELSE EXCLUDED.whatsapp_consent_source
+			END,
+			whatsapp_consent_at = CASE
+				WHEN whatsapp_contact_state.whatsapp_consent_status IN ('OPTED_OUT', 'DO_NOT_CONTACT')
+					THEN whatsapp_contact_state.whatsapp_consent_at
+				ELSE EXCLUDED.whatsapp_consent_at
+			END,
+			whatsapp_consent_scope = EXCLUDED.whatsapp_consent_scope,
+			whatsapp_consent_provenance_ok = EXCLUDED.whatsapp_consent_provenance_ok,
+			whatsapp_last_inbound_at = COALESCE(EXCLUDED.whatsapp_last_inbound_at, whatsapp_contact_state.whatsapp_last_inbound_at),
+			whatsapp_service_window_until = COALESCE(EXCLUDED.whatsapp_service_window_until, whatsapp_contact_state.whatsapp_service_window_until),
+			whatsapp_channel_status = EXCLUDED.whatsapp_channel_status,
+			whatsapp_opt_out_at = COALESCE(whatsapp_contact_state.whatsapp_opt_out_at, EXCLUDED.whatsapp_opt_out_at),
+			do_not_contact = whatsapp_contact_state.do_not_contact OR EXCLUDED.do_not_contact,
+			last_email_outbound_at = COALESCE(EXCLUDED.last_email_outbound_at, whatsapp_contact_state.last_email_outbound_at),
+			last_whatsapp_outbound_at = COALESCE(EXCLUDED.last_whatsapp_outbound_at, whatsapp_contact_state.last_whatsapp_outbound_at),
+			updated_at = EXCLUDED.updated_at
+	`, st.ID, st.OrganizationID, st.ContactID, st.OutreachCandidateID,
+		st.PhoneRaw, st.PhoneE164, st.PhoneCountry, st.PhoneValid, st.PhoneSource, st.PhoneSourceURL, st.PhoneVerifiedAt,
+		st.ConsentStatus, st.ConsentSource, st.ConsentAt, st.ConsentScope,
+		st.ConsentProvenanceOK, st.ConsentFormVersion, st.ConsentRecordedBy,
+		st.LastInboundAt, st.ServiceWindowUntil, st.ChannelStatus,
+		st.OptOutAt, st.DoNotContact,
+		st.LastEmailOutboundAt, st.LastWhatsAppOutboundAt,
+		st.CreatedAt, st.UpdatedAt,
+	)
+	if err != nil {
+		return errx.InternalError()
+	}
+	return nil
+}
+
+func (r *pgWhatsApp) GetContactStateByPhone(ctx context.Context, orgID uuid.UUID, phoneE164 string) (*models.WhatsAppContactState, *errx.Error) {
+	return r.scanState(ctx, `
+		SELECT id, organization_id, contact_id, outreach_candidate_id,
+			phone_raw, phone_e164, phone_country, phone_valid, phone_source, phone_source_url, phone_verified_at,
+			whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_scope,
+			whatsapp_consent_provenance_ok, whatsapp_consent_form_version, whatsapp_consent_recorded_by,
+			whatsapp_last_inbound_at, whatsapp_service_window_until, whatsapp_channel_status,
+			whatsapp_opt_out_at, do_not_contact,
+			last_email_outbound_at, last_whatsapp_outbound_at,
+			created_at, updated_at
+		FROM whatsapp_contact_state
+		WHERE organization_id = $1 AND phone_e164 = $2
+		ORDER BY updated_at DESC
+		LIMIT 1
+	`, orgID, phoneE164)
+}
+
+func (r *pgWhatsApp) GetContactStateByContact(ctx context.Context, orgID, contactID uuid.UUID) (*models.WhatsAppContactState, *errx.Error) {
+	return r.scanState(ctx, `
+		SELECT id, organization_id, contact_id, outreach_candidate_id,
+			phone_raw, phone_e164, phone_country, phone_valid, phone_source, phone_source_url, phone_verified_at,
+			whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_scope,
+			whatsapp_consent_provenance_ok, whatsapp_consent_form_version, whatsapp_consent_recorded_by,
+			whatsapp_last_inbound_at, whatsapp_service_window_until, whatsapp_channel_status,
+			whatsapp_opt_out_at, do_not_contact,
+			last_email_outbound_at, last_whatsapp_outbound_at,
+			created_at, updated_at
+		FROM whatsapp_contact_state
+		WHERE organization_id = $1 AND contact_id = $2
+		LIMIT 1
+	`, orgID, contactID)
+}
+
+func (r *pgWhatsApp) scanState(ctx context.Context, q string, args ...any) (*models.WhatsAppContactState, *errx.Error) {
+	if r == nil || r.db == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	row := r.db.QueryRow(ctx, q, args...)
+	var st models.WhatsAppContactState
+	err := row.Scan(
+		&st.ID, &st.OrganizationID, &st.ContactID, &st.OutreachCandidateID,
+		&st.PhoneRaw, &st.PhoneE164, &st.PhoneCountry, &st.PhoneValid, &st.PhoneSource, &st.PhoneSourceURL, &st.PhoneVerifiedAt,
+		&st.ConsentStatus, &st.ConsentSource, &st.ConsentAt, &st.ConsentScope,
+		&st.ConsentProvenanceOK, &st.ConsentFormVersion, &st.ConsentRecordedBy,
+		&st.LastInboundAt, &st.ServiceWindowUntil, &st.ChannelStatus,
+		&st.OptOutAt, &st.DoNotContact,
+		&st.LastEmailOutboundAt, &st.LastWhatsAppOutboundAt,
+		&st.CreatedAt, &st.UpdatedAt,
+	)
+	if err == pgx.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, errx.InternalError()
+	}
+	return &st, nil
+}
+
+func (r *pgWhatsApp) InsertMessage(ctx context.Context, msg *models.WhatsAppMessage) (bool, *errx.Error) {
+	if r == nil || r.db == nil || msg == nil {
+		return false, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	if msg.ID == uuid.Nil {
+		msg.ID = uuid.New()
+	}
+	if msg.CreatedAt.IsZero() {
+		msg.CreatedAt = time.Now().UTC()
+	}
+	if msg.Channel == "" {
+		msg.Channel = "WHATSAPP"
+	}
+	tag, err := r.db.Exec(ctx, `
+		INSERT INTO whatsapp_messages (
+			id, organization_id, contact_id, thread_key, direction, channel, provider,
+			provider_message_id, idempotency_key, body_text, template_name, template_language,
+			status, failure_code, draft_id, campaign_id, reviewed_by, approved_at, sent_at, occurred_at, created_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,
+			$8,$9,$10,$11,$12,
+			$13,$14,$15,$16,$17,$18,$19,$20,$21
+		)
+		ON CONFLICT (organization_id, idempotency_key) DO NOTHING
+	`, msg.ID, msg.OrganizationID, msg.ContactID, msg.ThreadKey, msg.Direction, msg.Channel, msg.Provider,
+		msg.ProviderMessageID, msg.IdempotencyKey, msg.BodyText, msg.TemplateName, msg.TemplateLanguage,
+		msg.Status, msg.FailureCode, msg.DraftID, msg.CampaignID, msg.ReviewedBy, msg.ApprovedAt, msg.SentAt, msg.OccurredAt, msg.CreatedAt,
+	)
+	if err != nil {
+		return false, errx.InternalError()
+	}
+	return tag.RowsAffected() > 0, nil
+}
+
+func (r *pgWhatsApp) GetTemplateStatus(ctx context.Context, orgID uuid.UUID, name, language string) (string, *errx.Error) {
+	if r == nil || r.db == nil {
+		return "MISSING", errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	var status string
+	err := r.db.QueryRow(ctx, `
+		SELECT status FROM whatsapp_templates
+		WHERE organization_id = $1 AND name = $2 AND language = $3
+	`, orgID, name, language).Scan(&status)
+	if err == pgx.ErrNoRows {
+		return "MISSING", nil
+	}
+	if err != nil {
+		return "MISSING", errx.InternalError()
+	}
+	return status, nil
+}
+
+func (r *pgWhatsApp) ListMessagesByThread(ctx context.Context, orgID uuid.UUID, threadKey string, limit int) ([]models.WhatsAppMessage, *errx.Error) {
+	if r == nil || r.db == nil {
+		return nil, errx.New(errx.ServiceUnavailable, "whatsapp repository unavailable")
+	}
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	rows, err := r.db.Query(ctx, `
+		SELECT id, organization_id, contact_id, thread_key, direction, channel, provider,
+			provider_message_id, idempotency_key, body_text, template_name, template_language,
+			status, failure_code, draft_id, campaign_id, reviewed_by, approved_at, sent_at, occurred_at, created_at
+		FROM whatsapp_messages
+		WHERE organization_id = $1 AND thread_key = $2
+		ORDER BY occurred_at DESC
+		LIMIT $3
+	`, orgID, threadKey, limit)
+	if err != nil {
+		return nil, errx.InternalError()
+	}
+	defer rows.Close()
+	var out []models.WhatsAppMessage
+	for rows.Next() {
+		var m models.WhatsAppMessage
+		if err := rows.Scan(
+			&m.ID, &m.OrganizationID, &m.ContactID, &m.ThreadKey, &m.Direction, &m.Channel, &m.Provider,
+			&m.ProviderMessageID, &m.IdempotencyKey, &m.BodyText, &m.TemplateName, &m.TemplateLanguage,
+			&m.Status, &m.FailureCode, &m.DraftID, &m.CampaignID, &m.ReviewedBy, &m.ApprovedAt, &m.SentAt, &m.OccurredAt, &m.CreatedAt,
+		); err != nil {
+			return nil, errx.InternalError()
+		}
+		out = append(out, m)
+	}
+	return out, nil
+}

--- a/site/package.json
+++ b/site/package.json
@@ -22,7 +22,9 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml": "4.3.1"
+      "js-yaml": "4.3.1",
+      "postcss": "8.5.23",
+      "svgo": "^4.0.2"
     }
   }
 }

--- a/site/package.json
+++ b/site/package.json
@@ -19,5 +19,10 @@
     "motion": "^12.34.0",
     "reading-time": "^1.5.0",
     "tailwindcss": "^4.1.10"
+  },
+  "pnpm": {
+    "overrides": {
+      "js-yaml": "4.3.1"
+    }
   }
 }

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -5,8 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: ^4.3.0
-  svgo: ^4.0.2
+  js-yaml: 4.3.1
 
 importers:
 
@@ -452,105 +451,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -643,79 +626,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -816,28 +786,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1306,8 +1272,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   jsonc-parser@3.3.1:
@@ -1348,28 +1314,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -2084,7 +2046,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.4
       retext-smartypants: 6.2.0
       shiki: 4.3.0
@@ -2780,7 +2742,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 0.30.21
       magicast: 0.5.3
@@ -3313,7 +3275,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 

--- a/site/pnpm-lock.yaml
+++ b/site/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   js-yaml: 4.3.1
+  postcss: 8.5.23
+  svgo: ^4.0.2
 
 importers:
 
@@ -1645,8 +1647,8 @@ packages:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.20:
-    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   prismjs@1.30.0:
@@ -3884,7 +3886,7 @@ snapshots:
 
   picomatch@4.0.5: {}
 
-  postcss@8.5.20:
+  postcss@8.5.23:
     dependencies:
       nanoid: 3.3.16
       picocolors: 1.1.1
@@ -4301,7 +4303,7 @@ snapshots:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
-      postcss: 8.5.20
+      postcss: 8.5.23
       rollup: 4.62.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -7,6 +7,8 @@ import {
     useConfengeDrafts,
     useConfengeStatus,
     useConfengeSummary,
+    useBootstrapConfengeCampaign,
+    useEnrollConfengeDraft,
     useGenerateConfengeDraft,
     useReviewConfengeDraft,
 } from "@/lib/api/hooks/app/confenge/useConfenge";
@@ -19,8 +21,11 @@ export default function ConfengePage() {
     const ready = useConfengeAccounts("READY_TO_GENERATE", enabled);
     const needsContact = useConfengeAccounts("NEEDS_CONTACT", enabled);
     const drafts = useConfengeDrafts("NEEDS_REVIEW", enabled);
+    const approved = useConfengeDrafts("APPROVED", enabled);
     const generate = useGenerateConfengeDraft();
     const review = useReviewConfengeDraft();
+    const enroll = useEnrollConfengeDraft();
+    const bootstrap = useBootstrapConfengeCampaign();
 
     const [idx, setIdx] = useState(0);
     const queue = drafts.data ?? [];
@@ -70,7 +75,16 @@ export default function ConfengePage() {
             <PageTopbar
                 eyebrow="CONFENGE"
                 subtitle="Review queue for intelligence-plane leads. Metric: commercial outcomes per human minute."
-            />
+            >
+                <button
+                    type="button"
+                    className="h-7 px-2.5 rounded-md border border-slate-200 text-[12.5px] text-slate-700 hover:bg-slate-50"
+                    disabled={bootstrap.isPending}
+                    onClick={() => bootstrap.mutate()}
+                >
+                    Bootstrap campaign
+                </button>
+            </PageTopbar>
             <div className="flex flex-col gap-4 p-4 md:p-6 max-w-6xl mx-auto w-full">
 
                 <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2">
@@ -138,6 +152,32 @@ export default function ConfengePage() {
                         </ul>
                     </section>
                 </div>
+
+                {(approved.data?.length ?? 0) > 0 && (
+                    <section className="rounded-md border border-slate-200 bg-white">
+                        <div className="px-3 h-10 flex items-center border-b border-slate-200 text-[12.5px] font-medium text-slate-900">
+                            Approved — ready to enroll ({approved.data?.length ?? 0})
+                        </div>
+                        <ul className="divide-y divide-slate-100">
+                            {(approved.data ?? []).map((d) => (
+                                <li key={d.id} className="px-3 py-2 flex items-center justify-between gap-2 text-[12.5px]">
+                                    <div className="min-w-0">
+                                        <div className="font-medium truncate">{d.recipient_email}</div>
+                                        <div className="text-slate-500 truncate">{d.subject}</div>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        className="shrink-0 h-7 px-2 rounded-md bg-sky-600 text-white hover:bg-sky-700"
+                                        disabled={enroll.isPending}
+                                        onClick={() => enroll.mutate(d.id)}
+                                    >
+                                        Enroll
+                                    </button>
+                                </li>
+                            ))}
+                        </ul>
+                    </section>
+                )}
 
                 <section className="rounded-md border border-slate-200 bg-white">
                     <div className="px-3 h-10 flex items-center justify-between border-b border-slate-200">

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -1,0 +1,320 @@
+import { useEffect, useMemo, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { Check, Loader2, RefreshCw, SkipForward, X } from "lucide-react";
+import { Page, PageTopbar } from "@/components/layout/Page";
+import {
+    useConfengeAccounts,
+    useConfengeDrafts,
+    useConfengeStatus,
+    useConfengeSummary,
+    useGenerateConfengeDraft,
+    useReviewConfengeDraft,
+} from "@/lib/api/hooks/app/confenge/useConfenge";
+import type { ConfengeDraft } from "@/lib/api/models/app/confenge/Confenge";
+
+export default function ConfengePage() {
+    const status = useConfengeStatus();
+    const enabled = !!status.data?.enabled;
+    const summary = useConfengeSummary(enabled);
+    const ready = useConfengeAccounts("READY_TO_GENERATE", enabled);
+    const needsContact = useConfengeAccounts("NEEDS_CONTACT", enabled);
+    const drafts = useConfengeDrafts("NEEDS_REVIEW", enabled);
+    const generate = useGenerateConfengeDraft();
+    const review = useReviewConfengeDraft();
+
+    const [idx, setIdx] = useState(0);
+    const queue = drafts.data ?? [];
+    const current: ConfengeDraft | undefined = queue[idx];
+
+    const [subject, setSubject] = useState("");
+    const [body, setBody] = useState("");
+
+    useEffect(() => {
+        if (current) {
+            setSubject(current.subject);
+            setBody(current.body_text);
+        }
+    }, [current?.id]);
+
+    const stats = useMemo(() => {
+        const s = summary.data;
+        if (!s) return [];
+        return [
+            { label: "Needs contact", value: s.needs_contact },
+            { label: "Ready", value: s.ready_to_generate },
+            { label: "Review", value: s.needs_review },
+            { label: "Approved", value: s.approved },
+            { label: "Enrolled", value: s.enrolled },
+            { label: "Sent", value: s.sent },
+            { label: "Replied", value: s.replied },
+            { label: "Blocked", value: s.blocked + s.do_not_contact },
+        ];
+    }, [summary.data]);
+
+    if (status.isLoading) {
+        return (
+            <Page>
+                <div className="flex items-center gap-2 text-slate-500 text-[12.5px] p-6">
+                    <Loader2 className="h-4 w-4 animate-spin" /> Loading…
+                </div>
+            </Page>
+        );
+    }
+
+    if (!enabled) {
+        return <Navigate to="/app" replace />;
+    }
+
+    return (
+        <Page>
+            <PageTopbar
+                eyebrow="CONFENGE"
+                subtitle="Review queue for intelligence-plane leads. Metric: commercial outcomes per human minute."
+            />
+            <div className="flex flex-col gap-4 p-4 md:p-6 max-w-6xl mx-auto w-full">
+
+                <div className="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2">
+                    {stats.map((s) => (
+                        <div
+                            key={s.label}
+                            className="rounded-md border border-slate-200 bg-white px-2.5 py-2"
+                        >
+                            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">{s.label}</div>
+                            <div className="text-lg font-semibold text-slate-900 tabular-nums">{s.value}</div>
+                        </div>
+                    ))}
+                </div>
+
+                <div className="grid md:grid-cols-2 gap-4">
+                    <section className="rounded-md border border-slate-200 bg-white">
+                        <div className="px-3 h-10 flex items-center border-b border-slate-200 text-[12.5px] font-medium text-slate-900">
+                            Ready to generate ({ready.data?.length ?? 0})
+                        </div>
+                        <ul className="divide-y divide-slate-100 max-h-64 overflow-auto">
+                            {(ready.data ?? []).map((a) => (
+                                <li key={a.id} className="px-3 py-2 flex items-center justify-between gap-2 text-[12.5px]">
+                                    <div className="min-w-0">
+                                        <div className="font-medium text-slate-900 truncate">
+                                            {a.nome_fantasia || a.razao_social}
+                                        </div>
+                                        <div className="text-slate-500 truncate">
+                                            {a.cnpj14} · {a.municipio}/{a.uf} · {a.service_code}
+                                        </div>
+                                    </div>
+                                    <button
+                                        type="button"
+                                        className="shrink-0 h-7 px-2 rounded-md bg-sky-50 text-sky-700 border border-sky-200 hover:bg-sky-100"
+                                        disabled={generate.isPending}
+                                        onClick={() => generate.mutate({ accountId: a.id })}
+                                    >
+                                        Generate
+                                    </button>
+                                </li>
+                            ))}
+                            {!ready.data?.length && (
+                                <li className="px-3 py-6 text-center text-slate-400 text-[12.5px]">No accounts ready</li>
+                            )}
+                        </ul>
+                    </section>
+
+                    <section className="rounded-md border border-slate-200 bg-white">
+                        <div className="px-3 h-10 flex items-center border-b border-slate-200 text-[12.5px] font-medium text-slate-900">
+                            Needs contact ({needsContact.data?.length ?? 0})
+                        </div>
+                        <ul className="divide-y divide-slate-100 max-h-64 overflow-auto">
+                            {(needsContact.data ?? []).map((a) => (
+                                <li key={a.id} className="px-3 py-2 text-[12.5px]">
+                                    <div className="font-medium text-slate-900 truncate">
+                                        {a.nome_fantasia || a.razao_social}
+                                    </div>
+                                    <div className="text-slate-500 truncate">
+                                        {a.cnpj14} · {a.moment_code || "—"} · {a.fact_to_mention || "no fact"}
+                                    </div>
+                                </li>
+                            ))}
+                            {!needsContact.data?.length && (
+                                <li className="px-3 py-6 text-center text-slate-400 text-[12.5px]">None waiting</li>
+                            )}
+                        </ul>
+                    </section>
+                </div>
+
+                <section className="rounded-md border border-slate-200 bg-white">
+                    <div className="px-3 h-10 flex items-center justify-between border-b border-slate-200">
+                        <span className="text-[12.5px] font-medium text-slate-900">
+                            Review queue ({queue.length})
+                            {current ? ` · ${idx + 1}/${queue.length}` : ""}
+                        </span>
+                        {current && (
+                            <span
+                                className={
+                                    "text-[10px] uppercase tracking-[0.14em] px-1.5 py-0.5 rounded " +
+                                    (current.risk_class === "GREEN"
+                                        ? "bg-emerald-50 text-emerald-700"
+                                        : current.risk_class === "RED"
+                                          ? "bg-rose-50 text-rose-700"
+                                          : "bg-amber-50 text-amber-700")
+                                }
+                            >
+                                {current.risk_class}
+                            </span>
+                        )}
+                    </div>
+
+                    {!current ? (
+                        <div className="px-3 py-10 text-center text-slate-400 text-[12.5px]">
+                            No drafts waiting for review. Generate from ready accounts first.
+                        </div>
+                    ) : (
+                        <div className="p-3 grid md:grid-cols-2 gap-4">
+                            <div className="space-y-2 text-[12.5px]">
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Recipient</div>
+                                    <div className="text-slate-900 font-medium">
+                                        {current.recipient_name || "—"} · {current.recipient_role || "—"}
+                                    </div>
+                                    <div className="text-slate-600">{current.recipient_email}</div>
+                                    <div className="text-slate-500">{current.verification_status}</div>
+                                </div>
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Fact</div>
+                                    <div className="text-slate-800">{current.fact_used || "—"}</div>
+                                </div>
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Service</div>
+                                    <div className="text-slate-800">{current.service_code}</div>
+                                </div>
+                                <div>
+                                    <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Provider</div>
+                                    <div className="text-slate-800">
+                                        {current.provider}/{current.model}
+                                        {current.provider === "template" ? " (fallback, not AI)" : ""}
+                                    </div>
+                                </div>
+                                {!!current.risk_flags?.length && (
+                                    <div>
+                                        <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Flags</div>
+                                        <div className="text-slate-600">{current.risk_flags.join(", ")}</div>
+                                    </div>
+                                )}
+                            </div>
+
+                            <div className="space-y-2">
+                                <label className="block text-[10px] uppercase tracking-[0.14em] text-slate-500">
+                                    Subject
+                                    <input
+                                        className="mt-1 w-full h-7 rounded-md border border-slate-200 px-2 text-[12.5px] text-slate-900 focus:border-sky-400 focus:ring-1 focus:ring-sky-100 outline-none"
+                                        value={subject}
+                                        onChange={(e) => setSubject(e.target.value)}
+                                    />
+                                </label>
+                                <label className="block text-[10px] uppercase tracking-[0.14em] text-slate-500">
+                                    Message
+                                    <textarea
+                                        className="mt-1 w-full min-h-[160px] rounded-md border border-slate-200 px-2 py-1.5 text-[12.5px] text-slate-900 focus:border-sky-400 focus:ring-1 focus:ring-sky-100 outline-none font-sans"
+                                        value={body}
+                                        onChange={(e) => setBody(e.target.value)}
+                                    />
+                                </label>
+
+                                <div className="flex flex-wrap gap-1.5 pt-1">
+                                    <ActionBtn
+                                        icon={<Check className="h-3.5 w-3.5" />}
+                                        label="Approve"
+                                        accent
+                                        disabled={review.isPending}
+                                        onClick={() =>
+                                            review.mutate(
+                                                {
+                                                    id: current.id,
+                                                    action: "edit",
+                                                    subject,
+                                                    body_text: body,
+                                                },
+                                                {
+                                                    onSuccess: () =>
+                                                        review.mutate({ id: current.id, action: "approve" }),
+                                                },
+                                            )
+                                        }
+                                    />
+                                    <ActionBtn
+                                        icon={<RefreshCw className="h-3.5 w-3.5" />}
+                                        label="Save edit"
+                                        disabled={review.isPending}
+                                        onClick={() =>
+                                            review.mutate({
+                                                id: current.id,
+                                                action: "edit",
+                                                subject,
+                                                body_text: body,
+                                            })
+                                        }
+                                    />
+                                    <ActionBtn
+                                        icon={<SkipForward className="h-3.5 w-3.5" />}
+                                        label="Skip"
+                                        disabled={review.isPending}
+                                        onClick={() => {
+                                            review.mutate({ id: current.id, action: "skip" });
+                                            setIdx((i) => Math.min(i, Math.max(0, queue.length - 2)));
+                                        }}
+                                    />
+                                    <ActionBtn
+                                        icon={<X className="h-3.5 w-3.5" />}
+                                        label="Block"
+                                        danger
+                                        disabled={review.isPending}
+                                        onClick={() =>
+                                            review.mutate({
+                                                id: current.id,
+                                                action: "block",
+                                                do_not_contact: false,
+                                            })
+                                        }
+                                    />
+                                </div>
+                                <p className="text-[11px] text-slate-400">
+                                    Shortcuts later: A approve · S skip · E edit focus. Auto-send stays off.
+                                </p>
+                            </div>
+                        </div>
+                    )}
+                </section>
+            </div>
+        </Page>
+    );
+}
+
+function ActionBtn({
+    icon,
+    label,
+    onClick,
+    disabled,
+    accent,
+    danger,
+}: {
+    icon: React.ReactNode;
+    label: string;
+    onClick: () => void;
+    disabled?: boolean;
+    accent?: boolean;
+    danger?: boolean;
+}) {
+    const cls = accent
+        ? "bg-sky-600 text-white border-sky-600 hover:bg-sky-700"
+        : danger
+          ? "bg-white text-rose-700 border-rose-200 hover:bg-rose-50"
+          : "bg-white text-slate-700 border-slate-200 hover:bg-slate-50";
+    return (
+        <button
+            type="button"
+            disabled={disabled}
+            onClick={onClick}
+            className={`h-7 px-2.5 inline-flex items-center gap-1 rounded-md border text-[12.5px] disabled:opacity-50 ${cls}`}
+        >
+            {icon}
+            {label}
+        </button>
+    );
+}

--- a/web/src/components/layout/AppNav.tsx
+++ b/web/src/components/layout/AppNav.tsx
@@ -17,6 +17,7 @@ import {
     FlameIcon,
     GitBranchIcon,
     InboxIcon,
+    Building2Icon,
     KeyIcon,
     ListChecksIcon,
     type LucideIcon,
@@ -48,6 +49,7 @@ import useTemplates from "@/lib/api/hooks/app/templates/useTemplates";
 import useUsageOverview from "@/lib/api/hooks/app/analytics/useUsageOverview";
 import useDashboard from "@/lib/api/hooks/app/analytics/useDashboard";
 import mailboxDisplayStatus from "@/lib/mailboxStatus";
+import { useConfengeStatus } from "@/lib/api/hooks/app/confenge/useConfenge";
 import useAPIKeys from "@/lib/api/hooks/app/api-keys/useAPIKeys";
 import useIntegrationConnections from "@/lib/api/hooks/app/integrations/useIntegrationConnections";
 import AnimatedNumber from "@/components/ui/AnimatedNumber";
@@ -102,6 +104,8 @@ interface NavItem {
         | "analytics"
         | "apikeys"
         | "integrations";
+    /** Optional server feature flag; currently only "confenge". */
+    featureFlag?: "confenge";
 }
 
 // Plan badge shown on locked sidebar rows. Plan names + colors come
@@ -139,6 +143,7 @@ const sections: NavSection[] = [
             { title: "Accounts", url: "/app/emails", icon: MailIcon, indicator: "accounts", advisorSurface: "emails", permission: "MANAGE_EMAILS", permissionLabel: "Manage mailboxes" },
             { title: "Campaigns", url: "/app/campaigns", icon: MegaphoneIcon, indicator: "campaigns", advisorSurface: "campaigns", permission: "VIEW_CAMPAIGNS", permissionLabel: "View campaigns" },
             { title: "Contacts", url: "/app/contacts", icon: UsersIcon, indicator: "contacts", advisorSurface: "contacts", permission: "VIEW_CONTACTS", permissionLabel: "View contacts" },
+            { title: "CONFENGE", url: "/app/confenge", icon: Building2Icon, permission: "VIEW_CONTACTS", permissionLabel: "View contacts", featureFlag: "confenge" },
             { title: "Analytics", url: "/app/analytics", icon: BarChart3Icon, indicator: "analytics", permission: "VIEW_ANALYTICS", permissionLabel: "View analytics" },
             { title: "Deliverability", url: "/app/deliverability", icon: ShieldCheckIcon, advisorSurface: "deliverability", permission: "VIEW_ANALYTICS", permissionLabel: "View analytics" },
         ],
@@ -169,10 +174,14 @@ function NavRow({ item }: { item: NavItem }) {
     const unseen = useAppStore((s) => s.unseenCount);
     const access = useFeatureAccess();
     const hasItemPermission = usePermission(item.permission ?? "VIEW_CAMPAIGNS");
+    const confengeStatus = useConfengeStatus();
     const [deniedOpen, setDeniedOpen] = useState(false);
     const active =
         pathname === item.url || pathname.startsWith(item.url + "/");
     const badge = item.badgeStoreKey === "unseenCount" ? unseen : undefined;
+
+    // Feature-flagged rows (CONFENGE) only appear when the backend flag is on.
+    if (item.featureFlag === "confenge" && !confengeStatus.data?.enabled) return null;
 
     // Role-gated items disappear from the sidebar for users that
     // can't access them, instead of showing a lock — these are

--- a/web/src/hooks/useRealtimeEvents.ts
+++ b/web/src/hooks/useRealtimeEvents.ts
@@ -322,6 +322,8 @@ export function useRealtimeEvents() {
           // or a teammate applying/snoozing/dismissing one. Refreshes every
           // strip and every nav badge at once.
           advisor_finding: [['advisor']],
+          outreach_import_run: [['confenge']],
+          outreach_account: [['confenge']],
           settings: [['organizations', 'current']],
           unibox: [['unibox']],
           crm_note: [['crm'], ['contacts']],

--- a/web/src/lib/api/client/app/confenge/confenge.ts
+++ b/web/src/lib/api/client/app/confenge/confenge.ts
@@ -88,3 +88,23 @@ export async function reviewConfengeDraft(
     });
     return res.data;
 }
+
+export async function enrollConfengeDraft(id: string): Promise<ConfengeDraft> {
+    const res = await Request<{ data: ConfengeDraft }>({
+        method: "POST",
+        url: `/confenge/drafts/${id}/enroll`,
+        authorization: true,
+        data: {},
+    });
+    return res.data;
+}
+
+export async function bootstrapConfengeCampaign(): Promise<{ id: string; name: string }> {
+    const res = await Request<{ data: { id: string; name: string } }>({
+        method: "POST",
+        url: "/confenge/campaign/bootstrap",
+        authorization: true,
+        data: {},
+    });
+    return res.data;
+}

--- a/web/src/lib/api/client/app/confenge/confenge.ts
+++ b/web/src/lib/api/client/app/confenge/confenge.ts
@@ -1,0 +1,90 @@
+import type {
+    ConfengeAccount,
+    ConfengeDraft,
+    ConfengeStatus,
+    ConfengeSummary,
+} from "@/lib/api/models/app/confenge/Confenge";
+import Request from "../../Request";
+
+export async function getConfengeStatus(): Promise<ConfengeStatus> {
+    return await Request<ConfengeStatus>({
+        method: "GET",
+        url: "/confenge/status",
+        authorization: true,
+    });
+}
+
+export async function getConfengeSummary(): Promise<ConfengeSummary> {
+    const res = await Request<{ data: ConfengeSummary }>({
+        method: "GET",
+        url: "/confenge/summary",
+        authorization: true,
+    });
+    return res.data;
+}
+
+export async function listConfengeAccounts(params?: {
+    queue_state?: string;
+    q?: string;
+    limit?: number;
+}): Promise<ConfengeAccount[]> {
+    const sp = new URLSearchParams();
+    if (params?.queue_state) sp.set("queue_state", params.queue_state);
+    if (params?.q) sp.set("q", params.q);
+    if (params?.limit) sp.set("limit", String(params.limit));
+    const qs = sp.toString();
+    const res = await Request<{ data: ConfengeAccount[] }>({
+        method: "GET",
+        url: `/confenge/accounts${qs ? `?${qs}` : ""}`,
+        authorization: true,
+    });
+    return res.data ?? [];
+}
+
+export async function getConfengeAccount(id: string): Promise<ConfengeAccount> {
+    const res = await Request<{ data: ConfengeAccount }>({
+        method: "GET",
+        url: `/confenge/accounts/${id}`,
+        authorization: true,
+    });
+    return res.data;
+}
+
+export async function generateConfengeDraft(accountId: string, contactCandidateId?: string): Promise<ConfengeDraft> {
+    const res = await Request<{ data: ConfengeDraft }>({
+        method: "POST",
+        url: `/confenge/accounts/${accountId}/generate`,
+        authorization: true,
+        data: contactCandidateId ? { contact_candidate_id: contactCandidateId } : {},
+    });
+    return res.data;
+}
+
+export async function listConfengeDrafts(status?: string): Promise<ConfengeDraft[]> {
+    const qs = status ? `?status=${encodeURIComponent(status)}` : "";
+    const res = await Request<{ data: ConfengeDraft[] }>({
+        method: "GET",
+        url: `/confenge/drafts${qs}`,
+        authorization: true,
+    });
+    return res.data ?? [];
+}
+
+export async function reviewConfengeDraft(
+    id: string,
+    body: {
+        action: "approve" | "reject" | "skip" | "edit" | "block";
+        subject?: string;
+        body_text?: string;
+        reason?: string;
+        do_not_contact?: boolean;
+    },
+): Promise<ConfengeDraft> {
+    const res = await Request<{ data: ConfengeDraft }>({
+        method: "POST",
+        url: `/confenge/drafts/${id}/review`,
+        authorization: true,
+        data: body,
+    });
+    return res.data;
+}

--- a/web/src/lib/api/hooks/app/confenge/useConfenge.ts
+++ b/web/src/lib/api/hooks/app/confenge/useConfenge.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import toast from "react-hot-toast";
 import {
+    bootstrapConfengeCampaign,
+    enrollConfengeDraft,
     generateConfengeDraft,
     getConfengeAccount,
     getConfengeStatus,
@@ -82,5 +84,25 @@ export function useReviewConfengeDraft() {
             toast.success(`Draft ${vars.action}d`);
         },
         onError: (e: Error) => toast.error(e.message || "Review failed"),
+    });
+}
+
+export function useEnrollConfengeDraft() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (id: string) => enrollConfengeDraft(id),
+        onSuccess: () => {
+            void qc.invalidateQueries({ queryKey: KEY });
+            toast.success("Enrolled in CONFENGE campaign");
+        },
+        onError: (e: Error) => toast.error(e.message || "Enroll failed"),
+    });
+}
+
+export function useBootstrapConfengeCampaign() {
+    return useMutation({
+        mutationFn: () => bootstrapConfengeCampaign(),
+        onSuccess: (c) => toast.success(`Campaign ready: ${c.name}`),
+        onError: (e: Error) => toast.error(e.message || "Bootstrap failed"),
     });
 }

--- a/web/src/lib/api/hooks/app/confenge/useConfenge.ts
+++ b/web/src/lib/api/hooks/app/confenge/useConfenge.ts
@@ -1,0 +1,86 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import toast from "react-hot-toast";
+import {
+    generateConfengeDraft,
+    getConfengeAccount,
+    getConfengeStatus,
+    getConfengeSummary,
+    listConfengeAccounts,
+    listConfengeDrafts,
+    reviewConfengeDraft,
+} from "@/lib/api/client/app/confenge/confenge";
+
+const KEY = ["confenge"] as const;
+
+export function useConfengeStatus() {
+    return useQuery({
+        queryKey: [...KEY, "status"],
+        queryFn: getConfengeStatus,
+        staleTime: 60_000,
+    });
+}
+
+export function useConfengeSummary(enabled = true) {
+    return useQuery({
+        queryKey: [...KEY, "summary"],
+        queryFn: getConfengeSummary,
+        enabled,
+        staleTime: 15_000,
+    });
+}
+
+export function useConfengeAccounts(queueState?: string, enabled = true) {
+    return useQuery({
+        queryKey: [...KEY, "accounts", queueState ?? ""],
+        queryFn: () => listConfengeAccounts({ queue_state: queueState, limit: 100 }),
+        enabled,
+    });
+}
+
+export function useConfengeAccount(id: string | null) {
+    return useQuery({
+        queryKey: [...KEY, "account", id],
+        queryFn: () => getConfengeAccount(id!),
+        enabled: !!id,
+    });
+}
+
+export function useConfengeDrafts(status?: string, enabled = true) {
+    return useQuery({
+        queryKey: [...KEY, "drafts", status ?? ""],
+        queryFn: () => listConfengeDrafts(status),
+        enabled,
+    });
+}
+
+export function useGenerateConfengeDraft() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: ({ accountId, contactId }: { accountId: string; contactId?: string }) =>
+            generateConfengeDraft(accountId, contactId),
+        onSuccess: () => {
+            void qc.invalidateQueries({ queryKey: KEY });
+            toast.success("Draft generated");
+        },
+        onError: (e: Error) => toast.error(e.message || "Generate failed"),
+    });
+}
+
+export function useReviewConfengeDraft() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (args: {
+            id: string;
+            action: "approve" | "reject" | "skip" | "edit" | "block";
+            subject?: string;
+            body_text?: string;
+            reason?: string;
+            do_not_contact?: boolean;
+        }) => reviewConfengeDraft(args.id, args),
+        onSuccess: (_d, vars) => {
+            void qc.invalidateQueries({ queryKey: KEY });
+            toast.success(`Draft ${vars.action}d`);
+        },
+        onError: (e: Error) => toast.error(e.message || "Review failed"),
+    });
+}

--- a/web/src/lib/api/models/app/confenge/Confenge.ts
+++ b/web/src/lib/api/models/app/confenge/Confenge.ts
@@ -1,0 +1,99 @@
+export type ConfengeStatus = {
+    enabled: boolean;
+    auto_send_enabled: boolean;
+    require_human_approval: boolean;
+    default_daily_limit: number;
+    max_initial_email_words: number;
+    feed_configured: boolean;
+};
+
+export type ConfengeSummary = {
+    needs_contact: number;
+    ready_to_generate: number;
+    needs_review: number;
+    approved: number;
+    enrolled: number;
+    sent: number;
+    replied: number;
+    meeting: number;
+    proposal: number;
+    won: number;
+    blocked: number;
+    bounced: number;
+    do_not_contact: number;
+    total: number;
+};
+
+export type ConfengeAccount = {
+    id: string;
+    organization_id: string;
+    source_lead_id: string;
+    cnpj14: string;
+    cnpj_root: string;
+    razao_social: string;
+    nome_fantasia: string;
+    municipio: string;
+    uf: string;
+    website: string;
+    priority_rank: number;
+    priority_score: number;
+    priority_tier: string;
+    moment_code: string;
+    moment_summary: string;
+    service_code: string;
+    service_name: string;
+    entry_offer: string;
+    fact_to_mention: string;
+    question_to_ask: string;
+    cta: string;
+    commercial_state: string;
+    queue_state: string;
+    blocked: boolean;
+    do_not_contact: boolean;
+    contacts?: ConfengeContact[];
+    evidence?: ConfengeEvidence[];
+};
+
+export type ConfengeContact = {
+    id: string;
+    name: string;
+    role: string;
+    email: string;
+    verification_status: string;
+    recommended: boolean;
+    do_not_contact: boolean;
+    bounced: boolean;
+};
+
+export type ConfengeEvidence = {
+    id: string;
+    source_evidence_id: string;
+    title: string;
+    url: string;
+    excerpt: string;
+    synthesis: string;
+    epistemic_class: string;
+};
+
+export type ConfengeDraft = {
+    id: string;
+    account_id: string;
+    recipient_name: string;
+    recipient_role: string;
+    recipient_email: string;
+    verification_status: string;
+    subject: string;
+    body_text: string;
+    service_code: string;
+    fact_used: string;
+    evidence_ids?: string[];
+    question: string;
+    cta: string;
+    provider: string;
+    model: string;
+    risk_class: string;
+    risk_flags?: string[];
+    status: string;
+    human_edited: boolean;
+    validation_ok?: boolean;
+};

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -50,6 +50,7 @@ import ReferralSettingsPage from './app/app/settings/referral/page';
 import LimitsSettingsPage from './app/app/settings/limits/page';
 import RolesSettingsPage from './app/app/settings/roles/page';
 import UniboxPage from './app/app/unibox/page';
+import ConfengePage from './app/app/confenge/page';
 import DashboardNotFound from './app/app/not-found';
 import NotFound from './app/not-found';
 
@@ -217,6 +218,10 @@ const router = createBrowserRouter([
           {
             path: "contacts",
             element: <ContactsPage />,
+          },
+          {
+            path: "confenge",
+            element: <ConfengePage />,
           },
           {
             path: "campaigns",


### PR DESCRIPTION
## Summary
- Stacks on `feat/confenge-outcome-ops` and merges PR transport from `feat/channels-whatsapp-evolution` (W1).
- Deterministic multichannel orchestrator (cases A–E): public phone never auto-sends WhatsApp; sticky opt-out; cross-channel cooldown; user-initiated service window.
- Backward-compatible feed extension: `phone_detail` + `whatsapp` consent facts (extra-cli facts; Warmbly policy).
- Short WhatsApp copy builder (not email paste).
- Migrations: `000083_whatsapp_channel` (renumbered vs confenge 080–082), `000084` draft channel + candidate phone/consent columns.
- Netcup runbook: `docs/confenge/whatsapp-netcup.md`.

## Dependencies
- **Depends on** open CONFENGE stack (`feat/confenge-outcome-ops` / PR #2/#4) and transport PR **#5** (`feat/channels-whatsapp-evolution`).
- Base: `feat/confenge-outcome-ops`. Do not merge before those land (or merge via full-stack coordination).

## Test plan
- [x] `go test ./internal/app/whatsapp/...`
- [x] `go test ./internal/app/confenge/ -run 'Case|Extract|Build|Cross'`
- [x] `go test ./internal/app/confenge/`
- [x] `go build ./cmd/backend`
- [ ] CI green
- [ ] No real WhatsApp outreach in tests (mock only)

## Flags (default off)
`CONFENGE_WHATSAPP_ENABLED=false`, auto-send/reply off, Baileys off, `CONFENGE_CROSS_CHANNEL_MIN_INTERVAL_HOURS=24`

## External blockers
Meta WABA, Cloud API number, approved templates, webhook secrets, Evolution deploy on Netcup.