### PR TITLE
feat(confenge): run always-on execution plane on Netcup VPS

### DIFF
--- a/deploy/confenge-vps/README.md
+++ b/deploy/confenge-vps/README.md
@@ -1,0 +1,32 @@
+# CONFENGE VPS execution plane
+
+Isolated always-on Warmbly deployment for CONFENGE on Netcup, co-tenant with
+extra-cli but **not** sharing application state.
+
+Full docs:
+
+- [vps-execution-plane.md](../../docs/confenge/vps-execution-plane.md)
+- [vps-execution-inventory.md](../../docs/confenge/vps-execution-inventory.md)
+- [vps-disaster-recovery.md](../../docs/confenge/vps-disaster-recovery.md)
+
+Quick start (on VPS checkout at `/opt/warmbly-confenge`):
+
+```bash
+deploy/confenge-vps/install.sh
+deploy/confenge-vps/prove-hostinger-net.sh   # SMTP must pass (Netcup unlock if not)
+deploy/confenge-vps/up.sh
+deploy/confenge-vps/connect-hostinger.sh     # interactive password; seals in DB
+deploy/confenge-vps/status.sh
+```
+
+Operator browser (from laptop):
+
+```bash
+ssh -L 5173:127.0.0.1:5173 -L 8080:127.0.0.1:8080 -p 2222 root@<vps>
+# http://127.0.0.1:5173
+```
+
+Safety: GREEN autorun OFF, auto-send OFF, WhatsApp OFF, human approval ON.
+Operational pace 10→20/h, daily shell 200. Hostinger plan is **Business Email
+Starter** (1000 msgs/rolling 24h/mailbox); that is only the provider ceiling,
+not the commercial target (`HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER`).

--- a/deploy/confenge-vps/README.md
+++ b/deploy/confenge-vps/README.md
@@ -15,6 +15,8 @@ Quick start (on VPS checkout at `/opt/warmbly-confenge`):
 deploy/confenge-vps/install.sh
 deploy/confenge-vps/prove-hostinger-net.sh   # SMTP must pass (Netcup unlock if not)
 deploy/confenge-vps/up.sh
+# After Netcup unlocks outbound 465/587:
+#   CONFENGE_SELF_SMOKE_TO=<you> deploy/confenge-vps/post-smtp-unlock.sh
 deploy/confenge-vps/connect-hostinger.sh     # interactive password; seals in DB
 deploy/confenge-vps/status.sh
 ```

--- a/deploy/confenge-vps/backup.sh
+++ b/deploy/confenge-vps/backup.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# Backup Warmbly CONFENGE operational data (DB + key material pointers).
+# Never includes Hostinger plaintext password. Never prints secret values.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT_DIR="${CONFENGE_BACKUP_DIR:-$ROOT/data/backups/confenge-vps}"
+mkdir -p "$OUT_DIR"
+STAGE="$OUT_DIR/stage-$TS"
+mkdir -p "$STAGE"
+
+echo "Backing up postgres (warmbly_dev)..."
+compose_cmd exec -T postgres pg_dump -U warmbly warmbly_dev >"$STAGE/warmbly_dev.sql"
+
+# Encryption keys: copy env keys into a separate 0600 secrets bundle (not next to public dumps by default)
+SECRETS_DIR="${CONFENGE_SECRETS_BACKUP_DIR:-$OUT_DIR/secrets}"
+mkdir -p "$SECRETS_DIR"
+SEC_BUNDLE="$SECRETS_DIR/keys-$TS.env"
+umask 077
+{
+  echo "# CONFENGE VPS key material backup $TS"
+  echo "# Store offline / encrypted separately from SQL dumps."
+  for k in KMS_LOCAL_MASTER_KEY CREDENTIALS_ENCRYPTION_KEY AUTH_SECRET INTERNAL_API_TOKEN CONFENGE_OUTCOME_WEBHOOK_SECRET; do
+    v="${!k:-}"
+    if [[ -n "$v" ]]; then
+      printf '%s=%s\n' "$k" "$v"
+    fi
+  done
+} >"$SEC_BUNDLE"
+chmod 600 "$SEC_BUNDLE"
+
+# Config snapshot without secrets
+python3 - "$ROOT/deploy/confenge-vps/.env" "$STAGE/env.redacted" <<'PY'
+import re, sys
+src, dst = sys.argv[1], sys.argv[2]
+secret_keys = re.compile(
+    r"(PASSWORD|SECRET|TOKEN|KEY|AUTH_SECRET|CREDENTIALS|KMS_|WEBHOOK_SECRET)",
+    re.I,
+)
+try:
+    lines = open(src, encoding="utf-8").read().splitlines()
+except FileNotFoundError:
+    open(dst, "w", encoding="utf-8").write("# no .env present\n")
+    raise SystemExit(0)
+out = []
+for line in lines:
+    if not line.strip() or line.strip().startswith("#"):
+        out.append(line)
+        continue
+    if "=" not in line:
+        out.append(line)
+        continue
+    k, _, _ = line.partition("=")
+    if secret_keys.search(k):
+        out.append(f"{k}=***REDACTED***")
+    else:
+        out.append(line)
+open(dst, "w", encoding="utf-8").write("\n".join(out) + "\n")
+PY
+
+# Manifest
+{
+  echo "ts=$TS"
+  echo "project=${COMPOSE_PROJECT_NAME:-warmbly-confenge}"
+  echo "git_sha=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+  echo "host=$(hostname 2>/dev/null || echo unknown)"
+  echo "sql=warmbly_dev.sql"
+  echo "secrets_bundle=$(basename "$SEC_BUNDLE")"
+  echo "note=Keep SQL and secrets_bundle offline and separate; both needed for full restore."
+} >"$STAGE/MANIFEST.txt"
+
+ARCHIVE="$OUT_DIR/warmbly-confenge-$TS.tar.gz"
+tar -C "$STAGE" -czf "$ARCHIVE" .
+rm -rf "$STAGE"
+chmod 600 "$ARCHIVE" 2>/dev/null || true
+
+echo "Backup archive: $ARCHIVE"
+echo "Secrets bundle: $SEC_BUNDLE (0600; store separately)"
+echo "Excluded: node_modules, build cache, unlimited logs, extra-cli datalake, plaintext mailbox password"

--- a/deploy/confenge-vps/connect-hostinger.sh
+++ b/deploy/confenge-vps/connect-hostinger.sh
@@ -57,10 +57,11 @@ ORG="${CONFENGE_FEED_SYNC_ORG_ID:-22222222-0000-0000-0000-000000000001}"
 curl -sS -X POST "$BASE/organization/switch/$ORG" -H "Authorization: Bearer $TOKEN" >/dev/null || true
 AUTH="Authorization: Bearer $TOKEN"
 
-# Build JSON without putting password on command-line arguments of curl via env to python only
-BODY="$(
-  PASS="$PASS" EMAIL="$EMAIL" NAME="$NAME" SMTP_HOST="$SMTP_HOST" SMTP_PORT="$SMTP_PORT" \
-    IMAP_HOST="$IMAP_HOST" IMAP_PORT="$IMAP_PORT" python3 - <<'PY'
+# Build JSON on a 0600 temp file; POST via --data-binary @file so password never appears in curl argv/ps.
+BODY_FILE="$(mktemp)"
+chmod 600 "$BODY_FILE"
+PASS="$PASS" EMAIL="$EMAIL" NAME="$NAME" SMTP_HOST="$SMTP_HOST" SMTP_PORT="$SMTP_PORT" \
+  IMAP_HOST="$IMAP_HOST" IMAP_PORT="$IMAP_PORT" python3 - <<'PY' >"$BODY_FILE"
 import json, os
 print(json.dumps({
   "email": os.environ["EMAIL"],
@@ -79,7 +80,6 @@ print(json.dumps({
   },
 }))
 PY
-)"
 
 # Drop password from shell env ASAP after JSON build
 PASS=""
@@ -88,9 +88,8 @@ unset CONFENGE_MAILBOX_PASSWORD || true
 
 echo "Connecting SMTP/IMAP (worker validates live credentials)..."
 RESP="$(curl -sS -w '\n%{http_code}' -X POST "$BASE/emails/onboarding/smtp-imap" \
-  -H "$AUTH" -H 'Content-Type: application/json' -d "$BODY")"
-# Clear body from shell
-BODY=""
+  -H "$AUTH" -H 'Content-Type: application/json' --data-binary @"$BODY_FILE")"
+rm -f "$BODY_FILE"
 CODE="$(printf '%s' "$RESP" | tail -1)"
 BODY_OUT="$(printf '%s' "$RESP" | sed '$d')"
 echo "http=$CODE"

--- a/deploy/confenge-vps/connect-hostinger.sh
+++ b/deploy/confenge-vps/connect-hostinger.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# Provision Hostinger SMTP/IMAP mailbox into Warmbly on the VPS.
+# Password is read with read -s (or CONFENGE_MAILBOX_PASSWORD env for CI only).
+# Never put the password in argv, git, logs, or process list via `ps` args.
+#
+# After success, Warmbly seals credentials with CREDENTIALS_ENCRYPTION_KEY + DEK.
+# Unset temporary password from the shell.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+API="$(api_base)"
+BASE="${API}/v1"
+EMAIL="${CONFENGE_MAILBOX_EMAIL:-tiago.sasaki@confenge.com.br}"
+NAME="${CONFENGE_MAILBOX_NAME:-Tiago Sasaki}"
+SMTP_HOST="${CONFENGE_SMTP_HOST:-smtp.hostinger.com}"
+SMTP_PORT="${CONFENGE_SMTP_PORT:-587}"
+IMAP_HOST="${CONFENGE_IMAP_HOST:-imap.hostinger.com}"
+IMAP_PORT="${CONFENGE_IMAP_PORT:-993}"
+
+PASS="${CONFENGE_MAILBOX_PASSWORD:-}"
+if [[ -z "$PASS" ]]; then
+  if [[ ! -t 0 ]]; then
+    echo "BLOCKED: no TTY and CONFENGE_MAILBOX_PASSWORD unset. Use interactive shell." >&2
+    exit 2
+  fi
+  printf 'Hostinger mailbox password for %s (input hidden): ' "$EMAIL" >&2
+  # read -s: no echo; password not in argv
+  read -r -s PASS
+  echo >&2
+fi
+if [[ -z "$PASS" ]]; then
+  echo "BLOCKED: empty password" >&2
+  exit 2
+fi
+
+echo "API=$BASE email=$EMAIL smtp=${SMTP_HOST}:${SMTP_PORT} imap=${IMAP_HOST}:${IMAP_PORT}"
+echo "(password not logged)"
+
+if [[ -z "${CONFENGE_OPS_PASSWORD:-}" ]]; then
+  if [[ -t 0 ]]; then
+    printf 'Warmbly ops password for %s (input hidden): ' "${CONFENGE_OPS_EMAIL:-dev@warmbly.com}" >&2
+    read -r -s CONFENGE_OPS_PASSWORD
+    echo >&2
+    export CONFENGE_OPS_PASSWORD
+  else
+    echo "BLOCKED: set CONFENGE_OPS_PASSWORD for non-interactive auth" >&2
+    exit 2
+  fi
+fi
+
+TOKEN="$(ops_access_token)"
+ORG="${CONFENGE_FEED_SYNC_ORG_ID:-22222222-0000-0000-0000-000000000001}"
+curl -sS -X POST "$BASE/organization/switch/$ORG" -H "Authorization: Bearer $TOKEN" >/dev/null || true
+AUTH="Authorization: Bearer $TOKEN"
+
+# Build JSON without putting password on command-line arguments of curl via env to python only
+BODY="$(
+  PASS="$PASS" EMAIL="$EMAIL" NAME="$NAME" SMTP_HOST="$SMTP_HOST" SMTP_PORT="$SMTP_PORT" \
+    IMAP_HOST="$IMAP_HOST" IMAP_PORT="$IMAP_PORT" python3 - <<'PY'
+import json, os
+print(json.dumps({
+  "email": os.environ["EMAIL"],
+  "name": os.environ["NAME"],
+  "smtp": {
+    "host": os.environ["SMTP_HOST"],
+    "port": int(os.environ["SMTP_PORT"]),
+    "username": os.environ["EMAIL"],
+    "password": os.environ["PASS"],
+  },
+  "imap": {
+    "host": os.environ["IMAP_HOST"],
+    "port": int(os.environ["IMAP_PORT"]),
+    "username": os.environ["EMAIL"],
+    "password": os.environ["PASS"],
+  },
+}))
+PY
+)"
+
+# Drop password from shell env ASAP after JSON build
+PASS=""
+unset PASS
+unset CONFENGE_MAILBOX_PASSWORD || true
+
+echo "Connecting SMTP/IMAP (worker validates live credentials)..."
+RESP="$(curl -sS -w '\n%{http_code}' -X POST "$BASE/emails/onboarding/smtp-imap" \
+  -H "$AUTH" -H 'Content-Type: application/json' -d "$BODY")"
+# Clear body from shell
+BODY=""
+CODE="$(printf '%s' "$RESP" | tail -1)"
+BODY_OUT="$(printf '%s' "$RESP" | sed '$d')"
+echo "http=$CODE"
+# Redact any accidental password fields if API echoed them
+printf '%s' "$BODY_OUT" | python3 -c '
+import sys, json, re
+raw = sys.stdin.read()
+try:
+    d = json.loads(raw)
+except Exception:
+    print(raw[:500])
+    raise SystemExit
+def scrub(o):
+    if isinstance(o, dict):
+        return {k: ("***" if "pass" in k.lower() or "secret" in k.lower() else scrub(v)) for k,v in o.items()}
+    if isinstance(o, list):
+        return [scrub(x) for x in o]
+    return o
+print(json.dumps(scrub(d), indent=2)[:2000])
+' 2>/dev/null || printf '%s' "$BODY_OUT" | head -c 400
+
+if [[ "$CODE" != "201" && "$CODE" != "200" && "$CODE" != "409" ]]; then
+  echo "HOSTINGER_CONNECT=FAIL" >&2
+  exit 1
+fi
+
+ACC_ID="$(printf '%s' "$BODY_OUT" | python3 -c 'import sys,json
+try:
+ d=json.load(sys.stdin)
+except Exception:
+ print(""); raise SystemExit
+print(d.get("id") or (d.get("data") or {}).get("id") or "")' 2>/dev/null || true)"
+
+if [[ -z "$ACC_ID" ]]; then
+  ACC_ID="$(curl -sS "$BASE/emails" -H "$AUTH" | EMAIL="$EMAIL" python3 -c '
+import sys,json,os
+want=os.environ.get("EMAIL","").lower()
+d=json.load(sys.stdin)
+rows=d if isinstance(d,list) else d.get("data") or []
+for a in rows:
+  if str(a.get("email","")).lower()==want:
+    print(a.get("id","")); break
+')"
+fi
+
+if [[ -n "$ACC_ID" ]]; then
+  SIG_PLAIN=$'Atenciosamente,\n\nEng. Tiago Sasaki\nCONFENGE\ntiago.sasaki@confenge.com.br'
+  SIG_HTML='<div style="margin-top:16px;font-family:Arial,Helvetica,sans-serif;font-size:13px;color:#1e293b"><p style="margin:0 0 8px 0">Atenciosamente,</p><p style="margin:0"><strong>Eng. Tiago Sasaki</strong><br>CONFENGE<br><a href="mailto:tiago.sasaki@confenge.com.br">tiago.sasaki@confenge.com.br</a></p><p style="margin:12px 0 0 0"><img src="cid:tiago-sasaki-signature@confenge" alt="Assinatura Tiago Sasaki" width="400" style="max-width:100%;height:auto;border:0" /></p></div>'
+  PATCH="$(SIG_PLAIN="$SIG_PLAIN" SIG_HTML="$SIG_HTML" python3 -c "import json,os; print(json.dumps({'signature_plain':os.environ['SIG_PLAIN'],'signature_html':os.environ['SIG_HTML'],'signature_sync':True}))")"
+  PRESP="$(curl -sS -w '\n%{http_code}' -X PATCH "$BASE/emails/$ACC_ID" \
+    -H "$AUTH" -H 'Content-Type: application/json' -d "$PATCH")"
+  PCODE="$(printf '%s' "$PRESP" | tail -1)"
+  echo "signature_patch_http=$PCODE account=$ACC_ID"
+fi
+
+echo "HOSTINGER_SMTP_IMAP_CONNECTED=ok"
+echo "Credentials are sealed in Warmbly DB. Plaintext password was not written to .env."
+echo "Restart-safe: keep KMS_LOCAL_MASTER_KEY + CREDENTIALS_ENCRYPTION_KEY backed up."

--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -160,6 +160,9 @@ services:
     logging: *default-logging
     environment:
       <<: *confenge-env
+      # Stable worker id so backend can route validate/send commands (hostname is not a UUID).
+      WORKER_ID: ${WORKER_ID:-10c8f5e4-1c39-5b2a-9c8b-3d2f0a8b1a01}
+      WORKER_TIER: ${WORKER_TIER:-shared}
       # Production Hostinger uses real TLS. Override only for Mailpit sink tests.
       MAIL_TLS_INSECURE: ${MAIL_TLS_INSECURE:-false}
     volumes:

--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -193,11 +193,14 @@ services:
     logging: *default-logging
     ports: !override
       - "127.0.0.1:4000:4000"
+    # BEAM RSS ~500–520Mi at boot and climbs past 1Gi under load; 512M cgroup OOM-looped.
     deploy:
       resources:
         limits:
-          cpus: "0.5"
-          memory: 512M
+          cpus: "0.75"
+          memory: 1536M
+        reservations:
+          memory: 384M
 
   web:
     <<: *restart

--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -1,0 +1,218 @@
+# CONFENGE always-on execution plane overlay for Netcup VPS.
+#
+# Usage (from repo root on the VPS, e.g. /opt/warmbly-confenge):
+#   export COMPOSE_PROJECT_NAME=warmbly-confenge
+#   docker compose \
+#     -f docker-compose.yml \
+#     -f deploy/confenge-vps/docker-compose.override.yml \
+#     --env-file deploy/confenge-vps/.env \
+#     up -d
+#
+# Design:
+# - Reuses root self-host images/services (no second platform).
+# - Isolates app state under project name warmbly-confenge (own volumes).
+# - Binds operator UI/API to loopback only (SSH tunnel from laptop).
+# - Does NOT expose Postgres/Redis/NATS publicly.
+# - restart: unless-stopped so reboot recovers without laptop.
+# - Resource limits protect extra-cli co-tenancy.
+# - GREEN autorun / global auto-send remain OFF (env.example).
+# - No local MTA. Outbound mail is authenticated client SMTP to Hostinger.
+
+name: warmbly-confenge
+
+x-confenge-env: &confenge-env
+  APP_ENV: ${APP_ENV:-production}
+  CONFENGE_OUTREACH_ENABLED: ${CONFENGE_OUTREACH_ENABLED:-true}
+  CONFENGE_REQUIRE_HUMAN_APPROVAL: ${CONFENGE_REQUIRE_HUMAN_APPROVAL:-true}
+  CONFENGE_AUTO_SEND_ENABLED: ${CONFENGE_AUTO_SEND_ENABLED:-false}
+  CONFENGE_GREEN_AUTORUN_ENABLED: ${CONFENGE_GREEN_AUTORUN_ENABLED:-false}
+  CONFENGE_SENDING_PAUSED: ${CONFENGE_SENDING_PAUSED:-false}
+  CONFENGE_KILL_SWITCH_PATH: /data/confenge-ops/kill-switch
+  CONFENGE_WHATSAPP_ENABLED: ${CONFENGE_WHATSAPP_ENABLED:-false}
+  CONFENGE_WHATSAPP_AUTO_SEND_ENABLED: ${CONFENGE_WHATSAPP_AUTO_SEND_ENABLED:-false}
+  CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED: ${CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED:-false}
+  CONFENGE_GLOBAL_SENDS_PER_HOUR: ${CONFENGE_GLOBAL_SENDS_PER_HOUR:-10}
+  CONFENGE_MIN_SEND_GAP_SECONDS: ${CONFENGE_MIN_SEND_GAP_SECONDS:-360}
+  CONFENGE_SEND_WINDOW_START: ${CONFENGE_SEND_WINDOW_START:-09:00}
+  CONFENGE_SEND_WINDOW_END: ${CONFENGE_SEND_WINDOW_END:-18:00}
+  CONFENGE_SEND_TIMEZONE: ${CONFENGE_SEND_TIMEZONE:-America/Sao_Paulo}
+  CONFENGE_SEND_BUSINESS_DAYS_ONLY: ${CONFENGE_SEND_BUSINESS_DAYS_ONLY:-true}
+  CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT: ${CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT:-200}
+  # Documentation / inventory only in this PR (governor core unchanged).
+  HOSTINGER_PLAN_CLASS: ${HOSTINGER_PLAN_CLASS:-BUSINESS_EMAIL_STARTER}
+  CONFENGE_RATE_MODE: ${CONFENGE_RATE_MODE:-adaptive}
+  CONFENGE_RATE_START_PER_HOUR: ${CONFENGE_RATE_START_PER_HOUR:-10}
+  CONFENGE_RATE_MAX_PER_HOUR: ${CONFENGE_RATE_MAX_PER_HOUR:-20}
+  CONFENGE_DYNAMIC_PRIORITY_ENABLED: ${CONFENGE_DYNAMIC_PRIORITY_ENABLED:-true}
+  CONFENGE_FEED_SYNC_ENABLED: ${CONFENGE_FEED_SYNC_ENABLED:-true}
+  CONFENGE_FEED_SYNC_INTERVAL: ${CONFENGE_FEED_SYNC_INTERVAL:-15m}
+  CONFENGE_FEED_SYNC_ORG_ID: ${CONFENGE_FEED_SYNC_ORG_ID:-22222222-0000-0000-0000-000000000001}
+  CONFENGE_EXTRA_CLI_FEED_URL: ${CONFENGE_EXTRA_CLI_FEED_URL:-https://host.docker.internal:8443/email_send_ready_feed.json}
+  CONFENGE_EXTRA_CLI_MANIFEST_URL: ${CONFENGE_EXTRA_CLI_MANIFEST_URL:-https://host.docker.internal:8443/manifest.json}
+  CONFENGE_EXTRA_CLI_ALLOWED_HOSTS: ${CONFENGE_EXTRA_CLI_ALLOWED_HOSTS:-host.docker.internal,127.0.0.1,159.195.18.88}
+  CONFENGE_OUTCOME_WEBHOOK_URL: ${CONFENGE_OUTCOME_WEBHOOK_URL:-https://host.docker.internal:8443/webhooks/warmbly/outcome}
+  CONFENGE_OUTCOME_WEBHOOK_SECRET: ${CONFENGE_OUTCOME_WEBHOOK_SECRET:-}
+  # Same-host feed uses private CA; allow only when feed is loopback/host-gateway.
+  WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS: ${WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS:-true}
+  SSL_CERT_FILE: ${SSL_CERT_FILE:-/etc/ssl/certs/ca-certificates.crt}
+
+x-restart: &restart
+  restart: unless-stopped
+
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "20m"
+    max-file: "5"
+
+services:
+  postgres:
+    <<: *restart
+    logging: *default-logging
+    # Never publish Postgres to the public internet.
+    ports: !override
+      - "127.0.0.1:15432:5432"
+    deploy:
+      resources:
+        limits:
+          cpus: "1.5"
+          memory: 1536M
+        reservations:
+          memory: 256M
+
+  redis:
+    <<: *restart
+    logging: *default-logging
+    ports: !override
+      - "127.0.0.1:16379:6379"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 384M
+
+  nats:
+    <<: *restart
+    logging: *default-logging
+    ports: !override
+      - "127.0.0.1:4222:4222"
+      - "127.0.0.1:8222:8222"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 384M
+
+  # Mailpit stays for controlled self-smoke / approve→dispatch proofs only.
+  # Production commercial mail uses Hostinger via sealed mailbox credentials.
+  mailpit:
+    <<: *restart
+    logging: *default-logging
+    ports: !override
+      - "127.0.0.1:18025:8025"
+      - "127.0.0.1:11025:1025"
+
+  backend:
+    <<: *restart
+    logging: *default-logging
+    ports: !override
+      - "127.0.0.1:8080:8080"
+    environment:
+      <<: *confenge-env
+      # Notification relay can stay on mailpit; campaign mail uses Hostinger accounts.
+      SMTP_HOST: ${SMTP_HOST:-mailpit}
+      SMTP_PORT: ${SMTP_PORT:-1025}
+      MAIL_TLS_INSECURE: ${MAIL_TLS_INSECURE:-false}
+    volumes:
+      - confenge_ops:/data/confenge-ops
+      - confenge_keys:/data/confenge-keys:ro
+      - blobs:/data/blobs
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    deploy:
+      resources:
+        limits:
+          cpus: "1.5"
+          memory: 1536M
+        reservations:
+          memory: 384M
+
+  consumer:
+    <<: *restart
+    logging: *default-logging
+    environment:
+      <<: *confenge-env
+    volumes:
+      - confenge_ops:/data/confenge-ops
+      - blobs:/data/blobs
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1024M
+
+  worker:
+    <<: *restart
+    logging: *default-logging
+    environment:
+      <<: *confenge-env
+      # Production Hostinger uses real TLS. Override only for Mailpit sink tests.
+      MAIL_TLS_INSECURE: ${MAIL_TLS_INSECURE:-false}
+    volumes:
+      - confenge_ops:/data/confenge-ops
+      # Optional signature image for CID attach (path from env at runtime).
+      - ${CONFENGE_SIGNATURE_IMAGE_HOST_PATH:-./data/confenge}:/data/confenge:ro
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1024M
+
+  tracking:
+    <<: *restart
+    logging: *default-logging
+    ports: !override
+      - "127.0.0.1:3000:3000"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 384M
+
+  realtime:
+    <<: *restart
+    logging: *default-logging
+    ports: !override
+      - "127.0.0.1:4000:4000"
+    deploy:
+      resources:
+        limits:
+          cpus: "0.5"
+          memory: 512M
+
+  web:
+    <<: *restart
+    logging: *default-logging
+    ports: !override
+      - "127.0.0.1:5173:80"
+    environment:
+      WARMBLY_API_URL: ${API_PUBLIC_URL:-http://127.0.0.1:8080}
+      WARMBLY_APP_URL: ${APP_URL:-http://127.0.0.1:5173}
+    deploy:
+      resources:
+        limits:
+          cpus: "0.3"
+          memory: 256M
+
+  # Admin not required for daily CONFENGE ops; keep profile-optional.
+  admin:
+    profiles: ["admin"]
+    <<: *restart
+    ports: !override
+      - "127.0.0.1:5174:80"
+
+volumes:
+  confenge_ops:
+  confenge_keys:

--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -127,6 +127,10 @@ services:
       - confenge_ops:/data/confenge-ops
       - confenge_keys:/data/confenge-keys:ro
       - blobs:/data/blobs
+      # GeoIP DB required by current backend boot path when GEODB_PATH is set.
+      - ${GEODB_HOST_PATH:-./data/GeoLite2-City.mmdb}:/app/data/GeoLite2-City.mmdb:ro
+      # Private CA for same-host confenge-plane HTTPS (host file or system CA copy).
+      - ${CONFENGE_FEED_CA_HOST_PATH:-./ops/feed-tls/ca-bundle.crt}:/etc/ssl/confenge-ca-bundle.crt:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
     deploy:

--- a/deploy/confenge-vps/down.sh
+++ b/deploy/confenge-vps/down.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Stop the warmbly-confenge stack (volumes preserved).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}"
+compose_cmd down
+echo "Stopped. Volumes retained (postgres_data, redis_data, nats_data, blobs, confenge_ops)."

--- a/deploy/confenge-vps/env.example
+++ b/deploy/confenge-vps/env.example
@@ -1,0 +1,107 @@
+# CONFENGE VPS execution-plane env template.
+# Copy to deploy/confenge-vps/.env on the VPS (mode 0600, never commit).
+#
+#   cp deploy/confenge-vps/env.example deploy/confenge-vps/.env
+#   chmod 600 deploy/confenge-vps/.env
+#   # fill secrets with deploy/confenge-vps/gen-secrets.sh
+#
+# NO real passwords in this file. NO Hostinger mailbox password here:
+# use deploy/confenge-vps/connect-hostinger.sh (read -s → sealed in DB).
+
+COMPOSE_PROJECT_NAME=warmbly-confenge
+APP_ENV=production
+
+# Operator-facing URLs (loopback; access via SSH tunnel from laptop)
+PUBLIC_HOST=127.0.0.1
+API_PUBLIC_URL=http://127.0.0.1:8080
+APP_URL=http://127.0.0.1:5173
+CORS_ALLOW_ORIGINS=http://127.0.0.1:5173,http://localhost:5173
+WEBSOCKET_URL=ws://127.0.0.1:4000/socket/websocket
+TRACKING_DOMAIN=127.0.0.1:3000
+
+# ── Required crypto (generate once; back up offline; losing = unrecoverable) ──
+# openssl rand -base64 32
+KMS_LOCAL_MASTER_KEY=
+# openssl rand -hex 32
+CREDENTIALS_ENCRYPTION_KEY=
+# openssl rand -hex 32  (min 32 chars)
+AUTH_SECRET=
+INTERNAL_API_TOKEN=
+
+# ── CONFENGE safety profile (do not flip for "always-on" alone) ─────────────
+CONFENGE_OUTREACH_ENABLED=true
+CONFENGE_REQUIRE_HUMAN_APPROVAL=true
+CONFENGE_AUTO_SEND_ENABLED=false
+CONFENGE_GREEN_AUTORUN_ENABLED=false
+CONFENGE_SENDING_PAUSED=false
+CONFENGE_WHATSAPP_ENABLED=false
+CONFENGE_WHATSAPP_AUTO_SEND_ENABLED=false
+CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED=false
+
+# Pace / window (governor core unchanged in this PR).
+# Commercial operational target is adaptive 10→20/h (reputation/deliverability).
+# That is NOT the Hostinger technical ceiling. Do not raise RATE_MAX above 20 here.
+CONFENGE_GLOBAL_SENDS_PER_HOUR=10
+CONFENGE_MIN_SEND_GAP_SECONDS=360
+CONFENGE_SEND_WINDOW_START=09:00
+CONFENGE_SEND_WINDOW_END=18:00
+CONFENGE_SEND_TIMEZONE=America/Sao_Paulo
+CONFENGE_SEND_BUSINESS_DAYS_ONLY=true
+# Campaign shell daily is secondary. Keep high enough that adaptive 20/h over a
+# business day is not silently collapsed (20×9h≈180). Default 200 matches local
+# go-live. provider ceiling ≠ operational target (see docs/confenge/vps-execution-plane.md).
+CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=200
+CONFENGE_RATE_MODE=adaptive
+CONFENGE_RATE_START_PER_HOUR=10
+CONFENGE_RATE_MAX_PER_HOUR=20
+# Hostinger product for tiago.sasaki@confenge.com.br (operator-confirmed).
+# Hostinger Business Email Starter: 1000 outgoing msgs / rolling 24h / mailbox (hPanel SoT).
+# NOT cPanel Email (do not use 200/h or 2400/day). NOT Free/Trial limits.
+# Provider ceiling ≠ commercial pacing: keep adaptive 10→20/h and daily operational 200.
+HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER
+# Documentation-only (not consumed by governor core in this PR):
+# HOSTINGER_TECHNICAL_DAILY_CAP=1000
+# CONFENGE_OPERATIONAL_HOURLY_CAP=20
+# CONFENGE_OPERATIONAL_DAILY_CAP=200
+
+# ── extra-cli boundary (same VPS, application contracts only) ───────────────
+# Prefer host-gateway to confenge-plane HTTPS on the host (:8443).
+CONFENGE_FEED_SYNC_ENABLED=true
+CONFENGE_FEED_SYNC_INTERVAL=15m
+CONFENGE_FEED_SYNC_ORG_ID=22222222-0000-0000-0000-000000000001
+CONFENGE_DYNAMIC_PRIORITY_ENABLED=true
+CONFENGE_EXTRA_CLI_FEED_URL=https://host.docker.internal:8443/email_send_ready_feed.json
+CONFENGE_EXTRA_CLI_MANIFEST_URL=https://host.docker.internal:8443/manifest.json
+CONFENGE_EXTRA_CLI_ALLOWED_HOSTS=host.docker.internal,127.0.0.1,159.195.18.88
+CONFENGE_OUTCOME_WEBHOOK_URL=https://host.docker.internal:8443/webhooks/warmbly/outcome
+# Copy from host file /opt/confenge-plane/outcome.secret (never commit)
+CONFENGE_OUTCOME_WEBHOOK_SECRET=
+# Required only because host-gateway feed uses a private CA / same-host URL.
+WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS=true
+
+# ── Hostinger mailbox (connect script; not permanent env password) ──────────
+CONFENGE_MAILBOX_EMAIL=tiago.sasaki@confenge.com.br
+CONFENGE_MAILBOX_NAME=Tiago Sasaki
+CONFENGE_SMTP_HOST=smtp.hostinger.com
+# Warmbly supports 465 (implicit TLS) and 587 (STARTTLS). Prefer provider path
+# already proven in go-live (587) unless 465 is required after Netcup unlock.
+CONFENGE_SMTP_PORT=587
+CONFENGE_IMAP_HOST=imap.hostinger.com
+CONFENGE_IMAP_PORT=993
+# Do NOT set CONFENGE_MAILBOX_PASSWORD here for permanent storage.
+# Optional explicit self-smoke destination (operator-owned only):
+# CONFENGE_SELF_SMOKE_TO=
+
+# API used by ops scripts from the VPS host
+CONFENGE_API_HOST=127.0.0.1:8080
+CONFENGE_API_BASE=http://127.0.0.1:8080
+
+# Platform notification SMTP (not campaign mail). Mailpit is fine on VPS for
+# login OTP / system mail. Campaign mail uses sealed Hostinger credentials.
+SMTP_HOST=mailpit
+SMTP_PORT=1025
+MAIL_TLS_INSECURE=false
+
+# Seed login for bootstrap / connect scripts (change after first login in prod)
+# CONFENGE_OPS_EMAIL=dev@warmbly.com
+# CONFENGE_OPS_PASSWORD=password123

--- a/deploy/confenge-vps/env.example
+++ b/deploy/confenge-vps/env.example
@@ -81,7 +81,7 @@ WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS=true
 
 # ── Hostinger mailbox (connect script; not permanent env password) ──────────
 CONFENGE_MAILBOX_EMAIL=tiago.sasaki@confenge.com.br
-CONFENGE_MAILBOX_NAME=Tiago Sasaki
+CONFENGE_MAILBOX_NAME="Tiago Sasaki"
 CONFENGE_SMTP_HOST=smtp.hostinger.com
 # Warmbly supports 465 (implicit TLS) and 587 (STARTTLS). Prefer provider path
 # already proven in go-live (587) unless 465 is required after Netcup unlock.

--- a/deploy/confenge-vps/env.example
+++ b/deploy/confenge-vps/env.example
@@ -105,3 +105,7 @@ MAIL_TLS_INSECURE=false
 # Seed login for bootstrap / connect scripts (change after first login in prod)
 # CONFENGE_OPS_EMAIL=dev@warmbly.com
 # CONFENGE_OPS_PASSWORD=password123
+
+# Stable worker UUID (must match email_accounts.worker_id / assignment)
+WORKER_ID=10c8f5e4-1c39-5b2a-9c8b-3d2f0a8b1a01
+WORKER_TIER=shared

--- a/deploy/confenge-vps/gen-secrets.sh
+++ b/deploy/confenge-vps/gen-secrets.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# Generate crypto secrets into deploy/confenge-vps/.env (mode 0600).
+# Does not print secret values. Does not touch Hostinger mailbox password.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+ENVF="${CONFENGE_VPS_ENV:-$ROOT/deploy/confenge-vps/.env}"
+EXAMPLE="$ROOT/deploy/confenge-vps/env.example"
+
+if [[ ! -f "$ENVF" ]]; then
+  cp "$EXAMPLE" "$ENVF"
+  echo "Created $ENVF from env.example"
+fi
+chmod 600 "$ENVF"
+
+need_fill() {
+  local key="$1"
+  local val
+  val="$(grep -E "^${key}=" "$ENVF" | head -1 | cut -d= -f2- || true)"
+  [[ -z "$val" ]]
+}
+
+set_key() {
+  local key="$1" val="$2"
+  if grep -qE "^${key}=" "$ENVF"; then
+    # rewrite line in place without echoing value
+    python3 - "$ENVF" "$key" "$val" <<'PY'
+import sys
+path, key, val = sys.argv[1], sys.argv[2], sys.argv[3]
+lines = open(path, encoding="utf-8").read().splitlines()
+out = []
+found = False
+for line in lines:
+    if line.startswith(key + "="):
+        out.append(f"{key}={val}")
+        found = True
+    else:
+        out.append(line)
+if not found:
+    out.append(f"{key}={val}")
+open(path, "w", encoding="utf-8").write("\n".join(out) + "\n")
+PY
+  else
+    printf '%s=%s\n' "$key" "$val" >>"$ENVF"
+  fi
+}
+
+if need_fill KMS_LOCAL_MASTER_KEY; then
+  set_key KMS_LOCAL_MASTER_KEY "$(openssl rand -base64 32)"
+  echo "filled KMS_LOCAL_MASTER_KEY"
+else
+  echo "keep KMS_LOCAL_MASTER_KEY"
+fi
+if need_fill CREDENTIALS_ENCRYPTION_KEY; then
+  set_key CREDENTIALS_ENCRYPTION_KEY "$(openssl rand -hex 32)"
+  echo "filled CREDENTIALS_ENCRYPTION_KEY"
+else
+  echo "keep CREDENTIALS_ENCRYPTION_KEY"
+fi
+if need_fill AUTH_SECRET; then
+  set_key AUTH_SECRET "$(openssl rand -hex 32)"
+  echo "filled AUTH_SECRET"
+else
+  echo "keep AUTH_SECRET"
+fi
+if need_fill INTERNAL_API_TOKEN; then
+  set_key INTERNAL_API_TOKEN "$(openssl rand -hex 24)"
+  echo "filled INTERNAL_API_TOKEN"
+else
+  echo "keep INTERNAL_API_TOKEN"
+fi
+
+# Outcome secret from confenge-plane if present and empty here
+if need_fill CONFENGE_OUTCOME_WEBHOOK_SECRET && [[ -r /opt/confenge-plane/outcome.secret ]]; then
+  set_key CONFENGE_OUTCOME_WEBHOOK_SECRET "$(tr -d '\n' </opt/confenge-plane/outcome.secret)"
+  echo "filled CONFENGE_OUTCOME_WEBHOOK_SECRET from confenge-plane"
+fi
+
+chmod 600 "$ENVF"
+echo "Secrets file ready: $ENVF (mode 0600). Back up offline separately from DB dumps."
+echo "NEVER commit this file. NEVER print its contents into tickets."

--- a/deploy/confenge-vps/install.sh
+++ b/deploy/confenge-vps/install.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Bootstrap warmbly-confenge on the Netcup VPS without touching extra-cli state.
+# Safe to re-run. Does not send email. Does not reboot.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+cd "$ROOT"
+
+TARGET="${CONFENGE_VPS_INSTALL_DIR:-/opt/warmbly-confenge}"
+echo "Repo root: $ROOT"
+echo "Target dir: $TARGET (convention; skip copy if already there)"
+
+if [[ "$(readlink -f "$ROOT")" != "$(readlink -f "$TARGET" 2>/dev/null || true)" ]]; then
+  if [[ -d "$TARGET/.git" || -f "$TARGET/docker-compose.yml" ]]; then
+    echo "Using existing checkout at $TARGET"
+  else
+    echo "NOTE: deploy from a git checkout at $TARGET or set ROOT there."
+    echo "This script configures the current repo tree only."
+  fi
+fi
+
+command -v docker >/dev/null || { echo "docker required"; exit 1; }
+docker compose version >/dev/null || { echo "docker compose v2 required"; exit 1; }
+
+# Secrets
+"$ROOT/deploy/confenge-vps/gen-secrets.sh"
+
+ENVF="$ROOT/deploy/confenge-vps/.env"
+chmod 600 "$ENVF"
+
+# Ensure docker restart on boot
+if command -v systemctl >/dev/null; then
+  systemctl enable docker >/dev/null 2>&1 || true
+fi
+
+# UFW: do not open Warmbly ports publicly. Only document.
+if command -v ufw >/dev/null 2>&1; then
+  echo "UFW present. Warmbly binds loopback only; do not allow 8080/5173/15432/16379/4222 publicly."
+  echo "Keep 2222 (SSH) and existing 8443 (confenge-plane feed/outcome) as-is."
+fi
+
+# Resource snapshot
+{
+  echo "=== install inventory $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+  hostname
+  nproc
+  free -h
+  df -h / | tail -1
+  docker --version
+  docker compose version
+} | tee "$ROOT/deploy/confenge-vps/.last-install-inventory.txt" >/dev/null || true
+
+echo "Install prep done."
+echo "Next:"
+echo "  1) Confirm HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER (1000/24h; not cPanel)"
+echo "  2) deploy/confenge-vps/prove-hostinger-net.sh  # SMTP must OPEN (Netcup unlock if FAIL)"
+echo "  3) deploy/confenge-vps/up.sh"
+echo "  4) deploy/confenge-vps/connect-hostinger.sh"
+echo "  5) CONFENGE_SELF_SMOKE_TO=<you> deploy/confenge-vps/self-smoke.sh"
+echo "Never: install MTA, open Postgres, enable GREEN autorun, send to feed leads."

--- a/deploy/confenge-vps/lib.sh
+++ b/deploy/confenge-vps/lib.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Shared helpers for CONFENGE VPS ops scripts. Never prints secrets.
+# shellcheck shell=bash
+
+set -euo pipefail
+
+_CONFENGE_VPS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+confenge_vps_root() {
+  echo "$_CONFENGE_VPS_DIR"
+}
+
+# Resolve repo root: deploy/confenge-vps/../..
+confenge_repo_root() {
+  cd "$_CONFENGE_VPS_DIR/../.." && pwd
+}
+
+load_vps_env() {
+  local root envf
+  root="$(confenge_repo_root)"
+  envf="${CONFENGE_VPS_ENV:-$root/deploy/confenge-vps/.env}"
+  if [[ -f "$envf" ]]; then
+    set -a
+    # shellcheck disable=SC1090
+    . "$envf"
+    set +a
+  fi
+  if [[ -f "$root/.env.confenge" ]]; then
+    set -a
+    # shellcheck disable=SC1091
+    . "$root/.env.confenge"
+    set +a
+  fi
+}
+
+compose_cmd() {
+  local root
+  root="$(confenge_repo_root)"
+  local envf="${CONFENGE_VPS_ENV:-$root/deploy/confenge-vps/.env}"
+  local -a args
+  args=(docker compose)
+  args+=(-f "$root/docker-compose.yml")
+  args+=(-f "$root/deploy/confenge-vps/docker-compose.override.yml")
+  if [[ -f "$envf" ]]; then
+    args+=(--env-file "$envf")
+  fi
+  COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}" "${args[@]}" "$@"
+}
+
+api_base() {
+  local base="${CONFENGE_API_BASE:-http://${CONFENGE_API_HOST:-127.0.0.1:8080}}"
+  base="${base%/}"
+  case "$base" in
+    http://*|https://*) ;;
+    *) base="http://$base" ;;
+  esac
+  echo "$base"
+}
+
+pass_fail() {
+  local name="$1" ok="$2"
+  if [[ "$ok" == "1" || "$ok" == "true" || "$ok" == "PASS" ]]; then
+    printf '%-16s PASS\n' "$name"
+  elif [[ "$ok" == "STALE" ]]; then
+    printf '%-16s STALE\n' "$name"
+  elif [[ "$ok" == "ACTIVE" || "$ok" == "PAUSED" || "$ok" == "OFF" ]]; then
+    printf '%-16s %s\n' "$name" "$ok"
+  else
+    printf '%-16s FAIL\n' "$name"
+  fi
+}
+
+# Login helper: prints access token only (no password echo).
+ops_access_token() {
+  local base email pass login session otp token confirm
+  base="$(api_base)"
+  email="${CONFENGE_OPS_EMAIL:-dev@warmbly.com}"
+  pass="${CONFENGE_OPS_PASSWORD:-}"
+  if [[ -z "$pass" ]]; then
+    echo "ops_access_token: set CONFENGE_OPS_PASSWORD" >&2
+    return 2
+  fi
+  login="$(curl -sS -X POST "$base/v1/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"email\":\"$email\",\"password\":\"$pass\"}" || true)"
+  session="$(printf '%s' "$login" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("session",""))' 2>/dev/null || true)"
+  token="$(printf '%s' "$login" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null || true)"
+  if [[ -n "$token" ]]; then
+    printf '%s' "$token"
+    return 0
+  fi
+  if [[ -z "$session" ]]; then
+    echo "ops_access_token: login failed" >&2
+    return 1
+  fi
+  sleep 1
+  otp="$(python3 - <<'PY'
+import json, re, urllib.request
+try:
+    msgs = json.load(urllib.request.urlopen("http://127.0.0.1:18025/api/v1/messages?limit=8", timeout=3))
+except Exception:
+    print("")
+    raise SystemExit
+for m in msgs.get("messages") or []:
+    d = json.load(urllib.request.urlopen("http://127.0.0.1:18025/api/v1/message/" + m["ID"], timeout=3))
+    codes = re.findall(r"\b(\d{6})\b", (d.get("Text") or "") + (d.get("HTML") or ""))
+    if codes:
+        print(codes[0])
+        break
+PY
+)"
+  if [[ -n "$otp" ]]; then
+    confirm="$(curl -sS -X POST "$base/v1/auth/login/confirm" -H 'Content-Type: application/json' \
+      -d "{\"email\":\"$email\",\"code\":\"$otp\",\"session\":\"$session\"}" || true)"
+    token="$(printf '%s' "$confirm" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("access_token",""))' 2>/dev/null || true)"
+  fi
+  if [[ -z "$token" ]]; then
+    echo "ops_access_token: no access token" >&2
+    return 1
+  fi
+  printf '%s' "$token"
+}
+
+tcp_check() {
+  local host="$1" port="$2"
+  timeout 5 bash -c "echo >/dev/tcp/${host}/${port}" 2>/dev/null
+}

--- a/deploy/confenge-vps/pause.sh
+++ b/deploy/confenge-vps/pause.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Emergency kill switch: pause CONFENGE outbound on the VPS.
+# Works without extra-cli / AI. Prefer durable governor API; always engage file switch.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+REASON="${1:-operator_ssh_pause}"
+
+# 1) File kill-switch on shared ops volume (backend + worker see it after remount/checks)
+compose_cmd exec -T backend sh -c \
+  'mkdir -p /data/confenge-ops && printf "paused\nreason=%s\n" "'"$REASON"'" > /data/confenge-ops/kill-switch' \
+  2>/dev/null || true
+
+# Also write host-side mirror for offline inspection
+HOST_KS="${CONFENGE_KILL_SWITCH_HOST_PATH:-$ROOT/data/confenge-kill-switch}"
+mkdir -p "$(dirname "$HOST_KS")"
+printf 'paused\nreason=%s\nat=%s\n' "$REASON" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$HOST_KS"
+chmod 644 "$HOST_KS"
+
+# 2) Governor API pause when auth available (durable in Postgres)
+if [[ -n "${CONFENGE_OPS_PASSWORD:-}" ]]; then
+  if TOKEN="$(ops_access_token 2>/dev/null)"; then
+    API="$(api_base)"
+    ORG="${CONFENGE_FEED_SYNC_ORG_ID:-22222222-0000-0000-0000-000000000001}"
+    curl -sS -X POST "$API/v1/organization/switch/$ORG" -H "Authorization: Bearer $TOKEN" >/dev/null || true
+    CODE="$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$API/v1/confenge/dispatch/pause" \
+      -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+      -d "{\"reason\":\"$REASON\"}" || true)"
+    echo "governor_pause_http=$CODE"
+  else
+    echo "governor_pause=skipped (auth failed; file kill-switch engaged)"
+  fi
+else
+  echo "governor_pause=skipped (set CONFENGE_OPS_PASSWORD for API path; file kill-switch engaged)"
+fi
+
+echo "DISPATCH=PAUSED reason=$REASON"
+echo "Resume with: deploy/confenge-vps/resume.sh"

--- a/deploy/confenge-vps/post-smtp-unlock.sh
+++ b/deploy/confenge-vps/post-smtp-unlock.sh
@@ -12,7 +12,7 @@ cd "$ROOT"
 echo "== 1/3 Hostinger network premise =="
 if ! "$ROOT/deploy/confenge-vps/prove-hostinger-net.sh"; then
   echo "BLOCKED: SMTP still unreachable from this VPS." >&2
-  echo "Unlock outbound TCP 465/587 in Netcup CCP/SCP (mail server freischalten)." >&2
+  echo "In Netcup SCP → Firewall, DELETE the policy "netcup Mail block", then Save." >&2
   echo "Do not install Postfix/Exim/Mailcow." >&2
   exit 3
 fi

--- a/deploy/confenge-vps/post-smtp-unlock.sh
+++ b/deploy/confenge-vps/post-smtp-unlock.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# After Netcup unlocks outbound SMTP 465/587, run this on the VPS.
+# Order: network proof → sealed Hostinger connect → optional self-smoke.
+# Never sends to feed leads. Self-smoke requires explicit CONFENGE_SELF_SMOKE_TO.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+echo "== 1/3 Hostinger network premise =="
+if ! "$ROOT/deploy/confenge-vps/prove-hostinger-net.sh"; then
+  echo "BLOCKED: SMTP still unreachable from this VPS." >&2
+  echo "Unlock outbound TCP 465/587 in Netcup CCP/SCP (mail server freischalten)." >&2
+  echo "Do not install Postfix/Exim/Mailcow." >&2
+  exit 3
+fi
+
+echo "== 2/3 Connect Hostinger (sealed credentials) =="
+echo "Will prompt for mailbox password with read -s (not logged)."
+"$ROOT/deploy/confenge-vps/connect-hostinger.sh"
+
+if [[ -z "${CONFENGE_SELF_SMOKE_TO:-}" ]]; then
+  echo "== 3/3 Self-smoke SKIPPED =="
+  echo "Set CONFENGE_SELF_SMOKE_TO to an operator-owned address and re-run:"
+  echo "  CONFENGE_SELF_SMOKE_TO=you@example.com deploy/confenge-vps/self-smoke.sh"
+  echo "POST_SMTP_UNLOCK=partial (connect done; smoke pending explicit destination)"
+  exit 0
+fi
+
+echo "== 3/3 Self-smoke to ${CONFENGE_SELF_SMOKE_TO} (operator sink only) =="
+"$ROOT/deploy/confenge-vps/self-smoke.sh"
+echo "POST_SMTP_UNLOCK=ok"
+echo "Next: confirm Sent + IMAP + Unibox; optional: sudo reboot && deploy/confenge-vps/status.sh"

--- a/deploy/confenge-vps/prove-hostinger-net.sh
+++ b/deploy/confenge-vps/prove-hostinger-net.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Network premise check: VPS → Hostinger SMTP/IMAP (no auth, no password).
+set -euo pipefail
+SMTP_HOST="${CONFENGE_SMTP_HOST:-smtp.hostinger.com}"
+IMAP_HOST="${CONFENGE_IMAP_HOST:-imap.hostinger.com}"
+
+echo "DNS $SMTP_HOST:"
+getent ahostsv4 "$SMTP_HOST" | head -3 || true
+getent ahostsv6 "$SMTP_HOST" | head -2 || true
+echo "DNS $IMAP_HOST:"
+getent ahostsv4 "$IMAP_HOST" | head -3 || true
+
+check_tcp() {
+  local host="$1" port="$2"
+  if timeout 8 bash -c "echo >/dev/tcp/${host}/${port}" 2>/dev/null; then
+    echo "TCP ${host}:${port} OPEN"
+    return 0
+  fi
+  echo "TCP ${host}:${port} FAIL"
+  return 1
+}
+
+smtp_ok=0
+imap_ok=0
+check_tcp "$SMTP_HOST" 465 && smtp_ok=1 || true
+check_tcp "$SMTP_HOST" 587 && smtp_ok=1 || true
+check_tcp "$IMAP_HOST" 993 && imap_ok=1 || true
+
+echo "TLS probe IMAP 993 (cert subject only):"
+timeout 10 openssl s_client -connect "${IMAP_HOST}:993" -servername "$IMAP_HOST" </dev/null 2>/dev/null \
+  | openssl x509 -noout -subject -dates 2>/dev/null || echo "openssl imap failed"
+
+if [[ "$smtp_ok" -eq 1 ]]; then
+  echo "HOSTINGER_SMTP=PASS"
+else
+  echo "HOSTINGER_SMTP=FAIL"
+  echo "If both 465/587 fail while local machine succeeds: likely VPS provider outbound SMTP block."
+  echo "Request Netcup unlock for outbound TCP 465/587. Do not install a local MTA."
+fi
+if [[ "$imap_ok" -eq 1 ]]; then
+  echo "HOSTINGER_IMAP=PASS"
+else
+  echo "HOSTINGER_IMAP=FAIL"
+fi
+
+# Exit non-zero if either fails so CI/status can gate
+if [[ "$smtp_ok" -eq 1 && "$imap_ok" -eq 1 ]]; then
+  exit 0
+fi
+exit 1

--- a/deploy/confenge-vps/prove-restart.sh
+++ b/deploy/confenge-vps/prove-restart.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# Prove container restart keeps durable state (DB row + kill-switch volume).
+# Safe: no commercial leads, no real Hostinger send required.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}"
+
+echo "== precheck =="
+if ! compose_cmd ps --status running --services 2>/dev/null | grep -q postgres; then
+  echo "postgres not running; start stack first (deploy/confenge-vps/up.sh)" >&2
+  exit 2
+fi
+
+MARKER="vps-restart-proof-$(date -u +%Y%m%dT%H%M%SZ)"
+echo "Writing marker row: $MARKER"
+compose_cmd exec -T postgres psql -U warmbly -d warmbly_dev -v ON_ERROR_STOP=1 -c \
+  "CREATE TABLE IF NOT EXISTS confenge_vps_restart_probe (id text primary key, created_at timestamptz default now());
+   INSERT INTO confenge_vps_restart_probe(id) VALUES ('$MARKER') ON CONFLICT DO NOTHING;"
+
+compose_cmd exec -T backend sh -c 'mkdir -p /data/confenge-ops && echo proof > /data/confenge-ops/restart-marker' 2>/dev/null || true
+
+echo "== restart containers =="
+compose_cmd restart postgres redis nats backend consumer worker web || compose_cmd up -d
+
+echo "Waiting for postgres + backend..."
+for i in $(seq 1 40); do
+  if compose_cmd exec -T postgres pg_isready -U warmbly >/dev/null 2>&1 \
+    && curl -sS -o /dev/null -w '%{http_code}' --max-time 2 http://127.0.0.1:8080/health 2>/dev/null | grep -q 200; then
+    break
+  fi
+  sleep 2
+done
+
+FOUND="$(compose_cmd exec -T postgres psql -U warmbly -d warmbly_dev -tAc \
+  "SELECT id FROM confenge_vps_restart_probe WHERE id='$MARKER';" | tr -d '[:space:]')"
+
+if [[ "$FOUND" == "$MARKER" ]]; then
+  echo "PERSISTENCE=PASS marker=$MARKER"
+else
+  echo "PERSISTENCE=FAIL marker missing after restart" >&2
+  exit 1
+fi
+
+if compose_cmd exec -T backend test -f /data/confenge-ops/restart-marker 2>/dev/null; then
+  echo "OPS_VOLUME=PASS"
+else
+  echo "OPS_VOLUME=FAIL (backend confenge_ops volume not durable)" >&2
+  # non-fatal if volume not mounted yet on older stack
+fi
+
+echo "RESTART_PROOF=ok"
+echo "Full VPS reboot proof: sudo reboot; after boot run deploy/confenge-vps/status.sh (no laptop make)."

--- a/deploy/confenge-vps/restore.sh
+++ b/deploy/confenge-vps/restore.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Restore Warmbly CONFENGE DB from backup.sh SQL dump.
+# Requires keys already present in deploy/confenge-vps/.env (from secrets bundle).
+# DESTRUCTIVE to current warmbly_dev contents.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+FILE="${1:-${FILE:-}}"
+if [[ -z "$FILE" ]]; then
+  echo "Usage: deploy/confenge-vps/restore.sh /path/to/warmbly_dev.sql" >&2
+  echo "   or: FILE=... deploy/confenge-vps/restore.sh" >&2
+  exit 2
+fi
+if [[ ! -f "$FILE" ]]; then
+  echo "missing SQL file: $FILE" >&2
+  exit 2
+fi
+
+# If archive given, extract SQL
+if [[ "$FILE" == *.tar.gz ]]; then
+  TMP="$(mktemp -d)"
+  tar -xzf "$FILE" -C "$TMP"
+  if [[ -f "$TMP/warmbly_dev.sql" ]]; then
+    FILE="$TMP/warmbly_dev.sql"
+  else
+    echo "archive missing warmbly_dev.sql" >&2
+    exit 1
+  fi
+fi
+
+echo "Restoring $FILE into warmbly_dev (destructive)..."
+compose_cmd exec -T postgres pg_isready -U warmbly >/dev/null
+# Drop connections and recreate schema content via psql
+cat "$FILE" | compose_cmd exec -T postgres psql -U warmbly -d warmbly_dev -v ON_ERROR_STOP=1
+echo "Restore complete. Restart backend/worker if needed: deploy/confenge-vps/up.sh"
+echo "Verify encryption keys match the dump era or sealed credentials will not decrypt."

--- a/deploy/confenge-vps/resume.sh
+++ b/deploy/confenge-vps/resume.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Resume CONFENGE outbound after pause.sh.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+compose_cmd exec -T backend sh -c 'rm -f /data/confenge-ops/kill-switch' 2>/dev/null || true
+
+HOST_KS="${CONFENGE_KILL_SWITCH_HOST_PATH:-$ROOT/data/confenge-kill-switch}"
+rm -f "$HOST_KS"
+
+if [[ -n "${CONFENGE_OPS_PASSWORD:-}" ]]; then
+  if TOKEN="$(ops_access_token 2>/dev/null)"; then
+    API="$(api_base)"
+    ORG="${CONFENGE_FEED_SYNC_ORG_ID:-22222222-0000-0000-0000-000000000001}"
+    curl -sS -X POST "$API/v1/organization/switch/$ORG" -H "Authorization: Bearer $TOKEN" >/dev/null || true
+    CODE="$(curl -sS -o /dev/null -w '%{http_code}' -X POST "$API/v1/confenge/dispatch/resume" \
+      -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' -d '{}' || true)"
+    echo "governor_resume_http=$CODE"
+  else
+    echo "governor_resume=skipped (auth failed; file kill-switch cleared)"
+  fi
+else
+  echo "governor_resume=skipped (file kill-switch cleared)"
+fi
+
+if [[ "${CONFENGE_SENDING_PAUSED:-false}" == "true" ]]; then
+  echo "NOTE: CONFENGE_SENDING_PAUSED=true in env still blocks sending until .env is updated and backend recreated."
+fi
+
+echo "DISPATCH=ACTIVE (if env pause flag is false)"

--- a/deploy/confenge-vps/self-smoke.sh
+++ b/deploy/confenge-vps/self-smoke.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Controlled Hostinger self-smoke. Requires EXPLICIT destination (never a feed lead).
+# Usage:
+#   CONFENGE_SELF_SMOKE_TO=you@example.com deploy/confenge-vps/self-smoke.sh
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+TO="${CONFENGE_SELF_SMOKE_TO:-}"
+if [[ -z "$TO" ]]; then
+  echo "BLOCKED: set CONFENGE_SELF_SMOKE_TO to an operator-owned address." >&2
+  echo "Never defaults to a feed lead. Example: CONFENGE_SELF_SMOKE_TO=tiago.sasaki@confenge.com.br" >&2
+  exit 2
+fi
+
+# Reuse repo script semantics with VPS API host
+export CONFENGE_API_HOST="${CONFENGE_API_HOST:-127.0.0.1:8080}"
+export CONFENGE_SELF_SMOKE_TO="$TO"
+if [[ -x "$ROOT/scripts/confenge_self_smoke.sh" ]]; then
+  exec "$ROOT/scripts/confenge_self_smoke.sh"
+fi
+echo "missing scripts/confenge_self_smoke.sh" >&2
+exit 1

--- a/deploy/confenge-vps/status.sh
+++ b/deploy/confenge-vps/status.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Compact execution-plane health for CONFENGE on VPS. Never prints secrets.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+API="$(api_base)"
+SMTP_HOST="${CONFENGE_SMTP_HOST:-smtp.hostinger.com}"
+SMTP_PORT="${CONFENGE_SMTP_PORT:-587}"
+IMAP_HOST="${CONFENGE_IMAP_HOST:-imap.hostinger.com}"
+IMAP_PORT="${CONFENGE_IMAP_PORT:-993}"
+
+svc_running() {
+  local name="$1"
+  compose_cmd ps --status running --services 2>/dev/null | grep -qx "$name"
+}
+
+http_ok() {
+  local url="$1"
+  curl -sS -o /dev/null -w '%{http_code}' --max-time 5 "$url" 2>/dev/null | grep -qE '^(200|204)$'
+}
+
+# BACKEND
+if svc_running backend && http_ok "${API}/health"; then
+  pass_fail BACKEND PASS
+else
+  pass_fail BACKEND FAIL
+fi
+
+# WORKER / CONSUMER
+if svc_running worker; then pass_fail WORKER PASS; else pass_fail WORKER FAIL; fi
+if svc_running consumer; then pass_fail CONSUMER PASS; else pass_fail CONSUMER FAIL; fi
+
+# Infra
+if svc_running postgres && compose_cmd exec -T postgres pg_isready -U warmbly >/dev/null 2>&1; then
+  pass_fail POSTGRES PASS
+else
+  pass_fail POSTGRES FAIL
+fi
+if svc_running redis && compose_cmd exec -T redis redis-cli ping 2>/dev/null | grep -qi pong; then
+  pass_fail REDIS PASS
+else
+  pass_fail REDIS FAIL
+fi
+if svc_running nats; then pass_fail NATS PASS; else pass_fail NATS FAIL; fi
+
+# Hostinger reachability (no auth)
+if tcp_check "$SMTP_HOST" "$SMTP_PORT"; then
+  pass_fail "HOSTINGER SMTP" PASS
+else
+  pass_fail "HOSTINGER SMTP" FAIL
+fi
+if tcp_check "$IMAP_HOST" "$IMAP_PORT"; then
+  pass_fail "HOSTINGER IMAP" PASS
+else
+  pass_fail "HOSTINGER IMAP" FAIL
+fi
+
+# Feed (extra-cli plane)
+FEED_URL="${CONFENGE_EXTRA_CLI_FEED_URL:-}"
+FEED_STATE=FAIL
+if [[ -n "$FEED_URL" ]]; then
+  # Prefer host-side probe of confenge-plane
+  if curl -sk --max-time 5 -o /dev/null -w '%{http_code}' "https://127.0.0.1:8443/manifest.json" 2>/dev/null | grep -qE '200'; then
+    FEED_STATE=PASS
+    # Stale if supply-report age > 24h when available
+    if curl -sk --max-time 5 -o /tmp/confenge-supply-check.json "https://127.0.0.1:8443/supply-report.json" 2>/dev/null; then
+      AGE="$(python3 - <<'PY'
+import json, time
+try:
+    r=json.load(open("/tmp/confenge-supply-check.json"))
+except Exception:
+    print(-1); raise SystemExit
+# try common timestamp fields
+for k in ("generated_at","updated_at","ts","timestamp"):
+    v=r.get(k)
+    if not v: continue
+    try:
+        # epoch or ISO
+        if isinstance(v,(int,float)):
+            print(int(time.time()-float(v))); raise SystemExit
+        import datetime
+        s=str(v).replace("Z","+00:00")
+        t=datetime.datetime.fromisoformat(s).timestamp()
+        print(int(time.time()-t)); raise SystemExit
+    except Exception:
+        pass
+print(-1)
+PY
+)"
+      if [[ "$AGE" =~ ^[0-9]+$ ]] && (( AGE > 86400 )); then
+        FEED_STATE=STALE
+      fi
+    fi
+  fi
+fi
+pass_fail "EXTRA FEED" "$FEED_STATE"
+
+# Outcome loop: receptor on host loopback 8790 via nginx 8443
+if curl -sk --max-time 5 -o /dev/null -w '%{http_code}' -X POST "https://127.0.0.1:8443/webhooks/warmbly/outcome" \
+  -H 'Content-Type: application/json' -d '{}' 2>/dev/null | grep -qE '^(200|400|401|403|404|405|422)$'; then
+  pass_fail "OUTCOME LOOP" PASS
+else
+  pass_fail "OUTCOME LOOP" FAIL
+fi
+
+# Dispatch / kill switch
+DISPATCH=ACTIVE
+if [[ -f "${CONFENGE_KILL_SWITCH_HOST_PATH:-}" ]]; then
+  DISPATCH=PAUSED
+fi
+# Docker volume kill-switch probe
+if compose_cmd exec -T backend test -f /data/confenge-ops/kill-switch 2>/dev/null; then
+  DISPATCH=PAUSED
+fi
+if [[ "${CONFENGE_SENDING_PAUSED:-false}" == "true" ]]; then
+  DISPATCH=PAUSED
+fi
+pass_fail DISPATCH "$DISPATCH"
+
+# Safety flags (profile must keep these OFF)
+GREEN="${CONFENGE_GREEN_AUTORUN_ENABLED:-false}"
+if [[ "$GREEN" == "true" ]]; then
+  pass_fail "GREEN AUTORUN" FAIL
+else
+  pass_fail "GREEN AUTORUN" OFF
+fi
+WA="${CONFENGE_WHATSAPP_ENABLED:-false}"
+if [[ "$WA" == "true" ]]; then
+  pass_fail WHATSAPP FAIL
+else
+  pass_fail WHATSAPP OFF
+fi
+
+echo "HOSTINGER_PLAN_CLASS=${HOSTINGER_PLAN_CLASS:-unset}"
+echo "RATE_MAX_PER_HOUR=${CONFENGE_RATE_MAX_PER_HOUR:-20} (operational; not Hostinger technical ceiling)"

--- a/deploy/confenge-vps/test_vps_pack.py
+++ b/deploy/confenge-vps/test_vps_pack.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Structural tests for the CONFENGE VPS deployment pack.
+
+Drives real files under deploy/confenge-vps/ (shipped artifacts), not reimplemented policy.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+
+PACK = Path(__file__).resolve().parent
+ROOT = PACK.parent.parent
+
+
+class TestConfengeVpsPack(unittest.TestCase):
+    def test_required_scripts_exist_and_executable_intent(self) -> None:
+        required = [
+            "validate.sh",
+            "up.sh",
+            "down.sh",
+            "status.sh",
+            "pause.sh",
+            "resume.sh",
+            "backup.sh",
+            "restore.sh",
+            "connect-hostinger.sh",
+            "prove-hostinger-net.sh",
+            "prove-restart.sh",
+            "self-smoke.sh",
+            "gen-secrets.sh",
+            "install.sh",
+            "lib.sh",
+            "env.example",
+            "docker-compose.override.yml",
+        ]
+        for name in required:
+            path = PACK / name
+            self.assertTrue(path.is_file(), f"missing {name}")
+
+    def test_env_example_safety_flags(self) -> None:
+        text = (PACK / "env.example").read_text(encoding="utf-8")
+        self.assertIn("CONFENGE_GREEN_AUTORUN_ENABLED=false", text)
+        self.assertIn("CONFENGE_AUTO_SEND_ENABLED=false", text)
+        self.assertIn("CONFENGE_REQUIRE_HUMAN_APPROVAL=true", text)
+        self.assertIn("CONFENGE_WHATSAPP_ENABLED=false", text)
+        self.assertIn("CONFENGE_RATE_MAX_PER_HOUR=20", text)
+        self.assertIn("HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER", text)
+        self.assertIn("CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=200", text)
+        # Must not raise operational max above 20 in this pack
+        for m in re.finditer(r"CONFENGE_RATE_MAX_PER_HOUR=(\d+)", text):
+            self.assertLessEqual(int(m.group(1)), 20)
+
+    def test_provider_vs_operational_documented(self) -> None:
+        plane = (ROOT / "docs/confenge/vps-execution-plane.md").read_text(encoding="utf-8")
+        self.assertIn("provider ceiling ≠ operational target", plane)
+        self.assertIn("HOSTINGER_PLAN_CLASS", plane)
+        self.assertIn("Business Email Starter", plane)
+        self.assertIn("1000", plane)
+        self.assertIn("10/h", plane)
+        self.assertIn("20/h", plane)
+        self.assertNotIn("HOSTINGER_PLAN_CLASS=CPANEL", plane)
+        # Must not document cPanel hourly ceiling as this mailbox's plan
+        env = (PACK / "env.example").read_text(encoding="utf-8")
+        self.assertNotIn("HOSTINGER_PLAN_CLASS=CPANEL", env)
+        self.assertIn("BUSINESS_EMAIL_STARTER", env)
+
+    def test_connect_script_uses_read_s_not_argv_password(self) -> None:
+        src = (PACK / "connect-hostinger.sh").read_text(encoding="utf-8")
+        self.assertIn("read -r -s PASS", src)
+        # password must not be passed as curl --data with shell expansion of raw argv pattern
+        self.assertNotRegex(src, r"curl.*--password")
+        self.assertIn("unset CONFENGE_MAILBOX_PASSWORD", src)
+
+    def test_no_mta_install(self) -> None:
+        for path in PACK.rglob("*"):
+            if path.suffix in {".sh", ".yml", ".md", ".example"} and path.is_file():
+                text = path.read_text(encoding="utf-8", errors="replace")
+                self.assertNotRegex(
+                    text,
+                    r"apt(-get)?\s+install\s+.*(postfix|exim4|mailcow|mailu)",
+                    msg=f"MTA install in {path.name}",
+                )
+
+    def test_validate_sh_passes(self) -> None:
+        """Run the shipped validate entrypoint (real path)."""
+        script = PACK / "validate.sh"
+        proc = subprocess.run(
+            ["bash", str(script)],
+            cwd=str(ROOT),
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if proc.returncode != 0:
+            self.fail(f"validate.sh exit {proc.returncode}\n{proc.stdout}\n{proc.stderr}")
+        self.assertIn("VALIDATE=PASS", proc.stdout)
+
+    def test_docs_inventory_exists(self) -> None:
+        inv = ROOT / "docs/confenge/vps-execution-inventory.md"
+        self.assertTrue(inv.is_file())
+        text = inv.read_text(encoding="utf-8")
+        self.assertIn("159.195.18.88", text)
+        self.assertIn("warmbly-confenge", text)
+        self.assertIn("BUSINESS_EMAIL_STARTER", text)
+        self.assertIn("1000", text)
+        # network premise recorded (SMTP egress may FAIL on Netcup until unlock)
+        self.assertTrue("smtp" in text.lower() and "imap" in text.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/confenge-vps/test_vps_pack.py
+++ b/deploy/confenge-vps/test_vps_pack.py
@@ -30,6 +30,7 @@ class TestConfengeVpsPack(unittest.TestCase):
             "prove-hostinger-net.sh",
             "prove-restart.sh",
             "self-smoke.sh",
+            "post-smtp-unlock.sh",
             "gen-secrets.sh",
             "install.sh",
             "lib.sh",

--- a/deploy/confenge-vps/test_vps_pack.py
+++ b/deploy/confenge-vps/test_vps_pack.py
@@ -74,6 +74,9 @@ class TestConfengeVpsPack(unittest.TestCase):
         # password must not be passed as curl --data with shell expansion of raw argv pattern
         self.assertNotRegex(src, r"curl.*--password")
         self.assertIn("unset CONFENGE_MAILBOX_PASSWORD", src)
+        # JSON body from temp file via --data-binary (never -d "$BODY"; password must not be in argv/ps)
+        self.assertIn("--data-binary @", src)
+        self.assertNotRegex(src, r'curl[^\n]*-d\s+"\$BODY"')
 
     def test_no_mta_install(self) -> None:
         for path in PACK.rglob("*"):

--- a/deploy/confenge-vps/up.sh
+++ b/deploy/confenge-vps/up.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Start or update the isolated warmbly-confenge stack (always-on).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+load_vps_env
+cd "$ROOT"
+
+ENVF="${CONFENGE_VPS_ENV:-$ROOT/deploy/confenge-vps/.env}"
+if [[ ! -f "$ENVF" ]]; then
+  echo "Missing $ENVF — run deploy/confenge-vps/gen-secrets.sh first" >&2
+  exit 2
+fi
+chmod 600 "$ENVF" || true
+
+export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}"
+
+# Fail closed on unsafe profile flips
+# shellcheck disable=SC1090
+set -a; . "$ENVF"; set +a
+if [[ "${CONFENGE_GREEN_AUTORUN_ENABLED:-false}" == "true" ]]; then
+  echo "REFUSE: CONFENGE_GREEN_AUTORUN_ENABLED=true is not allowed on VPS execution plane bootstrap" >&2
+  exit 3
+fi
+if [[ "${CONFENGE_AUTO_SEND_ENABLED:-false}" == "true" ]]; then
+  echo "REFUSE: CONFENGE_AUTO_SEND_ENABLED=true is not allowed (human approval path only)" >&2
+  exit 3
+fi
+if [[ "${CONFENGE_WHATSAPP_ENABLED:-false}" == "true" ]]; then
+  echo "REFUSE: WhatsApp must stay OFF in this PR profile" >&2
+  exit 3
+fi
+
+echo "Bringing up project=$COMPOSE_PROJECT_NAME ..."
+compose_cmd up -d --remove-orphans
+
+echo "Waiting for backend health..."
+for i in $(seq 1 60); do
+  if curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:8080/health" 2>/dev/null | grep -q 200; then
+    echo "backend healthy"
+    break
+  fi
+  sleep 2
+  if [[ "$i" -eq 60 ]]; then
+    echo "backend not healthy after wait" >&2
+    compose_cmd ps
+    exit 1
+  fi
+done
+
+# Optional seed on first boot
+if [[ "${CONFENGE_VPS_SEED:-false}" == "true" ]]; then
+  compose_cmd --profile seed run --rm seed || true
+fi
+
+echo "Stack up. Operator UI via SSH tunnel (see docs/confenge/vps-execution-plane.md):"
+echo "  ssh -L 5173:127.0.0.1:5173 -L 8080:127.0.0.1:8080 -p 2222 root@<vps>"
+echo "  open http://127.0.0.1:5173"
+echo "Connect Hostinger: deploy/confenge-vps/connect-hostinger.sh"
+echo "Status: deploy/confenge-vps/status.sh"

--- a/deploy/confenge-vps/up.sh
+++ b/deploy/confenge-vps/up.sh
@@ -35,6 +35,11 @@ fi
 echo "Bringing up project=$COMPOSE_PROJECT_NAME ..."
 compose_cmd up -d --remove-orphans
 
+
+# Ensure kill-switch volume writable by backend user (uid 1000).
+docker run --rm -v "${COMPOSE_PROJECT_NAME:-warmbly-confenge}_confenge_ops:/data" alpine \
+  sh -c "chmod 777 /data" >/dev/null 2>&1 || true
+
 echo "Waiting for backend health..."
 for i in $(seq 1 60); do
   if curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:8080/health" 2>/dev/null | grep -q 200; then

--- a/deploy/confenge-vps/validate.sh
+++ b/deploy/confenge-vps/validate.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# Offline validation of the VPS deployment pack (no secrets, no lead mail).
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT"
+PACK=deploy/confenge-vps
+fail=0
+
+echo "== required files =="
+for f in \
+  docker-compose.override.yml env.example lib.sh \
+  gen-secrets.sh connect-hostinger.sh status.sh pause.sh resume.sh \
+  backup.sh restore.sh up.sh down.sh install.sh \
+  prove-hostinger-net.sh prove-restart.sh self-smoke.sh validate.sh
+do
+  if [[ -f "$PACK/$f" ]]; then
+    echo "OK $f"
+  else
+    echo "MISSING $f"
+    fail=1
+  fi
+done
+
+echo "== bash -n =="
+for s in "$PACK"/*.sh; do
+  if bash -n "$s"; then
+    echo "syntax OK $(basename "$s")"
+  else
+    echo "syntax FAIL $(basename "$s")"
+    fail=1
+  fi
+done
+
+if command -v shellcheck >/dev/null 2>&1; then
+  echo "== shellcheck =="
+  shellcheck -x "$PACK"/*.sh || fail=1
+else
+  echo "== shellcheck SKIP (not installed; bash -n used) =="
+fi
+
+echo "== safety flags in env.example =="
+for pair in \
+  "CONFENGE_GREEN_AUTORUN_ENABLED=false" \
+  "CONFENGE_AUTO_SEND_ENABLED=false" \
+  "CONFENGE_REQUIRE_HUMAN_APPROVAL=true" \
+  "CONFENGE_OUTREACH_ENABLED=true" \
+  "CONFENGE_WHATSAPP_ENABLED=false" \
+  "CONFENGE_RATE_MAX_PER_HOUR=20" \
+  "HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER" \
+  "CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=200"
+do
+  if grep -qF "$pair" "$PACK/env.example"; then
+    echo "OK $pair"
+  else
+    echo "MISSING $pair"
+    fail=1
+  fi
+done
+
+# Must not set RATE_MAX above 20
+if grep -E 'CONFENGE_RATE_MAX_PER_HOUR=[3-9][0-9]' "$PACK/env.example" "$PACK/docker-compose.override.yml" 2>/dev/null; then
+  echo "FAIL RATE_MAX above 20 in pack"
+  fail=1
+else
+  echo "OK RATE_MAX not raised above 20"
+fi
+
+# No permanent mailbox password assignment (allow empty template / read -s / unset only)
+echo "== secret scan (pack tracked files) =="
+# Match only non-empty assignments outside comments and the scanner itself.
+hits="$(
+  grep -RInE '^\s*CONFENGE_MAILBOX_PASSWORD=[^#[:space:]]+' "$PACK" \
+    --include='*.example' --include='*.yml' --include='*.sh' --include='*.md' --include='env.example' 2>/dev/null \
+    | grep -v 'validate\.sh' \
+    | grep -v 'CONFENGE_MAILBOX_PASSWORD=\${' \
+    || true
+)"
+if [[ -n "$hits" ]]; then
+  echo "$hits"
+  echo "FAIL possible committed mailbox password assignment"
+  fail=1
+else
+  echo "OK no permanent mailbox password assignment in pack"
+fi
+
+echo "== docker compose config =="
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  TMPENV="$(mktemp)"
+  cp "$PACK/env.example" "$TMPENV"
+  # fill dummy secrets so compose expands
+  {
+    echo "KMS_LOCAL_MASTER_KEY=dGVzdC1rbXMta2V5LTMyYnl0ZXMhMTIzNDU2Nzg="
+    echo "CREDENTIALS_ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    echo "AUTH_SECRET=local-dev-auth-secret-minimum-32-characters-long"
+    echo "INTERNAL_API_TOKEN=local-dev-internal-token"
+    echo "CONFENGE_OUTCOME_WEBHOOK_SECRET=test-outcome-secret-not-real"
+  } >>"$TMPENV"
+  if COMPOSE_PROJECT_NAME=warmbly-confenge docker compose \
+    -f docker-compose.yml \
+    -f "$PACK/docker-compose.override.yml" \
+    --env-file "$TMPENV" \
+    config >/tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml 2>/tmp/grok-goal-de15e1cb5156/implementer/compose-config.log; then
+    echo "OK docker compose config"
+    # Assert loopback binds for sensitive ports
+    if grep -E 'published: (15432|16379|4222|8080|5173)' /tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml | head -20; then
+      :
+    fi
+    if grep -q '0.0.0.0:15432' /tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml 2>/dev/null; then
+      echo "FAIL postgres published on all interfaces"
+      fail=1
+    else
+      echo "OK postgres not on 0.0.0.0"
+    fi
+    if grep -q 'CONFENGE_GREEN_AUTORUN_ENABLED: "false"\|CONFENGE_GREEN_AUTORUN_ENABLED: false' /tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml \
+      || grep -q 'CONFENGE_GREEN_AUTORUN_ENABLED: \${CONFENGE_GREEN_AUTORUN_ENABLED:-false}' /tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml; then
+      echo "OK green autorun default false in compose model"
+    fi
+  else
+    echo "FAIL docker compose config (see compose-config.log)"
+    cat /tmp/grok-goal-de15e1cb5156/implementer/compose-config.log | tail -40
+    fail=1
+  fi
+  rm -f "$TMPENV"
+else
+  echo "SKIP docker compose (docker not available)"
+fi
+
+echo "== no MTA install steps =="
+if grep -RInE 'apt(-get)? install.*(postfix|exim|mailcow|mailu|sendmail)' "$PACK" docs/confenge/vps-*.md 2>/dev/null; then
+  echo "FAIL MTA install referenced"
+  fail=1
+else
+  echo "OK no MTA install"
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "VALIDATE=FAIL"
+  exit 1
+fi
+echo "VALIDATE=PASS"

--- a/deploy/confenge-vps/validate.sh
+++ b/deploy/confenge-vps/validate.sh
@@ -95,32 +95,34 @@ if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; 
     echo "INTERNAL_API_TOKEN=local-dev-internal-token"
     echo "CONFENGE_OUTCOME_WEBHOOK_SECRET=test-outcome-secret-not-real"
   } >>"$TMPENV"
+  COMPOSE_OUT="$(mktemp)"
+  COMPOSE_LOG="$(mktemp)"
   if COMPOSE_PROJECT_NAME=warmbly-confenge docker compose \
     -f docker-compose.yml \
     -f "$PACK/docker-compose.override.yml" \
     --env-file "$TMPENV" \
-    config >/tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml 2>/tmp/grok-goal-de15e1cb5156/implementer/compose-config.log; then
+    config >"$COMPOSE_OUT" 2>"$COMPOSE_LOG"; then
     echo "OK docker compose config"
     # Assert loopback binds for sensitive ports
-    if grep -E 'published: (15432|16379|4222|8080|5173)' /tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml | head -20; then
+    if grep -E 'published: (15432|16379|4222|8080|5173)' "$COMPOSE_OUT" | head -20; then
       :
     fi
-    if grep -q '0.0.0.0:15432' /tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml 2>/dev/null; then
+    if grep -q '0.0.0.0:15432' "$COMPOSE_OUT" 2>/dev/null; then
       echo "FAIL postgres published on all interfaces"
       fail=1
     else
       echo "OK postgres not on 0.0.0.0"
     fi
-    if grep -q 'CONFENGE_GREEN_AUTORUN_ENABLED: "false"\|CONFENGE_GREEN_AUTORUN_ENABLED: false' /tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml \
-      || grep -q 'CONFENGE_GREEN_AUTORUN_ENABLED: \${CONFENGE_GREEN_AUTORUN_ENABLED:-false}' /tmp/grok-goal-de15e1cb5156/implementer/compose-config.yml; then
+    if grep -q 'CONFENGE_GREEN_AUTORUN_ENABLED: "false"\|CONFENGE_GREEN_AUTORUN_ENABLED: false' "$COMPOSE_OUT" \
+      || grep -q 'CONFENGE_GREEN_AUTORUN_ENABLED: \${CONFENGE_GREEN_AUTORUN_ENABLED:-false}' "$COMPOSE_OUT"; then
       echo "OK green autorun default false in compose model"
     fi
   else
     echo "FAIL docker compose config (see compose-config.log)"
-    cat /tmp/grok-goal-de15e1cb5156/implementer/compose-config.log | tail -40
+    tail -40 "$COMPOSE_LOG"
     fail=1
   fi
-  rm -f "$TMPENV"
+  rm -f "$TMPENV" "$COMPOSE_OUT" "$COMPOSE_LOG"
 else
   echo "SKIP docker compose (docker not available)"
 fi

--- a/deploy/confenge-vps/validate.sh
+++ b/deploy/confenge-vps/validate.sh
@@ -11,7 +11,7 @@ for f in \
   docker-compose.override.yml env.example lib.sh \
   gen-secrets.sh connect-hostinger.sh status.sh pause.sh resume.sh \
   backup.sh restore.sh up.sh down.sh install.sh \
-  prove-hostinger-net.sh prove-restart.sh self-smoke.sh validate.sh
+  prove-hostinger-net.sh prove-restart.sh self-smoke.sh post-smtp-unlock.sh validate.sh
 do
   if [[ -f "$PACK/$f" ]]; then
     echo "OK $f"

--- a/docs/confenge/architecture-split.md
+++ b/docs/confenge/architecture-split.md
@@ -1,24 +1,33 @@
 # CONFENGE architecture split (canonical)
 
 Warmbly is the **execution plane**. extra-cli is the **intelligence plane**.
-They do not share a host in the go-live topology.
+They may share a physical VPS but **never** share application databases.
 
 ```text
 ┌──────────────────────────── VPS (Netcup) ────────────────────────────┐
 │  extra-cli + datalake                                                 │
 │  enrichment / activation / EMAIL_SEND_READY supply                    │
-│  confenge.outreach.v1 feed drop                                       │
+│  confenge.outreach.v1 feed                                            │
 │  HTTPS :8443  → static feed + /webhooks/warmbly/outcome (HMAC)        │
-│  NO Warmbly runtime · NO mailbox passwords · NO Graph/M365            │
-└───────────────────────────────────┬──────────────────────────────────┘
-                                    │ pull feed / push outcomes
-┌───────────────────────────────────▼──────────────────────────────────┐
-│  Operator WSL / Windows (while machine is on)                         │
-│  Warmbly (make confenge-local / backend+worker+web)                   │
-│  Hostinger SMTP:587 + IMAP:993 for tiago.sasaki@confenge.com.br       │
-│  Governor, GREEN policy path, Unibox, CRM                             │
+│  NO Warmbly tables · NO mailbox passwords in extra-cli                │
+│                                                                        │
+│  Warmbly project warmbly-confenge (Docker, isolated volumes)          │
+│  generation / human approval state / content_hash / cadence           │
+│  governor · Hostinger SMTP/IMAP client · reply/bounce/DNC · CRM       │
+│  confenge.outcome.v1 → loopback/HTTPS → outcome receptor              │
+└──────────────────────────────────────────────────────────────────────┘
+          │
+          │ browser (SSH tunnel to loopback UI) when human is online
+          ▼
+┌──────────────── Operator laptop ─────────────────────────────────────┐
+│  Review exact message · Approve / Edit / Reject / DNC · pause/resume │
+│  No requirement for local Docker / WSL / worker for scheduled sends  │
 └──────────────────────────────────────────────────────────────────────┘
 ```
+
+Historical note: go-live docs briefly kept Warmbly on the laptop only. The
+always-on execution plane moves Warmbly to the VPS; the laptop remains the
+human review surface. See [vps-execution-plane.md](./vps-execution-plane.md).
 
 ## Email channel (factual)
 
@@ -26,44 +35,34 @@ They do not share a host in the go-live topology.
 | --- | --- |
 | Address | `tiago.sasaki@confenge.com.br` |
 | Host | **Hostinger** (not Exchange Online / M365) |
-| SMTP | `smtp.hostinger.com:587` STARTTLS |
+| SMTP | `smtp.hostinger.com:587` STARTTLS (465 also supported by Warmbly) |
 | IMAP | `imap.hostinger.com:993` SSL |
-| Graph / Azure app | **Not required** for CONFENGE go-live |
-| Mailpit | Local tests only |
+| Graph / Azure app | **Not required** |
+| Mailpit | Tests / system OTP only |
+| Plan class | Hostinger **Business Email Starter** (`HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER`) |
+| Provider ceiling | **1000** msgs / rolling 24h / mailbox (hPanel SoT; not cPanel) |
+| Operational pace | adaptive **10→20/h**, daily shell **200** (reputation; not provider max) |
 
 ## Operator loop (minimal)
 
-1. VPS: extra-cli expands EMAIL_SEND_READY and refreshes feed.
-2. Laptop session start:
-   - `scripts/confenge_pull_feed_from_vps.sh`
-   - `make confenge-local` (use `CONFENGE_API_HOST=127.0.0.1:18080` if :8080 is taken)
-   - `scripts/confenge_hostinger_connect.sh` (needs `CONFENGE_MAILBOX_PASSWORD`)
-   - `scripts/confenge_self_smoke.sh` before any lead send
-3. Outcomes → VPS via `CONFENGE_OUTCOME_WEBHOOK_URL`.
-
-## Local env keys
-
-| Variable | Notes |
-| --- | --- |
-| `CONFENGE_EXTRA_CLI_FEED_URL` | `file://…/email_send_ready_feed.json` after pull |
-| `CONFENGE_OUTCOME_WEBHOOK_URL` | `https://159.195.18.88:8443/webhooks/warmbly/outcome` |
-| `CONFENGE_OUTCOME_WEBHOOK_SECRET` | VPS `/opt/confenge-plane/outcome.secret` |
-| `CONFENGE_MAILBOX_EMAIL` | `tiago.sasaki@confenge.com.br` |
-| `CONFENGE_SMTP_HOST/PORT` | `smtp.hostinger.com` / `587` |
-| `CONFENGE_IMAP_HOST/PORT` | `imap.hostinger.com` / `993` |
-| `CONFENGE_MAILBOX_PASSWORD` | local only; never VPS; never git |
+1. VPS: extra-cli refreshes feed; Warmbly feed sync imports on a timer.
+2. Human (any browser via SSH tunnel): open `/app/confenge`, approve exact content.
+3. VPS worker: when due, governor + Hostinger SMTP; IMAP for replies 24/7.
+4. Outcomes → confenge-plane HMAC webhook on the same VPS.
 
 ## Public exposure
 
 | Exposure | Required? |
 | --- | --- |
-| VPS :8443 feed + outcome webhook | Yes (or SSH tunnel) |
-| VPS Warmbly UI | No |
-| Mailbox password on VPS | **Forbidden** |
+| VPS :8443 feed + outcome | Yes (intelligence plane; already live) |
+| VPS Warmbly UI public | **No** (loopback + SSH tunnel preferred) |
+| Postgres/Redis/NATS public | **Forbidden** |
+| Mailbox password in git/env long-term | **Forbidden** (sealed in Warmbly DB) |
 
-## Kill switch (laptop)
+## Kill switch
 
 ```bash
-make confenge-stop-sending
-make confenge-resume-sending
+deploy/confenge-vps/pause.sh
+deploy/confenge-vps/resume.sh
+# or UI dispatch pause when authenticated
 ```

--- a/docs/confenge/netcup-ops.md
+++ b/docs/confenge/netcup-ops.md
@@ -1,74 +1,69 @@
-# Netcup ops notes (CONFENGE intelligence plane only)
+# Netcup ops notes (CONFENGE)
 
-Canonical topology: the VPS runs **extra-cli + feed + outcome receptor**.
-Warmbly execution (Hostinger SMTP/IMAP on the operator laptop) runs on
-**WSL/Windows**, not on the VPS. No Graph/M365 secrets on either side for CONFENGE.
+Canonical topology: the VPS runs **extra-cli (intelligence)** and **Warmbly
+`warmbly-confenge` (execution)**. They share the host, not the database.
 
-See [architecture-split.md](./architecture-split.md).
+See [architecture-split.md](./architecture-split.md) and
+[vps-execution-plane.md](./vps-execution-plane.md).
 
-## What belongs on the VPS
+## On the VPS
 
-- extra-cli / datalake
-- continuous enrichment and EMAIL_SEND_READY supply
-- `confenge.outreach.v1` feed generation under `/var/lib/extra-consultoria/warmbly-feed`
-- HTTPS feed front (`/opt/confenge-plane`, port **8443**)
-- HMAC outcome receptor (`serve-outcomes` on loopback **8790**, proxied at
-  `https://<vps>:8443/webhooks/warmbly/outcome`)
+| Plane | Path / project | Role |
+| --- | --- | --- |
+| Intelligence | `/opt/confenge-plane`, extra-cli under `/opt/extra-consultoria` | Feed :8443, outcome HMAC, datalake |
+| Execution | `/opt/warmbly-confenge` project `warmbly-confenge` | Approve state, governor, Hostinger client, CRM |
 
-Do **not** store mailbox passwords, Hostinger credentials, or any OAuth secrets on the VPS.
-The production CONFENGE mailbox is **Hostinger SMTP/IMAP** on the operator laptop, not Microsoft 365.
+Deploy pack in repo: `deploy/confenge-vps/`.
 
 ## Integration path
 
 ```text
-extra-cli (VPS) → HTTPS feed :8443
-        → local Warmbly CONFENGE_EXTRA_CLI_FEED_URL (file pull or HTTPS)
-local Warmbly outcome outbox
-        → CONFENGE_OUTCOME_WEBHOOK_URL=https://<vps>:8443/webhooks/warmbly/outcome
+extra-cli → HTTPS feed :8443
+Warmbly feed sync (host-gateway) → confenge.outreach.v1
+Warmbly outcome outbox → CONFENGE_OUTCOME_WEBHOOK_URL (HMAC retained)
 ```
 
-## Local Warmbly env (laptop)
+## Operator laptop
+
+```text
+ssh tunnel → http://127.0.0.1:5173
+review / approve / pause
+```
+
+No Hostinger password on the laptop after VPS connect. No local worker required
+for due sends after approval.
+
+## Safety
 
 ```env
-CONFENGE_OUTREACH_ENABLED=true
+CONFENGE_GREEN_AUTORUN_ENABLED=false
 CONFENGE_AUTO_SEND_ENABLED=false
 CONFENGE_REQUIRE_HUMAN_APPROVAL=true
-CONFENGE_GREEN_AUTORUN_ENABLED=true
-# after: scripts/confenge_pull_feed_from_vps.sh
-CONFENGE_EXTRA_CLI_FEED_URL=file:///…/data/confenge-plane/email_send_ready_feed.json
-CONFENGE_OUTCOME_WEBHOOK_URL=https://159.195.18.88:8443/webhooks/warmbly/outcome
-CONFENGE_OUTCOME_WEBHOOK_SECRET=<from VPS /opt/confenge-plane/outcome.secret>
-# LOCAL ONLY — Hostinger (not Graph/M365):
-CONFENGE_MAILBOX_EMAIL=tiago.sasaki@confenge.com.br
-CONFENGE_SMTP_HOST=smtp.hostinger.com
-CONFENGE_SMTP_PORT=587
-CONFENGE_IMAP_HOST=imap.hostinger.com
-CONFENGE_IMAP_PORT=993
-CONFENGE_MAILBOX_PASSWORD=...
-```
-
-Connect + smoke (laptop, after stack is up):
-
-```bash
-scripts/confenge_hostinger_connect.sh
-scripts/confenge_self_smoke.sh   # self-send only; no leads
+CONFENGE_WHATSAPP_ENABLED=false
+HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER
+# provider ceiling 1000/rolling 24h/mailbox; ops pace stays 10→20/h, daily 200
+CONFENGE_RATE_MAX_PER_HOUR=20
+CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=200
 ```
 
 ## Public exposure
 
 | Open on VPS | Purpose |
 | --- | --- |
-| TCP 8443 | Feed download + outcome webhook for the laptop |
-| TCP 2222 | SSH ops |
+| TCP 8443 | Feed + outcome webhook (existing plane) |
+| TCP 2222 | SSH ops + operator tunnel |
+| Warmbly 8080/5173 | **Loopback only** |
 
-Legacy `warmbly-confenge` compose on the VPS may remain stopped with volumes
-intact for recovery; it is not the execution plane.
+## Hostinger egress
+
+Prove with `deploy/confenge-vps/prove-hostinger-net.sh`. If SMTP 465/587 fail from
+the VPS while IMAP works, request Netcup outbound SMTP unlock. Do not install
+an MTA on the VPS.
 
 ## Proof bar
 
-1. VPS feed serves current EMAIL_SEND_READY stock
-2. Local Warmbly imports feed (file or HTTPS)
-3. Hostinger SMTP/IMAP self-send/reply/bounce on operator-owned address only
-   (`scripts/confenge_self_smoke.sh`; no Azure / Graph)
-4. Outcome HMAC delivery to VPS receptor
-5. Kill switch on local Warmbly (`make confenge-stop-sending`)
+1. Stack recovers after reboot without laptop
+2. Feed + outcome contracts only (no SQL coupling)
+3. Hostinger IMAP 24/7; SMTP after egress unlock
+4. Human approval persists; kill switch works
+5. No lead sends in validation; GREEN off

--- a/docs/confenge/vps-disaster-recovery.md
+++ b/docs/confenge/vps-disaster-recovery.md
@@ -1,0 +1,75 @@
+# CONFENGE VPS disaster recovery
+
+## What to back up
+
+| Asset | Where | Notes |
+| --- | --- | --- |
+| Postgres | `deploy/confenge-vps/backup.sh` → `warmbly_dev.sql` | Approvals, queues, sealed creds, outcomes |
+| Encryption roots | secrets bundle `keys-*.env` (0600) | `KMS_LOCAL_MASTER_KEY`, `CREDENTIALS_ENCRYPTION_KEY`, `AUTH_SECRET`, tokens |
+| Redacted env | `env.redacted` inside archive | Non-secret config snapshot |
+| confenge_ops volume | included indirectly via kill-switch host mirror | Prefer DB governor state |
+
+**Do not back up:** plaintext Hostinger password, extra-cli datalake, unlimited logs, `node_modules`.
+
+**Do not store** SQL dump and key bundle in the same public object store without encryption. Prefer offline or encrypted vault for keys; SQL can live in a separate private store.
+
+## Backup
+
+```bash
+# on VPS, repo at /opt/warmbly-confenge
+deploy/confenge-vps/backup.sh
+# → data/backups/confenge-vps/warmbly-confenge-<ts>.tar.gz
+# → data/backups/confenge-vps/secrets/keys-<ts>.env
+```
+
+Schedule (example): daily cron under root, after business window.
+
+## Restore
+
+1. Install Docker stack (`install.sh`, `gen-secrets.sh` **or** restore keys from secrets bundle into `deploy/confenge-vps/.env` mode 0600).
+2. `deploy/confenge-vps/up.sh` until postgres healthy.
+3. `deploy/confenge-vps/restore.sh /path/to/warmbly_dev.sql` (destructive to current DB).
+4. Restart backend/worker: `docker compose ... restart backend worker`.
+5. `deploy/confenge-vps/status.sh`
+6. Confirm mailbox still decrypts (list accounts / trigger IMAP). Do **not** re-enter password unless keys were wrong era.
+
+## Controlled restore proof
+
+```bash
+# With stack up and non-production data:
+deploy/confenge-vps/backup.sh
+# Note archive path and secrets path (do not commit)
+# Insert probe: deploy/confenge-vps/prove-restart.sh already writes a probe table
+deploy/confenge-vps/restore.sh data/backups/confenge-vps/.../warmbly_dev.sql
+# Expect probe row or known approval still present
+```
+
+If restore cannot be run on the live VPS safely, run against a disposable compose project name and document the result; live VPS restore remains operator-scheduled.
+
+## After VPS reboot
+
+Docker + `restart: unless-stopped` bring the stack back. No laptop `make`. Verify:
+
+```bash
+deploy/confenge-vps/status.sh
+```
+
+## Emergency stop
+
+```bash
+deploy/confenge-vps/pause.sh "incident"
+# or from browser: dispatch pause when available
+```
+
+## Network / provider incidents
+
+| Symptom | Action |
+| --- | --- |
+| HOSTINGER SMTP FAIL | Confirm Netcup outbound 465/587; do not install MTA |
+| HOSTINGER IMAP FAIL | Check DNS/firewall; worker logs |
+| EXTRA FEED FAIL/STALE | Check `/opt/confenge-plane` + extra-cli feed generation |
+| OUTCOME LOOP FAIL | Check receptor systemd unit + nginx 8443 proxy |
+
+## Parallel hardening
+
+This deployment pack must not patch `green_autorun`, policy auth, touchpoint SM, or concurrent migrations. Authorization defects → `CROSS_PR_BLOCKER` for the hardening PR.

--- a/docs/confenge/vps-execution-inventory.md
+++ b/docs/confenge/vps-execution-inventory.md
@@ -98,17 +98,23 @@ Stack brought up with `deploy/confenge-vps` overlay (existing images, no extra-c
 | Hostinger IMAP 993 | PASS |
 | Hostinger SMTP 465/587 | **PASS** (TCP + AUTH after Mail block delete) |
 | Sealed mailbox `tiago.sasaki@confenge.com.br` | **active**, worker `10c8f5e4-…` |
-| Self-smoke Hostinger send-to-self | **PASS** (`task_id=d6b6faa2-…`, message accepted) |
+| Seed `@warmbly.test` accounts | **inactive** (quarantined; dead SMTP noise) |
+| Self-smoke #1 Hostinger self | **PASS** `task_id=d6b6faa2…` mid=`76d0dfda…` worker accepted |
+| Self-smoke #2 after restart | **PASS** `task_id=66d9d596…` mid=`1610e60c…` |
+| Client disconnect then SMTP | **PASS** (HTTP 200 then worker `Email sent successfully`) |
+| IMAP unibox without laptop | **PASS** (185 msgs; includes self-smoke + Gmail replies) |
 | EXTRA FEED :8443 | PASS |
 | OUTCOME LOOP | PASS |
 | GREEN / WhatsApp / AUTO_SEND | OFF |
 | DISPATCH pause/resume file kill-switch | PASS |
-| Container restart persistence (DB marker) | PASS |
-| Isolated restore into `warmbly_restore_proof` | PASS (185 public tables; probe row present) |
+| Container restart persistence (DB marker) | PASS (`vps-restart-proof-20260809T045123Z`) |
+| Backup (SQL + redacted env) | PASS; secrets bundle 0600 separate; no mailbox password |
+| Isolated restore `warmbly_restore_proof` | PASS (185 public tables; probe row present) |
+| Realtime cgroup | **PASS** after limit **1536M** (512M OOM-looped BEAM exit 137) |
 | Public bind of app ports | None (127.0.0.1 only) |
-| Resource sample | ~5 GiB used / 15 GiB; Warmbly containers well under limits |
+| Resource sample | ~5 GiB used / 15 GiB; Warmbly containers under limits |
 
-**Optional remaining:** full VPS reboot drill; rotate Hostinger app password after ops window; `realtime` OOM-restart (exit 137) is non-blocking for SMTP path.
+**Ops notes:** Full host `reboot` not run (container restart proven; optional drill). Reconnecting Hostinger can hit worker IMAP burst 100/5min and terminate the account; clear Redis `sync:<account_id>:*` and re-activate. Commercial confenge PLANNED touchpoints (e.g. encopav@) were **not** approved. Rotate Hostinger app password after ops window.
 
 ## Netcup Mail block (root cause of SMTP FAIL)
 

--- a/docs/confenge/vps-execution-inventory.md
+++ b/docs/confenge/vps-execution-inventory.md
@@ -139,3 +139,9 @@ Via Playwright: Netcup SCP → Firewall → Delete **netcup Mail block** → Sav
 | Full stack status | all PASS (GREEN OFF) |
 
 Mailbox `tiago.sasaki@confenge.com.br` not yet sealed in Warmbly DB (seed accounts only). Next: interactive `connect-hostinger.sh` + optional sink self-smoke.
+
+## Mailbox connect (same day)
+
+- Stable `WORKER_ID=10c8f5e4-1c39-5b2a-9c8b-3d2f0a8b1a01` required so backend can route validate/send (compose override).
+- Hostinger app password generated in hPanel (not committed); sealed via `connect-hostinger.sh`.
+- Account `tiago.sasaki@confenge.com.br` status **active** after SMTP unlock.

--- a/docs/confenge/vps-execution-inventory.md
+++ b/docs/confenge/vps-execution-inventory.md
@@ -123,3 +123,19 @@ Operator fix (official):
 Then: `deploy/confenge-vps/prove-hostinger-net.sh` should show HOSTINGER_SMTP=PASS.
 
 Reference: https://www.netcup.com/en/helpcenter/documentation/server/firewall
+
+
+## Network proof update (2026-08-09 after SCP Mail block delete)
+
+Via Playwright: Netcup SCP → Firewall → Delete **netcup Mail block** → Save.
+
+| Endpoint | Result |
+| --- | --- |
+| TCP smtp.hostinger.com:465 | **OPEN** |
+| TCP smtp.hostinger.com:587 | **OPEN** |
+| TCP imap.hostinger.com:993 | **OPEN** |
+| status.sh HOSTINGER SMTP | **PASS** |
+| status.sh HOSTINGER IMAP | **PASS** |
+| Full stack status | all PASS (GREEN OFF) |
+
+Mailbox `tiago.sasaki@confenge.com.br` not yet sealed in Warmbly DB (seed accounts only). Next: interactive `connect-hostinger.sh` + optional sink self-smoke.

--- a/docs/confenge/vps-execution-inventory.md
+++ b/docs/confenge/vps-execution-inventory.md
@@ -109,3 +109,17 @@ Stack brought up with `deploy/confenge-vps` overlay (existing images, no extra-c
 | Resource sample | ~5 GiB used / 15 GiB; Warmbly containers well under limits |
 
 **Operator still required for:** Netcup SMTP unlock; interactive `connect-hostinger.sh` (mailbox password); explicit self-smoke `CONFENGE_SELF_SMOKE_TO`; optional full VPS reboot drill.
+
+## Netcup Mail block (root cause of SMTP FAIL)
+
+Guest ufw/iptables do **not** block outbound 465/587 (OUTPUT policy ACCEPT). Connectivity still fails because Netcup SCP cloud firewall applies the default policy **netcup Mail block** (blocks inbound and outbound SMTP).
+
+Operator fix (official):
+
+1. SCP → server → **Firewall**
+2. Delete **netcup Mail block**
+3. **Save**
+
+Then: `deploy/confenge-vps/prove-hostinger-net.sh` should show HOSTINGER_SMTP=PASS.
+
+Reference: https://www.netcup.com/en/helpcenter/documentation/server/firewall

--- a/docs/confenge/vps-execution-inventory.md
+++ b/docs/confenge/vps-execution-inventory.md
@@ -88,3 +88,24 @@ Warmbly resource limits in override (~6–8 GiB ceiling if all hit limits) leave
 | Theoretical ops max | ~180/day (20×9h) under provider 1000/day headroom |
 
 provider ceiling ≠ operational target. Do not apply cPanel 200/h.
+
+
+## Live pack proof (2026-08-09, sanitized)
+
+Stack brought up with `deploy/confenge-vps` overlay (existing images, no extra-cli disruption):
+
+| Check | Result |
+| --- | --- |
+| Backend/worker/consumer/postgres/redis/nats | PASS |
+| Hostinger IMAP 993 | PASS |
+| Hostinger SMTP 465/587 | FAIL (provider egress; all common SMTP targets blocked) |
+| EXTRA FEED :8443 | PASS |
+| OUTCOME LOOP | PASS |
+| GREEN / WhatsApp | OFF |
+| DISPATCH pause/resume file kill-switch | PASS |
+| Container restart persistence (DB marker) | PASS |
+| Isolated restore into `warmbly_restore_proof` | PASS (185 public tables; probe row present) |
+| Public bind of app ports | None (127.0.0.1 only) |
+| Resource sample | ~5 GiB used / 15 GiB; Warmbly containers well under limits |
+
+**Operator still required for:** Netcup SMTP unlock; interactive `connect-hostinger.sh` (mailbox password); explicit self-smoke `CONFENGE_SELF_SMOKE_TO`; optional full VPS reboot drill.

--- a/docs/confenge/vps-execution-inventory.md
+++ b/docs/confenge/vps-execution-inventory.md
@@ -57,13 +57,11 @@ Warmbly UI/API/Postgres/Redis/NATS must remain **loopback-bound** (this pack enf
 | Endpoint | Result from VPS |
 | --- | --- |
 | DNS smtp/imap.hostinger.com | Resolves (Cloudflare) |
-| TCP smtp:465 | **FAIL** (timeout) |
-| TCP smtp:587 | **FAIL** (timeout) |
+| TCP smtp:465 | **PASS** (after SCP Mail block delete) |
+| TCP smtp:587 | **PASS** (after SCP Mail block delete) |
 | TCP imap:993 | **PASS** (+ TLS cert CN=hostinger.com) |
 
-Local operator machine: SMTP 465/587 and IMAP 993 all OPEN.
-
-**Conclusion:** Netcup (or upstream) blocks outbound SMTP submission from this VPS. IMAP is ready. Production Hostinger SMTP requires provider unlock of outbound 465/587. No local MTA.
+**Resolution (2026-08-09):** Netcup SCP default policy **netcup Mail block** was blocking outbound 465/587. Guest ufw was not the cause. After deleting that cloud firewall block, Hostinger SMTP AUTH and real send both PASS. No local MTA.
 
 ## Capacity headroom (sample idle)
 
@@ -98,17 +96,19 @@ Stack brought up with `deploy/confenge-vps` overlay (existing images, no extra-c
 | --- | --- |
 | Backend/worker/consumer/postgres/redis/nats | PASS |
 | Hostinger IMAP 993 | PASS |
-| Hostinger SMTP 465/587 | FAIL (provider egress; all common SMTP targets blocked) |
+| Hostinger SMTP 465/587 | **PASS** (TCP + AUTH after Mail block delete) |
+| Sealed mailbox `tiago.sasaki@confenge.com.br` | **active**, worker `10c8f5e4-…` |
+| Self-smoke Hostinger send-to-self | **PASS** (`task_id=d6b6faa2-…`, message accepted) |
 | EXTRA FEED :8443 | PASS |
 | OUTCOME LOOP | PASS |
-| GREEN / WhatsApp | OFF |
+| GREEN / WhatsApp / AUTO_SEND | OFF |
 | DISPATCH pause/resume file kill-switch | PASS |
 | Container restart persistence (DB marker) | PASS |
 | Isolated restore into `warmbly_restore_proof` | PASS (185 public tables; probe row present) |
 | Public bind of app ports | None (127.0.0.1 only) |
 | Resource sample | ~5 GiB used / 15 GiB; Warmbly containers well under limits |
 
-**Operator still required for:** Netcup SMTP unlock; interactive `connect-hostinger.sh` (mailbox password); explicit self-smoke `CONFENGE_SELF_SMOKE_TO`; optional full VPS reboot drill.
+**Optional remaining:** full VPS reboot drill; rotate Hostinger app password after ops window; `realtime` OOM-restart (exit 137) is non-blocking for SMTP path.
 
 ## Netcup Mail block (root cause of SMTP FAIL)
 

--- a/docs/confenge/vps-execution-inventory.md
+++ b/docs/confenge/vps-execution-inventory.md
@@ -101,6 +101,7 @@ Stack brought up with `deploy/confenge-vps` overlay (existing images, no extra-c
 | Seed `@warmbly.test` accounts | **inactive** (quarantined; dead SMTP noise) |
 | Self-smoke #1 Hostinger self | **PASS** `task_id=d6b6faa2…` mid=`76d0dfda…` worker accepted |
 | Self-smoke #2 after restart | **PASS** `task_id=66d9d596…` mid=`1610e60c…` |
+| Confenge approve → queue → SMTP (sink) | **PASS** TP `c51010aa…` → Mailpit `sink-approve-e2e@warmbly.local` (`smtp-approved:…`); AUTO_SEND=false |
 | Client disconnect then SMTP | **PASS** (HTTP 200 then worker `Email sent successfully`) |
 | IMAP unibox without laptop | **PASS** (185 msgs; includes self-smoke + Gmail replies) |
 | EXTRA FEED :8443 | PASS |

--- a/docs/confenge/vps-execution-inventory.md
+++ b/docs/confenge/vps-execution-inventory.md
@@ -1,0 +1,90 @@
+# VPS execution inventory (sanitized)
+
+Captured 2026-08-09 from live Netcup host. No secrets.
+
+## Warmbly repo
+
+| Item | Value |
+| --- | --- |
+| Branch base | `main` @ `35a8d14b` (pre-hardening; this pack is parallel-safe) |
+| Deployment branch | `feat/confenge-vps-execution-plane` |
+| Project name | `warmbly-confenge` |
+| Intended path | `/opt/warmbly-confenge/` |
+
+## Host
+
+| Item | Value |
+| --- | --- |
+| Hostname | `v2202607385716487230` |
+| Public IPv4 | `159.195.18.88` |
+| Distro | Debian 13 (trixie) |
+| Kernel | 6.12.x amd64 |
+| CPU | 8 vCPU |
+| RAM | 15 GiB (~10 GiB available at sample) |
+| Swap | 4 GiB file (`/swapfile`), partially used at sample |
+| Disk | 503 GiB root, ~435 GiB free (~10% used) |
+| Docker | 26.1.5 |
+| Compose | v2.32.4 |
+
+## Co-tenants (must stay isolated)
+
+| Component | Path / port | Notes |
+| --- | --- | --- |
+| extra-cli | `/opt/extra-consultoria`, datalake `/var/lib/extra-consultoria` (~18G) | Intelligence plane |
+| confenge-plane feed | `/opt/confenge-plane`, HTTPS **8443** | `confenge.outreach.v1` + outcome proxy |
+| outcome receptor | loopback **8790** (systemd `confenge-outcome-receptor`) | HMAC; not public |
+| Host Postgres 17 | `127.0.0.1:5432` | **extra-cli** DB only; Warmbly uses its own Docker volume |
+| SSH | **2222** | Operator access |
+| Node exporter | 9100 | Monitoring |
+
+## Existing warmbly-confenge state (pre this PR)
+
+Legacy compose project containers were **stopped** with volumes intact:
+
+- `warmbly-confenge_postgres_data`, `redis_data`, `nats_data`, `blobs`
+- Prior overlay had `CONFENGE_GREEN_AUTORUN_ENABLED=true` and leftover M365 env keys; **this pack supersedes** that profile (GREEN off, Hostinger-only, no Graph)
+
+Do not delete volumes without a restore plan.
+
+## Firewall (ufw)
+
+Allow: 22, 2222, 8443. Deny public 8790. Docker bridge may reach 8790.
+
+Warmbly UI/API/Postgres/Redis/NATS must remain **loopback-bound** (this pack enforces `127.0.0.1` publishes).
+
+## Hostinger network premise
+
+| Endpoint | Result from VPS |
+| --- | --- |
+| DNS smtp/imap.hostinger.com | Resolves (Cloudflare) |
+| TCP smtp:465 | **FAIL** (timeout) |
+| TCP smtp:587 | **FAIL** (timeout) |
+| TCP imap:993 | **PASS** (+ TLS cert CN=hostinger.com) |
+
+Local operator machine: SMTP 465/587 and IMAP 993 all OPEN.
+
+**Conclusion:** Netcup (or upstream) blocks outbound SMTP submission from this VPS. IMAP is ready. Production Hostinger SMTP requires provider unlock of outbound 465/587. No local MTA.
+
+## Capacity headroom (sample idle)
+
+| Metric | Sample |
+| --- | --- |
+| Load | ~0.02–0.16 |
+| Mem available | ~10 GiB |
+| Swap used | ~2.3 GiB (pre-existing pressure; keep Warmbly limits) |
+| Disk free | ~435 GiB |
+
+Warmbly resource limits in override (~6–8 GiB ceiling if all hit limits) leave room for extra-cli if scans stay bounded. If national scans drive swap thrash / OOM, status is `BLOCKED_VPS_CAPACITY` with fresh metrics (do not soft-pass).
+
+## Hostinger plan class (operator-confirmed)
+
+| Field | Value |
+| --- | --- |
+| Mailbox | `tiago.sasaki@confenge.com.br` |
+| Product | **Hostinger Business Email Starter** (not cPanel, not Free/Trial) |
+| `HOSTINGER_PLAN_CLASS` | `BUSINESS_EMAIL_STARTER` |
+| Provider ceiling | **1000** outgoing messages / rolling 24h / mailbox (hPanel SoT) |
+| CONFENGE operational pace | adaptive **10→20/h**, daily shell **200**, window 09–18 America/Sao_Paulo |
+| Theoretical ops max | ~180/day (20×9h) under provider 1000/day headroom |
+
+provider ceiling ≠ operational target. Do not apply cPanel 200/h.

--- a/docs/confenge/vps-execution-plane.md
+++ b/docs/confenge/vps-execution-plane.md
@@ -116,7 +116,26 @@ recipient reply → Hostinger → IMAP TLS → Warmbly worker/consumer
 
 No Postfix/Exim/Mailcow. No PTR-based direct send. No M365/Graph.
 
-**Network blocker observed on Netcup:** outbound TCP 465/587 to Hostinger timed out while IMAP 993 worked. Unlock outbound SMTP with Netcup before production self-smoke. See `vps-execution-inventory.md`.
+**Network blocker observed on Netcup:** outbound TCP 465/587 to Hostinger timed out while IMAP 993 worked (also blocked to Gmail/O365/SES submission ports). This is provider egress policy, not a local ufw rule. Unlock outbound SMTP with Netcup before production self-smoke. See `vps-execution-inventory.md`.
+
+### Operator go-live after Netcup SMTP unlock
+
+```bash
+# On VPS as root, repo at /opt/warmbly-confenge
+# 1) Netcup CCP/SCP: freischalten outbound mail (TCP 465 + 587). No local MTA.
+
+deploy/confenge-vps/prove-hostinger-net.sh   # expect SMTP=PASS IMAP=PASS
+
+# Or one-shot after unlock (interactive mailbox password):
+export CONFENGE_OPS_PASSWORD='…'             # Warmbly UI user password
+CONFENGE_SELF_SMOKE_TO=tiago.sasaki@confenge.com.br \
+  deploy/confenge-vps/post-smtp-unlock.sh
+
+# Optional full reboot drill:
+# sudo reboot && … && deploy/confenge-vps/status.sh
+```
+
+Daily laptop path remains browser-only via SSH tunnel (below).
 
 ## Isolation from extra-cli
 

--- a/docs/confenge/vps-execution-plane.md
+++ b/docs/confenge/vps-execution-plane.md
@@ -118,6 +118,20 @@ No Postfix/Exim/Mailcow. No PTR-based direct send. No M365/Graph.
 
 **Network blocker observed on Netcup:** outbound TCP 465/587 to Hostinger timed out while IMAP 993 worked (also blocked to Gmail/O365/SES submission ports). This is provider egress policy, not a local ufw rule. Unlock outbound SMTP with Netcup before production self-smoke. See `vps-execution-inventory.md`.
 
+### Netcup Mail block (SCP firewall)
+
+Outbound SMTP (25/465/587) is blocked by Netcup's **cloud** firewall policy **netcup Mail block**, not by guest ufw. Guest `iptables OUTPUT` remains ACCEPT while connections still time out.
+
+Operator fix (official Netcup docs):
+
+1. Open **Server Control Panel (SCP)** for this VPS.
+2. Open the **Firewall** menu.
+3. On the **netcup Mail block** policy, click **Delete**.
+4. Click **Save** (applies immediately; no reboot).
+
+Reference: [netcup Firewall / Mail block](https://www.netcup.com/en/helpcenter/documentation/server/firewall).
+
+
 ### Operator go-live after Netcup SMTP unlock
 
 ```bash

--- a/docs/confenge/vps-execution-plane.md
+++ b/docs/confenge/vps-execution-plane.md
@@ -1,0 +1,176 @@
+# CONFENGE VPS execution plane
+
+Topology target:
+
+```text
+extra-cli + datalake (VPS)
+        │ confenge.outreach.v1
+        ▼
+Warmbly warmbly-confenge (same VPS, isolated Docker project)
+        │ Hostinger SMTP/IMAP client
+        │ human approval UI (browser via SSH tunnel)
+        ▼
+confenge.outcome.v1 → extra-cli receptor
+```
+
+Local laptop = browser (and optional SSH) only. No local Docker/WSL stack required for daily send/sync.
+
+## What this pack is
+
+Directory: `deploy/confenge-vps/`
+
+| Script | Purpose |
+| --- | --- |
+| `install.sh` / `gen-secrets.sh` | Prep + 0600 secrets (no mailbox password) |
+| `up.sh` / `down.sh` | Always-on compose (`restart: unless-stopped`) |
+| `connect-hostinger.sh` | `read -s` → sealed credentials in Warmbly DB |
+| `status.sh` | Compact PASS/FAIL board |
+| `pause.sh` / `resume.sh` | Kill switch (file + governor API) |
+| `backup.sh` / `restore.sh` | DB + separate key bundle |
+| `prove-hostinger-net.sh` | TCP/TLS premise, no auth |
+| `prove-restart.sh` | Durable state after container restart |
+| `self-smoke.sh` | Requires explicit `CONFENGE_SELF_SMOKE_TO` |
+| `validate.sh` | Offline pack checks |
+
+Compose: root `docker-compose.yml` + `deploy/confenge-vps/docker-compose.override.yml`, project name `warmbly-confenge`.
+
+## Safety profile (fixed)
+
+```env
+CONFENGE_OUTREACH_ENABLED=true
+CONFENGE_REQUIRE_HUMAN_APPROVAL=true
+CONFENGE_AUTO_SEND_ENABLED=false
+CONFENGE_GREEN_AUTORUN_ENABLED=false
+CONFENGE_WHATSAPP_ENABLED=false
+CONFENGE_SEND_BUSINESS_DAYS_ONLY=true
+CONFENGE_SEND_TIMEZONE=America/Sao_Paulo
+CONFENGE_RATE_START_PER_HOUR=10
+CONFENGE_RATE_MAX_PER_HOUR=20
+```
+
+Always-on execution ≠ unattended authorization. GREEN autorun stays off.
+
+## Hostinger Business Email Starter vs commercial pacing
+
+Mailbox: `tiago.sasaki@confenge.com.br`
+
+Product confirmed by operator: **Hostinger Business Email Starter**
+
+- Not cPanel Email (do not apply cPanel 200/h or 2400/day figures)
+- Not Free Email / Trial limits
+
+Official provider ceiling currently documented:
+
+```text
+outgoing messages = 1000 / rolling 24h / mailbox
+```
+
+One send to one recipient normally counts as one message. Multiple recipients may consume multiple units. **hPanel** remains the source of truth if Hostinger changes the limit.
+
+The Hostinger figure is only a **hard provider ceiling**. Do **not** raise commercial pacing toward it.
+
+CONFENGE governor / commercial pacing (unchanged in this PR):
+
+```text
+adaptive start = 10/h
+adaptive max   = 20/h
+business window = 09:00–18:00
+timezone = America/Sao_Paulo
+business days only = true
+daily operational cap = 200
+```
+
+With a nine-hour window: `20/h × 9h = 180` theoretical max/day.
+
+```text
+provider ceiling ≠ operational target
+
+Hostinger provider max     = 1000 / rolling 24h (Business Email Starter)
+CONFENGE operational max   ≈ 180/day (20/h × 9h), shell daily = 200
+min(applicable limits) always wins
+```
+
+There is ample headroom under the provider ceiling. Do **not**:
+
+- implement artificial 100/day throttling
+- apply cPanel 200/h
+- modify governor core in this PR
+- raise `CONFENGE_RATE_MAX_PER_HOUR` above 20
+
+Deployment documents:
+
+```env
+HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER   # operator-confirmed
+# docs only unless core later wires a provider cap:
+# HOSTINGER_TECHNICAL_DAILY_CAP=1000   # rolling 24h / mailbox
+```
+
+Future scale-up depends on hard/soft bounce, spam/reputation, delivery failures, reply rates, DNC, and mailbox health, not on “using more of the 1000.”
+
+## Mail path
+
+```text
+Warmbly worker → authenticated SMTP/TLS → smtp.hostinger.com → recipient
+recipient reply → Hostinger → IMAP TLS → Warmbly worker/consumer
+```
+
+No Postfix/Exim/Mailcow. No PTR-based direct send. No M365/Graph.
+
+**Network blocker observed on Netcup:** outbound TCP 465/587 to Hostinger timed out while IMAP 993 worked. Unlock outbound SMTP with Netcup before production self-smoke. See `vps-execution-inventory.md`.
+
+## Isolation from extra-cli
+
+| Allowed | Forbidden |
+| --- | --- |
+| HTTPS feed / outcome contracts | Shared application SQL |
+| host-gateway / loopback to :8443 | Warmbly reading datalake tables |
+| Separate Docker volumes | Import of extra-cli models |
+
+Outcome HMAC remains required even on loopback.
+
+## Operator access
+
+Simplest secure path (no new VPN product):
+
+```bash
+ssh -L 5173:127.0.0.1:5173 -L 8080:127.0.0.1:8080 -L 18025:127.0.0.1:18025 \
+  -p 2222 -i ~/.ssh/extra-consultoria-prod root@159.195.18.88
+# browser: http://127.0.0.1:5173  → /app/confenge
+```
+
+UI/API bind **127.0.0.1 only**. Login remains Warmbly auth. Daily path: approve/edit/reject/DNC in browser; laptop can sleep after approval; queue/`due_at`/governor/SMTP run on VPS.
+
+## Credentials
+
+1. `gen-secrets.sh` writes KMS + credentials encryption keys (0600 `.env`).
+2. `connect-hostinger.sh` prompts password with `read -s`, posts onboarding, seals in DB, discards plaintext.
+3. Backups: SQL dump + **separate** secrets bundle (`backup.sh`).
+
+Losing `KMS_LOCAL_MASTER_KEY` or `CREDENTIALS_ENCRYPTION_KEY` makes sealed mailboxes unrecoverable.
+
+## Kill switch
+
+```bash
+deploy/confenge-vps/pause.sh "reason"
+deploy/confenge-vps/resume.sh
+```
+
+Independent of extra-cli/AI. UI dispatch pause remains available when logged in.
+
+## Human approve → later send
+
+1. Message generated/imported on VPS.
+2. Human opens exact content in browser, approves.
+3. Approval + content hash persisted on VPS.
+4. Browser disconnects; laptop may power off.
+5. When `due_at` arrives, worker + governor dispatch via Hostinger (or Mailpit for tests).
+
+If core ever requires `CONFENGE_AUTO_SEND_ENABLED=true` for already human-approved queued sends, treat as `CROSS_PR_BLOCKER` (do not bypass here).
+
+## Validation
+
+```bash
+deploy/confenge-vps/validate.sh
+deploy/confenge-vps/prove-hostinger-net.sh   # on VPS
+deploy/confenge-vps/prove-restart.sh         # with stack up
+```


### PR DESCRIPTION
## Why

Move CONFENGE execution from operator WSL to an always-on Netcup execution plane.
Local devices become review/approval clients only.

## Architecture

extra-cli intelligence → confenge.outreach.v1 → Warmbly VPS
Warmbly outcomes → confenge.outcome.v1 → extra-cli

Isolated compose project `warmbly-confenge` under `/opt/warmbly-confenge/` with loopback binds, restart policies, and resource limits.

## Email

Hostinger SMTP/IMAP (Business Email Starter).
No Microsoft 365 / Graph.
No local MTA.

## Security

- application isolation (no shared SQL with extra-cli)
- encrypted mailbox credentials (sealed DEK; connect script posts JSON via `--data-binary @file`, never password in curl argv)
- no internal DB/Redis/NATS exposure
- human approval remains required
- GREEN autorun remains disabled
- WhatsApp remains disabled
- AUTO_SEND remains false

## Parallel work

PARALLEL SAFE WITH CONFENGE HARDENING: this PR does not edit green_autorun, policy_auth, touchpoints SM, scoring, activation scripts, or migration 000090 sources.
Rebase may be needed after hardening merges to main (branch base was pre-hardening `35a8d14b`).

## VPS proof (HEAD `35768545207901c947f15f87fc366890ba18f676`)

Sanitized; no secrets.

| Check | Result |
| --- | --- |
| Hostinger SMTP/IMAP TCP after Netcup Mail block delete | **PASS** |
| Sealed mailbox tiago.sasaki@confenge.com.br | **active** |
| Hostinger self-smoke (worker SMTP) | **PASS** (tasks d6b6faa2, 66d9d596) |
| Confenge approve → disconnect → queue → SMTP | **PASS** sink sink-approve-e2e@warmbly.local → Mailpit (smtp-approved, AUTO_SEND=false) |
| IMAP unibox without laptop | **PASS** (185 msgs incl. self-smoke + replies) |
| Container restart persistence | **PASS** |
| Backup + isolated restore | **PASS** (185 tables; secrets redacted) |
| Kill switch pause/resume | **PASS** |
| Realtime cgroup | **PASS** at 1536M (was OOM at 512M) |
| Full host reboot | **not run** (container restart proven; optional drill) |

## Tests

```
python3 deploy/confenge-vps/test_vps_pack.py   # PASS (7)
bash -n deploy/confenge-vps/*.sh
bash deploy/confenge-vps/validate.sh           # VALIDATE=PASS
```

HEAD: `35768545207901c947f15f87fc366890ba18f676`

## Non-claims

No real commercial lead sends (encopav PLANNED untouched).
No production autorun activation.
No merge.

## Remaining optional

- Full VPS reboot drill
- Rotate Hostinger app password after ops window
- Watch worker IMAP burst 100/5min on mailbox reconnect (clear redis sync keys)