### PR TITLE
feat(confenge): add evidence-led world-class outreach doctrine and learning loop

### DIFF
--- a/data/confenge/outreach_playbook/copy_rules.yaml
+++ b/data/confenge/outreach_playbook/copy_rules.yaml
@@ -1,0 +1,127 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+banned_phrases:
+  - espero que este email o encontre bem
+  - espero que esta mensagem o encontre bem
+  - venho por meio deste
+  - gostaria de apresentar
+  - soluções personalizadas
+  - solucoes personalizadas
+  - maximizar resultados
+  - potencializar
+  - sinergia
+  - transformação digital
+  - transformacao digital
+  - solução 360
+  - solucao 360
+  - ia de ponta
+  - revolucionário
+  - revolucionario
+  - imperdível
+  - imperdivel
+  - estamos monitorando sua empresa
+  - analisamos toda a carteira
+  - detectamos que vocês deixaram de
+  - dinheiro a receber
+  - crédito identificado
+  - credito identificado
+  - identificamos perda de
+  - tem 15 minutos amanhã
+  - tem 15 minutos amanha
+  - podemos marcar uma call
+  - qual horário funciona
+  - qual horario funciona
+  - segue o link do meu calendário
+  - segue o link do meu calendario
+
+meeting_cta_phrases:
+  - marcar uma call
+  - marcar uma reunião
+  - marcar uma reuniao
+  - 15 minutos
+  - 30 minutos
+  - calendly
+  - agendar uma call
+  - tem um horário
+  - tem um horario
+
+fake_re_fwd:
+  - "^re:"
+  - "^fw:"
+  - "^fwd:"
+
+preferred_public_source_phrasing:
+  - Vi no PNCP
+  - Pelo contrato publicado
+  - Nas informações públicas do contrato
+  - Pela publicação
+
+creepy_phrasing:
+  - estamos monitorando
+  - monitoramos sua empresa
+  - sabemos que vocês
+  - sabemos que voces
+  - detectamos que vocês
+  - detectamos que voces
+  - analisamos toda a carteira
+  - acesso privilegiado
+
+unsupported_monetary:
+  - r$
+  - milhão a receber
+  - milhao a receber
+  - milhões a recuperar
+  - milhoes a recuperar
+
+annualidade_bad_claims:
+  - reajuste a receber
+  - reajuste não pago
+  - reajuste nao pago
+  - o órgão deixou de pagar
+  - o orgao deixou de pagar
+  - vocês têm direito ao reajuste
+  - voces tem direito ao reajuste
+  - crédito de reajuste
+  - credito de reajuste
+
+rejection_reasons:
+  - factual_error
+  - too_generic
+  - too_salesy
+  - wrong_service
+  - wrong_offer
+  - wrong_recipient
+  - too_long
+  - creepy
+  - unsupported_claim
+  - tone
+  - other
+
+edit_signal_codes:
+  - shortened
+  - softened_claim
+  - changed_cta
+  - removed_jargon
+  - corrected_fact
+  - changed_offer
+  - other
+
+commercial_reply_classes:
+  - POSITIVE_INTEREST
+  - OFFER_ACCEPTED
+  - SEND_MORE_INFO
+  - WRONG_PERSON
+  - REFERRAL
+  - ALREADY_HANDLED_INTERNAL
+  - ALREADY_HAS_CONSULTANT
+  - NOT_A_PRIORITY
+  - NOT_INTERESTED
+  - CONTACT_LATER
+  - PRICE_QUESTION
+  - CREDIBILITY_QUESTION
+  - TECHNICAL_QUESTION
+  - PROCUREMENT_CONCERN
+  - DNC
+  - OUT_OF_OFFICE
+  - AUTO_REPLY
+  - OTHER

--- a/data/confenge/outreach_playbook/doctrine.yaml
+++ b/data/confenge/outreach_playbook/doctrine.yaml
@@ -1,0 +1,66 @@
+# CONFENGE outreach doctrine — machine-readable core
+# Human narrative: docs/confenge/OUTREACH-DOCTRINE.md
+outreach_doctrine_version: confenge-outreach-v1
+channel_policy:
+  runtime_allowed: [EMAIL]
+  whatsapp: OFF
+  auto_call: OFF
+  green_autorun: OFF
+
+north_star_metric: positive_conversations_per_delivered
+secondary_metrics:
+  - human_reply_rate
+  - positive_reply_rate
+  - qualified_conversation_rate
+  - meeting_rate
+  - proposal_rate
+  - win_rate
+  - attributed_revenue
+
+principles:
+  - id: strategy_before_copy
+    summary: Plan commercial strategy before any wording.
+  - id: extra_cli_owns_who
+    summary: extra-cli decides WHO/WHY NOW; Warmbly decides HOW TO APPROACH.
+  - id: no_local_rescoring
+    summary: Never create lead/commercial/conversion priority scores here.
+  - id: fact_neq_hypothesis
+    summary: Facts from evidence only; inferences marked as hypothesis.
+  - id: know_a_lot_say_little
+    summary: Anti-creepy public-data phrasing; minimal necessary fact.
+  - id: value_before_meeting
+    summary: First CTA prefers micro-offer permission, not calendar link.
+  - id: no_institutional_pitch_first
+    summary: First email sells attention and low-friction next step only.
+  - id: each_touch_earns_existence
+    summary: No empty following-up; each touch adds value.
+  - id: fail_closed_on_claims
+    summary: Unsupported material claims block approval path.
+  - id: human_approval_unchanged
+    summary: Strategy and generation may be automatic; send approval stays human.
+
+first_email_defaults:
+  min_words: 40
+  max_words: 100
+  target_sentences: "3-4"
+  max_ctas: 1
+  max_links: 1
+  attachments: false
+  meeting_cta_default: false
+  language: pt-BR
+  subject:
+    max_words: 6
+    no_emoji: true
+    no_all_caps: true
+    no_fake_re: true
+    no_fake_fwd: true
+    no_urgency: true
+    no_financial_promise: true
+
+hierarchy_of_evidence:
+  - confenge_own_measured_outcomes
+  - large_modern_datasets
+  - behavioral_empirical_research
+  - established_methodology
+  - expert_recommendation
+  - sales_folklore

--- a/data/confenge/outreach_playbook/objection_playbook.yaml
+++ b/data/confenge/outreach_playbook/objection_playbook.yaml
@@ -1,0 +1,58 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+objections:
+  - id: already_internal
+    match: [já fazemos internamente, ja fazemos internamente, temos equipe interna]
+    strategy: complement_second_read_peak_demand
+    guidance: |
+      Não atacar a equipe. Oferecer segunda leitura, pico de demanda, validação independente ou tema pontual.
+    never: [vocês não têm estrutura, equipe insuficiente]
+
+  - id: have_legal
+    match: [temos jurídico, nosso jurídico, advogado interno]
+    strategy: technical_complement
+    guidance: |
+      Nunca substituir o jurídico. Enfatizar engenharia, cálculo, memória, evidência técnica e interface técnico-contratual.
+    never: [melhor que o jurídico, substituímos o jurídico]
+
+  - id: no_interest
+    match: [não tenho interesse, nao tenho interesse, sem interesse]
+    strategy: respect_and_stop
+    guidance: Respeitar. Não argumentar compulsivamente. Encerrar e marcar NOT_INTERESTED.
+    never: [mas deixa eu só]
+
+  - id: price
+    match: [quanto custa, qual o valor, preço, preco]
+    strategy: transparent_by_offer
+    guidance: Não esconder. Encaminhar conforme micro-offer/service; se ainda cedo, amarrar ao escopo.
+    never: [depende de conversar 30 minutos sem faixa]
+
+  - id: send_material
+    match: [manda material, envia material, brochure, apresentação institucional]
+    strategy: problem_specific_not_brochure
+    guidance: Não enviar brochure genérico. Responder ao problema que iniciou a conversa; cumprir micro-offer se prometido.
+    never: [segue nosso deck institucional genérico]
+
+  - id: who_are_you
+    match: [quem é você, quem e voce, o que é a confenge, o que e a confenge]
+    strategy: short_verifiable_identity
+    guidance: Explicação curta, verificável, sem mini-CV nem superlativos.
+    never: [líderes de mercado, especialistas número 1]
+
+  - id: wrong_person
+    match: [não sou a pessoa, nao sou a pessoa, fale com]
+    strategy: thank_and_route
+    guidance: Agradecer, pedir indicação curta, não insistir no mesmo contato.
+    never: [pode só olhar rapidinho]
+
+  - id: already_has_consultant
+    match: [já temos consultor, ja temos consultor, já contratamos]
+    strategy: complement_or_close
+    guidance: Oferecer complementaridade pontual ou encerrar com respeito.
+    never: [eles não fazem o que fazemos]
+
+  - id: contact_later
+    match: [mais tarde, no próximo trimestre, depois do carnaval]
+    strategy: schedule_respect
+    guidance: Registrar CONTACT_LATER; não pressionar.
+    never: [é agora ou nunca]

--- a/data/confenge/outreach_playbook/offers.yaml
+++ b/data/confenge/outreach_playbook/offers.yaml
@@ -1,0 +1,127 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+# Micro-offers: value before meeting. Cold path only suggests LOW budget.
+offers:
+  - code: CONTRACT_CHECK
+    description: Pontos objetivos que eu conferiria no contrato público citado
+    buyer_value: Clareza sobre o que verificar antes de qualquer diagnóstico pago
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [any_public_contract_fact]
+    applicable_service_codes: ["*"]
+    prohibited_claims: [crédito confirmado, valor a receber]
+    cta_patterns:
+      - Posso te mandar os pontos que eu conferiria?
+      - Faz sentido eu te enviar o recorte que encontrei?
+
+  - code: REAJUSTE_CHECK
+    description: Checklist de verificação de reajuste (documentos e memórias), sem afirmar crédito
+    buyer_value: Separar sinal de anualidade de conclusão de valor devido
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [moment_or_contract]
+    applicable_service_codes: [REAJUSTE, REEQUILIBRIO]
+    prohibited_claims:
+      - reajuste a receber
+      - o órgão deixou de pagar
+      - perda de R$
+    cta_patterns:
+      - Posso te mandar o checklist do que eu verificaria no reajuste?
+      - Quer que eu te envie os pontos documentais que eu conferiria primeiro?
+
+  - code: ADITIVO_RISK_CHECK
+    description: Leitura curta de efeitos colaterais de aditivo recente
+    buyer_value: Enxergar o que o aditivo pode ter alterado além do texto assinado
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [aditivo_or_moment]
+    applicable_service_codes: [ADITIVOS, REAJUSTE, MEDICOES]
+    prohibited_claims: [aditivo irregular, valor perdido no aditivo]
+    cta_patterns:
+      - Posso te mostrar o que eu checaria depois desse aditivo?
+
+  - code: MEDICAO_CHECK
+    description: Pontos de medição/critério a validar com base pública
+    buyer_value: Antecipar onde divergência de campo vs planilha costuma nascer
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [moment_or_contract]
+    applicable_service_codes: [MEDICOES, PLANILHAS, ADITIVOS]
+    prohibited_claims: [glosa indevida, medição não paga de]
+    cta_patterns:
+      - Posso te mandar o que eu verificaria na medição?
+
+  - code: CLOSEOUT_CHECK
+    description: Checklist de close-out / pendências perto do término
+    buyer_value: Lista objetiva do que ainda cabe regularizar
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [moment_or_contract]
+    applicable_service_codes: [ENCERRAMENTO_CONTRATUAL, REAJUSTE, MEDICOES]
+    prohibited_claims: [contrato sem quitação]
+    cta_patterns:
+      - Quer o checklist do que eu conferiria antes do encerramento?
+
+  - code: DOCUMENT_CHECKLIST
+    description: Lista curta de documentos públicos/internos a reunir
+    buyer_value: Reduz caça documental sem vender o serviço completo
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [any]
+    applicable_service_codes: ["*"]
+    prohibited_claims: []
+    cta_patterns:
+      - Posso te mandar a lista do que eu reuniria primeiro?
+
+  - code: CONTRACT_TIMELINE
+    description: Linha do tempo pública do contrato (marcos publicados)
+    buyer_value: Visão cronológica sem dossiê intimidador
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [public_dates]
+    applicable_service_codes: ["*"]
+    prohibited_claims: []
+    cta_patterns:
+      - Quer que eu te envie a linha do tempo pública que montei?
+
+  - code: PUBLIC_DATA_SNAPSHOT
+    description: Recorte de dados públicos relevantes (sem parecer vigilância)
+    buyer_value: Amostra da capacidade de leitura pública da CONFENGE
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [public_fact]
+    applicable_service_codes: ["*"]
+    prohibited_claims: [estamos monitorando sua empresa, analisamos toda a carteira]
+    cta_patterns:
+      - Posso te mandar o recorte público que encontrei?
+
+  - code: CLAIM_READINESS_CHECK
+    description: Prontidão documental para eventual pleito (sem afirmar mérito)
+    buyer_value: Saber o que falta antes de investir em pedido formal
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [moment_or_contract]
+    applicable_service_codes: [REEQUILIBRIO, REAJUSTE, EXTRACONTRATUAIS]
+    prohibited_claims: [direito confirmado, valor devido]
+    cta_patterns:
+      - Posso te mostrar o que eu checaria antes de qualquer pleito?
+
+  - code: PROCUREMENT_RISK_SNAPSHOT
+    description: Snapshot de risco documental em contexto de licitação/contratação
+    buyer_value: Antecipar premissas frágeis
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [public_fact]
+    applicable_service_codes: [APOIO_LICITACAO, ADITIVOS]
+    prohibited_claims: [vão perder a licitação]
+    cta_patterns:
+      - Quer um snapshot do que eu verificaria no edital/instrumento?
+
+# Explicitly not auto-offered on cold path
+restricted_offers:
+  - code: FULL_DIAGNOSTIC
+    fulfillment_cost: HIGH
+    note: Never offer full unpaid diagnostic on cold email.
+  - code: PAID_CONSULTING_PITCH
+    fulfillment_cost: HIGH
+    note: Not a micro-offer; belongs after interest.

--- a/data/confenge/outreach_playbook/personas.yaml
+++ b/data/confenge/outreach_playbook/personas.yaml
@@ -1,0 +1,58 @@
+# Buyer roles — map only when role evidence exists; else UNKNOWN.
+outreach_doctrine_version: confenge-outreach-v1
+
+roles:
+  - code: OWNER_PARTNER
+    match_keywords: [sócio, socio, proprietário, proprietario, dono, founder, partner, owner]
+    priorities: [dinheiro, risco, margem, tempo, crescimento, sobrecarga]
+    tone: peer_direct
+    prefer_angles: [economic_window, risk_clarity, time_saved]
+  - code: DIRECTOR
+    match_keywords: [diretor, directora, director, superintendente, gerente geral]
+    priorities: [resultado, risco, previsibilidade, delegação]
+    tone: peer_concise
+    prefer_angles: [portfolio_risk, decision_clarity]
+  - code: COMMERCIAL
+    match_keywords: [comercial, vendas, business development, captacao, captação]
+    priorities: [oportunidade, relacionamento, pipeline]
+    tone: collaborative
+    prefer_angles: [client_retention, bid_quality]
+  - code: CONTRACTS
+    match_keywords: [contratos, contratual, administrativo, gestão de contratos, gestao de contratos]
+    priorities: [precisão, documentação, fechamento correto]
+    tone: technical_precise
+    prefer_angles: [document_checklist, process_gap]
+  - code: ENGINEERING
+    match_keywords: [engenheiro, engenheira, engenharia, técnico, tecnico, obras, fiscal]
+    priorities: [precisão técnica, documentação, risco operacional, medição]
+    tone: technical_peer
+    prefer_angles: [measurement, memory, technical_evidence]
+  - code: PLANNING
+    match_keywords: [planejamento, pmo, cronograma, orçamento, orcamento]
+    priorities: [prazo, custo, desvio]
+    tone: analytical
+    prefer_angles: [timeline, variance]
+  - code: FINANCE
+    match_keywords: [financeiro, cfo, controller, contábil, contabil, faturamento]
+    priorities: [fluxo, valores, previsibilidade, recebimento, exposição]
+    tone: quantitative_careful
+    prefer_angles: [cash_timing, exposure]
+  - code: LEGAL
+    match_keywords: [jurídico, juridico, advogado, advogada, legal]
+    priorities: [fatos, rastreabilidade, suporte técnico-documental]
+    tone: complement_not_compete
+    prefer_angles: [technical_support_to_legal, evidence_trail]
+    rules:
+      - never_position_as_legal_substitute
+  - code: PROCUREMENT
+    match_keywords: [compras, licitação, licitacao, procurement, suprimentos]
+    priorities: [conformidade, risco de contratação]
+    tone: process_aware
+    prefer_angles: [procurement_risk, documentation]
+  - code: UNKNOWN
+    match_keywords: []
+    priorities: [relevância, clareza, baixo atrito]
+    tone: neutral_professional
+    prefer_angles: [public_fact, micro_offer]
+    rules:
+      - never_infer_title_from_generic_email

--- a/data/confenge/outreach_playbook/sequence.yaml
+++ b/data/confenge/outreach_playbook/sequence.yaml
@@ -1,0 +1,62 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+# Each touch must earn existence. Cadence delays are defaults (experimental priors), not governor limits.
+sequence:
+  max_touches: 5
+  stop_on:
+    - human_reply
+    - dnc
+    - bounce
+    - active_conversation
+  account_rules:
+    no_simultaneous_identical_copy: true
+    no_multithread_without_reason: true
+    pause_other_contacts_on_active_conversation: true
+
+  touches:
+    - position: 1
+      name: SIGNAL
+      objective: fact + honest hypothesis + micro-offer
+      adds_value: public_fact_and_micro_offer
+      forbidden: [just_following_up, meeting_default, institutional_pitch]
+      default_delay_days: 0
+
+    - position: 2
+      name: IMPLICATION
+      objective: another technical angle or implication; simple CTA
+      adds_value: new_implication_or_angle
+      forbidden: [just_following_up, last_attempt_guilt]
+      default_delay_days: 4
+
+    - position: 3
+      name: VALUE
+      objective: mini-checklist, benchmark, or useful public insight
+      adds_value: checklist_or_insight
+      forbidden: [just_following_up]
+      default_delay_days: 5
+
+    - position: 4
+      name: ROUTING
+      objective: short ask if another person owns the theme (internal referral)
+      adds_value: routing_question
+      forbidden: [spam_all_stakeholders]
+      default_delay_days: 5
+
+    - position: 5
+      name: GRACEFUL_CLOSE
+      objective: close without guilt trip or false urgency
+      adds_value: respectful_close
+      forbidden: [ultima_tentativa, last_chance, following_up]
+      default_delay_days: 7
+
+empty_followup_phrases:
+  - só acompanhando
+  - so acompanhando
+  - subindo no seu inbox
+  - teve chance de ver
+  - última tentativa
+  - ultima tentativa
+  - just following up
+  - bumping this
+  - checking in
+  - looping back

--- a/data/confenge/outreach_playbook/services.yaml
+++ b/data/confenge/outreach_playbook/services.yaml
@@ -1,0 +1,152 @@
+# Service playbooks mapped to real-ish CONFENGE service_code patterns used in feeds.
+# Codes are matched case-insensitively by exact code or prefix (e.g. REAJUSTE_14133 → REAJUSTE).
+outreach_doctrine_version: confenge-outreach-v1
+
+services:
+  - code: REAJUSTE
+    name: Reajuste contratual
+    aliases: [REAJUSTE_14133, REAJUSTE_CONTRATUAL, reajuste]
+    commercial_insight: |
+      Anualidade e marco temporal mudam quais documentos e memórias deveriam ser conferidos,
+      mas não provam sozinhos crédito econômico ou reajuste não pago.
+    common_miss: Tratar aniversário contratual como prova de valor a receber.
+    problem_hypotheses:
+      - índice aplicável não formalizado no prazo esperado
+      - memória de cálculo incompleta para o ciclo
+      - base de reajuste divergente da cláusula
+    implications:
+      - atraso de fluxo se o pedido precisar de reconstituição documental
+      - risco de pleito frágil se a evidência pública for lida como certeza
+    disallowed_claims:
+      - vocês têm reajuste a receber
+      - o órgão deixou de pagar o reajuste
+      - identificamos perda de
+      - crédito de reajuste confirmado
+    default_micro_offer: REAJUSTE_CHECK
+    cta_families: [permission_checklist, permission_points]
+
+  - code: REEQUILIBRIO
+    name: Reequilíbrio econômico-financeiro
+    aliases: [REEQUILIBRIO_ECO, REEQUILIBRIO_ECONOMICO, reequilibrio]
+    commercial_insight: |
+      Eventos de desequilíbrio pedem nexo, quantificação e memória; publicação isolada raramente basta.
+    common_miss: Confundir dificuldade operacional com direito ao reequilíbrio.
+    problem_hypotheses:
+      - evento extraordinário sem memória organizada
+      - nexo causal ainda não documentado
+    implications:
+      - pedido frágil ou tardio
+    disallowed_claims:
+      - vocês têm direito ao reequilíbrio
+      - o contrato está desequilibrado
+    default_micro_offer: CLAIM_READINESS_CHECK
+    cta_families: [permission_checklist, permission_snapshot]
+
+  - code: MEDICOES
+    name: Medições e medições contratuais
+    aliases: [MEDICAO, MEDICOES, MEDIÇÃO, MEDICÃO]
+    commercial_insight: |
+      Medição é onde volume, critério e evidência de campo se encontram; divergência costuma nascer em memória, não só em planilha.
+    common_miss: Tratar atraso de medição como mero problema de cobrança.
+    problem_hypotheses:
+      - critério de medição ambíguo em trecho crítico
+      - divergência entre campo e planilha
+    implications:
+      - glosa ou atraso de faturamento
+    disallowed_claims:
+      - o órgão glosou indevidamente
+      - há medição não paga de
+    default_micro_offer: MEDICAO_CHECK
+    cta_families: [permission_points, permission_checklist]
+
+  - code: ADITIVOS
+    name: Aditivos contratuais
+    aliases: [ADITIVO, ADDITIVE_REVIEW, ADITIVOS, additive_review]
+    commercial_insight: |
+      Aditivo recente muda o escopo e a base de comparação; o risco está no que deixa de ser revisado depois da assinatura.
+    common_miss: Celebrar o aditivo e não revalidar planilha, prazos e reajustes derivados.
+    problem_hypotheses:
+      - inconsistência entre aditivo e planilha base
+      - efeito em reajuste ou medição não mapeado
+    implications:
+      - execução e cobrança desalinhadas ao instrumento
+    disallowed_claims:
+      - o aditivo está irregular
+      - vocês perderam valor no aditivo
+    default_micro_offer: ADITIVO_RISK_CHECK
+    cta_families: [permission_snapshot, permission_points]
+
+  - code: EXTRACONTRATUAIS
+    name: Serviços e custos extracontratuais
+    aliases: [EXTRA, EXTRACONTRATUAL, EXTRAS]
+    commercial_insight: |
+      Trabalho fora do instrumento precisa de ordem, evidência e enquadramento; volume sozinho não sustenta pedido.
+    common_miss: Acumular extras sem trilha documental contemporânea.
+    problem_hypotheses:
+      - extras executados sem formalização suficiente
+    implications:
+      - dificuldade de reconhecimento e cobrança
+    disallowed_claims:
+      - o órgão deve pagar os extras
+    default_micro_offer: DOCUMENT_CHECKLIST
+    cta_families: [permission_checklist]
+
+  - code: PLANILHAS
+    name: Planilhas e quantitativos
+    aliases: [PLANILHA, QUANTITATIVOS, ORCAMENTO]
+    commercial_insight: |
+      Planilha é a memória econômica do contrato; divergência silenciosa vira disputa tarde demais.
+    common_miss: Atualizar planilha só no fechamento.
+    problem_hypotheses:
+      - quantitativos desalinhados da execução
+    implications:
+      - reajuste/medição em base frágil
+    disallowed_claims:
+      - a planilha está errada em
+    default_micro_offer: DOCUMENT_CHECKLIST
+    cta_families: [permission_points]
+
+  - code: ENCERRAMENTO_CONTRATUAL
+    name: Encerramento e close-out
+    aliases: [ENCERRAMENTO, CLOSEOUT, CLOSE_OUT, TERMINO]
+    commercial_insight: |
+      Proximidade de fim de vigência concentra o que ainda pode ser regularizado documentalmente.
+    common_miss: Deixar close-out para o último mês sem checklist.
+    problem_hypotheses:
+      - pendências de medição/reajuste perto do término
+    implications:
+      - perda de janela operacional para regularização
+    disallowed_claims:
+      - o contrato vence sem quitação
+    default_micro_offer: CLOSEOUT_CHECK
+    cta_families: [permission_checklist, permission_timeline]
+
+  - code: APOIO_LICITACAO
+    name: Apoio a licitação e propostas
+    aliases: [LICITACAO, BID_SUPPORT, PROPOSTA]
+    commercial_insight: |
+      Risco de proposta nasce em premissas e quantitativos, não só no preço final.
+    common_miss: Revisar só o valor unitário e ignorar inconsistências de edital/planilha.
+    problem_hypotheses:
+      - premissas de edital subavaliadas
+    implications:
+      - margem e execução sob pressão
+    disallowed_claims:
+      - vocês vão perder a licitação
+    default_micro_offer: PROCUREMENT_RISK_SNAPSHOT
+    cta_families: [permission_snapshot]
+
+  - code: MONITORAMENTO_CONTRATUAL
+    name: Monitoramento contratual contínuo
+    aliases: [MONITORAMENTO, PORTFOLIO, ACOMPANHAMENTO]
+    commercial_insight: |
+      Carteira grande esconde eventos de baixo ruído; o valor está em priorizar o que merece leitura agora.
+    common_miss: Tratar todos os contratos com a mesma atenção.
+    problem_hypotheses:
+      - eventos públicos relevantes sem triagem
+    implications:
+      - sobrecarga e atraso em temas de maior impacto
+    disallowed_claims:
+      - sua carteira está descontrolada
+    default_micro_offer: PUBLIC_DATA_SNAPSHOT
+    cta_families: [permission_snapshot, permission_points]

--- a/data/confenge/outreach_playbook/triggers.yaml
+++ b/data/confenge/outreach_playbook/triggers.yaml
@@ -1,0 +1,74 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+# Activation / moment triggers → why_now framing (not scores).
+triggers:
+  - code: ANUALIDADE
+    aliases: [ANNUALITY, ANIVERSARIO, ANIVERSÁRIO, REAJUSTE_JANELA]
+    why_now_template: marco temporal/anualidade do contrato sugere janela de verificação documental
+    fact_vs_claim: |
+      Annualidade is a verify-now signal, never proof of unpaid reajuste.
+    preferred_offers: [REAJUSTE_CHECK, DOCUMENT_CHECKLIST]
+    risk_flags: [annualidade_verify_only]
+    claims_to_avoid:
+      - reajuste a receber
+      - não pago
+      - credito de
+      - crédito de
+
+  - code: ADITIVO_RECENTE
+    aliases: [ADITIVO, ADDITIVE, TERMO_ADITIVO]
+    why_now_template: aditivo ou alteração recente publicada merece leitura de efeitos colaterais
+    preferred_offers: [ADITIVO_RISK_CHECK, CONTRACT_TIMELINE]
+    risk_flags: []
+
+  - code: MEDICAO
+    aliases: [MEDIÇÃO, MEDICOES, MEASUREMENT]
+    why_now_template: contexto de medição/execução em fase em que critérios e memórias importam
+    preferred_offers: [MEDICAO_CHECK, DOCUMENT_CHECKLIST]
+    risk_flags: []
+
+  - code: ENCERRAMENTO
+    aliases: [CLOSEOUT, TERMINO, FIM_VIGENCIA, VIGENCIA]
+    why_now_template: proximidade de encerramento concentra pendências que ainda podem ser regularizadas
+    preferred_offers: [CLOSEOUT_CHECK, CONTRACT_TIMELINE]
+    risk_flags: []
+
+  - code: NOVA_CONTRATACAO
+    aliases: [NOVO_CONTRATO, LICITACAO, AWARD]
+    why_now_template: nova contratação/publicação abre janela de leitura preventiva
+    preferred_offers: [CONTRACT_CHECK, PROCUREMENT_RISK_SNAPSHOT]
+    risk_flags: []
+
+  - code: PRORROGACAO
+    aliases: [PRORROGAÇÃO, EXTENSION]
+    why_now_template: prorrogação altera horizonte e pode reabrir bases de cálculo e prazos
+    preferred_offers: [CONTRACT_TIMELINE, DOCUMENT_CHECKLIST]
+    risk_flags: []
+
+  - code: DOCUMENTACAO_PUBLICADA
+    aliases: [DOC_PUBLICADA, PUBLICACAO, PNCP]
+    why_now_template: documentação recentemente publicada permite checagem pontual
+    preferred_offers: [PUBLIC_DATA_SNAPSHOT, DOCUMENT_CHECKLIST]
+    risk_flags: []
+
+  - code: DIVERGENCIA
+    aliases: [DIVERGÊNCIA, INCONSISTENCIA, INCONSISTÊNCIA]
+    why_now_template: há sinal público de possível divergência que merece validação (não conclusão)
+    preferred_offers: [CONTRACT_CHECK, CLAIM_READINESS_CHECK]
+    risk_flags: [hypothesis_language_required]
+    claims_to_avoid:
+      - irregularidade confirmada
+      - fraude
+      - o órgão errou
+
+  - code: PORTFOLIO
+    aliases: [CARTEIRA, MONITORAMENTO]
+    why_now_template: contexto de carteira/monitoramento prioriza um recorte público específico
+    preferred_offers: [PUBLIC_DATA_SNAPSHOT]
+    risk_flags: []
+
+  - code: GENERIC
+    aliases: [UNKNOWN, OTHER, ""]
+    why_now_template: momento comercial indicado pelo extra-cli (sem reinventar prioridade)
+    preferred_offers: [CONTRACT_CHECK, DOCUMENT_CHECKLIST]
+    risk_flags: [weak_trigger]

--- a/docs/confenge/OUTREACH-DOCTRINE.md
+++ b/docs/confenge/OUTREACH-DOCTRINE.md
@@ -1,0 +1,86 @@
+# CONFENGE outreach doctrine (confenge-outreach-v1)
+
+Machine-readable twin: `internal/app/confenge/outreach_playbook/` (mirrored under `data/confenge/outreach_playbook/`).
+
+Constant: `OutreachDoctrineVersion` in `internal/app/confenge/playbook.go`.
+
+## Purpose
+
+Maximize:
+
+```
+meaningful positive conversations ÷ emails effectively delivered
+```
+
+Not volume, not prettier templates, not fake personalization.
+
+## Architectural boundary
+
+| Plane | Owns |
+| --- | --- |
+| extra-cli | WHO / WHY NOW (activation, ranking) |
+| Warmbly strategy | WHAT TO SAY / WHAT TO OFFER / WHAT NEXT |
+
+Warmbly does **not** create `lead_score`, `commercial_score`, or re-rank activation.
+
+## Pipeline
+
+```
+intelligence (dossier)
+  → commercial strategy (OutreachStrategy)
+  → constrained generation
+  → deterministic validation (copy QA)
+  → human approval
+  → send (existing gates)
+  → outcomes / experiments
+```
+
+Never: lead data → freestyle LLM → email.
+
+## First email
+
+Sells only: attention + relevance + rational curiosity + low-friction next step.
+
+Does **not** sell: consulting package, retainer, paid diagnostic, or meeting by default.
+
+Structure:
+
+1. Relevant public observation (minimal fact)
+2. Honest implication / hypothesis (not accusation)
+3. Useful perspective (Challenger insight, not fearmongering)
+4. Micro-offer CTA (permission / interest)
+
+Defaults (experimental priors): ~40–100 words, 3–4 sentences, one CTA, PT-BR, no attachment.
+
+## Fact vs hypothesis
+
+- Facts: evidence-backed, public, traceable
+- Hypothesis: linguistically scoped (`parece`, `talvez valha conferir`, `não dá para concluir só com a publicação`)
+- Annualidade alone = verify-now signal, **never** “reajuste a receber”
+
+## Anti-creepy
+
+`KNOW A LOT / SAY LITTLE`. Prefer “Vi no PNCP…” / “Pelo contrato publicado…”. Never “estamos monitorando sua empresa”.
+
+## Micro-offers
+
+Only LOW fulfillment budget on cold path. Fulfill promised value before asking for a meeting.
+
+## Sequence (5 touches)
+
+1. SIGNAL — fact + hypothesis + micro-offer  
+2. IMPLICATION — new angle  
+3. VALUE — checklist / insight  
+4. ROUTING — internal referral when appropriate  
+5. GRACEFUL CLOSE — no guilt trip  
+
+No empty “just following up”.
+
+## Experiments
+
+Primary metric: positive conversation rate (not opens).  
+Account-level assignment; single dimension when possible; small-n → INCONCLUSIVE.
+
+## Safety non-goals of this layer
+
+Does not change: governor, green_autorun, policy_auth, transport, activation scoring, DNC transport gate, WhatsApp runtime (stays OFF).

--- a/docs/confenge/OUTREACH-RESEARCH-SYNTHESIS.md
+++ b/docs/confenge/OUTREACH-RESEARCH-SYNTHESIS.md
@@ -1,0 +1,95 @@
+# Outreach research synthesis (CONFENGE)
+
+Labels used below:
+
+- **EVIDENCE**: public / empirical claim with published support  
+- **PRINCIPLE**: operational principle extracted without copying proprietary text  
+- **LOCAL HYPOTHESIS**: CONFENGE adaptation for Brazilian public-works B2G; must be measured  
+
+Hierarchy when sources diverge: own measured outcomes → large modern datasets → behavioral research → methodology books → expert opinion → sales folklore.
+
+---
+
+## Predictable Revenue (Aaron Ross)
+
+| | |
+| --- | --- |
+| PRINCIPLE | Systematic outbound; specialize prospecting; ICP; repeatable process; measured funnel; activity→outcome relationship; route when wrong person |
+| ADOPTS | Process discipline, role clarity (extra-cli vs Warmbly), wrong-person routing (touch 4), funnel metrics beyond vanity |
+| REJECTS | Historical sales-dev headcount ratios, rigid cadences from another decade, treating volume as the goal |
+| PRODUCT | Strategy planner + experiment funnel + routing touch |
+| MEASURE | positive_reply_rate, qualified_conversation_rate, referral rate |
+
+## Fanatical Prospecting (Jeb Blount)
+
+| | |
+| --- | --- |
+| PRINCIPLE | Consistent prospecting, sequence discipline, familiarity over time, multiple thoughtful touches, relevance, persistence without desperation |
+| ADOPTS | Multi-touch sequence where each touch earns existence; persistence without guilt |
+| REJECTS | Using “fanatical” as justification for spam or empty bumps |
+| PRODUCT | `sequence.yaml` + empty-followup ban in copy QA |
+| MEASURE | stop-on-reply compliance; multi-touch contribution to positive replies |
+
+## Challenger Sale
+
+| | |
+| --- | --- |
+| PRINCIPLE | Teach, Tailor, Take Control; commercial insight; reframe status quo; constructive tension |
+| ADOPTS | Arrive with evidence-backed hypothesis; commercial insights per `service_code`; reframe without aggression |
+| REJECTS | Confrontational tone; insight without evidence; turning cold email into a lecture |
+| PRODUCT | `services.yaml` commercial_insight + strategy.commercial_reframe |
+| MEASURE | positive replies that accept micro-offer vs generic interest |
+
+## SPIN Selling
+
+| | |
+| --- | --- |
+| PRINCIPLE | Situation → Problem → Implication → Need-payoff as progressive discovery |
+| ADOPTS | SPIN **after** engagement; one relevant question at a time; use known situation from extra-cli |
+| REJECTS | Cold email as SPIN questionnaire; asking for facts already in the dossier |
+| PRODUCT | Reply / conversation strategy after POSITIVE_INTEREST |
+| MEASURE | qualified_conversation quality (not question count) |
+
+## Cialdini / Influence
+
+| | |
+| --- | --- |
+| PRINCIPLE | Reciprocity, authority, social proof, consistency, scarcity, liking, unity |
+| ADOPTS | Ethical reciprocity (value before ask); authority via observation quality, not biography |
+| REJECTS | Fake scarcity, invented clients/cases/percents, artificial urgency, invented authority |
+| PRODUCT | Micro-offer engine + fulfillment path; social proof omit-if-missing |
+| MEASURE | offer_accepted rate; fulfillment-before-meeting rate |
+
+## Gong Labs / modern cold email practice (LOCAL HYPOTHESIS priors)
+
+Public outbound research and practitioner datasets (Gong, 30MPC-style guidance, deliverability practitioners) commonly favor:
+
+| Prior | Label |
+| --- | --- |
+| Shorter emails, lower cognitive load | LOCAL HYPOTHESIS (start 40–100 words) |
+| Problem/priority before solution dump | PRINCIPLE + LOCAL HYPOTHESIS |
+| Buyer language, low marketing-speak | PRINCIPLE |
+| Interest/permission CTA over meeting-first | LOCAL HYPOTHESIS for CONFENGE |
+| Real why-you / why-now | PRINCIPLE |
+| Scannable structure without headings | LOCAL HYPOTHESIS |
+
+These are **starting priors**, not laws. Experiment engine may overturn them with CONFENGE data.
+
+---
+
+## CONFENGE-specific adaptations (B2G / obras públicas)
+
+1. **Public contracts as commercial asset**: personalize from PNCP/contract events, not LinkedIn flattery.  
+2. **Annualidade ≠ unpaid claim**: legal/commercial honesty is a differentiator.  
+3. **Anti-creepy public intelligence**: deep data, sparse wording.  
+4. **Complement legal, never replace**: especially vs in-house jurídico.  
+5. **Robust vs regional contractors**: peer-level vs overload-help language; never insult structure.  
+6. **LGPD / DNC**: public data ≠ unlimited use; durable DNC; no auto-reactivation by new trigger (existing gates).  
+
+## What we will not do
+
+- Copy book/course proprietary scripts  
+- Optimize opens as primary success  
+- Declare experiment winners on small-n  
+- Let copy performance re-score activation order  
+- Enable WhatsApp cold or GREEN autorun in this doctrine layer  

--- a/docs/confenge/copy-generation.md
+++ b/docs/confenge/copy-generation.md
@@ -9,8 +9,10 @@ There is **no research** in this path: the model receives structured JSON and re
 | --- | --- |
 | `confenge.draft.v1` | Initial evidence-bound email generator + template fallback |
 | `confenge.draft.v2` | Channel-aware modes, `claims[]`, internal `rationale`, anti-template linter, near-dup single regen |
+| `confenge.draft.v3` | Strategy-first composition (`OutreachStrategy`), doctrine `confenge-outreach-v1`, micro-offers, doctrine QA |
 
 Constant: `internal/app/confenge/validators.go` → `PromptVersion`.
+Doctrine: `OutreachDoctrineVersion` + `internal/app/confenge/outreach_playbook/`.
 
 Bump the constant when the system prompt schema or hard safety rules change. Store the version on each `OutreachDraft.PromptVersion` for audit.
 

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -832,12 +832,13 @@ func (h *Handler) RejectSkipConfengeTouchpoint(c *gin.Context) {
 	}
 	var body struct {
 		Action string `json:"action" binding:"required"`
+		Reason string `json:"reason"`
 	}
 	if err := c.ShouldBindJSON(&body); err != nil {
 		errx.JSON(c, errx.ErrInvalid)
 		return
 	}
-	tp, xerr := h.ConfengeService.RejectOrSkipTouchpoint(c.Request.Context(), orgID, userID, id, body.Action)
+	tp, xerr := h.ConfengeService.RejectOrSkipTouchpointReason(c.Request.Context(), orgID, userID, id, body.Action, body.Reason)
 	if xerr != nil {
 		errx.JSON(c, xerr)
 		return

--- a/internal/app/confenge/doctrine_qa.go
+++ b/internal/app/confenge/doctrine_qa.go
@@ -1,0 +1,285 @@
+package confenge
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"unicode/utf8"
+)
+
+// DoctrineQAResult is deterministic copy QA against doctrine + strategy.
+type DoctrineQAResult struct {
+	OK       bool     `json:"ok"`
+	Errors   []string `json:"errors,omitempty"`
+	Warnings []string `json:"warnings,omitempty"`
+	Alerts   []string `json:"alerts,omitempty"` // operator-facing short codes
+}
+
+var (
+	fakeReFwdRe = regexp.MustCompile(`(?i)^\s*(re|fw|fwd)\s*:`)
+	linkRe      = regexp.MustCompile(`(?i)https?://[^\s]+`)
+)
+
+// ValidateDoctrineCopy enforces world-class outreach constraints after structural ValidateDraft.
+func ValidateDoctrineCopy(out *DraftOutput, st *OutreachStrategy, pb *Playbook, channel string) DoctrineQAResult {
+	res := DoctrineQAResult{OK: true}
+	if out == nil {
+		res.OK = false
+		res.Errors = append(res.Errors, "empty draft")
+		return res
+	}
+	if pb == nil {
+		pb, _ = LoadPlaybook()
+	}
+	body := strings.TrimSpace(out.BodyText)
+	subj := strings.TrimSpace(out.Subject)
+	blob := strings.ToLower(subj + "\n" + body)
+	isInitial := channel == ChannelEmailInitial || channel == ""
+
+	// Empty follow-up phrases (any touch)
+	if pb != nil {
+		for _, p := range pb.Sequence.EmptyFollowupPhrases {
+			if p != "" && strings.Contains(blob, strings.ToLower(p)) {
+				res.OK = false
+				res.Errors = append(res.Errors, "empty follow-up phrase: "+p)
+				res.Alerts = append(res.Alerts, "empty_followup")
+			}
+		}
+		for _, p := range pb.CopyRules.BannedPhrases {
+			if p != "" && strings.Contains(blob, strings.ToLower(p)) {
+				res.OK = false
+				res.Errors = append(res.Errors, "doctrine banned phrase: "+p)
+				res.Alerts = append(res.Alerts, "banned_phrase")
+			}
+		}
+		for _, p := range pb.CopyRules.CreepyPhrasing {
+			if p != "" && strings.Contains(blob, strings.ToLower(p)) {
+				res.OK = false
+				res.Errors = append(res.Errors, "creepy phrasing: "+p)
+				res.Alerts = append(res.Alerts, "creepy")
+			}
+		}
+	}
+
+	// Meeting-first CTA on first touch
+	if isInitial && st != nil && st.SequencePosition <= 1 {
+		if pb != nil {
+			for _, p := range pb.CopyRules.MeetingCTAPhrases {
+				if p != "" && strings.Contains(blob, strings.ToLower(p)) {
+					res.OK = false
+					res.Errors = append(res.Errors, "meeting CTA not allowed as first-touch default: "+p)
+					res.Alerts = append(res.Alerts, "meeting_default_cta")
+				}
+			}
+		}
+		// Multiple CTAs (question marks as proxy + explicit calendar)
+		if strings.Count(body, "?") > 2 {
+			res.Warnings = append(res.Warnings, "multiple question marks / possible multi-CTA")
+			res.Alerts = append(res.Alerts, "multiple_ctas")
+		}
+	}
+
+	// Fake Re:/Fwd: on first touch subject
+	if isInitial && subj != "" && fakeReFwdRe.MatchString(subj) {
+		res.OK = false
+		res.Errors = append(res.Errors, "fake Re:/Fwd: subject not allowed on first touch")
+		res.Alerts = append(res.Alerts, "fake_re_fwd")
+	}
+
+	// Annualidade unpaid claim
+	if st != nil && containsStr(st.RiskFlags, "annualidade_verify_only") {
+		for _, bad := range annualidadeBadFromPB(pb) {
+			if strings.Contains(blob, strings.ToLower(bad)) {
+				res.OK = false
+				res.Errors = append(res.Errors, "annualidade must not claim unpaid reajuste: "+bad)
+				res.Alerts = append(res.Alerts, "unsupported_claim")
+			}
+		}
+	}
+
+	// Strategy claims_to_avoid
+	if st != nil {
+		for _, avoid := range st.ClaimsToAvoid {
+			avoid = strings.TrimSpace(strings.ToLower(avoid))
+			if avoid != "" && strings.Contains(blob, avoid) {
+				res.OK = false
+				res.Errors = append(res.Errors, "claims_to_avoid: "+avoid)
+				res.Alerts = append(res.Alerts, "unsupported_claim")
+			}
+		}
+		// WHY NOW required for first touch (strategy field, not necessarily in body)
+		if st.SequencePosition <= 1 && strings.TrimSpace(st.WhyNow) == "" {
+			res.OK = false
+			res.Errors = append(res.Errors, "strategy missing why_now")
+			res.Alerts = append(res.Alerts, "missing_why_now")
+		}
+		if st.SequencePosition <= 1 && strings.TrimSpace(st.WhyThisAccount) == "" {
+			res.OK = false
+			res.Errors = append(res.Errors, "strategy missing why_this_account")
+		}
+		// Offer fulfillable
+		if st.MicroOfferCode != "" && pb != nil {
+			o := pb.FindOffer(st.MicroOfferCode)
+			if o == nil {
+				res.OK = false
+				res.Errors = append(res.Errors, "unknown micro_offer: "+st.MicroOfferCode)
+				res.Alerts = append(res.Alerts, "offer_cannot_be_fulfilled")
+			} else if strings.ToUpper(o.FulfillmentCost) != "LOW" && st.SequencePosition <= 1 {
+				res.OK = false
+				res.Errors = append(res.Errors, "cold path may only offer LOW fulfillment offers")
+				res.Alerts = append(res.Alerts, "offer_cannot_be_fulfilled")
+			}
+		}
+		if containsStr(st.RiskFlags, "no_safe_factual_hook") && isInitial {
+			res.Warnings = append(res.Warnings, "weak factual hook; prefer needs-review over generic pitch")
+			res.Alerts = append(res.Alerts, "evidence_weak")
+		}
+		if containsStr(st.RiskFlags, "evidence_requires_hypothesis_language") {
+			if looksLikeHardMonetaryOrCertainty(blob) {
+				res.OK = false
+				res.Errors = append(res.Errors, "hypothesis-grade evidence phrased as certainty")
+				res.Alerts = append(res.Alerts, "hypothesis_as_fact")
+			}
+		}
+	}
+
+	// Word count doctrine defaults for first email
+	words := countWords(body)
+	if isInitial && pb != nil {
+		minW := pb.Doctrine.FirstEmailDefaults.MinWords
+		maxW := pb.Doctrine.FirstEmailDefaults.MaxWords
+		if minW > 0 && words > 0 && words < minW {
+			res.Warnings = append(res.Warnings, fmt.Sprintf("shorter than doctrine min %d words (%d)", minW, words))
+			res.Alerts = append(res.Alerts, "short_email")
+		}
+		if maxW > 0 && words > maxW {
+			// Soft doctrine cap as warning if under hard MaxInitial; hard fail if way over
+			if words > maxW+40 {
+				res.OK = false
+				res.Errors = append(res.Errors, fmt.Sprintf("body exceeds doctrine max %d words (%d)", maxW, words))
+			} else {
+				res.Warnings = append(res.Warnings, fmt.Sprintf("body above doctrine preferred max %d words (%d)", maxW, words))
+			}
+			res.Alerts = append(res.Alerts, "long_email")
+		}
+	}
+
+	// Links on first email
+	if isInitial {
+		links := linkRe.FindAllString(body, -1)
+		if len(links) > 1 {
+			res.OK = false
+			res.Errors = append(res.Errors, fmt.Sprintf("too many links on first email (%d)", len(links)))
+		}
+	}
+
+	// Generic opening
+	if isInitial && isGenericOpening(body) {
+		res.Warnings = append(res.Warnings, "generic opening")
+		res.Alerts = append(res.Alerts, "generic_opening")
+	}
+
+	// SO WHAT: value_to_recipient must exist on strategy for first touch
+	if isInitial && st != nil && strings.TrimSpace(st.ValueToRecipient) == "" {
+		res.OK = false
+		res.Errors = append(res.Errors, "strategy missing value_to_recipient (so-what test)")
+	}
+
+	// Subject: no ALL CAPS shouting, no emoji
+	if subj != "" {
+		if subj == strings.ToUpper(subj) && utf8.RuneCountInString(subj) > 4 && hasLetter(subj) {
+			res.OK = false
+			res.Errors = append(res.Errors, "subject is ALL CAPS")
+		}
+		if containsEmoji(subj) {
+			res.OK = false
+			res.Errors = append(res.Errors, "emoji in subject not allowed")
+		}
+	}
+
+	if !res.OK && len(res.Errors) == 0 {
+		res.Errors = append(res.Errors, "doctrine validation failed")
+	}
+	return res
+}
+
+func annualidadeBadFromPB(pb *Playbook) []string {
+	if pb != nil && len(pb.CopyRules.AnnualidadeBadClaims) > 0 {
+		return pb.CopyRules.AnnualidadeBadClaims
+	}
+	return []string{
+		"reajuste a receber", "reajuste não pago", "reajuste nao pago",
+		"o órgão deixou de pagar", "o orgao deixou de pagar",
+		"crédito de reajuste", "credito de reajuste",
+	}
+}
+
+func looksLikeHardMonetaryOrCertainty(blob string) bool {
+	for _, p := range []string{
+		"vocês têm r$", "voces tem r$", "têm r$ a receber", "tem r$ a receber",
+		"é certo que", "e certo que", "comprovamos que", "identificamos perda de r$",
+	} {
+		if strings.Contains(blob, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func isGenericOpening(body string) bool {
+	low := strings.ToLower(strings.TrimSpace(body))
+	// First ~80 chars
+	if utf8.RuneCountInString(low) > 80 {
+		low = string([]rune(low)[:80])
+	}
+	for _, g := range []string{
+		"vi que sua empresa atua",
+		"notei que vocês atuam",
+		"notei que voces atuam",
+		"parabéns pela trajetória",
+		"parabens pela trajetoria",
+		"empresa incrível",
+		"empresa incrivel",
+		"vi seu linkedin",
+		"vi o site de vocês",
+		"vi o site de voces",
+	} {
+		if strings.Contains(low, g) {
+			return true
+		}
+	}
+	return false
+}
+
+func hasLetter(s string) bool {
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= 'á' && r <= 'ž') {
+			return true
+		}
+	}
+	return false
+}
+
+func containsEmoji(s string) bool {
+	for _, r := range s {
+		if r >= 0x1F300 && r <= 0x1FAFF {
+			return true
+		}
+		if r >= 0x2600 && r <= 0x27BF {
+			return true
+		}
+	}
+	return false
+}
+
+// MergeDoctrineIntoValidation folds doctrine QA into ValidationResult.
+func MergeDoctrineIntoValidation(val *ValidationResult, dqa DoctrineQAResult) {
+	if val == nil {
+		return
+	}
+	for _, e := range dqa.Errors {
+		val.OK = false
+		val.Errors = append(val.Errors, e)
+	}
+	val.Warnings = append(val.Warnings, dqa.Warnings...)
+}

--- a/internal/app/confenge/doctrine_qa_test.go
+++ b/internal/app/confenge/doctrine_qa_test.go
@@ -1,0 +1,140 @@
+package confenge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestDoctrineQA_BadAnnualidadeFails(t *testing.T) {
+	pb := MustPlaybook()
+	acc := testAccount("REAJUSTE", "ANUALIDADE", "aniversário contratual 2024")
+	st := PlanOutreachStrategy(pb, acc, testCand("Sócio"), []models.OutreachEvidence{{
+		SourceEvidenceID: "ev-1", EpistemicClass: models.OutreachEpistemicConfirmedFact,
+	}}, 1)
+	bad := &DraftOutput{
+		Channel: ChannelEmailInitial,
+		Subject: "Oportunidade",
+		BodyText: "Olá, identificamos que vocês têm reajuste a receber no contrato. " +
+			"O órgão deixou de pagar o reajuste. Podemos marcar uma call de 30 minutos amanhã?",
+		FactUsed: st.ObservedFact, EvidenceIDs: []string{"ev-1"}, ServiceCode: "REAJUSTE",
+		CTA: "Podemos marcar uma call?",
+	}
+	dqa := ValidateDoctrineCopy(bad, &st, pb, ChannelEmailInitial)
+	if dqa.OK {
+		t.Fatalf("expected fail: %+v", dqa)
+	}
+	joined := strings.Join(dqa.Errors, " ")
+	if !strings.Contains(joined, "annualidade") && !strings.Contains(joined, "meeting") && !strings.Contains(joined, "reajuste") {
+		t.Fatalf("errors should cite annualidade/meeting/claim: %v", dqa.Errors)
+	}
+}
+
+func TestDoctrineQA_GoodVerifyPasses(t *testing.T) {
+	pb := MustPlaybook()
+	acc := testAccount("REAJUSTE", "ANUALIDADE", "contrato 1149 atingiu aniversário de reajuste")
+	cand := testCand("Sócio")
+	ev := []models.OutreachEvidence{{SourceEvidenceID: "ev-1", EpistemicClass: models.OutreachEpistemicConfirmedFact}}
+	st := PlanOutreachStrategy(pb, acc, cand, ev, 1)
+	good := ComposeFromStrategy(st, acc, cand, ChannelEmailInitial)
+	// Ensure body long enough for contact enroll path later
+	val := ValidateDraft(&good, acc, cand, ValidateOpts{
+		MaxWords: 200, Evidence: ev, Channel: ChannelEmailInitial, Strategy: &st, Playbook: pb,
+	})
+	// Compose may still warn on short email; hard errors on annualidade claim must be empty
+	for _, e := range val.Errors {
+		if strings.Contains(e, "annualidade") || strings.Contains(e, "reajuste a receber") {
+			t.Fatalf("good path annualidade error: %s body=%s", e, good.BodyText)
+		}
+		if strings.Contains(e, "meeting CTA") {
+			t.Fatalf("good path meeting: %s", e)
+		}
+	}
+	dqa := ValidateDoctrineCopy(&good, &st, pb, ChannelEmailInitial)
+	for _, e := range dqa.Errors {
+		if strings.Contains(e, "annualidade") {
+			t.Fatal(e)
+		}
+	}
+}
+
+func TestDoctrineQA_EmptyFollowUpFails(t *testing.T) {
+	pb := MustPlaybook()
+	st := PlanOutreachStrategy(pb, testAccount("REAJUSTE", "PORTFOLIO", "fato X"), testCand(""), nil, 2)
+	out := &DraftOutput{
+		Subject: "Re: X", BodyText: "Olá, só acompanhando e subindo no seu inbox. Teve chance de ver?",
+		FactUsed: "fato X", EvidenceIDs: []string{"ev-1"},
+	}
+	dqa := ValidateDoctrineCopy(out, &st, pb, ChannelEmailFollowup)
+	if dqa.OK {
+		t.Fatal("empty follow-up must fail")
+	}
+}
+
+func TestDoctrineQA_FakeReFirstTouch(t *testing.T) {
+	pb := MustPlaybook()
+	st := PlanOutreachStrategy(pb, testAccount("ADITIVOS", "ADITIVO", "aditivo 2"), testCand("Engenheiro"), nil, 1)
+	out := &DraftOutput{
+		Subject: "Re: aditivo", BodyText: strings.Repeat("ponto relevante sobre o aditivo publicado. ", 8) + "Posso te mandar os pontos?",
+		FactUsed: "aditivo 2", EvidenceIDs: []string{"ev-1"},
+	}
+	dqa := ValidateDoctrineCopy(out, &st, pb, ChannelEmailInitial)
+	if dqa.OK {
+		t.Fatal("fake Re must fail on first touch")
+	}
+}
+
+func TestContrastBadVsGood(t *testing.T) {
+	pb := MustPlaybook()
+	acc := testAccount("REAJUSTE", "ANUALIDADE", "contrato DER-PR 88/2021 aniversário de reajuste")
+	cand := testCand("Diretor de Contratos")
+	ev := []models.OutreachEvidence{{SourceEvidenceID: "ev-1", Title: "PNCP", EpistemicClass: models.OutreachEpistemicConfirmedFact}}
+	st := PlanOutreachStrategy(pb, acc, cand, ev, 1)
+
+	bad := DraftOutput{
+		Subject: "PARCERIA IMPERDÍVEL",
+		BodyText: "A CONFENGE é especializada em contratos públicos e pode ajudar sua empresa a recuperar valores. " +
+			"Gostaria de agendar 30 minutos? Somos líderes de mercado.",
+		FactUsed: "x", EvidenceIDs: []string{"ev-1"},
+	}
+	good := ComposeFromStrategy(st, acc, cand, ChannelEmailInitial)
+
+	badQA := ValidateDoctrineCopy(&bad, &st, pb, ChannelEmailInitial)
+	goodQA := ValidateDoctrineCopy(&good, &st, pb, ChannelEmailInitial)
+	if badQA.OK {
+		t.Fatalf("BAD should fail: %v", badQA)
+	}
+	// GOOD may have soft warnings but must not claim unpaid reajuste
+	for _, e := range goodQA.Errors {
+		if strings.Contains(e, "annualidade") || strings.Contains(e, "meeting CTA") {
+			t.Fatalf("GOOD hard fail: %s\n%s", e, good.BodyText)
+		}
+	}
+}
+
+func TestAntiTemplateDiversity(t *testing.T) {
+	pb := MustPlaybook()
+	bodies := map[string]bool{}
+	fixtures := []struct {
+		svc, moment, fact, role string
+		pos                     int
+	}{
+		{"REAJUSTE", "ANUALIDADE", "contrato 1149 aniversário reajuste", "Sócio", 1},
+		{"ADITIVOS", "ADITIVO_RECENTE", "termo aditivo 3 ao contrato 220/2023", "Engenheiro", 1},
+		{"MEDICOES", "MEDICAO", "medição do lote 2 publicada", "Analista Financeiro", 1},
+		{"ENCERRAMENTO_CONTRATUAL", "ENCERRAMENTO", "vigência encerra em 90 dias", "Diretor", 1},
+		{"REAJUSTE", "ANUALIDADE", "contrato 1149 aniversário reajuste", "Sócio", 5},
+	}
+	for _, f := range fixtures {
+		acc := testAccount(f.svc, f.moment, f.fact)
+		st := PlanOutreachStrategy(pb, acc, testCand(f.role), nil, f.pos)
+		out := ComposeFromStrategy(st, acc, testCand(f.role), ChannelEmailInitial)
+		// Normalize names
+		key := strings.TrimSpace(out.BodyText)
+		bodies[key] = true
+	}
+	if len(bodies) < 4 {
+		t.Fatalf("expected diverse bodies, got %d unique", len(bodies))
+	}
+}

--- a/internal/app/confenge/drafts.go
+++ b/internal/app/confenge/drafts.go
@@ -71,14 +71,17 @@ func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uu
 
 	recent := recentDraftBodies(ctx, s, orgID, accountID, models.OutreachChannelEmail)
 	in := BuildGenerateInput(ChannelEmailInitial, acc, cand, evidence, recent)
+	pb, _ := LoadPlaybook()
+	st := PlanOutreachStrategy(pb, acc, cand, evidence, 1)
 	gen := s.generator()
 	out, provider, model, genErr := gen.Generate(ctx, in)
 	usedTemplate := false
 	if genErr != nil {
-		out = TemplateDraftChannel(ChannelEmailInitial, acc, cand, evidence)
+		out = ComposeFromStrategy(st, acc, cand, ChannelEmailInitial)
 		provider = "template"
-		model = "deterministic"
+		model = "strategy_compose"
 		usedTemplate = true
+		out.RiskFlags = append(out.RiskFlags, "generation_failed_strategy_compose")
 	}
 	if out.ServiceCode == "" {
 		out.ServiceCode = acc.ServiceCode
@@ -93,6 +96,7 @@ func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uu
 	val := ValidateDraft(&out, acc, cand, ValidateOpts{
 		MaxWords: s.cfg.MaxInitialEmailWords, Evidence: evidence,
 		Channel: ChannelEmailInitial, RecentBodies: recent,
+		Strategy: &st, Playbook: pb,
 	})
 	risk, flags := ClassifyRisk(acc, cand, &out, val)
 	if usedTemplate {
@@ -104,14 +108,18 @@ func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uu
 	val.Claims = out.Claims
 	val.Rationale = out.Rationale
 	val.Channel = out.Channel
-
-	valJSON, _ := json.Marshal(val)
+	recipient := cand.Email
+	if cand.Name != "" {
+		recipient = cand.Name + " <" + cand.Email + ">"
+	}
+	valJSON := PackValidationWithStrategy(val, st, recipient)
 	followJSON, _ := json.Marshal(out.Followups)
 	draft.Subject = SanitizeText(out.Subject, 200)
 	draft.BodyText = SanitizeText(out.BodyText, 8000)
 	draft.BodyHTML = ""
 	draft.FollowupsJSON = followJSON
 	draft.ServiceCode = SanitizeText(out.ServiceCode, 100)
+	draft.StrategyCode = SanitizeText(StrategyCodeFor(st), 200)
 	draft.FactUsed = SanitizeText(out.FactUsed, 2000)
 	draft.EvidenceIDs = collectEvidenceIDs(&out)
 	draft.Question = SanitizeText(out.Question, 1000)

--- a/internal/app/confenge/experiment.go
+++ b/internal/app/confenge/experiment.go
@@ -1,0 +1,200 @@
+package confenge
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"math"
+	"strings"
+)
+
+// Experiment dimensions — assign one at a time when possible.
+const (
+	ExpDimOffer   = "offer"
+	ExpDimCTA     = "cta"
+	ExpDimSubject = "subject"
+	ExpDimOpening = "opening"
+	ExpDimReframe = "reframe"
+)
+
+// Default minimum sample before a variant may be considered non-inconclusive.
+const ExperimentMinSamplePerArm = 50
+
+// ExperimentAssignment is account-level A/B metadata (not a priority score).
+type ExperimentAssignment struct {
+	HypothesisID    string `json:"hypothesis_id"`
+	VariantID       string `json:"variant_id"` // champion | challenger
+	Dimension       string `json:"dimension"`
+	DoctrineVersion string `json:"doctrine_version"`
+	StrategyVersion string `json:"strategy_version"`
+	ServiceCode     string `json:"service_code,omitempty"`
+	OfferCode       string `json:"offer_code,omitempty"`
+}
+
+// ExperimentArmStats is observed counts for one arm (no open-tracking primacy).
+type ExperimentArmStats struct {
+	VariantID             string  `json:"variant_id"`
+	Sent                  int     `json:"sent"`
+	Delivered             int     `json:"delivered"`
+	HumanReply            int     `json:"human_reply"`
+	PositiveReply         int     `json:"positive_reply"`
+	QualifiedConversation int     `json:"qualified_conversation"`
+	Meeting               int     `json:"meeting"`
+	Proposal              int     `json:"proposal"`
+	Won                   int     `json:"won"`
+	AttributedRevenue     float64 `json:"attributed_revenue,omitempty"`
+}
+
+// ExperimentEvaluation is a statistically honest comparison result.
+type ExperimentEvaluation struct {
+	Status            string  `json:"status"` // INCONCLUSIVE | CHAMPION_LEADS | CHALLENGER_LEADS
+	PrimaryMetric     string  `json:"primary_metric"`
+	ChampionRate      float64 `json:"champion_rate"`
+	ChallengerRate    float64 `json:"challenger_rate"`
+	SampleChampion    int     `json:"sample_champion"`
+	SampleChallenger  int     `json:"sample_challenger"`
+	MinSampleRequired int     `json:"min_sample_required"`
+	Reason            string  `json:"reason"`
+}
+
+// AssignExperiment assigns champion/challenger at account grain (stable hash).
+// Single dimension: offer wording family (challenger uses alternate CTA framing metadata only).
+func AssignExperiment(accountID, serviceCode, offerCode string) *ExperimentAssignment {
+	accountID = strings.TrimSpace(accountID)
+	if accountID == "" {
+		return nil
+	}
+	h := sha256.Sum256([]byte("confenge-exp-v1|" + accountID))
+	n := binary.BigEndian.Uint64(h[:8])
+	variant := "champion"
+	if n%2 == 1 {
+		variant = "challenger"
+	}
+	// Rotate dimension by account bucket so we don't mix all dimensions at once.
+	dims := []string{ExpDimCTA, ExpDimSubject, ExpDimOpening, ExpDimOffer}
+	dim := dims[int(n%uint64(len(dims)))]
+	return &ExperimentAssignment{
+		HypothesisID:    "h1-permission-cta-vs-interest",
+		VariantID:       variant,
+		Dimension:       dim,
+		DoctrineVersion: OutreachDoctrineVersion,
+		StrategyVersion: "strategy-v1",
+		ServiceCode:     serviceCode,
+		OfferCode:       offerCode,
+	}
+}
+
+// PositiveReplyRate = positive_reply / delivered (0 if no delivered).
+func PositiveReplyRate(arm ExperimentArmStats) float64 {
+	den := arm.Delivered
+	if den <= 0 {
+		den = arm.Sent
+	}
+	if den <= 0 {
+		return 0
+	}
+	return float64(arm.PositiveReply) / float64(den)
+}
+
+// HumanReplyRate includes all human replies (positive or not). Distinct from positive.
+func HumanReplyRate(arm ExperimentArmStats) float64 {
+	den := arm.Delivered
+	if den <= 0 {
+		den = arm.Sent
+	}
+	if den <= 0 {
+		return 0
+	}
+	return float64(arm.HumanReply) / float64(den)
+}
+
+// EvaluateExperiment enforces small-n protection; never declares a global winner early.
+func EvaluateExperiment(champion, challenger ExperimentArmStats, minSample int) ExperimentEvaluation {
+	if minSample <= 0 {
+		minSample = ExperimentMinSamplePerArm
+	}
+	ev := ExperimentEvaluation{
+		Status:            "INCONCLUSIVE",
+		PrimaryMetric:     "positive_reply_rate",
+		MinSampleRequired: minSample,
+		SampleChampion:    sampleSize(champion),
+		SampleChallenger:  sampleSize(challenger),
+	}
+	ev.ChampionRate = PositiveReplyRate(champion)
+	ev.ChallengerRate = PositiveReplyRate(challenger)
+
+	if ev.SampleChampion < minSample || ev.SampleChallenger < minSample {
+		ev.Reason = "sample below minimum; keep both arms"
+		return ev
+	}
+
+	// Wilson-ish rough check: require absolute difference and enough events.
+	diff := ev.ChallengerRate - ev.ChampionRate
+	// Approximate standard error for two proportions
+	se := math.Sqrt(propVar(ev.ChampionRate, ev.SampleChampion) + propVar(ev.ChallengerRate, ev.SampleChallenger))
+	if se == 0 || math.Abs(diff) < 1.96*se {
+		ev.Reason = "difference not statistically distinguishable"
+		return ev
+	}
+	if diff > 0 {
+		ev.Status = "CHALLENGER_LEADS"
+		ev.Reason = "challenger higher positive_reply_rate with adequate sample"
+	} else {
+		ev.Status = "CHAMPION_LEADS"
+		ev.Reason = "champion higher positive_reply_rate with adequate sample"
+	}
+	return ev
+}
+
+func sampleSize(a ExperimentArmStats) int {
+	if a.Delivered > 0 {
+		return a.Delivered
+	}
+	return a.Sent
+}
+
+func propVar(p float64, n int) float64 {
+	if n <= 0 {
+		return 1
+	}
+	return p * (1 - p) / float64(n)
+}
+
+// FunnelSnapshot is the operator experiment dashboard shape.
+type FunnelSnapshot struct {
+	Sent                  int     `json:"sent"`
+	Delivered             int     `json:"delivered"`
+	HumanReply            int     `json:"human_reply"`
+	PositiveReply         int     `json:"positive_reply"`
+	QualifiedConversation int     `json:"qualified"`
+	Meeting               int     `json:"meeting"`
+	Proposal              int     `json:"proposal"`
+	Won                   int     `json:"won"`
+	Revenue               float64 `json:"revenue"`
+	HumanReplyPct         float64 `json:"human_reply_pct"`
+	PositiveReplyPct      float64 `json:"positive_reply_pct"`
+	QualifiedPct          float64 `json:"qualified_pct"`
+}
+
+// BuildFunnelSnapshot computes rates from counts (opens intentionally omitted as primary).
+func BuildFunnelSnapshot(s ExperimentArmStats) FunnelSnapshot {
+	den := s.Delivered
+	if den <= 0 {
+		den = s.Sent
+	}
+	pct := func(n int) float64 {
+		if den <= 0 {
+			return 0
+		}
+		return 100 * float64(n) / float64(den)
+	}
+	return FunnelSnapshot{
+		Sent: s.Sent, Delivered: s.Delivered,
+		HumanReply: s.HumanReply, PositiveReply: s.PositiveReply,
+		QualifiedConversation: s.QualifiedConversation,
+		Meeting:               s.Meeting, Proposal: s.Proposal, Won: s.Won,
+		Revenue:          s.AttributedRevenue,
+		HumanReplyPct:    pct(s.HumanReply),
+		PositiveReplyPct: pct(s.PositiveReply),
+		QualifiedPct:     pct(s.QualifiedConversation),
+	}
+}

--- a/internal/app/confenge/experiment_test.go
+++ b/internal/app/confenge/experiment_test.go
@@ -1,0 +1,85 @@
+package confenge
+
+import (
+	"testing"
+)
+
+func TestAssignExperimentAccountLevelStable(t *testing.T) {
+	a1 := AssignExperiment("acct-aaa", "REAJUSTE", "REAJUSTE_CHECK")
+	a2 := AssignExperiment("acct-aaa", "REAJUSTE", "REAJUSTE_CHECK")
+	if a1 == nil || a2 == nil {
+		t.Fatal("nil")
+	}
+	if a1.VariantID != a2.VariantID || a1.Dimension != a2.Dimension {
+		t.Fatalf("unstable: %+v vs %+v", a1, a2)
+	}
+	if a1.DoctrineVersion != OutreachDoctrineVersion {
+		t.Fatal("doctrine stamp")
+	}
+	// Different accounts can differ
+	b := AssignExperiment("acct-bbb", "REAJUSTE", "REAJUSTE_CHECK")
+	_ = b
+}
+
+func TestEvaluateExperimentSmallNInconclusive(t *testing.T) {
+	ch := ExperimentArmStats{VariantID: "champion", Sent: 5, Delivered: 5, PositiveReply: 2}
+	cg := ExperimentArmStats{VariantID: "challenger", Sent: 5, Delivered: 5, PositiveReply: 4}
+	ev := EvaluateExperiment(ch, cg, 50)
+	if ev.Status != "INCONCLUSIVE" {
+		t.Fatalf("status %s", ev.Status)
+	}
+	if PositiveReplyRate(ch) == HumanReplyRate(ch) {
+		// with only positive set, human may be 0 — ensure helpers distinct fields
+	}
+	ch.HumanReply = 3
+	if PositiveReplyRate(ch) >= HumanReplyRate(ch) && ch.PositiveReply > ch.HumanReply {
+		t.Fatal("positive cannot exceed human when counted properly — just checking rates compute")
+	}
+}
+
+func TestEvaluateExperimentAdequateSample(t *testing.T) {
+	ch := ExperimentArmStats{VariantID: "champion", Sent: 200, Delivered: 200, PositiveReply: 10, HumanReply: 20}
+	cg := ExperimentArmStats{VariantID: "challenger", Sent: 200, Delivered: 200, PositiveReply: 60, HumanReply: 70}
+	ev := EvaluateExperiment(ch, cg, 50)
+	if ev.Status == "INCONCLUSIVE" {
+		// large difference should usually win; if se is weird still ok as long as not panicking
+		t.Logf("eval: %+v", ev)
+	}
+	if ev.PrimaryMetric != "positive_reply_rate" {
+		t.Fatal(ev.PrimaryMetric)
+	}
+}
+
+func TestFunnelSnapshotNoOpens(t *testing.T) {
+	s := BuildFunnelSnapshot(ExperimentArmStats{
+		Sent: 100, Delivered: 90, HumanReply: 18, PositiveReply: 9,
+		QualifiedConversation: 4, Meeting: 2, Proposal: 1, Won: 1, AttributedRevenue: 50000,
+	})
+	if s.PositiveReplyPct <= 0 || s.HumanReplyPct <= 0 {
+		t.Fatalf("%+v", s)
+	}
+	// positive rate should be half of human in this fixture
+	if s.PositiveReply != 9 || s.HumanReply != 18 {
+		t.Fatal("distinct positive vs human")
+	}
+}
+
+func TestPositiveReplyDistinctFromAnyReply(t *testing.T) {
+	// DNC is a reply class but not positive commercial success
+	if IsPositiveCommercialReply(ReplyClassDNC) {
+		t.Fatal("DNC is not positive")
+	}
+	if IsPositiveCommercialReply(ReplyClassNotInterested) {
+		t.Fatal("not interested is not positive")
+	}
+	if !IsPositiveCommercialReply(ReplyClassOfferAccepted) {
+		t.Fatal("offer accepted is positive")
+	}
+	class := MapCommercialReplyClass(IntentPositiveInterest, "", "Sim, pode enviar o checklist")
+	if class != ReplyClassOfferAccepted {
+		t.Fatalf("got %s", class)
+	}
+	if !IsPositiveCommercialReply(class) {
+		t.Fatal("should be positive")
+	}
+}

--- a/internal/app/confenge/fulfillment.go
+++ b/internal/app/confenge/fulfillment.go
@@ -1,0 +1,184 @@
+package confenge
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// FulfillmentDraft is the promised micro-deliverable after offer acceptance.
+type FulfillmentDraft struct {
+	OfferCode       string       `json:"offer_code"`
+	Subject         string       `json:"subject"`
+	BodyText        string       `json:"body_text"`
+	EvidenceIDs     []string     `json:"evidence_ids"`
+	Claims          []DraftClaim `json:"claims,omitempty"`
+	ProhibitedHit   bool         `json:"prohibited_hit"`
+	RiskFlags       []string     `json:"risk_flags,omitempty"`
+	DoctrineVersion string       `json:"doctrine_version"`
+	StrategyRef     string       `json:"strategy_ref,omitempty"`
+}
+
+// BuildFulfillmentDraft generates the promised micro-deliverable from strategy + evidence.
+// Never pivots to "let's book a call" without delivering value first.
+func BuildFulfillmentDraft(pb *Playbook, st OutreachStrategy, acc *models.OutreachAccount, evidence []models.OutreachEvidence) (FulfillmentDraft, error) {
+	if pb == nil {
+		var err error
+		pb, err = LoadPlaybook()
+		if err != nil {
+			return FulfillmentDraft{}, err
+		}
+	}
+	offer := pb.FindOffer(st.MicroOfferCode)
+	if offer == nil {
+		return FulfillmentDraft{}, fmt.Errorf("unknown offer %q", st.MicroOfferCode)
+	}
+	if strings.ToUpper(offer.FulfillmentCost) == "HIGH" {
+		return FulfillmentDraft{}, fmt.Errorf("offer %s is HIGH cost; not auto-fulfillable", offer.Code)
+	}
+
+	company := ""
+	if acc != nil {
+		company = firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
+	}
+	fact := st.ObservedFact
+	if fact == "" && acc != nil {
+		fact = acc.FactToMention
+	}
+	ids := st.EvidenceIDs
+	if len(ids) == 0 {
+		ids = evidenceIDsFrom(evidence, acc)
+	}
+
+	points := fulfillmentPoints(offer.Code, st, fact, company)
+	var b strings.Builder
+	b.WriteString("Segue o que prometi, de forma objetiva.\n\n")
+	if fact != "" {
+		b.WriteString("Contexto público: ")
+		b.WriteString(fact)
+		b.WriteString(".\n\n")
+	}
+	b.WriteString("O que eu conferiria:\n")
+	for i, p := range points {
+		b.WriteString(fmt.Sprintf("%d) %s\n", i+1, p))
+	}
+	b.WriteString("\nIsso não conclui mérito econômico sozinho; é só a checagem inicial.\n")
+	b.WriteString("Se fizer sentido aprofundar depois, me diga.")
+
+	body := strings.TrimSpace(b.String())
+	// Guard prohibited claims
+	low := strings.ToLower(body)
+	hit := false
+	for _, p := range offer.ProhibitedClaims {
+		if p != "" && strings.Contains(low, strings.ToLower(p)) {
+			hit = true
+		}
+	}
+	for _, p := range st.ClaimsToAvoid {
+		if p != "" && strings.Contains(low, strings.ToLower(p)) {
+			hit = true
+		}
+	}
+
+	subj := "Checklist: " + firstNonEmpty(offer.Code, "pontos a conferir")
+	if company != "" {
+		subj = trimSubject("Checklist · " + company)
+	}
+
+	fd := FulfillmentDraft{
+		OfferCode:       offer.Code,
+		Subject:         subj,
+		BodyText:        body,
+		EvidenceIDs:     ids,
+		Claims:          claimsFromFact(fact, ids),
+		ProhibitedHit:   hit,
+		DoctrineVersion: OutreachDoctrineVersion,
+		StrategyRef:     st.DoctrineVersion + "/" + st.MicroOfferCode,
+	}
+	if hit {
+		fd.RiskFlags = append(fd.RiskFlags, "fulfillment_prohibited_claim")
+	}
+	// Must not be meeting-first
+	if strings.Contains(low, "marcar uma call") || strings.Contains(low, "calendly") {
+		fd.RiskFlags = append(fd.RiskFlags, "fulfillment_pivoted_to_meeting")
+		return fd, fmt.Errorf("fulfillment must deliver value before meeting")
+	}
+	if hit {
+		return fd, fmt.Errorf("fulfillment draft hit prohibited claim")
+	}
+	return fd, nil
+}
+
+func fulfillmentPoints(offerCode string, st OutreachStrategy, fact, company string) []string {
+	base := []string{
+		"Confirmar o instrumento e o trecho público relevante" + when(fact != "", " ("+truncateRunesOffer(fact, 80)+")"),
+		"Separar fato publicado de hipótese ainda não validada",
+		"Listar documentos/memórias que sustentariam qualquer pedido formal",
+	}
+	switch strings.ToUpper(offerCode) {
+	case "REAJUSTE_CHECK":
+		return []string{
+			"Cláusula de reajuste e índice referenciado no instrumento público",
+			"Marco temporal / anualidade (sinal de verificação, não de crédito automático)",
+			"Memória de cálculo e base de incidência a reunir internamente",
+			"Publicações que confirmem ou não formalização recente",
+		}
+	case "ADITIVO_RISK_CHECK":
+		return []string{
+			"Escopo e valores alterados no aditivo publicado",
+			"Efeito em planilha base, prazos e reajuste derivado",
+			"Consistência entre aditivo e medições subsequentes",
+		}
+	case "MEDICAO_CHECK":
+		return []string{
+			"Critério de medição no trecho crítico",
+			"Alinhamento entre campo, planilha e publicação",
+			"Documentos que fecham glosa/divergência",
+		}
+	case "CLOSEOUT_CHECK":
+		return []string{
+			"Pendências de medição e reajuste perto do término",
+			"Documentos de quitação / termo de recebimento",
+			"Janela operacional restante para regularização",
+		}
+	case "CONTRACT_TIMELINE":
+		return []string{
+			"Marcos públicos conhecidos (assinatura, aditivos, vigência)",
+			"Eventos recentes ligados a " + firstNonEmpty(company, "o contrato"),
+			"Próximas datas que mudam o que deve ser conferido",
+		}
+	case "PUBLIC_DATA_SNAPSHOT":
+		return []string{
+			"Recorte público usado: " + firstNonEmpty(fact, "publicação contratual"),
+			"O que o recorte permite afirmar com segurança",
+			"O que ainda exige confirmação da empresa",
+		}
+	case "CLAIM_READINESS_CHECK":
+		return []string{
+			"Nexo e fatos públicos disponíveis",
+			"Lacunas documentais antes de qualquer pleito",
+			"Ordem sugerida de reconstituição de memória",
+		}
+	default:
+		if st.CommercialReframe != "" {
+			base = append(base, "Perspectiva: "+truncateRunesOffer(st.CommercialReframe, 120))
+		}
+		return base
+	}
+}
+
+func when(cond bool, s string) string {
+	if cond {
+		return s
+	}
+	return ""
+}
+
+func truncateRunesOffer(s string, n int) string {
+	r := []rune(strings.TrimSpace(s))
+	if len(r) <= n {
+		return string(r)
+	}
+	return string(r[:n]) + "..."
+}

--- a/internal/app/confenge/fulfillment_test.go
+++ b/internal/app/confenge/fulfillment_test.go
@@ -1,0 +1,57 @@
+package confenge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestFulfillmentDeliversBeforeMeeting(t *testing.T) {
+	pb := MustPlaybook()
+	acc := testAccount("REAJUSTE", "ANUALIDADE", "contrato 1149 aniversário")
+	st := PlanOutreachStrategy(pb, acc, testCand("Sócio"), []models.OutreachEvidence{{
+		SourceEvidenceID: "ev-1",
+	}}, 1)
+	fd, err := BuildFulfillmentDraft(pb, st, acc, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	low := strings.ToLower(fd.BodyText)
+	if strings.Contains(low, "marcar uma call") || strings.Contains(low, "calendly") {
+		t.Fatal("must not pivot to meeting")
+	}
+	if !strings.Contains(low, "confer") && !strings.Contains(low, "checklist") && !strings.Contains(low, "1)") {
+		t.Fatalf("expected deliverable content: %s", fd.BodyText)
+	}
+	if strings.Contains(low, "reajuste a receber") {
+		t.Fatal("prohibited claim in fulfillment")
+	}
+	if fd.DoctrineVersion != OutreachDoctrineVersion {
+		t.Fatal(fd.DoctrineVersion)
+	}
+}
+
+func TestOperatorEditAndReject(t *testing.T) {
+	pb := MustPlaybook()
+	if !ValidRejectionReason(pb, "too_salesy") {
+		t.Fatal("rejection reason")
+	}
+	if ValidRejectionReason(pb, "not_a_real_reason_xyz") {
+		t.Fatal("invalid reason")
+	}
+	orig := "Olá, temos sinergia e vocês têm R$ a receber. Podemos marcar uma call?"
+	edited := "Olá, pelo contrato publicado há um ponto a conferir. Posso mandar o checklist?"
+	codes := ClassifyEditSignals(orig, edited)
+	if len(codes) == 0 {
+		t.Fatal("expected edit codes")
+	}
+	sig := NewOperatorEditSignal("d1", orig, edited)
+	if sig.DoctrineVersion != OutreachDoctrineVersion {
+		t.Fatal()
+	}
+	rej := NewOperatorRejection("unsupported_claim", "d1", "REAJUSTE", "REAJUSTE_CHECK")
+	if rej.Reason != "unsupported_claim" {
+		t.Fatal()
+	}
+}

--- a/internal/app/confenge/generate.go
+++ b/internal/app/confenge/generate.go
@@ -46,6 +46,7 @@ type AIDraftGenerator struct {
 }
 
 // Generate asks the model for JSON only from structured inputs (no research).
+// Strategy is planned first; the model only words within those constraints.
 func (g *AIDraftGenerator) Generate(ctx context.Context, in GenerateInput) (DraftOutput, string, string, error) {
 	if g == nil || g.Provider == nil {
 		return DraftOutput{}, "", "", generation.ErrNotConfigured
@@ -54,8 +55,10 @@ func (g *AIDraftGenerator) Generate(ctx context.Context, in GenerateInput) (Draf
 	if channel == "" {
 		channel = ChannelEmailInitial
 	}
-	system := draftSystemPrompt(channel)
-	user := draftUserPrompt(in)
+	pb, _ := LoadPlaybook()
+	st := PlanOutreachStrategy(pb, in.Account, in.Contact, in.Evidence, sequencePosFromChannel(channel, in.Touches))
+	system := draftSystemPromptDoctrine(channel, st)
+	user := draftUserPromptWithStrategy(in, st)
 	model := g.Model
 	if model == "" {
 		model = g.Provider.ModelForTier(true)
@@ -66,6 +69,13 @@ func (g *AIDraftGenerator) Generate(ctx context.Context, in GenerateInput) (Draf
 	}
 	out.Channel = channel
 	out.ServiceOverrideAudited = in.ServiceOverrideAudited
+	if out.ServiceCode == "" {
+		out.ServiceCode = st.ServiceCode
+	}
+	if out.CTA == "" {
+		out.CTA = st.CTASuggested
+	}
+	out.RiskFlags = appendUnique(out.RiskFlags, st.RiskFlags...)
 
 	if in.AllowNearDupRegen && len(in.RecentBodies) > 0 {
 		if _, hit := NearDuplicate(out.BodyText, in.RecentBodies); hit {
@@ -75,12 +85,24 @@ func (g *AIDraftGenerator) Generate(ctx context.Context, in GenerateInput) (Draf
 				out2.Channel = channel
 				out2.ServiceOverrideAudited = in.ServiceOverrideAudited
 				out2.RiskFlags = append(out2.RiskFlags, "near_dup_regenerated")
+				out2.RiskFlags = appendUnique(out2.RiskFlags, st.RiskFlags...)
 				return out2, g.Provider.Name(), usedModel2, nil
 			}
 			out.RiskFlags = append(out.RiskFlags, "near_dup_regen_failed")
 		}
 	}
 	return out, g.Provider.Name(), usedModel, nil
+}
+
+func sequencePosFromChannel(channel string, touches []TouchSummary) int {
+	if channel == ChannelEmailFollowup {
+		n := len(touches) + 2
+		if n > 5 {
+			n = 5
+		}
+		return n
+	}
+	return 1
 }
 
 func (g *AIDraftGenerator) completeOnce(ctx context.Context, system, user, model string) (DraftOutput, string, error) {
@@ -107,7 +129,13 @@ func (TemplateGenerator) Generate(ctx context.Context, in GenerateInput) (DraftO
 	if ch == "" {
 		ch = ChannelEmailInitial
 	}
-	out := TemplateDraftChannel(ch, in.Account, in.Contact, in.Evidence)
+	pb, _ := LoadPlaybook()
+	st := PlanOutreachStrategy(pb, in.Account, in.Contact, in.Evidence, sequencePosFromChannel(ch, in.Touches))
+	out := ComposeFromStrategy(st, in.Account, in.Contact, ch)
+	if IsWhatsAppChannel(ch) || ch == ChannelReplyDraft {
+		out = TemplateDraftChannel(ch, in.Account, in.Contact, in.Evidence)
+		out.RiskFlags = appendUnique(out.RiskFlags, st.RiskFlags...)
+	}
 	out.ServiceOverrideAudited = in.ServiceOverrideAudited
 	if in.AllowNearDupRegen && len(in.RecentBodies) > 0 {
 		if _, hit := NearDuplicate(out.BodyText, in.RecentBodies); hit {
@@ -123,6 +151,12 @@ func varyTemplateHook(body string) string {
 	const to = "Escrevo da CONFENGE."
 	if strings.Contains(body, from) {
 		return strings.Replace(body, from, to, 1)
+	}
+	if strings.Contains(body, "Pelo que está público") {
+		return strings.Replace(body, "Pelo que está público", "Nas informações públicas", 1)
+	}
+	if strings.Contains(body, "Escrevo da CONFENGE") {
+		return strings.Replace(body, "Escrevo da CONFENGE", "Falo da CONFENGE", 1)
 	}
 	if strings.HasPrefix(body, "Olá") {
 		return strings.Replace(body, "Olá", "Bom dia", 1)

--- a/internal/app/confenge/generate_test.go
+++ b/internal/app/confenge/generate_test.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/pkg/generation"
 )
@@ -282,6 +284,7 @@ func TestWhatsAppNotEmailPaste(t *testing.T) {
 
 func TestNearDupSingleRegenCap(t *testing.T) {
 	acc := &models.OutreachAccount{
+		ID:           uuid.MustParse("11111111-1111-1111-1111-111111111111"),
 		NomeFantasia: "ACME", FactToMention: "contrato 001/2025 prorrogado no PNCP",
 		ServiceCode: "ADDITIVE_REVIEW", ServiceName: "revisao",
 		QuestionToAsk: "Faz sentido?", CTA: "Posso enviar?",
@@ -291,8 +294,14 @@ func TestNearDupSingleRegenCap(t *testing.T) {
 		Name: "Ana", Email: "a@example.com", VerificationStatus: models.OutreachVerifyOfficialSource,
 	}
 	ev := []models.OutreachEvidence{{SourceEvidenceID: "e1"}}
-	first := TemplateDraftChannel(ChannelEmailInitial, acc, cand, ev)
 	gen := TemplateGenerator{}
+	// First body from the same strategy-compose path so near-dup is meaningful.
+	first, _, _, err := gen.Generate(context.Background(), GenerateInput{
+		Channel: ChannelEmailInitial, Account: acc, Contact: cand, Evidence: ev,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 	in := GenerateInput{
 		Channel: ChannelEmailInitial, Account: acc, Contact: cand, Evidence: ev,
 		RecentBodies: []string{first.BodyText}, AllowNearDupRegen: true,
@@ -353,8 +362,11 @@ func TestDraftUserPromptContainsNoResearchInstruction(t *testing.T) {
 	var _ generation.Provider
 }
 
-func TestPromptVersionV2(t *testing.T) {
-	if PromptVersion != "confenge.draft.v2" {
+func TestPromptVersionV3(t *testing.T) {
+	if PromptVersion != "confenge.draft.v3" {
 		t.Fatalf("PromptVersion=%s", PromptVersion)
+	}
+	if OutreachDoctrineVersion != "confenge-outreach-v1" {
+		t.Fatalf("doctrine=%s", OutreachDoctrineVersion)
 	}
 }

--- a/internal/app/confenge/golden_strategy_test.go
+++ b/internal/app/confenge/golden_strategy_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
+// models used for TouchpointPurpose* in purposeForPos.
+
 // Golden fixtures (~20 scenarios) assert strategy properties, not one universal template.
 func TestGoldenStrategyFixtures(t *testing.T) {
 	pb := MustPlaybook()
@@ -84,23 +86,79 @@ func TestGoldenStrategyFixtures(t *testing.T) {
 			if strings.Contains(string(raw), "lead_score") || strings.Contains(string(raw), "conversion_score") {
 				t.Fatal("scores leaked")
 			}
-			out := ComposeFromStrategy(st, acc, cand, ChannelEmailInitial)
+			// Production channel mapping: pos>=2 uses EMAIL_FOLLOWUP so legitimate Re: is allowed.
+			genCh := GenerationChannelForTouch(f.pos, purposeForPos(f.pos))
+			if f.pos >= 2 && genCh != ChannelEmailFollowup {
+				t.Fatalf("pos %d must map to EMAIL_FOLLOWUP, got %s", f.pos, genCh)
+			}
+			if f.pos <= 1 && genCh != ChannelEmailInitial {
+				t.Fatalf("pos %d must map to EMAIL_INITIAL, got %s", f.pos, genCh)
+			}
+			out := ComposeFromStrategy(st, acc, cand, genCh)
 			low := strings.ToLower(out.BodyText + " " + out.Subject)
 			for _, bad := range f.mustNotBody {
 				if bad != "" && strings.Contains(low, strings.ToLower(bad)) {
 					t.Fatalf("body contains %q: %s", bad, out.BodyText)
 				}
 			}
-			dqa := ValidateDoctrineCopy(&out, &st, pb, ChannelEmailInitial)
+			dqa := ValidateDoctrineCopy(&out, &st, pb, genCh)
 			for _, e := range dqa.Errors {
 				if strings.Contains(e, "annualidade must not") || strings.Contains(e, "empty follow-up") {
 					t.Fatalf("doctrine: %s", e)
 				}
+				// Legitimate in-thread Re: on follow-up must not fail as fake first-touch Re.
+				if strings.Contains(e, "fake Re") {
+					t.Fatalf("production channel mapping should allow Re: on follow-up: %s subj=%q", e, out.Subject)
+				}
+			}
+			if f.pos >= 2 && !strings.HasPrefix(strings.ToLower(strings.TrimSpace(out.Subject)), "re:") {
+				t.Fatalf("follow-up subject should be Re: got %q", out.Subject)
 			}
 			ex := ExplainStrategy(st, cand.Email)
 			if ex.Doctrine == "" || (f.pos == 1 && ex.WhyNow == "") {
 				t.Fatalf("explain incomplete: %+v", ex)
 			}
 		})
+	}
+}
+
+func purposeForPos(pos int) string {
+	switch {
+	case pos >= 5:
+		return models.TouchpointPurposeClose
+	case pos >= 2:
+		return models.TouchpointPurposeFollowUp
+	default:
+		return models.TouchpointPurposeInitial
+	}
+}
+
+// Production path: GenerateTouchpointDraft validation channel for ordinal>=2 must accept Re: subjects.
+func TestFollowUpChannelAllowsReSubject(t *testing.T) {
+	pb := MustPlaybook()
+	acc := testAccount("REAJUSTE", "ANUALIDADE", "contrato 1149 aniversário de reajuste")
+	cand := testCand("Sócio")
+	ev := []models.OutreachEvidence{{SourceEvidenceID: "ev-1", EpistemicClass: models.OutreachEpistemicConfirmedFact, Synthesis: acc.FactToMention}}
+
+	for _, pos := range []int{2, 3, 4, 5} {
+		genCh := GenerationChannelForTouch(pos, purposeForPos(pos))
+		if genCh != ChannelEmailFollowup {
+			t.Fatalf("pos %d channel %s", pos, genCh)
+		}
+		st := PlanOutreachStrategy(pb, acc, cand, ev, SequencePositionForTouch(pos, purposeForPos(pos)))
+		out := ComposeFromStrategy(st, acc, cand, genCh)
+		out.Channel = genCh
+		val := ValidateDraft(&out, acc, cand, ValidateOpts{
+			MaxWords: 200, Evidence: ev, Channel: genCh, Strategy: &st, Playbook: pb,
+		})
+		for _, e := range val.Errors {
+			if strings.Contains(e, "fake Re") {
+				t.Fatalf("pos %d: Re: subject wrongly rejected: %s subj=%q", pos, e, out.Subject)
+			}
+		}
+		// Implication body must not leak English mash from annualidade strategy.
+		if strings.Contains(out.BodyText, "reconstituting") {
+			t.Fatalf("pos %d: English leak in body: %s", pos, out.BodyText)
+		}
 	}
 }

--- a/internal/app/confenge/golden_strategy_test.go
+++ b/internal/app/confenge/golden_strategy_test.go
@@ -1,0 +1,106 @@
+package confenge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Golden fixtures (~20 scenarios) assert strategy properties, not one universal template.
+func TestGoldenStrategyFixtures(t *testing.T) {
+	pb := MustPlaybook()
+	type fix struct {
+		id, svc, moment, fact, role string
+		pos                         int
+		wantOffer                   string
+		wantFlag                    string
+		wantRole                    string
+		mustNotBody                 []string
+	}
+	fixtures := []fix{
+		{"01_strong_reajuste", "REAJUSTE", "ANUALIDADE", "contrato 1149/2022 aniversário de reajuste publicado", "Sócio", 1, "REAJUSTE_CHECK", "annualidade_verify_only", "OWNER_PARTNER", []string{"reajuste a receber"}},
+		{"02_annualidade_no_proof", "REAJUSTE", "ANUALIDADE", "marco temporal de reajuste sem publicação de pagamento", "Diretor", 1, "REAJUSTE_CHECK", "annualidade_verify_only", "DIRECTOR", []string{"deixou de pagar"}},
+		{"03_aditivo", "ADDITIVE_REVIEW", "ADITIVO_RECENTE", "termo aditivo 2 ao contrato 88/2021", "Engenheiro", 1, "ADITIVO_RISK_CHECK", "", "ENGINEERING", []string{"aditivo irregular"}},
+		{"04_closeout", "ENCERRAMENTO_CONTRATUAL", "ENCERRAMENTO", "vigência encerra em 60 dias", "Planejamento", 1, "CLOSEOUT_CHECK", "", "PLANNING", nil},
+		{"05_medicao", "MEDICOES", "MEDICAO", "medição lote 3 no DER-PR", "Analista Financeiro", 1, "MEDICAO_CHECK", "", "FINANCE", []string{"glosa indevida"}},
+		{"06_regional", "REAJUSTE", "ANUALIDADE", "contrato regional pequeno porte aniversário", "Proprietário", 1, "REAJUSTE_CHECK", "annualidade_verify_only", "OWNER_PARTNER", []string{"não tem estrutura", "nao tem estrutura"}},
+		{"07_robust", "MONITORAMENTO_CONTRATUAL", "PORTFOLIO", "carteira corporativa robusta com evento PNCP", "Diretor de Contratos", 1, "", "", "DIRECTOR", []string{"não têm equipe", "nao tem equipe"}},
+		{"08_owner", "REAJUSTE", "DOCUMENTACAO_PUBLICADA", "publicação PNCP do contrato 12", "Sócio-administrador", 1, "", "", "OWNER_PARTNER", nil},
+		{"09_engineering", "PLANILHAS", "MEDICAO", "quantitativos do trecho sul", "Engenheira responsável", 1, "", "", "ENGINEERING", nil},
+		{"10_finance", "REAJUSTE", "PRORROGACAO", "prorrogação de prazo publicada", "Controller", 1, "", "", "FINANCE", nil},
+		{"11_legal", "REEQUILIBRIO", "DIVERGENCIA", "possível divergência em aditivo (hipótese)", "Advogado interno", 1, "CLAIM_READINESS_CHECK", "hypothesis_language_required", "LEGAL", []string{"o contrato está desequilibrado"}},
+		{"12_unknown_role", "REAJUSTE", "ANUALIDADE", "aniversário contratual", "", 1, "REAJUSTE_CHECK", "annualidade_verify_only", "UNKNOWN", nil},
+		{"13_routing_touch", "REAJUSTE", "ANUALIDADE", "aniversário contratual", "Assistente", 4, "", "", "UNKNOWN", nil},
+		{"14_no_social_proof", "ADITIVOS", "ADITIVO", "aditivo 1", "Comercial", 1, "", "", "COMMERCIAL", []string{"líderes de mercado", "lideres de mercado"}},
+		{"15_no_name", "MEDICOES", "MEDICAO", "medição publicada", "Engenheiro", 1, "", "", "ENGINEERING", nil},
+		{"16_low_confidence", "REAJUSTE", "ANUALIDADE", "possível janela de reajuste", "Sócio", 1, "REAJUSTE_CHECK", "", "OWNER_PARTNER", []string{"comprovamos que"}},
+		{"17_contradictory", "REEQUILIBRIO", "DIVERGENCIA", "publicações conflitantes sobre aditivo", "Jurídico", 1, "", "hypothesis_language_required", "LEGAL", []string{"irregularidade confirmada"}},
+		{"18_no_hook", "REAJUSTE", "GENERIC", "", "Sócio", 1, "", "no_safe_factual_hook", "OWNER_PARTNER", []string{"somos especialistas líderes"}},
+		{"19_touch2", "ADITIVOS", "ADITIVO_RECENTE", "aditivo 3", "Engenheiro", 2, "", "", "ENGINEERING", []string{"só acompanhando"}},
+		{"20_graceful_close", "REAJUSTE", "ANUALIDADE", "aniversário", "Sócio", 5, "", "", "OWNER_PARTNER", []string{"última tentativa", "ultima tentativa"}},
+	}
+
+	for _, f := range fixtures {
+		t.Run(f.id, func(t *testing.T) {
+			acc := testAccount(f.svc, f.moment, f.fact)
+			if strings.Contains(f.fact, "robusta") || strings.Contains(f.fact, "corporativa") {
+				acc.OfferRationale = "conta corporativa robusta"
+			}
+			if strings.Contains(f.fact, "regional") || strings.Contains(f.fact, "pequeno porte") {
+				acc.MomentSummary = "empresa regional enxuta " + acc.MomentSummary
+			}
+			cand := testCand(f.role)
+			if f.id == "15_no_name" {
+				cand.Name = ""
+			}
+			var ev []models.OutreachEvidence
+			if f.id == "16_low_confidence" {
+				ev = []models.OutreachEvidence{{SourceEvidenceID: "ev-1", EpistemicClass: models.OutreachEpistemicWeakInference, Synthesis: f.fact}}
+			} else if f.id == "17_contradictory" {
+				ev = []models.OutreachEvidence{{SourceEvidenceID: "ev-1", EpistemicClass: models.OutreachEpistemicContradictoryEvidence, Synthesis: f.fact}}
+			} else if f.fact != "" {
+				ev = []models.OutreachEvidence{{SourceEvidenceID: "ev-1", EpistemicClass: models.OutreachEpistemicConfirmedFact, Synthesis: f.fact}}
+			}
+			st := PlanOutreachStrategy(pb, acc, cand, ev, f.pos)
+			if st.DoctrineVersion != OutreachDoctrineVersion {
+				t.Fatal("doctrine")
+			}
+			if st.WhyNow == "" && f.pos == 1 {
+				t.Fatal("why_now")
+			}
+			if f.wantRole != "" && st.BuyerRole != f.wantRole {
+				t.Fatalf("role got %s want %s", st.BuyerRole, f.wantRole)
+			}
+			if f.wantOffer != "" && st.MicroOfferCode != f.wantOffer {
+				t.Fatalf("offer got %s want %s", st.MicroOfferCode, f.wantOffer)
+			}
+			if f.wantFlag != "" && !containsStr(st.RiskFlags, f.wantFlag) {
+				t.Fatalf("flag %s missing in %v", f.wantFlag, st.RiskFlags)
+			}
+			// No commercial scores in strategy JSON
+			raw, _ := json.Marshal(st)
+			if strings.Contains(string(raw), "lead_score") || strings.Contains(string(raw), "conversion_score") {
+				t.Fatal("scores leaked")
+			}
+			out := ComposeFromStrategy(st, acc, cand, ChannelEmailInitial)
+			low := strings.ToLower(out.BodyText + " " + out.Subject)
+			for _, bad := range f.mustNotBody {
+				if bad != "" && strings.Contains(low, strings.ToLower(bad)) {
+					t.Fatalf("body contains %q: %s", bad, out.BodyText)
+				}
+			}
+			dqa := ValidateDoctrineCopy(&out, &st, pb, ChannelEmailInitial)
+			for _, e := range dqa.Errors {
+				if strings.Contains(e, "annualidade must not") || strings.Contains(e, "empty follow-up") {
+					t.Fatalf("doctrine: %s", e)
+				}
+			}
+			ex := ExplainStrategy(st, cand.Email)
+			if ex.Doctrine == "" || (f.pos == 1 && ex.WhyNow == "") {
+				t.Fatalf("explain incomplete: %+v", ex)
+			}
+		})
+	}
+}

--- a/internal/app/confenge/operator_learning.go
+++ b/internal/app/confenge/operator_learning.go
@@ -1,0 +1,104 @@
+package confenge
+
+import (
+	"strings"
+	"time"
+)
+
+// OperatorRejection captures one-click rejection reasons for doctrine improvement.
+type OperatorRejection struct {
+	Reason          string    `json:"reason"`
+	DraftID         string    `json:"draft_id,omitempty"`
+	DoctrineVersion string    `json:"doctrine_version"`
+	ServiceCode     string    `json:"service_code,omitempty"`
+	OfferCode       string    `json:"offer_code,omitempty"`
+	At              time.Time `json:"at"`
+}
+
+// OperatorEditSignal summarizes human edits before approval (accumulate only; no auto-train).
+type OperatorEditSignal struct {
+	Codes           []string  `json:"codes"`
+	DraftID         string    `json:"draft_id,omitempty"`
+	DoctrineVersion string    `json:"doctrine_version"`
+	OriginalLen     int       `json:"original_len"`
+	EditedLen       int       `json:"edited_len"`
+	At              time.Time `json:"at"`
+}
+
+// ValidRejectionReason checks against doctrine copy_rules.
+func ValidRejectionReason(pb *Playbook, reason string) bool {
+	reason = strings.TrimSpace(strings.ToLower(reason))
+	if reason == "" {
+		return false
+	}
+	if pb == nil {
+		pb, _ = LoadPlaybook()
+	}
+	if pb == nil {
+		return reason == "other"
+	}
+	for _, r := range pb.CopyRules.RejectionReasons {
+		if strings.EqualFold(r, reason) {
+			return true
+		}
+	}
+	return false
+}
+
+// ClassifyEditSignals infers coarse edit codes from original vs edited body (heuristic).
+func ClassifyEditSignals(original, edited string) []string {
+	o, e := strings.TrimSpace(original), strings.TrimSpace(edited)
+	if o == e {
+		return nil
+	}
+	var codes []string
+	if countWords(e) < countWords(o) {
+		codes = append(codes, "shortened")
+	}
+	ol, el := strings.ToLower(o), strings.ToLower(e)
+	// Softened: removed hard claim markers
+	for _, hard := range []string{"têm r$", "tem r$", "é certo", "garantimos", "a receber"} {
+		if strings.Contains(ol, hard) && !strings.Contains(el, hard) {
+			codes = append(codes, "softened_claim")
+			break
+		}
+	}
+	if strings.Count(o, "?") != strings.Count(e, "?") ||
+		(strings.Contains(ol, "checklist") != strings.Contains(el, "checklist")) {
+		codes = append(codes, "changed_cta")
+	}
+	for _, j := range []string{"sinergia", "potencializar", "solução 360", "revolucion"} {
+		if strings.Contains(ol, j) && !strings.Contains(el, j) {
+			codes = append(codes, "removed_jargon")
+			break
+		}
+	}
+	if len(codes) == 0 {
+		codes = append(codes, "other")
+	}
+	return codes
+}
+
+// NewOperatorRejection builds a rejection learning record.
+func NewOperatorRejection(reason, draftID, service, offer string) OperatorRejection {
+	return OperatorRejection{
+		Reason:          reason,
+		DraftID:         draftID,
+		DoctrineVersion: OutreachDoctrineVersion,
+		ServiceCode:     service,
+		OfferCode:       offer,
+		At:              time.Now().UTC(),
+	}
+}
+
+// NewOperatorEditSignal builds an edit learning record.
+func NewOperatorEditSignal(draftID, original, edited string) OperatorEditSignal {
+	return OperatorEditSignal{
+		Codes:           ClassifyEditSignals(original, edited),
+		DraftID:         draftID,
+		DoctrineVersion: OutreachDoctrineVersion,
+		OriginalLen:     len([]rune(original)),
+		EditedLen:       len([]rune(edited)),
+		At:              time.Now().UTC(),
+	}
+}

--- a/internal/app/confenge/operator_learning_test.go
+++ b/internal/app/confenge/operator_learning_test.go
@@ -1,0 +1,66 @@
+package confenge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestOperatorEditSignalPackedIntoValidationJSON(t *testing.T) {
+	orig := "Olá, temos sinergia e vocês têm R$ a receber. Podemos marcar uma call?"
+	edited := "Olá, pelo contrato publicado há um ponto a conferir. Posso mandar o checklist?"
+	sig := NewOperatorEditSignal("draft-1", orig, edited)
+	if len(sig.Codes) == 0 {
+		t.Fatal("expected codes")
+	}
+	val := ValidationResult{OK: true, DoctrineVersion: OutreachDoctrineVersion}
+	val.OperatorEdit = &sig
+	b, err := json.Marshal(val)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back ValidationResult
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatal(err)
+	}
+	if back.OperatorEdit == nil || len(back.OperatorEdit.Codes) == 0 {
+		t.Fatal("operator_edit not round-tripped")
+	}
+}
+
+func TestOperatorRejectReasonPacked(t *testing.T) {
+	rej := NewOperatorRejection("too_salesy", "d1", "REAJUSTE", "REAJUSTE_CHECK")
+	val := ValidationResult{OK: false}
+	val.OperatorReject = &rej
+	b, _ := json.Marshal(val)
+	if !strings.Contains(string(b), "too_salesy") {
+		t.Fatalf("%s", b)
+	}
+	if !ValidRejectionReason(MustPlaybook(), "unsupported_claim") {
+		t.Fatal("valid reason")
+	}
+}
+
+// Ensures EditTouchpoint path shape: original vs edited bodies produce learning codes.
+func TestEditLearningCodesMatchApproveEditPath(t *testing.T) {
+	// Mirrors approve&queue which calls editConfengeTouchpoint before approve.
+	orig := "A CONFENGE é especializada e pode maximizar resultados. Gostaria de agendar 30 minutos?"
+	edited := "Pelo contrato publicado, há um ponto a conferir. Posso te mandar o checklist?"
+	codes := ClassifyEditSignals(orig, edited)
+	wantAny := map[string]bool{"shortened": true, "softened_claim": true, "changed_cta": true, "removed_jargon": true, "other": true}
+	ok := false
+	for _, c := range codes {
+		if wantAny[c] {
+			ok = true
+		}
+	}
+	if !ok {
+		t.Fatalf("codes %v", codes)
+	}
+	_ = uuid.New()
+	_ = models.OutreachDraftNeedsReview
+}

--- a/internal/app/confenge/outreach_playbook/copy_rules.yaml
+++ b/internal/app/confenge/outreach_playbook/copy_rules.yaml
@@ -1,0 +1,127 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+banned_phrases:
+  - espero que este email o encontre bem
+  - espero que esta mensagem o encontre bem
+  - venho por meio deste
+  - gostaria de apresentar
+  - soluções personalizadas
+  - solucoes personalizadas
+  - maximizar resultados
+  - potencializar
+  - sinergia
+  - transformação digital
+  - transformacao digital
+  - solução 360
+  - solucao 360
+  - ia de ponta
+  - revolucionário
+  - revolucionario
+  - imperdível
+  - imperdivel
+  - estamos monitorando sua empresa
+  - analisamos toda a carteira
+  - detectamos que vocês deixaram de
+  - dinheiro a receber
+  - crédito identificado
+  - credito identificado
+  - identificamos perda de
+  - tem 15 minutos amanhã
+  - tem 15 minutos amanha
+  - podemos marcar uma call
+  - qual horário funciona
+  - qual horario funciona
+  - segue o link do meu calendário
+  - segue o link do meu calendario
+
+meeting_cta_phrases:
+  - marcar uma call
+  - marcar uma reunião
+  - marcar uma reuniao
+  - 15 minutos
+  - 30 minutos
+  - calendly
+  - agendar uma call
+  - tem um horário
+  - tem um horario
+
+fake_re_fwd:
+  - "^re:"
+  - "^fw:"
+  - "^fwd:"
+
+preferred_public_source_phrasing:
+  - Vi no PNCP
+  - Pelo contrato publicado
+  - Nas informações públicas do contrato
+  - Pela publicação
+
+creepy_phrasing:
+  - estamos monitorando
+  - monitoramos sua empresa
+  - sabemos que vocês
+  - sabemos que voces
+  - detectamos que vocês
+  - detectamos que voces
+  - analisamos toda a carteira
+  - acesso privilegiado
+
+unsupported_monetary:
+  - r$
+  - milhão a receber
+  - milhao a receber
+  - milhões a recuperar
+  - milhoes a recuperar
+
+annualidade_bad_claims:
+  - reajuste a receber
+  - reajuste não pago
+  - reajuste nao pago
+  - o órgão deixou de pagar
+  - o orgao deixou de pagar
+  - vocês têm direito ao reajuste
+  - voces tem direito ao reajuste
+  - crédito de reajuste
+  - credito de reajuste
+
+rejection_reasons:
+  - factual_error
+  - too_generic
+  - too_salesy
+  - wrong_service
+  - wrong_offer
+  - wrong_recipient
+  - too_long
+  - creepy
+  - unsupported_claim
+  - tone
+  - other
+
+edit_signal_codes:
+  - shortened
+  - softened_claim
+  - changed_cta
+  - removed_jargon
+  - corrected_fact
+  - changed_offer
+  - other
+
+commercial_reply_classes:
+  - POSITIVE_INTEREST
+  - OFFER_ACCEPTED
+  - SEND_MORE_INFO
+  - WRONG_PERSON
+  - REFERRAL
+  - ALREADY_HANDLED_INTERNAL
+  - ALREADY_HAS_CONSULTANT
+  - NOT_A_PRIORITY
+  - NOT_INTERESTED
+  - CONTACT_LATER
+  - PRICE_QUESTION
+  - CREDIBILITY_QUESTION
+  - TECHNICAL_QUESTION
+  - PROCUREMENT_CONCERN
+  - DNC
+  - OUT_OF_OFFICE
+  - AUTO_REPLY
+  - OTHER

--- a/internal/app/confenge/outreach_playbook/doctrine.yaml
+++ b/internal/app/confenge/outreach_playbook/doctrine.yaml
@@ -1,0 +1,66 @@
+# CONFENGE outreach doctrine — machine-readable core
+# Human narrative: docs/confenge/OUTREACH-DOCTRINE.md
+outreach_doctrine_version: confenge-outreach-v1
+channel_policy:
+  runtime_allowed: [EMAIL]
+  whatsapp: OFF
+  auto_call: OFF
+  green_autorun: OFF
+
+north_star_metric: positive_conversations_per_delivered
+secondary_metrics:
+  - human_reply_rate
+  - positive_reply_rate
+  - qualified_conversation_rate
+  - meeting_rate
+  - proposal_rate
+  - win_rate
+  - attributed_revenue
+
+principles:
+  - id: strategy_before_copy
+    summary: Plan commercial strategy before any wording.
+  - id: extra_cli_owns_who
+    summary: extra-cli decides WHO/WHY NOW; Warmbly decides HOW TO APPROACH.
+  - id: no_local_rescoring
+    summary: Never create lead/commercial/conversion priority scores here.
+  - id: fact_neq_hypothesis
+    summary: Facts from evidence only; inferences marked as hypothesis.
+  - id: know_a_lot_say_little
+    summary: Anti-creepy public-data phrasing; minimal necessary fact.
+  - id: value_before_meeting
+    summary: First CTA prefers micro-offer permission, not calendar link.
+  - id: no_institutional_pitch_first
+    summary: First email sells attention and low-friction next step only.
+  - id: each_touch_earns_existence
+    summary: No empty following-up; each touch adds value.
+  - id: fail_closed_on_claims
+    summary: Unsupported material claims block approval path.
+  - id: human_approval_unchanged
+    summary: Strategy and generation may be automatic; send approval stays human.
+
+first_email_defaults:
+  min_words: 40
+  max_words: 100
+  target_sentences: "3-4"
+  max_ctas: 1
+  max_links: 1
+  attachments: false
+  meeting_cta_default: false
+  language: pt-BR
+  subject:
+    max_words: 6
+    no_emoji: true
+    no_all_caps: true
+    no_fake_re: true
+    no_fake_fwd: true
+    no_urgency: true
+    no_financial_promise: true
+
+hierarchy_of_evidence:
+  - confenge_own_measured_outcomes
+  - large_modern_datasets
+  - behavioral_empirical_research
+  - established_methodology
+  - expert_recommendation
+  - sales_folklore

--- a/internal/app/confenge/outreach_playbook/objection_playbook.yaml
+++ b/internal/app/confenge/outreach_playbook/objection_playbook.yaml
@@ -1,0 +1,58 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+objections:
+  - id: already_internal
+    match: [já fazemos internamente, ja fazemos internamente, temos equipe interna]
+    strategy: complement_second_read_peak_demand
+    guidance: |
+      Não atacar a equipe. Oferecer segunda leitura, pico de demanda, validação independente ou tema pontual.
+    never: [vocês não têm estrutura, equipe insuficiente]
+
+  - id: have_legal
+    match: [temos jurídico, nosso jurídico, advogado interno]
+    strategy: technical_complement
+    guidance: |
+      Nunca substituir o jurídico. Enfatizar engenharia, cálculo, memória, evidência técnica e interface técnico-contratual.
+    never: [melhor que o jurídico, substituímos o jurídico]
+
+  - id: no_interest
+    match: [não tenho interesse, nao tenho interesse, sem interesse]
+    strategy: respect_and_stop
+    guidance: Respeitar. Não argumentar compulsivamente. Encerrar e marcar NOT_INTERESTED.
+    never: [mas deixa eu só]
+
+  - id: price
+    match: [quanto custa, qual o valor, preço, preco]
+    strategy: transparent_by_offer
+    guidance: Não esconder. Encaminhar conforme micro-offer/service; se ainda cedo, amarrar ao escopo.
+    never: [depende de conversar 30 minutos sem faixa]
+
+  - id: send_material
+    match: [manda material, envia material, brochure, apresentação institucional]
+    strategy: problem_specific_not_brochure
+    guidance: Não enviar brochure genérico. Responder ao problema que iniciou a conversa; cumprir micro-offer se prometido.
+    never: [segue nosso deck institucional genérico]
+
+  - id: who_are_you
+    match: [quem é você, quem e voce, o que é a confenge, o que e a confenge]
+    strategy: short_verifiable_identity
+    guidance: Explicação curta, verificável, sem mini-CV nem superlativos.
+    never: [líderes de mercado, especialistas número 1]
+
+  - id: wrong_person
+    match: [não sou a pessoa, nao sou a pessoa, fale com]
+    strategy: thank_and_route
+    guidance: Agradecer, pedir indicação curta, não insistir no mesmo contato.
+    never: [pode só olhar rapidinho]
+
+  - id: already_has_consultant
+    match: [já temos consultor, ja temos consultor, já contratamos]
+    strategy: complement_or_close
+    guidance: Oferecer complementaridade pontual ou encerrar com respeito.
+    never: [eles não fazem o que fazemos]
+
+  - id: contact_later
+    match: [mais tarde, no próximo trimestre, depois do carnaval]
+    strategy: schedule_respect
+    guidance: Registrar CONTACT_LATER; não pressionar.
+    never: [é agora ou nunca]

--- a/internal/app/confenge/outreach_playbook/offers.yaml
+++ b/internal/app/confenge/outreach_playbook/offers.yaml
@@ -1,0 +1,127 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+# Micro-offers: value before meeting. Cold path only suggests LOW budget.
+offers:
+  - code: CONTRACT_CHECK
+    description: Pontos objetivos que eu conferiria no contrato público citado
+    buyer_value: Clareza sobre o que verificar antes de qualquer diagnóstico pago
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [any_public_contract_fact]
+    applicable_service_codes: ["*"]
+    prohibited_claims: [crédito confirmado, valor a receber]
+    cta_patterns:
+      - Posso te mandar os pontos que eu conferiria?
+      - Faz sentido eu te enviar o recorte que encontrei?
+
+  - code: REAJUSTE_CHECK
+    description: Checklist de verificação de reajuste (documentos e memórias), sem afirmar crédito
+    buyer_value: Separar sinal de anualidade de conclusão de valor devido
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [moment_or_contract]
+    applicable_service_codes: [REAJUSTE, REEQUILIBRIO]
+    prohibited_claims:
+      - reajuste a receber
+      - o órgão deixou de pagar
+      - perda de R$
+    cta_patterns:
+      - Posso te mandar o checklist do que eu verificaria no reajuste?
+      - Quer que eu te envie os pontos documentais que eu conferiria primeiro?
+
+  - code: ADITIVO_RISK_CHECK
+    description: Leitura curta de efeitos colaterais de aditivo recente
+    buyer_value: Enxergar o que o aditivo pode ter alterado além do texto assinado
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [aditivo_or_moment]
+    applicable_service_codes: [ADITIVOS, REAJUSTE, MEDICOES]
+    prohibited_claims: [aditivo irregular, valor perdido no aditivo]
+    cta_patterns:
+      - Posso te mostrar o que eu checaria depois desse aditivo?
+
+  - code: MEDICAO_CHECK
+    description: Pontos de medição/critério a validar com base pública
+    buyer_value: Antecipar onde divergência de campo vs planilha costuma nascer
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [moment_or_contract]
+    applicable_service_codes: [MEDICOES, PLANILHAS, ADITIVOS]
+    prohibited_claims: [glosa indevida, medição não paga de]
+    cta_patterns:
+      - Posso te mandar o que eu verificaria na medição?
+
+  - code: CLOSEOUT_CHECK
+    description: Checklist de close-out / pendências perto do término
+    buyer_value: Lista objetiva do que ainda cabe regularizar
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [moment_or_contract]
+    applicable_service_codes: [ENCERRAMENTO_CONTRATUAL, REAJUSTE, MEDICOES]
+    prohibited_claims: [contrato sem quitação]
+    cta_patterns:
+      - Quer o checklist do que eu conferiria antes do encerramento?
+
+  - code: DOCUMENT_CHECKLIST
+    description: Lista curta de documentos públicos/internos a reunir
+    buyer_value: Reduz caça documental sem vender o serviço completo
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [any]
+    applicable_service_codes: ["*"]
+    prohibited_claims: []
+    cta_patterns:
+      - Posso te mandar a lista do que eu reuniria primeiro?
+
+  - code: CONTRACT_TIMELINE
+    description: Linha do tempo pública do contrato (marcos publicados)
+    buyer_value: Visão cronológica sem dossiê intimidador
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [public_dates]
+    applicable_service_codes: ["*"]
+    prohibited_claims: []
+    cta_patterns:
+      - Quer que eu te envie a linha do tempo pública que montei?
+
+  - code: PUBLIC_DATA_SNAPSHOT
+    description: Recorte de dados públicos relevantes (sem parecer vigilância)
+    buyer_value: Amostra da capacidade de leitura pública da CONFENGE
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [public_fact]
+    applicable_service_codes: ["*"]
+    prohibited_claims: [estamos monitorando sua empresa, analisamos toda a carteira]
+    cta_patterns:
+      - Posso te mandar o recorte público que encontrei?
+
+  - code: CLAIM_READINESS_CHECK
+    description: Prontidão documental para eventual pleito (sem afirmar mérito)
+    buyer_value: Saber o que falta antes de investir em pedido formal
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [moment_or_contract]
+    applicable_service_codes: [REEQUILIBRIO, REAJUSTE, EXTRACONTRATUAIS]
+    prohibited_claims: [direito confirmado, valor devido]
+    cta_patterns:
+      - Posso te mostrar o que eu checaria antes de qualquer pleito?
+
+  - code: PROCUREMENT_RISK_SNAPSHOT
+    description: Snapshot de risco documental em contexto de licitação/contratação
+    buyer_value: Antecipar premissas frágeis
+    fulfillment_path: draft_from_evidence
+    fulfillment_cost: LOW
+    required_evidence: [public_fact]
+    applicable_service_codes: [APOIO_LICITACAO, ADITIVOS]
+    prohibited_claims: [vão perder a licitação]
+    cta_patterns:
+      - Quer um snapshot do que eu verificaria no edital/instrumento?
+
+# Explicitly not auto-offered on cold path
+restricted_offers:
+  - code: FULL_DIAGNOSTIC
+    fulfillment_cost: HIGH
+    note: Never offer full unpaid diagnostic on cold email.
+  - code: PAID_CONSULTING_PITCH
+    fulfillment_cost: HIGH
+    note: Not a micro-offer; belongs after interest.

--- a/internal/app/confenge/outreach_playbook/personas.yaml
+++ b/internal/app/confenge/outreach_playbook/personas.yaml
@@ -1,0 +1,58 @@
+# Buyer roles — map only when role evidence exists; else UNKNOWN.
+outreach_doctrine_version: confenge-outreach-v1
+
+roles:
+  - code: OWNER_PARTNER
+    match_keywords: [sócio, socio, proprietário, proprietario, dono, founder, partner, owner]
+    priorities: [dinheiro, risco, margem, tempo, crescimento, sobrecarga]
+    tone: peer_direct
+    prefer_angles: [economic_window, risk_clarity, time_saved]
+  - code: DIRECTOR
+    match_keywords: [diretor, directora, director, superintendente, gerente geral]
+    priorities: [resultado, risco, previsibilidade, delegação]
+    tone: peer_concise
+    prefer_angles: [portfolio_risk, decision_clarity]
+  - code: COMMERCIAL
+    match_keywords: [comercial, vendas, business development, captacao, captação]
+    priorities: [oportunidade, relacionamento, pipeline]
+    tone: collaborative
+    prefer_angles: [client_retention, bid_quality]
+  - code: CONTRACTS
+    match_keywords: [contratos, contratual, administrativo, gestão de contratos, gestao de contratos]
+    priorities: [precisão, documentação, fechamento correto]
+    tone: technical_precise
+    prefer_angles: [document_checklist, process_gap]
+  - code: ENGINEERING
+    match_keywords: [engenheiro, engenheira, engenharia, técnico, tecnico, obras, fiscal]
+    priorities: [precisão técnica, documentação, risco operacional, medição]
+    tone: technical_peer
+    prefer_angles: [measurement, memory, technical_evidence]
+  - code: PLANNING
+    match_keywords: [planejamento, pmo, cronograma, orçamento, orcamento]
+    priorities: [prazo, custo, desvio]
+    tone: analytical
+    prefer_angles: [timeline, variance]
+  - code: FINANCE
+    match_keywords: [financeiro, cfo, controller, contábil, contabil, faturamento]
+    priorities: [fluxo, valores, previsibilidade, recebimento, exposição]
+    tone: quantitative_careful
+    prefer_angles: [cash_timing, exposure]
+  - code: LEGAL
+    match_keywords: [jurídico, juridico, advogado, advogada, legal]
+    priorities: [fatos, rastreabilidade, suporte técnico-documental]
+    tone: complement_not_compete
+    prefer_angles: [technical_support_to_legal, evidence_trail]
+    rules:
+      - never_position_as_legal_substitute
+  - code: PROCUREMENT
+    match_keywords: [compras, licitação, licitacao, procurement, suprimentos]
+    priorities: [conformidade, risco de contratação]
+    tone: process_aware
+    prefer_angles: [procurement_risk, documentation]
+  - code: UNKNOWN
+    match_keywords: []
+    priorities: [relevância, clareza, baixo atrito]
+    tone: neutral_professional
+    prefer_angles: [public_fact, micro_offer]
+    rules:
+      - never_infer_title_from_generic_email

--- a/internal/app/confenge/outreach_playbook/sequence.yaml
+++ b/internal/app/confenge/outreach_playbook/sequence.yaml
@@ -1,0 +1,62 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+# Each touch must earn existence. Cadence delays are defaults (experimental priors), not governor limits.
+sequence:
+  max_touches: 5
+  stop_on:
+    - human_reply
+    - dnc
+    - bounce
+    - active_conversation
+  account_rules:
+    no_simultaneous_identical_copy: true
+    no_multithread_without_reason: true
+    pause_other_contacts_on_active_conversation: true
+
+  touches:
+    - position: 1
+      name: SIGNAL
+      objective: fact + honest hypothesis + micro-offer
+      adds_value: public_fact_and_micro_offer
+      forbidden: [just_following_up, meeting_default, institutional_pitch]
+      default_delay_days: 0
+
+    - position: 2
+      name: IMPLICATION
+      objective: another technical angle or implication; simple CTA
+      adds_value: new_implication_or_angle
+      forbidden: [just_following_up, last_attempt_guilt]
+      default_delay_days: 4
+
+    - position: 3
+      name: VALUE
+      objective: mini-checklist, benchmark, or useful public insight
+      adds_value: checklist_or_insight
+      forbidden: [just_following_up]
+      default_delay_days: 5
+
+    - position: 4
+      name: ROUTING
+      objective: short ask if another person owns the theme (internal referral)
+      adds_value: routing_question
+      forbidden: [spam_all_stakeholders]
+      default_delay_days: 5
+
+    - position: 5
+      name: GRACEFUL_CLOSE
+      objective: close without guilt trip or false urgency
+      adds_value: respectful_close
+      forbidden: [ultima_tentativa, last_chance, following_up]
+      default_delay_days: 7
+
+empty_followup_phrases:
+  - só acompanhando
+  - so acompanhando
+  - subindo no seu inbox
+  - teve chance de ver
+  - última tentativa
+  - ultima tentativa
+  - just following up
+  - bumping this
+  - checking in
+  - looping back

--- a/internal/app/confenge/outreach_playbook/services.yaml
+++ b/internal/app/confenge/outreach_playbook/services.yaml
@@ -1,0 +1,152 @@
+# Service playbooks mapped to real-ish CONFENGE service_code patterns used in feeds.
+# Codes are matched case-insensitively by exact code or prefix (e.g. REAJUSTE_14133 → REAJUSTE).
+outreach_doctrine_version: confenge-outreach-v1
+
+services:
+  - code: REAJUSTE
+    name: Reajuste contratual
+    aliases: [REAJUSTE_14133, REAJUSTE_CONTRATUAL, reajuste]
+    commercial_insight: |
+      Anualidade e marco temporal mudam quais documentos e memórias deveriam ser conferidos,
+      mas não provam sozinhos crédito econômico ou reajuste não pago.
+    common_miss: Tratar aniversário contratual como prova de valor a receber.
+    problem_hypotheses:
+      - índice aplicável não formalizado no prazo esperado
+      - memória de cálculo incompleta para o ciclo
+      - base de reajuste divergente da cláusula
+    implications:
+      - atraso de fluxo se o pedido precisar de reconstituição documental
+      - risco de pleito frágil se a evidência pública for lida como certeza
+    disallowed_claims:
+      - vocês têm reajuste a receber
+      - o órgão deixou de pagar o reajuste
+      - identificamos perda de
+      - crédito de reajuste confirmado
+    default_micro_offer: REAJUSTE_CHECK
+    cta_families: [permission_checklist, permission_points]
+
+  - code: REEQUILIBRIO
+    name: Reequilíbrio econômico-financeiro
+    aliases: [REEQUILIBRIO_ECO, REEQUILIBRIO_ECONOMICO, reequilibrio]
+    commercial_insight: |
+      Eventos de desequilíbrio pedem nexo, quantificação e memória; publicação isolada raramente basta.
+    common_miss: Confundir dificuldade operacional com direito ao reequilíbrio.
+    problem_hypotheses:
+      - evento extraordinário sem memória organizada
+      - nexo causal ainda não documentado
+    implications:
+      - pedido frágil ou tardio
+    disallowed_claims:
+      - vocês têm direito ao reequilíbrio
+      - o contrato está desequilibrado
+    default_micro_offer: CLAIM_READINESS_CHECK
+    cta_families: [permission_checklist, permission_snapshot]
+
+  - code: MEDICOES
+    name: Medições e medições contratuais
+    aliases: [MEDICAO, MEDICOES, MEDIÇÃO, MEDICÃO]
+    commercial_insight: |
+      Medição é onde volume, critério e evidência de campo se encontram; divergência costuma nascer em memória, não só em planilha.
+    common_miss: Tratar atraso de medição como mero problema de cobrança.
+    problem_hypotheses:
+      - critério de medição ambíguo em trecho crítico
+      - divergência entre campo e planilha
+    implications:
+      - glosa ou atraso de faturamento
+    disallowed_claims:
+      - o órgão glosou indevidamente
+      - há medição não paga de
+    default_micro_offer: MEDICAO_CHECK
+    cta_families: [permission_points, permission_checklist]
+
+  - code: ADITIVOS
+    name: Aditivos contratuais
+    aliases: [ADITIVO, ADDITIVE_REVIEW, ADITIVOS, additive_review]
+    commercial_insight: |
+      Aditivo recente muda o escopo e a base de comparação; o risco está no que deixa de ser revisado depois da assinatura.
+    common_miss: Celebrar o aditivo e não revalidar planilha, prazos e reajustes derivados.
+    problem_hypotheses:
+      - inconsistência entre aditivo e planilha base
+      - efeito em reajuste ou medição não mapeado
+    implications:
+      - execução e cobrança desalinhadas ao instrumento
+    disallowed_claims:
+      - o aditivo está irregular
+      - vocês perderam valor no aditivo
+    default_micro_offer: ADITIVO_RISK_CHECK
+    cta_families: [permission_snapshot, permission_points]
+
+  - code: EXTRACONTRATUAIS
+    name: Serviços e custos extracontratuais
+    aliases: [EXTRA, EXTRACONTRATUAL, EXTRAS]
+    commercial_insight: |
+      Trabalho fora do instrumento precisa de ordem, evidência e enquadramento; volume sozinho não sustenta pedido.
+    common_miss: Acumular extras sem trilha documental contemporânea.
+    problem_hypotheses:
+      - extras executados sem formalização suficiente
+    implications:
+      - dificuldade de reconhecimento e cobrança
+    disallowed_claims:
+      - o órgão deve pagar os extras
+    default_micro_offer: DOCUMENT_CHECKLIST
+    cta_families: [permission_checklist]
+
+  - code: PLANILHAS
+    name: Planilhas e quantitativos
+    aliases: [PLANILHA, QUANTITATIVOS, ORCAMENTO]
+    commercial_insight: |
+      Planilha é a memória econômica do contrato; divergência silenciosa vira disputa tarde demais.
+    common_miss: Atualizar planilha só no fechamento.
+    problem_hypotheses:
+      - quantitativos desalinhados da execução
+    implications:
+      - reajuste/medição em base frágil
+    disallowed_claims:
+      - a planilha está errada em
+    default_micro_offer: DOCUMENT_CHECKLIST
+    cta_families: [permission_points]
+
+  - code: ENCERRAMENTO_CONTRATUAL
+    name: Encerramento e close-out
+    aliases: [ENCERRAMENTO, CLOSEOUT, CLOSE_OUT, TERMINO]
+    commercial_insight: |
+      Proximidade de fim de vigência concentra o que ainda pode ser regularizado documentalmente.
+    common_miss: Deixar close-out para o último mês sem checklist.
+    problem_hypotheses:
+      - pendências de medição/reajuste perto do término
+    implications:
+      - perda de janela operacional para regularização
+    disallowed_claims:
+      - o contrato vence sem quitação
+    default_micro_offer: CLOSEOUT_CHECK
+    cta_families: [permission_checklist, permission_timeline]
+
+  - code: APOIO_LICITACAO
+    name: Apoio a licitação e propostas
+    aliases: [LICITACAO, BID_SUPPORT, PROPOSTA]
+    commercial_insight: |
+      Risco de proposta nasce em premissas e quantitativos, não só no preço final.
+    common_miss: Revisar só o valor unitário e ignorar inconsistências de edital/planilha.
+    problem_hypotheses:
+      - premissas de edital subavaliadas
+    implications:
+      - margem e execução sob pressão
+    disallowed_claims:
+      - vocês vão perder a licitação
+    default_micro_offer: PROCUREMENT_RISK_SNAPSHOT
+    cta_families: [permission_snapshot]
+
+  - code: MONITORAMENTO_CONTRATUAL
+    name: Monitoramento contratual contínuo
+    aliases: [MONITORAMENTO, PORTFOLIO, ACOMPANHAMENTO]
+    commercial_insight: |
+      Carteira grande esconde eventos de baixo ruído; o valor está em priorizar o que merece leitura agora.
+    common_miss: Tratar todos os contratos com a mesma atenção.
+    problem_hypotheses:
+      - eventos públicos relevantes sem triagem
+    implications:
+      - sobrecarga e atraso em temas de maior impacto
+    disallowed_claims:
+      - sua carteira está descontrolada
+    default_micro_offer: PUBLIC_DATA_SNAPSHOT
+    cta_families: [permission_snapshot, permission_points]

--- a/internal/app/confenge/outreach_playbook/triggers.yaml
+++ b/internal/app/confenge/outreach_playbook/triggers.yaml
@@ -1,0 +1,74 @@
+outreach_doctrine_version: confenge-outreach-v1
+
+# Activation / moment triggers → why_now framing (not scores).
+triggers:
+  - code: ANUALIDADE
+    aliases: [ANNUALITY, ANIVERSARIO, ANIVERSÁRIO, REAJUSTE_JANELA]
+    why_now_template: marco temporal/anualidade do contrato sugere janela de verificação documental
+    fact_vs_claim: |
+      Annualidade is a verify-now signal, never proof of unpaid reajuste.
+    preferred_offers: [REAJUSTE_CHECK, DOCUMENT_CHECKLIST]
+    risk_flags: [annualidade_verify_only]
+    claims_to_avoid:
+      - reajuste a receber
+      - não pago
+      - credito de
+      - crédito de
+
+  - code: ADITIVO_RECENTE
+    aliases: [ADITIVO, ADDITIVE, TERMO_ADITIVO]
+    why_now_template: aditivo ou alteração recente publicada merece leitura de efeitos colaterais
+    preferred_offers: [ADITIVO_RISK_CHECK, CONTRACT_TIMELINE]
+    risk_flags: []
+
+  - code: MEDICAO
+    aliases: [MEDIÇÃO, MEDICOES, MEASUREMENT]
+    why_now_template: contexto de medição/execução em fase em que critérios e memórias importam
+    preferred_offers: [MEDICAO_CHECK, DOCUMENT_CHECKLIST]
+    risk_flags: []
+
+  - code: ENCERRAMENTO
+    aliases: [CLOSEOUT, TERMINO, FIM_VIGENCIA, VIGENCIA]
+    why_now_template: proximidade de encerramento concentra pendências que ainda podem ser regularizadas
+    preferred_offers: [CLOSEOUT_CHECK, CONTRACT_TIMELINE]
+    risk_flags: []
+
+  - code: NOVA_CONTRATACAO
+    aliases: [NOVO_CONTRATO, LICITACAO, AWARD]
+    why_now_template: nova contratação/publicação abre janela de leitura preventiva
+    preferred_offers: [CONTRACT_CHECK, PROCUREMENT_RISK_SNAPSHOT]
+    risk_flags: []
+
+  - code: PRORROGACAO
+    aliases: [PRORROGAÇÃO, EXTENSION]
+    why_now_template: prorrogação altera horizonte e pode reabrir bases de cálculo e prazos
+    preferred_offers: [CONTRACT_TIMELINE, DOCUMENT_CHECKLIST]
+    risk_flags: []
+
+  - code: DOCUMENTACAO_PUBLICADA
+    aliases: [DOC_PUBLICADA, PUBLICACAO, PNCP]
+    why_now_template: documentação recentemente publicada permite checagem pontual
+    preferred_offers: [PUBLIC_DATA_SNAPSHOT, DOCUMENT_CHECKLIST]
+    risk_flags: []
+
+  - code: DIVERGENCIA
+    aliases: [DIVERGÊNCIA, INCONSISTENCIA, INCONSISTÊNCIA]
+    why_now_template: há sinal público de possível divergência que merece validação (não conclusão)
+    preferred_offers: [CONTRACT_CHECK, CLAIM_READINESS_CHECK]
+    risk_flags: [hypothesis_language_required]
+    claims_to_avoid:
+      - irregularidade confirmada
+      - fraude
+      - o órgão errou
+
+  - code: PORTFOLIO
+    aliases: [CARTEIRA, MONITORAMENTO]
+    why_now_template: contexto de carteira/monitoramento prioriza um recorte público específico
+    preferred_offers: [PUBLIC_DATA_SNAPSHOT]
+    risk_flags: []
+
+  - code: GENERIC
+    aliases: [UNKNOWN, OTHER, ""]
+    why_now_template: momento comercial indicado pelo extra-cli (sem reinventar prioridade)
+    preferred_offers: [CONTRACT_CHECK, DOCUMENT_CHECKLIST]
+    risk_flags: [weak_trigger]

--- a/internal/app/confenge/playbook.go
+++ b/internal/app/confenge/playbook.go
@@ -1,0 +1,402 @@
+package confenge
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+)
+
+// OutreachDoctrineVersion is stamped on every strategy and draft metadata.
+const OutreachDoctrineVersion = "confenge-outreach-v1"
+
+//go:embed outreach_playbook/*.yaml
+var playbookFS embed.FS
+
+// Playbook is the machine-readable commercial doctrine.
+type Playbook struct {
+	Doctrine   DoctrineFile   `yaml:"-"`
+	Personas   PersonasFile   `yaml:"-"`
+	Services   ServicesFile   `yaml:"-"`
+	Triggers   TriggersFile   `yaml:"-"`
+	Offers     OffersFile     `yaml:"-"`
+	Sequence   SequenceFile   `yaml:"-"`
+	Objections ObjectionsFile `yaml:"-"`
+	CopyRules  CopyRulesFile  `yaml:"-"`
+}
+
+type DoctrineFile struct {
+	OutreachDoctrineVersion string `yaml:"outreach_doctrine_version"`
+	ChannelPolicy           struct {
+		RuntimeAllowed []string `yaml:"runtime_allowed"`
+		WhatsApp       string   `yaml:"whatsapp"`
+		AutoCall       string   `yaml:"auto_call"`
+		GreenAutorun   string   `yaml:"green_autorun"`
+	} `yaml:"channel_policy"`
+	NorthStarMetric    string   `yaml:"north_star_metric"`
+	SecondaryMetrics   []string `yaml:"secondary_metrics"`
+	FirstEmailDefaults struct {
+		MinWords          int    `yaml:"min_words"`
+		MaxWords          int    `yaml:"max_words"`
+		MaxCTAs           int    `yaml:"max_ctas"`
+		MaxLinks          int    `yaml:"max_links"`
+		Attachments       bool   `yaml:"attachments"`
+		MeetingCTADefault bool   `yaml:"meeting_cta_default"`
+		Language          string `yaml:"language"`
+	} `yaml:"first_email_defaults"`
+}
+
+type PersonasFile struct {
+	OutreachDoctrineVersion string        `yaml:"outreach_doctrine_version"`
+	Roles                   []PersonaRole `yaml:"roles"`
+}
+
+type PersonaRole struct {
+	Code          string   `yaml:"code"`
+	MatchKeywords []string `yaml:"match_keywords"`
+	Priorities    []string `yaml:"priorities"`
+	Tone          string   `yaml:"tone"`
+	PreferAngles  []string `yaml:"prefer_angles"`
+	Rules         []string `yaml:"rules"`
+}
+
+type ServicesFile struct {
+	OutreachDoctrineVersion string            `yaml:"outreach_doctrine_version"`
+	Services                []ServicePlaybook `yaml:"services"`
+}
+
+type ServicePlaybook struct {
+	Code              string   `yaml:"code"`
+	Name              string   `yaml:"name"`
+	Aliases           []string `yaml:"aliases"`
+	CommercialInsight string   `yaml:"commercial_insight"`
+	CommonMiss        string   `yaml:"common_miss"`
+	ProblemHypotheses []string `yaml:"problem_hypotheses"`
+	Implications      []string `yaml:"implications"`
+	DisallowedClaims  []string `yaml:"disallowed_claims"`
+	DefaultMicroOffer string   `yaml:"default_micro_offer"`
+	CTAFamilies       []string `yaml:"cta_families"`
+}
+
+type TriggersFile struct {
+	OutreachDoctrineVersion string        `yaml:"outreach_doctrine_version"`
+	Triggers                []TriggerRule `yaml:"triggers"`
+}
+
+type TriggerRule struct {
+	Code            string   `yaml:"code"`
+	Aliases         []string `yaml:"aliases"`
+	WhyNowTemplate  string   `yaml:"why_now_template"`
+	FactVsClaim     string   `yaml:"fact_vs_claim"`
+	PreferredOffers []string `yaml:"preferred_offers"`
+	RiskFlags       []string `yaml:"risk_flags"`
+	ClaimsToAvoid   []string `yaml:"claims_to_avoid"`
+}
+
+type OffersFile struct {
+	OutreachDoctrineVersion string           `yaml:"outreach_doctrine_version"`
+	Offers                  []MicroOfferDef  `yaml:"offers"`
+	RestrictedOffers        []map[string]any `yaml:"restricted_offers"`
+}
+
+type MicroOfferDef struct {
+	Code                   string   `yaml:"code"`
+	Description            string   `yaml:"description"`
+	BuyerValue             string   `yaml:"buyer_value"`
+	FulfillmentPath        string   `yaml:"fulfillment_path"`
+	FulfillmentCost        string   `yaml:"fulfillment_cost"`
+	RequiredEvidence       []string `yaml:"required_evidence"`
+	ApplicableServiceCodes []string `yaml:"applicable_service_codes"`
+	ProhibitedClaims       []string `yaml:"prohibited_claims"`
+	CTAPatterns            []string `yaml:"cta_patterns"`
+}
+
+type SequenceFile struct {
+	OutreachDoctrineVersion string `yaml:"outreach_doctrine_version"`
+	Sequence                struct {
+		MaxTouches int `yaml:"max_touches"`
+		Touches    []struct {
+			Position     int      `yaml:"position"`
+			Name         string   `yaml:"name"`
+			Objective    string   `yaml:"objective"`
+			AddsValue    string   `yaml:"adds_value"`
+			Forbidden    []string `yaml:"forbidden"`
+			DefaultDelay int      `yaml:"default_delay_days"`
+		} `yaml:"touches"`
+	} `yaml:"sequence"`
+	EmptyFollowupPhrases []string `yaml:"empty_followup_phrases"`
+}
+
+type ObjectionsFile struct {
+	OutreachDoctrineVersion string `yaml:"outreach_doctrine_version"`
+	Objections              []struct {
+		ID       string   `yaml:"id"`
+		Match    []string `yaml:"match"`
+		Strategy string   `yaml:"strategy"`
+		Guidance string   `yaml:"guidance"`
+		Never    []string `yaml:"never"`
+	} `yaml:"objections"`
+}
+
+type CopyRulesFile struct {
+	OutreachDoctrineVersion string   `yaml:"outreach_doctrine_version"`
+	BannedPhrases           []string `yaml:"banned_phrases"`
+	MeetingCTAPhrases       []string `yaml:"meeting_cta_phrases"`
+	CreepyPhrasing          []string `yaml:"creepy_phrasing"`
+	UnsupportedMonetary     []string `yaml:"unsupported_monetary"`
+	AnnualidadeBadClaims    []string `yaml:"annualidade_bad_claims"`
+	RejectionReasons        []string `yaml:"rejection_reasons"`
+	EditSignalCodes         []string `yaml:"edit_signal_codes"`
+	CommercialReplyClasses  []string `yaml:"commercial_reply_classes"`
+}
+
+var (
+	playbookOnce sync.Once
+	playbookInst *Playbook
+	playbookErr  error
+)
+
+// LoadPlaybook loads and validates the embedded outreach playbook (singleton).
+func LoadPlaybook() (*Playbook, error) {
+	playbookOnce.Do(func() {
+		playbookInst, playbookErr = loadPlaybookFS(playbookFS)
+	})
+	return playbookInst, playbookErr
+}
+
+// MustPlaybook returns the playbook or panics (tests / boot paths that require it).
+func MustPlaybook() *Playbook {
+	pb, err := LoadPlaybook()
+	if err != nil {
+		panic(err)
+	}
+	return pb
+}
+
+func loadPlaybookFS(fs embed.FS) (*Playbook, error) {
+	pb := &Playbook{}
+	if err := decodeYAML(fs, "outreach_playbook/doctrine.yaml", &pb.Doctrine); err != nil {
+		return nil, err
+	}
+	if err := decodeYAML(fs, "outreach_playbook/personas.yaml", &pb.Personas); err != nil {
+		return nil, err
+	}
+	if err := decodeYAML(fs, "outreach_playbook/services.yaml", &pb.Services); err != nil {
+		return nil, err
+	}
+	if err := decodeYAML(fs, "outreach_playbook/triggers.yaml", &pb.Triggers); err != nil {
+		return nil, err
+	}
+	if err := decodeYAML(fs, "outreach_playbook/offers.yaml", &pb.Offers); err != nil {
+		return nil, err
+	}
+	if err := decodeYAML(fs, "outreach_playbook/sequence.yaml", &pb.Sequence); err != nil {
+		return nil, err
+	}
+	if err := decodeYAML(fs, "outreach_playbook/objection_playbook.yaml", &pb.Objections); err != nil {
+		return nil, err
+	}
+	if err := decodeYAML(fs, "outreach_playbook/copy_rules.yaml", &pb.CopyRules); err != nil {
+		return nil, err
+	}
+	if err := ValidatePlaybook(pb); err != nil {
+		return nil, err
+	}
+	return pb, nil
+}
+
+func decodeYAML(fs embed.FS, path string, dest any) error {
+	b, err := fs.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+	if err := yaml.Unmarshal(b, dest); err != nil {
+		return fmt.Errorf("yaml %s: %w", path, err)
+	}
+	return nil
+}
+
+// ValidatePlaybook checks schema essentials (version + required libraries).
+func ValidatePlaybook(pb *Playbook) error {
+	if pb == nil {
+		return fmt.Errorf("nil playbook")
+	}
+	ver := strings.TrimSpace(pb.Doctrine.OutreachDoctrineVersion)
+	if ver == "" {
+		return fmt.Errorf("doctrine missing outreach_doctrine_version")
+	}
+	if ver != OutreachDoctrineVersion {
+		return fmt.Errorf("doctrine version %q != constant %q", ver, OutreachDoctrineVersion)
+	}
+	for _, label := range []struct {
+		name string
+		v    string
+	}{
+		{"personas", pb.Personas.OutreachDoctrineVersion},
+		{"services", pb.Services.OutreachDoctrineVersion},
+		{"triggers", pb.Triggers.OutreachDoctrineVersion},
+		{"offers", pb.Offers.OutreachDoctrineVersion},
+		{"sequence", pb.Sequence.OutreachDoctrineVersion},
+		{"objections", pb.Objections.OutreachDoctrineVersion},
+		{"copy_rules", pb.CopyRules.OutreachDoctrineVersion},
+	} {
+		if strings.TrimSpace(label.v) != ver {
+			return fmt.Errorf("%s version %q != doctrine %q", label.name, label.v, ver)
+		}
+	}
+	if len(pb.Services.Services) == 0 {
+		return fmt.Errorf("services playbook empty")
+	}
+	if len(pb.Offers.Offers) == 0 {
+		return fmt.Errorf("offers library empty")
+	}
+	if len(pb.Sequence.Sequence.Touches) == 0 {
+		return fmt.Errorf("sequence touches empty")
+	}
+	offerCodes := map[string]bool{}
+	for _, o := range pb.Offers.Offers {
+		if o.Code == "" {
+			return fmt.Errorf("offer missing code")
+		}
+		if strings.ToUpper(o.FulfillmentCost) != "LOW" && strings.ToUpper(o.FulfillmentCost) != "MEDIUM" && strings.ToUpper(o.FulfillmentCost) != "HIGH" {
+			return fmt.Errorf("offer %s invalid fulfillment_cost %q", o.Code, o.FulfillmentCost)
+		}
+		offerCodes[o.Code] = true
+	}
+	for _, s := range pb.Services.Services {
+		if s.DefaultMicroOffer != "" && !offerCodes[s.DefaultMicroOffer] {
+			return fmt.Errorf("service %s default offer %s not in library", s.Code, s.DefaultMicroOffer)
+		}
+	}
+	return nil
+}
+
+// ResolveServicePlaybook matches service_code (exact, alias, or prefix before _).
+func (pb *Playbook) ResolveServicePlaybook(serviceCode string) *ServicePlaybook {
+	if pb == nil {
+		return nil
+	}
+	sc := strings.ToUpper(strings.TrimSpace(serviceCode))
+	if sc == "" {
+		return nil
+	}
+	for i := range pb.Services.Services {
+		s := &pb.Services.Services[i]
+		if strings.EqualFold(s.Code, sc) {
+			return s
+		}
+		for _, a := range s.Aliases {
+			if strings.EqualFold(a, sc) {
+				return s
+			}
+		}
+	}
+	// Prefix: REAJUSTE_14133 → REAJUSTE
+	if i := strings.Index(sc, "_"); i > 0 {
+		return pb.ResolveServicePlaybook(sc[:i])
+	}
+	return nil
+}
+
+// ResolveTrigger matches moment/trigger codes.
+func (pb *Playbook) ResolveTrigger(code string) *TriggerRule {
+	if pb == nil {
+		return nil
+	}
+	c := strings.ToUpper(strings.TrimSpace(code))
+	if c == "" {
+		c = "GENERIC"
+	}
+	for i := range pb.Triggers.Triggers {
+		t := &pb.Triggers.Triggers[i]
+		if strings.EqualFold(t.Code, c) {
+			return t
+		}
+		for _, a := range t.Aliases {
+			if strings.EqualFold(a, c) {
+				return t
+			}
+		}
+	}
+	// Heuristic keywords in free-text codes from feeds
+	low := strings.ToLower(c)
+	for i := range pb.Triggers.Triggers {
+		t := &pb.Triggers.Triggers[i]
+		if strings.Contains(low, strings.ToLower(t.Code)) {
+			return t
+		}
+		for _, a := range t.Aliases {
+			if a != "" && strings.Contains(low, strings.ToLower(a)) {
+				return t
+			}
+		}
+	}
+	for i := range pb.Triggers.Triggers {
+		if strings.EqualFold(pb.Triggers.Triggers[i].Code, "GENERIC") {
+			return &pb.Triggers.Triggers[i]
+		}
+	}
+	return nil
+}
+
+// FindOffer returns a micro-offer by code.
+func (pb *Playbook) FindOffer(code string) *MicroOfferDef {
+	if pb == nil {
+		return nil
+	}
+	for i := range pb.Offers.Offers {
+		if strings.EqualFold(pb.Offers.Offers[i].Code, code) {
+			return &pb.Offers.Offers[i]
+		}
+	}
+	return nil
+}
+
+// MapBuyerRole maps free-text role to persona code; UNKNOWN if no evidence.
+func (pb *Playbook) MapBuyerRole(role string) string {
+	r := strings.ToLower(strings.TrimSpace(role))
+	if r == "" || r == "contato" || r == "email genérico" || r == "email generico" {
+		return "UNKNOWN"
+	}
+	// Generic institutional addresses must not become OWNER/DIRECTOR.
+	if strings.Contains(r, "contato@") || r == "geral" || r == "administrativo genérico" {
+		return "UNKNOWN"
+	}
+	if pb == nil {
+		return "UNKNOWN"
+	}
+	for _, p := range pb.Personas.Roles {
+		if p.Code == "UNKNOWN" {
+			continue
+		}
+		for _, kw := range p.MatchKeywords {
+			if kw != "" && strings.Contains(r, strings.ToLower(kw)) {
+				return p.Code
+			}
+		}
+	}
+	return "UNKNOWN"
+}
+
+// OfferApplicable checks service match and LOW budget for cold path.
+func (pb *Playbook) OfferApplicable(offer *MicroOfferDef, serviceCode string, coldPath bool) bool {
+	if offer == nil {
+		return false
+	}
+	if coldPath && strings.ToUpper(offer.FulfillmentCost) != "LOW" {
+		return false
+	}
+	sc := strings.ToUpper(strings.TrimSpace(serviceCode))
+	canon := sc
+	if sp := pb.ResolveServicePlaybook(serviceCode); sp != nil {
+		canon = strings.ToUpper(sp.Code)
+	}
+	for _, a := range offer.ApplicableServiceCodes {
+		if a == "*" || strings.EqualFold(a, sc) || strings.EqualFold(a, canon) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/confenge/playbook_test.go
+++ b/internal/app/confenge/playbook_test.go
@@ -1,0 +1,80 @@
+package confenge
+
+import (
+	"testing"
+)
+
+func TestLoadPlaybookSchema(t *testing.T) {
+	pb, err := LoadPlaybook()
+	if err != nil {
+		t.Fatalf("LoadPlaybook: %v", err)
+	}
+	if pb.Doctrine.OutreachDoctrineVersion != OutreachDoctrineVersion {
+		t.Fatalf("version %q", pb.Doctrine.OutreachDoctrineVersion)
+	}
+	if OutreachDoctrineVersion != "confenge-outreach-v1" {
+		t.Fatalf("unexpected doctrine version constant")
+	}
+	if len(pb.Offers.Offers) < 5 {
+		t.Fatalf("offers too few: %d", len(pb.Offers.Offers))
+	}
+	if len(pb.Services.Services) < 8 {
+		t.Fatalf("services too few: %d", len(pb.Services.Services))
+	}
+	// Cold path only LOW
+	for _, o := range pb.Offers.Offers {
+		if o.FulfillmentCost == "" {
+			t.Fatalf("offer %s missing cost", o.Code)
+		}
+	}
+	if pb.ChannelPolicyWhatsAppOn() {
+		t.Fatal("whatsapp must be OFF in doctrine")
+	}
+}
+
+// helper for channel policy check without exporting field path noise
+func (pb *Playbook) ChannelPolicyWhatsAppOn() bool {
+	if pb == nil {
+		return false
+	}
+	return pb.Doctrine.ChannelPolicy.WhatsApp == "ON"
+}
+
+func TestResolveServiceAndOffer(t *testing.T) {
+	pb := MustPlaybook()
+	s := pb.ResolveServicePlaybook("REAJUSTE_14133")
+	if s == nil || s.Code != "REAJUSTE" {
+		t.Fatalf("prefix resolve: %+v", s)
+	}
+	s2 := pb.ResolveServicePlaybook("ADDITIVE_REVIEW")
+	if s2 == nil || s2.Code != "ADITIVOS" {
+		t.Fatalf("alias additive: %+v", s2)
+	}
+	o := pb.FindOffer("REAJUSTE_CHECK")
+	if o == nil || o.FulfillmentCost != "LOW" {
+		t.Fatalf("reajuste check: %+v", o)
+	}
+	if !pb.OfferApplicable(o, "REAJUSTE", true) {
+		t.Fatal("offer should apply to REAJUSTE cold")
+	}
+}
+
+func TestMapBuyerRoleNeverInfersFromGeneric(t *testing.T) {
+	pb := MustPlaybook()
+	if pb.MapBuyerRole("") != "UNKNOWN" {
+		t.Fatal("empty")
+	}
+	if pb.MapBuyerRole("Engenheiro de Obras") != "ENGINEERING" {
+		t.Fatal("engineering")
+	}
+	if pb.MapBuyerRole("Diretor Financeiro") != "DIRECTOR" && pb.MapBuyerRole("Diretor Financeiro") != "FINANCE" {
+		// "Diretor" matches first; acceptable either DIRECTOR or if finance keywords win
+		role := pb.MapBuyerRole("Diretor Financeiro")
+		if role != "DIRECTOR" && role != "FINANCE" {
+			t.Fatalf("role %s", role)
+		}
+	}
+	if pb.MapBuyerRole("contato@empresa.com.br") == "OWNER_PARTNER" {
+		t.Fatal("must not infer owner from email")
+	}
+}

--- a/internal/app/confenge/reply_intent.go
+++ b/internal/app/confenge/reply_intent.go
@@ -18,6 +18,26 @@ const (
 	IntentDoNotContact     = "DO_NOT_CONTACT"
 	IntentOutOfOffice      = "OUT_OF_OFFICE"
 	IntentUnknown          = "UNKNOWN"
+
+	// Fine-grained commercial reply classes (doctrine mapping; next strategy, not auto-send).
+	ReplyClassPositiveInterest     = "POSITIVE_INTEREST"
+	ReplyClassOfferAccepted        = "OFFER_ACCEPTED"
+	ReplyClassSendMoreInfo         = "SEND_MORE_INFO"
+	ReplyClassWrongPerson          = "WRONG_PERSON"
+	ReplyClassReferral             = "REFERRAL"
+	ReplyClassAlreadyHandled       = "ALREADY_HANDLED_INTERNAL"
+	ReplyClassAlreadyHasConsultant = "ALREADY_HAS_CONSULTANT"
+	ReplyClassNotAPriority         = "NOT_A_PRIORITY"
+	ReplyClassNotInterested        = "NOT_INTERESTED"
+	ReplyClassContactLater         = "CONTACT_LATER"
+	ReplyClassPriceQuestion        = "PRICE_QUESTION"
+	ReplyClassCredibilityQuestion  = "CREDIBILITY_QUESTION"
+	ReplyClassTechnicalQuestion    = "TECHNICAL_QUESTION"
+	ReplyClassProcurementConcern   = "PROCUREMENT_CONCERN"
+	ReplyClassDNC                  = "DNC"
+	ReplyClassOutOfOffice          = "OUT_OF_OFFICE"
+	ReplyClassAutoReply            = "AUTO_REPLY"
+	ReplyClassOther                = "OTHER"
 )
 
 type CommercialIntent struct {
@@ -120,24 +140,30 @@ func ExtractOOODate(text string) *time.Time {
 
 func SuggestNextAction(intent string, oooDate *time.Time, referralHint string) string {
 	switch intent {
-	case IntentPositiveInterest:
+	case IntentPositiveInterest: // same string as ReplyClassPositiveInterest
 		return "Priorizar: redigir resposta consultiva e marcar follow-up humano (nao marcar Ganho)."
-	case IntentReferral:
+	case ReplyClassOfferAccepted:
+		return "Cumprir micro-oferta prometida (fulfillment draft) antes de pedir reuniao; aprovacao humana."
+	case ReplyClassSendMoreInfo:
+		return "Enviar material especifico ao problema do fio (nao brochure generico); aprovacao humana."
+	case IntentReferral, ReplyClassReferral, ReplyClassWrongPerson:
 		if referralHint != "" {
 			return "Atualizar destinatario para o contato indicado (" + referralHint + ") sem perder a timeline; gerar novo toque com aprovacao."
 		}
 		return "Pedir o contato indicado e trocar o destinatario sem perder a timeline da conta."
-	case IntentQuestion:
+	case IntentQuestion, ReplyClassTechnicalQuestion, ReplyClassCredibilityQuestion:
 		return "Responder a pergunta com fatos do dossie; sem inventar numeros ou prazos."
-	case IntentObjection:
-		return "Reconhecer a objecao, esclarecer com fatos do dossie; nao discutir juridicamente nem inventar fatos."
-	case IntentNotNow:
+	case ReplyClassPriceQuestion:
+		return "Responder faixa/escopo conforme offer/service; nao esconder preco artificialmente; aprovacao humana."
+	case IntentObjection, ReplyClassAlreadyHandled, ReplyClassAlreadyHasConsultant, ReplyClassProcurementConcern:
+		return "Reconhecer a objecao, posicionar complementaridade; nao discutir juridicamente nem inventar fatos."
+	case IntentNotNow, ReplyClassContactLater, ReplyClassNotAPriority:
 		return "Oferecer retomar em data X (toque futuro explicito, sujeito a aprovacao). Nao reabrir cadencia automaticamente."
-	case IntentNegative:
+	case IntentNegative, ReplyClassNotInterested:
 		return "Registrar desinteresse, interromper cadencia. Nao insistir."
-	case IntentDoNotContact:
+	case IntentDoNotContact, ReplyClassDNC:
 		return "Bloqueio sticky DO_NOT_CONTACT: parar todos os toques e suprimir contato."
-	case IntentOutOfOffice:
+	case IntentOutOfOffice, ReplyClassAutoReply: // OUT_OF_OFFICE shared with ReplyClassOutOfOffice
 		if oooDate != nil {
 			return "OOO com data clara: sugerir retomar apos " + oooDate.UTC().Format("2006-01-02") + " (toque futuro com aprovacao)."
 		}
@@ -145,6 +171,72 @@ func SuggestNextAction(intent string, oooDate *time.Time, referralHint string) s
 	default:
 		return "Classificacao manual necessaria; IA opcional desligada ou inconclusiva."
 	}
+}
+
+// MapCommercialReplyClass refines intent into doctrine commercial reply classes.
+// Positive reply is distinct from any human reply (e.g. DNC is reply but not success).
+func MapCommercialReplyClass(intent string, subject, body string) string {
+	text := strings.ToLower(strings.TrimSpace(subject + "\n" + body))
+	switch intent {
+	case IntentDoNotContact:
+		return ReplyClassDNC
+	case IntentOutOfOffice:
+		return ReplyClassOutOfOffice
+	case IntentReferral:
+		return ReplyClassReferral
+	case IntentNotNow:
+		return ReplyClassContactLater
+	case IntentNegative:
+		return ReplyClassNotInterested
+	case IntentObjection:
+		if strings.Contains(text, "jurídico") || strings.Contains(text, "juridico") {
+			return ReplyClassAlreadyHandled
+		}
+		if strings.Contains(text, "consultor") || strings.Contains(text, "já temos") || strings.Contains(text, "ja temos") {
+			return ReplyClassAlreadyHasConsultant
+		}
+		return ReplyClassNotAPriority
+	case IntentQuestion:
+		if strings.Contains(text, "quanto custa") || strings.Contains(text, "preço") || strings.Contains(text, "preco") {
+			return ReplyClassPriceQuestion
+		}
+		if strings.Contains(text, "quem é") || strings.Contains(text, "quem e") || strings.Contains(text, "confenge") {
+			return ReplyClassCredibilityQuestion
+		}
+		return ReplyClassTechnicalQuestion
+	case IntentPositiveInterest:
+		for _, kw := range offerAcceptedKeywords {
+			if strings.Contains(text, kw) {
+				return ReplyClassOfferAccepted
+			}
+		}
+		for _, kw := range sendMoreInfoKeywords {
+			if strings.Contains(text, kw) {
+				return ReplyClassSendMoreInfo
+			}
+		}
+		return ReplyClassPositiveInterest
+	default:
+		if strings.Contains(text, "não sou a pessoa") || strings.Contains(text, "nao sou a pessoa") {
+			return ReplyClassWrongPerson
+		}
+		return ReplyClassOther
+	}
+}
+
+// IsPositiveCommercialReply reports success-class replies (not mere human reply).
+func IsPositiveCommercialReply(class string) bool {
+	switch class {
+	case ReplyClassPositiveInterest, ReplyClassOfferAccepted, ReplyClassSendMoreInfo, ReplyClassReferral:
+		return true
+	default:
+		return false
+	}
+}
+
+// NextCommercialStrategy returns the playbook next step label for a reply class.
+func NextCommercialStrategy(class string) string {
+	return SuggestNextAction(class, nil, "")
 }
 
 func ObjectionReplyGuardrails() []string {
@@ -266,3 +358,5 @@ var objectionKeywords = []string{"muito caro", "too expensive", "sem orcamento",
 var questionKeywords = []string{"quanto custa", "how much", "qual o prazo", "como funciona", "pode enviar", "pode detalhar", "what does", "could you", "voce pode", "você pode", "tem case", "tem material"}
 var positiveCommercialKeywords = []string{"tenho interesse", "interessado", "interessada", "vamos agendar", "pode ligar", "marcamos", "bora conversar", "sounds good", "interested", "let's chat", "lets chat", "agendar uma call", "enviar proposta"}
 var negativeCommercialKeywords = []string{"not interested", "sem interesse", "nao tenho interesse", "não tenho interesse", "no thanks", "no thank you", "dispenso", "nao precisamos", "não precisamos"}
+var offerAcceptedKeywords = []string{"manda", "pode enviar", "pode mandar", "quero ver", "envia o checklist", "envia o recorte", "sim, pode", "sim pode", "pode sim", "send it", "please send"}
+var sendMoreInfoKeywords = []string{"manda material", "mais informações", "mais informacoes", "send more", "mais detalhes", "tem material"}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -93,6 +93,7 @@ type Service interface {
 	EditTouchpoint(ctx context.Context, orgID, userID, id uuid.UUID, subject, body, recipient, channel *string) (*models.OutreachTouchpoint, *errx.Error)
 	ApproveTouchpoint(ctx context.Context, orgID, userID, id uuid.UUID) (*models.OutreachTouchpoint, *errx.Error)
 	RejectOrSkipTouchpoint(ctx context.Context, orgID, userID, id uuid.UUID, action string) (*models.OutreachTouchpoint, *errx.Error)
+	RejectOrSkipTouchpointReason(ctx context.Context, orgID, userID, id uuid.UUID, action, reason string) (*models.OutreachTouchpoint, *errx.Error)
 	QueueTouchpoint(ctx context.Context, orgID, userID, id uuid.UUID) (*models.OutreachTouchpoint, *errx.Error)
 	CancelAccountTouchpoints(ctx context.Context, orgID, userID, accountID uuid.UUID, reason string) (int, *errx.Error)
 

--- a/internal/app/confenge/strategy.go
+++ b/internal/app/confenge/strategy.go
@@ -1,0 +1,420 @@
+package confenge
+
+import (
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// CTA types for first-touch strategy.
+const (
+	CTATypePermissionOffer = "PERMISSION_OFFER"
+	CTATypeInterest        = "INTEREST"
+	CTATypeRouting         = "ROUTING"
+	CTATypeGracefulClose   = "GRACEFUL_CLOSE"
+	CTATypeMeeting         = "MEETING" // only after sufficient interest
+	CTATypeFulfillment     = "FULFILLMENT"
+)
+
+// OutreachStrategy is the commercial plan produced BEFORE any copy.
+// It never contains activation/lead/commercial scores.
+type OutreachStrategy struct {
+	DoctrineVersion string `json:"doctrine_version"`
+	AccountID       string `json:"account_id,omitempty"`
+	ContactID       string `json:"contact_id,omitempty"`
+
+	BuyerRole   string `json:"buyer_role"`
+	ServiceCode string `json:"service_code"`
+	ServiceName string `json:"service_name,omitempty"`
+
+	ActivationTrigger string   `json:"activation_trigger"`
+	TriggerSummary    string   `json:"trigger_summary"`
+	EvidenceIDs       []string `json:"evidence_ids"`
+
+	WhyThisAccount string `json:"why_this_account"`
+	WhyNow         string `json:"why_now"`
+
+	ObservedFact          string `json:"observed_fact"`
+	ProblemHypothesis     string `json:"problem_hypothesis"`
+	ImplicationHypothesis string `json:"implication_hypothesis"`
+	CommercialReframe     string `json:"commercial_reframe"`
+	MicroOfferCode        string `json:"micro_offer_code"`
+	MicroOfferDescription string `json:"micro_offer_description,omitempty"`
+	CredibilityBasis      string `json:"credibility_basis"`
+	CTAType               string `json:"cta_type"`
+	CTASuggested          string `json:"cta_suggested,omitempty"`
+	SequencePosition      int    `json:"sequence_position"`
+	SequenceTouchName     string `json:"sequence_touch_name,omitempty"`
+
+	ClaimsAllowed        []string `json:"claims_allowed,omitempty"`
+	ClaimsToAvoid        []string `json:"claims_to_avoid,omitempty"`
+	PersonalizationBasis string   `json:"personalization_basis"`
+	RiskFlags            []string `json:"risk_flags,omitempty"`
+
+	ValueToRecipient string `json:"value_to_recipient,omitempty"`
+	AccountArchetype string `json:"account_archetype,omitempty"` // robust | regional | unknown
+
+	// Experiment metadata (assignment only; not a score).
+	Experiment *ExperimentAssignment `json:"experiment,omitempty"`
+}
+
+// StrategyExplain is the compact operator cockpit projection.
+type StrategyExplain struct {
+	WhyNow     string   `json:"why_now"`
+	FactUsed   string   `json:"fact_used"`
+	Hypothesis string   `json:"hypothesis"`
+	Service    string   `json:"service"`
+	Offer      string   `json:"offer"`
+	Recipient  string   `json:"recipient"`
+	Sources    []string `json:"sources,omitempty"`
+	Touch      string   `json:"touch"`
+	Experiment string   `json:"experiment,omitempty"`
+	Doctrine   string   `json:"doctrine_version"`
+}
+
+// PlanOutreachStrategy builds strategy from dossier only (no re-scoring).
+func PlanOutreachStrategy(
+	pb *Playbook,
+	acc *models.OutreachAccount,
+	cand *models.OutreachContactCandidate,
+	evidence []models.OutreachEvidence,
+	sequencePosition int,
+) OutreachStrategy {
+	if pb == nil {
+		pb, _ = LoadPlaybook()
+	}
+	st := OutreachStrategy{
+		DoctrineVersion:  OutreachDoctrineVersion,
+		SequencePosition: sequencePosition,
+		BuyerRole:        "UNKNOWN",
+		CTAType:          CTATypePermissionOffer,
+		CredibilityBasis: "quality_of_public_observation",
+	}
+	if sequencePosition <= 0 {
+		st.SequencePosition = 1
+	}
+	if pb != nil {
+		for _, t := range pb.Sequence.Sequence.Touches {
+			if t.Position == st.SequencePosition {
+				st.SequenceTouchName = t.Name
+				break
+			}
+		}
+	}
+
+	if acc != nil {
+		st.AccountID = acc.ID.String()
+		st.ServiceCode = strings.TrimSpace(acc.ServiceCode)
+		st.ServiceName = strings.TrimSpace(acc.ServiceName)
+		st.ActivationTrigger = strings.TrimSpace(acc.MomentCode)
+		st.TriggerSummary = strings.TrimSpace(acc.MomentSummary)
+		st.EvidenceIDs = append([]string{}, acc.MomentEvidenceIDs...)
+		st.ObservedFact = strings.TrimSpace(acc.FactToMention)
+		st.ClaimsToAvoid = append([]string{}, acc.ClaimsToAvoid...)
+		company := firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
+		st.WhyThisAccount = "empresa com momento comercial público: " + firstNonEmpty(company, acc.CNPJ14)
+		st.AccountArchetype = inferArchetype(acc, evidence)
+	}
+	if cand != nil {
+		st.ContactID = cand.ID.String()
+		if pb != nil {
+			st.BuyerRole = pb.MapBuyerRole(cand.Role)
+		}
+	}
+
+	// Evidence IDs from rows
+	for _, e := range evidence {
+		id := strings.TrimSpace(e.SourceEvidenceID)
+		if id == "" {
+			continue
+		}
+		if !containsStr(st.EvidenceIDs, id) {
+			st.EvidenceIDs = append(st.EvidenceIDs, id)
+		}
+		if st.ObservedFact == "" {
+			st.ObservedFact = firstNonEmpty(e.Synthesis, e.Excerpt, e.Title)
+		}
+	}
+
+	var svc *ServicePlaybook
+	var trig *TriggerRule
+	if pb != nil {
+		svc = pb.ResolveServicePlaybook(st.ServiceCode)
+		trig = pb.ResolveTrigger(st.ActivationTrigger)
+	}
+
+	if trig != nil {
+		st.WhyNow = strings.TrimSpace(trig.WhyNowTemplate)
+		if st.TriggerSummary != "" {
+			st.WhyNow = st.TriggerSummary
+		}
+		st.ClaimsToAvoid = appendUnique(st.ClaimsToAvoid, trig.ClaimsToAvoid...)
+		st.RiskFlags = appendUnique(st.RiskFlags, trig.RiskFlags...)
+	} else if st.TriggerSummary != "" {
+		st.WhyNow = st.TriggerSummary
+	} else {
+		st.WhyNow = "momento comercial indicado pelo extra-cli"
+		st.RiskFlags = appendUnique(st.RiskFlags, "weak_trigger")
+	}
+
+	if svc != nil {
+		if st.ServiceName == "" {
+			st.ServiceName = svc.Name
+		}
+		st.CommercialReframe = strings.TrimSpace(svc.CommercialInsight)
+		if len(svc.ProblemHypotheses) > 0 {
+			st.ProblemHypothesis = svc.ProblemHypotheses[0]
+		}
+		if len(svc.Implications) > 0 {
+			st.ImplicationHypothesis = svc.Implications[0]
+		}
+		st.ClaimsToAvoid = appendUnique(st.ClaimsToAvoid, svc.DisallowedClaims...)
+		st.MicroOfferCode = svc.DefaultMicroOffer
+	}
+
+	// Annualidade special case: never claim unpaid reajuste
+	if isAnnualidadeContext(st.ActivationTrigger, st.TriggerSummary, st.ObservedFact) {
+		st.RiskFlags = appendUnique(st.RiskFlags, "annualidade_verify_only")
+		st.ProblemHypothesis = "pode haver documentos e memórias de reajuste a conferir neste ciclo (hipótese, não crédito comprovado)"
+		st.ImplicationHypothesis = "sem verificação, a equipe pode perder tempo reconstituting memória depois"
+		st.CommercialReframe = "Anualidade é sinal de verificação, não prova de reajuste devido."
+		st.MicroOfferCode = "REAJUSTE_CHECK"
+		st.ClaimsToAvoid = appendUnique(st.ClaimsToAvoid,
+			"reajuste a receber", "o órgão deixou de pagar", "crédito de reajuste", "identificamos perda")
+		st.ClaimsAllowed = appendUnique(st.ClaimsAllowed,
+			"janela de verificação documental", "checklist de reajuste", "dados públicos sugerem conferência")
+	}
+
+	// Prefer trigger offers when set; keep service default if it is already preferred.
+	if pb != nil && trig != nil && len(trig.PreferredOffers) > 0 {
+		keepDefault := false
+		if st.MicroOfferCode != "" {
+			for _, oc := range trig.PreferredOffers {
+				if strings.EqualFold(oc, st.MicroOfferCode) {
+					keepDefault = true
+					break
+				}
+			}
+		}
+		if !keepDefault {
+			for _, oc := range trig.PreferredOffers {
+				if o := pb.FindOffer(oc); o != nil && pb.OfferApplicable(o, st.ServiceCode, true) {
+					st.MicroOfferCode = o.Code
+					break
+				}
+			}
+		}
+	}
+
+	if pb != nil && st.MicroOfferCode != "" {
+		if o := pb.FindOffer(st.MicroOfferCode); o != nil {
+			if !pb.OfferApplicable(o, st.ServiceCode, true) {
+				st.RiskFlags = appendUnique(st.RiskFlags, "offer_not_applicable")
+				st.MicroOfferCode = fallbackLOWOffer(pb, st.ServiceCode)
+			} else {
+				st.MicroOfferDescription = o.Description
+				st.ValueToRecipient = o.BuyerValue
+				st.ClaimsToAvoid = appendUnique(st.ClaimsToAvoid, o.ProhibitedClaims...)
+				if len(o.CTAPatterns) > 0 {
+					st.CTASuggested = o.CTAPatterns[0]
+				}
+			}
+		}
+	}
+	if st.MicroOfferCode == "" && pb != nil {
+		st.MicroOfferCode = fallbackLOWOffer(pb, st.ServiceCode)
+		if o := pb.FindOffer(st.MicroOfferCode); o != nil {
+			st.MicroOfferDescription = o.Description
+			st.ValueToRecipient = o.BuyerValue
+			if len(o.CTAPatterns) > 0 {
+				st.CTASuggested = o.CTAPatterns[0]
+			}
+		}
+	}
+
+	// Sequence-specific CTA
+	switch st.SequencePosition {
+	case 4:
+		st.CTAType = CTATypeRouting
+		if st.CTASuggested == "" {
+			st.CTASuggested = "Quem na equipe acompanha este tema no dia a dia?"
+		}
+	case 5:
+		st.CTAType = CTATypeGracefulClose
+		st.CTASuggested = "Encerro por aqui para não ocupar sua caixa."
+	default:
+		st.CTAType = CTATypePermissionOffer
+	}
+
+	// Tailor hypothesis language by buyer role (still hypothesis)
+	st.ProblemHypothesis = tailorHypothesis(st.BuyerRole, st.ProblemHypothesis, st.AccountArchetype)
+
+	if st.ObservedFact == "" {
+		st.RiskFlags = appendUnique(st.RiskFlags, "no_safe_factual_hook")
+		st.PersonalizationBasis = "insufficient_public_fact"
+	} else {
+		st.PersonalizationBasis = "public_contract_fact"
+	}
+
+	// Low-confidence evidence
+	for _, e := range evidence {
+		switch e.EpistemicClass {
+		case models.OutreachEpistemicWeakInference, models.OutreachEpistemicCommercialHypothesis,
+			models.OutreachEpistemicRequiresCompanyConfirm, models.OutreachEpistemicContradictoryEvidence:
+			st.RiskFlags = appendUnique(st.RiskFlags, "evidence_requires_hypothesis_language")
+		}
+	}
+
+	if st.ValueToRecipient == "" {
+		st.ValueToRecipient = "clareza objetiva sobre um ponto contratual público"
+	}
+	if st.ClaimsAllowed == nil {
+		st.ClaimsAllowed = []string{"fato público citado", "hipótese linguistically scoped", "micro-oferta de verificação"}
+	}
+
+	// Account-level experiment (single dimension, no scores)
+	if acc != nil {
+		st.Experiment = AssignExperiment(acc.ID.String(), st.ServiceCode, st.MicroOfferCode)
+	}
+
+	return st
+}
+
+// ExplainStrategy projects operator cockpit fields.
+func ExplainStrategy(st OutreachStrategy, recipient string) StrategyExplain {
+	touch := ""
+	if st.SequenceTouchName != "" {
+		touch = st.SequenceTouchName
+	}
+	if st.SequencePosition > 0 {
+		if touch != "" {
+			touch = touch + " "
+		}
+		touch += "#" + itoa(st.SequencePosition)
+	}
+	exp := ""
+	if st.Experiment != nil {
+		exp = st.Experiment.VariantID
+		if st.Experiment.Dimension != "" {
+			exp = st.Experiment.Dimension + ":" + exp
+		}
+	}
+	return StrategyExplain{
+		WhyNow:     st.WhyNow,
+		FactUsed:   st.ObservedFact,
+		Hypothesis: firstNonEmpty(st.ProblemHypothesis, st.ImplicationHypothesis),
+		Service:    firstNonEmpty(st.ServiceName, st.ServiceCode),
+		Offer:      firstNonEmpty(st.MicroOfferDescription, st.MicroOfferCode),
+		Recipient:  recipient,
+		Sources:    st.EvidenceIDs,
+		Touch:      touch,
+		Experiment: exp,
+		Doctrine:   st.DoctrineVersion,
+	}
+}
+
+func isAnnualidadeContext(trigger, summary, fact string) bool {
+	blob := strings.ToLower(trigger + " " + summary + " " + fact)
+	for _, k := range []string{"anualidade", "aniversário", "aniversario", "annuality", "marco temporal de reajuste", "janela de reajuste"} {
+		if strings.Contains(blob, k) {
+			return true
+		}
+	}
+	return strings.EqualFold(strings.TrimSpace(trigger), "ANUALIDADE")
+}
+
+func inferArchetype(acc *models.OutreachAccount, evidence []models.OutreachEvidence) string {
+	// Prefer explicit hints in moment/summary; never invent from email domain alone.
+	blob := ""
+	if acc != nil {
+		blob = strings.ToLower(acc.MomentSummary + " " + acc.OfferRationale + " " + acc.PriorityTier)
+	}
+	for _, e := range evidence {
+		blob += " " + strings.ToLower(e.Synthesis)
+	}
+	if strings.Contains(blob, "robusta") || strings.Contains(blob, "corporativ") ||
+		strings.Contains(blob, "grande porte") || strings.Contains(blob, "strategic") {
+		return "robust"
+	}
+	if strings.Contains(blob, "regional") || strings.Contains(blob, "enxut") ||
+		strings.Contains(blob, "pequeno porte") || strings.Contains(blob, "mei ") {
+		return "regional"
+	}
+	return "unknown"
+}
+
+func tailorHypothesis(role, hyp, archetype string) string {
+	hyp = strings.TrimSpace(hyp)
+	if hyp == "" {
+		return hyp
+	}
+	if archetype == "robust" {
+		return hyp + " (como segunda leitura / validação independente, sem presumir falta de capacidade interna)"
+	}
+	switch role {
+	case "FINANCE":
+		return hyp + " com impacto potencial em previsibilidade de recebimento (hipótese)"
+	case "LEGAL":
+		return hyp + " no plano técnico-documental que costuma apoiar o jurídico (hipótese)"
+	case "ENGINEERING", "CONTRACTS":
+		return hyp + " em documentação e memória de cálculo (hipótese)"
+	case "OWNER_PARTNER", "DIRECTOR":
+		return hyp + " com leitura de risco/margem, não de acusação (hipótese)"
+	default:
+		return hyp
+	}
+}
+
+func fallbackLOWOffer(pb *Playbook, serviceCode string) string {
+	if pb == nil {
+		return "DOCUMENT_CHECKLIST"
+	}
+	for _, o := range pb.Offers.Offers {
+		if pb.OfferApplicable(&o, serviceCode, true) {
+			return o.Code
+		}
+	}
+	return "DOCUMENT_CHECKLIST"
+}
+
+func appendUnique(dst []string, extra ...string) []string {
+	seen := map[string]bool{}
+	for _, d := range dst {
+		seen[strings.ToLower(strings.TrimSpace(d))] = true
+	}
+	for _, e := range extra {
+		e = strings.TrimSpace(e)
+		if e == "" {
+			continue
+		}
+		k := strings.ToLower(e)
+		if seen[k] {
+			continue
+		}
+		seen[k] = true
+		dst = append(dst, e)
+	}
+	return dst
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [12]byte
+	i := len(b)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	if neg {
+		i--
+		b[i] = '-'
+	}
+	return string(b[i:])
+}

--- a/internal/app/confenge/strategy.go
+++ b/internal/app/confenge/strategy.go
@@ -176,7 +176,7 @@ func PlanOutreachStrategy(
 	if isAnnualidadeContext(st.ActivationTrigger, st.TriggerSummary, st.ObservedFact) {
 		st.RiskFlags = appendUnique(st.RiskFlags, "annualidade_verify_only")
 		st.ProblemHypothesis = "pode haver documentos e memórias de reajuste a conferir neste ciclo (hipótese, não crédito comprovado)"
-		st.ImplicationHypothesis = "sem verificação, a equipe pode perder tempo reconstituting memória depois"
+		st.ImplicationHypothesis = "sem verificação, a equipe pode perder tempo reconstituindo a memória documental depois"
 		st.CommercialReframe = "Anualidade é sinal de verificação, não prova de reajuste devido."
 		st.MicroOfferCode = "REAJUSTE_CHECK"
 		st.ClaimsToAvoid = appendUnique(st.ClaimsToAvoid,
@@ -417,4 +417,34 @@ func itoa(n int) string {
 		b[i] = '-'
 	}
 	return string(b[i:])
+}
+
+// SequencePositionForTouch maps touchpoint ordinal/purpose to doctrine sequence position (1–5).
+func SequencePositionForTouch(ordinal int, purpose string) int {
+	pos := ordinal
+	if pos <= 0 {
+		pos = 1
+	}
+	switch purpose {
+	case models.TouchpointPurposeFollowUp:
+		if pos < 2 {
+			pos = 2
+		}
+	case models.TouchpointPurposeClose:
+		pos = 5
+	}
+	if pos > 5 {
+		pos = 5
+	}
+	return pos
+}
+
+// GenerationChannelForTouch maps sequence position to generation/validation channel.
+// Follow-ups and close must use EMAIL_FOLLOWUP so legitimate in-thread "Re:" subjects
+// are not treated as fake first-touch Re/Fwd.
+func GenerationChannelForTouch(ordinal int, purpose string) string {
+	if SequencePositionForTouch(ordinal, purpose) >= 2 {
+		return ChannelEmailFollowup
+	}
+	return ChannelEmailInitial
 }

--- a/internal/app/confenge/strategy_compose.go
+++ b/internal/app/confenge/strategy_compose.go
@@ -1,0 +1,213 @@
+package confenge
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// ComposeFromStrategy builds constrained copy from OutreachStrategy (no freestyle).
+// Used as template path and as the deterministic scaffold when AI is unavailable.
+func ComposeFromStrategy(st OutreachStrategy, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, channel string) DraftOutput {
+	if channel == "" {
+		channel = ChannelEmailInitial
+	}
+	name := ""
+	if cand != nil {
+		name = strings.TrimSpace(cand.Name)
+	}
+	greeting := "Olá"
+	if name != "" && cand != nil && cand.VerificationStatus != models.OutreachVerifyInstitutionalGeneric {
+		greeting = "Olá, " + firstName(name)
+	} else if cand != nil && cand.VerificationStatus == models.OutreachVerifyInstitutionalGeneric {
+		greeting = "Olá, equipe"
+	}
+
+	fact := strings.TrimSpace(st.ObservedFact)
+	company := ""
+	if acc != nil {
+		company = firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
+	}
+
+	// Fail closed commercially when no safe hook: diagnostic path, not institutional pitch or invented facts.
+	if containsStr(st.RiskFlags, "no_safe_factual_hook") || fact == "" {
+		body := greeting + ",\n\n"
+		body += "Escrevo da CONFENGE sobre " + firstNonEmpty(company, "sua empresa") + ".\n\n"
+		body += "Sem um fato público específico o bastante neste fio, o caminho diagnóstico costuma começar "
+		body += "por um checklist de aditivo ou reajuste a partir do que já está publicado, sem inventar contexto.\n\n"
+		if st.CTASuggested != "" {
+			body += st.CTASuggested
+		} else {
+			body += "Posso te mandar o checklist diagnóstico do que eu conferiria primeiro?"
+		}
+		return DraftOutput{
+			Channel: channel, Subject: trimSubject(firstNonEmpty(company, "Contrato público")),
+			BodyText:    emDashRe.ReplaceAllString(body, ","),
+			FactUsed:    "insufficient_public_fact",
+			EvidenceIDs: st.EvidenceIDs, ServiceCode: st.ServiceCode,
+			Question: st.CTASuggested, CTA: st.CTASuggested,
+			RiskFlags: append([]string{"needs_review", "no_safe_factual_hook", "strategy_compose"}, st.RiskFlags...),
+			Rationale: "strategy-compose: no safe factual hook; diagnostic fail-closed (no institutional pitch)",
+		}
+	}
+
+	cta := st.CTASuggested
+	if cta == "" {
+		cta = "Posso te mandar os pontos que eu conferiria?"
+	}
+	// Challenger experiment variant: softer interest CTA
+	if st.Experiment != nil && st.Experiment.VariantID == "challenger" && st.Experiment.Dimension == ExpDimCTA {
+		cta = "Faz sentido eu te enviar o recorte que encontrei?"
+	}
+
+	var body string
+	switch st.SequencePosition {
+	case 2:
+		body = greeting + ",\n\n"
+		body += "Outro ângulo sobre " + fact + ": "
+		if st.ImplicationHypothesis != "" {
+			body += st.ImplicationHypothesis
+		} else {
+			body += "o que muda na prática é a documentação que passa a importar agora."
+		}
+		body += "\n\n" + cta
+		// Follow-ups stay in-thread when channel is EMAIL_FOLLOWUP (subject set below).
+	case 3:
+		body = greeting + ",\n\n"
+		body += "Se for útil, um mini-checklist objetivo a partir de " + fact + ":\n"
+		body += "1) confirmar o trecho público relevante;\n"
+		body += "2) separar fato de hipótese;\n"
+		body += "3) reunir memórias antes de qualquer pedido formal.\n\n"
+		body += cta
+	case 4:
+		body = greeting + ",\n\n"
+		body += "Sobre " + fact + ", quem na equipe acompanha este tema no dia a dia?\n\n"
+		body += "Se não for você, um encaminhamento curto já ajuda."
+	case 5:
+		body = greeting + ",\n\n"
+		body += "Parece que não é prioridade agora; encerro por aqui para não ocupar sua caixa.\n\n"
+		body += "Se fizer sentido no futuro, é só responder este fio."
+	default:
+		// Touch 1 SIGNAL: fact → hypothesis → insight → micro-offer
+		body = greeting + ",\n\n"
+		// Public-source phrasing when natural
+		body += "Pelo que está público, " + ensureLowerStart(fact) + ".\n\n"
+		if st.ProblemHypothesis != "" {
+			body += "Isso não prova crédito sozinho, mas " + ensureLowerStart(st.ProblemHypothesis) + ".\n\n"
+		} else if st.CommercialReframe != "" {
+			body += truncateRunesOffer(st.CommercialReframe, 180) + "\n\n"
+		}
+		// Role-light: no mini-CV
+		if st.BuyerRole == "LEGAL" {
+			body += "No plano técnico-documental (complementar ao jurídico), "
+		} else if st.AccountArchetype == "robust" {
+			body += "Como segunda leitura pontual, "
+		}
+		body += cta
+	}
+
+	body = emDashRe.ReplaceAllString(body, ",")
+	subj := strategySubject(st, company, fact)
+	if channel == ChannelEmailFollowup || st.SequencePosition >= 2 {
+		// Same-thread convention for follow-ups (tests + operator UX).
+		if company != "" {
+			subj = trimSubject("Re: " + company)
+		} else {
+			subj = "Re: conversa anterior"
+		}
+	}
+
+	return DraftOutput{
+		Channel: channel, Subject: subj, BodyText: body,
+		FactUsed: fact, EvidenceIDs: st.EvidenceIDs,
+		Claims:      claimsFromFact(fact, st.EvidenceIDs),
+		ServiceCode: st.ServiceCode, Question: cta, CTA: cta,
+		RiskFlags: append([]string{"strategy_compose"}, st.RiskFlags...),
+		Rationale: "composed from OutreachStrategy " + st.DoctrineVersion + " offer=" + st.MicroOfferCode,
+	}
+}
+
+func strategySubject(st OutreachStrategy, company, fact string) string {
+	// Short, natural, context-linked; no fake Re, no urgency
+	if containsStr(st.RiskFlags, "annualidade_verify_only") {
+		return "Reajuste contratual"
+	}
+	if st.ActivationTrigger != "" {
+		switch strings.ToUpper(st.ActivationTrigger) {
+		case "ADITIVO_RECENTE", "ADITIVO":
+			return trimSubject("Aditivo " + firstNonEmpty(company, ""))
+		case "MEDICAO", "MEDICOES":
+			return trimSubject("Medições " + firstNonEmpty(company, ""))
+		case "ENCERRAMENTO":
+			return "Encerramento contratual"
+		}
+	}
+	if fact != "" && hasConcreteToken(fact) {
+		return trimSubject(firstWords(fact, 4))
+	}
+	if company != "" {
+		return trimSubject("Contrato " + company)
+	}
+	return "Contrato público"
+}
+
+func ensureLowerStart(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
+	}
+	r := []rune(s)
+	// Avoid double-capital awkwardness mid-sentence; keep if looks like proper noun acronym
+	if len(r) > 0 && r[0] >= 'A' && r[0] <= 'Z' {
+		// keep as-is for names; for long sentences lower first if second is lower
+		if len(r) > 1 && r[1] >= 'a' && r[1] <= 'z' {
+			r[0] = rune(strings.ToLower(string(r[0]))[0])
+		}
+	}
+	return string(r)
+}
+
+// draftSystemPromptDoctrine extends the system prompt with doctrine constraints.
+func draftSystemPromptDoctrine(channel string, st OutreachStrategy) string {
+	base := draftSystemPrompt(channel)
+	base += "\n\nDOUTRINA " + OutreachDoctrineVersion + ":\n"
+	base += "- Gere copy SOMENTE após a estratégia JSON; não invente fatos.\n"
+	base += "- hypothesis != fact; use linguagem hipotética quando indicado.\n"
+	base += "- Primeiro email: micro-oferta / permissão; NÃO peça reunião por padrão.\n"
+	base += "- Sem pitch institucional, sem lista de serviços, sem mini-CV.\n"
+	base += "- KNOW A LOT / SAY LITTLE; prefira 'pelo contrato publicado' a 'estamos monitorando'.\n"
+	base += "- CTA alinhado a: " + st.CTAType + " / offer " + st.MicroOfferCode + "\n"
+	base += "- claims_to_avoid são proibições absolutas.\n"
+	if containsStr(st.RiskFlags, "annualidade_verify_only") {
+		base += "- ANUALIDADE: nunca diga que há reajuste a receber; só verificação/checklist.\n"
+	}
+	return base
+}
+
+// draftUserPromptWithStrategy includes strategy object before dossier.
+func draftUserPromptWithStrategy(in GenerateInput, st OutreachStrategy) string {
+	// Reuse dossier builder then prepend strategy.
+	dossier := draftUserPrompt(in)
+	b, _ := json.MarshalIndent(st, "", "  ")
+	return "ESTRATÉGIA COMERCIAL (obrigatória; a copy deve segui-la):\n" + string(b) + "\n\n" + dossier
+}
+
+// ApplyStrategyToGenerateInput is a marker that generation was strategy-first.
+func StrategyCodeFor(st OutreachStrategy) string {
+	parts := []string{st.DoctrineVersion, st.MicroOfferCode, st.CTAType}
+	if st.SequenceTouchName != "" {
+		parts = append(parts, st.SequenceTouchName)
+	}
+	return strings.Join(parts, "/")
+}
+
+// PackValidationWithStrategy marshals validation including strategy explain for UI.
+func PackValidationWithStrategy(val ValidationResult, st OutreachStrategy, recipient string) []byte {
+	val.DoctrineVersion = st.DoctrineVersion
+	val.Strategy = &st
+	ex := ExplainStrategy(st, recipient)
+	val.StrategyExplain = &ex
+	b, _ := json.Marshal(val)
+	return b
+}

--- a/internal/app/confenge/strategy_test.go
+++ b/internal/app/confenge/strategy_test.go
@@ -1,0 +1,127 @@
+package confenge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func testAccount(service, moment, fact string) *models.OutreachAccount {
+	return &models.OutreachAccount{
+		ID:                uuid.New(),
+		RazaoSocial:       "Construtora Exemplo LTDA",
+		NomeFantasia:      "Exemplo",
+		CNPJ14:            "12345678000199",
+		ServiceCode:       service,
+		ServiceName:       service,
+		MomentCode:        moment,
+		MomentSummary:     moment + " context",
+		FactToMention:     fact,
+		ClaimsToAvoid:     []string{"dinheiro a receber"},
+		MomentEvidenceIDs: []string{"ev-1"},
+	}
+}
+
+func testCand(role string) *models.OutreachContactCandidate {
+	return &models.OutreachContactCandidate{
+		ID:                 uuid.New(),
+		Name:               "Ana Silva",
+		Role:               role,
+		Email:              "ana@exemplo.com.br",
+		VerificationStatus: models.OutreachVerifyVerified,
+	}
+}
+
+func TestPlanStrategyAnnualidadeNoUnpaidClaim(t *testing.T) {
+	pb := MustPlaybook()
+	acc := testAccount("REAJUSTE", "ANUALIDADE", "contrato 1149/2022 atingiu aniversário de reajuste em 2024")
+	cand := testCand("Sócio")
+	ev := []models.OutreachEvidence{{
+		SourceEvidenceID: "ev-1",
+		Synthesis:        "publicação de vigência",
+		EpistemicClass:   models.OutreachEpistemicConfirmedFact,
+	}}
+	st := PlanOutreachStrategy(pb, acc, cand, ev, 1)
+	if st.DoctrineVersion != OutreachDoctrineVersion {
+		t.Fatalf("doctrine %s", st.DoctrineVersion)
+	}
+	if st.WhyNow == "" || st.WhyThisAccount == "" {
+		t.Fatal("why you/now required")
+	}
+	if !containsStr(st.RiskFlags, "annualidade_verify_only") {
+		t.Fatalf("flags %v", st.RiskFlags)
+	}
+	if st.MicroOfferCode != "REAJUSTE_CHECK" {
+		t.Fatalf("offer %s", st.MicroOfferCode)
+	}
+	if st.CTAType != CTATypePermissionOffer {
+		t.Fatalf("cta %s", st.CTAType)
+	}
+	// No score fields exist on struct — compile-time guarantee via JSON tags check
+	blob, _ := json.Marshal(st)
+	for _, banned := range []string{"lead_score", "priority_score", "commercial_score", "conversion_score"} {
+		if strings.Contains(string(blob), banned) {
+			t.Fatalf("must not emit %s", banned)
+		}
+	}
+	for _, bad := range []string{"reajuste a receber", "crédito de reajuste"} {
+		if containsStr(st.ClaimsToAvoid, bad) || strings.Contains(strings.Join(st.ClaimsToAvoid, " "), bad) {
+			// good, in avoid list
+			continue
+		}
+	}
+	// Compose must not claim unpaid
+	out := ComposeFromStrategy(st, acc, cand, ChannelEmailInitial)
+	low := strings.ToLower(out.BodyText)
+	for _, bad := range []string{"reajuste a receber", "deixou de pagar", "crédito de reajuste"} {
+		if strings.Contains(low, bad) {
+			t.Fatalf("body claims unpaid: %s\n%s", bad, out.BodyText)
+		}
+	}
+	if !strings.Contains(low, "checklist") && !strings.Contains(low, "confer") && !strings.Contains(low, "verific") {
+		// CTA should invite check
+		if !strings.Contains(low, "posso") {
+			t.Fatalf("expected verify/offer language: %s", out.BodyText)
+		}
+	}
+}
+
+func TestPlanStrategyBuyerRoles(t *testing.T) {
+	pb := MustPlaybook()
+	acc := testAccount("MEDICOES", "MEDICAO", "medição do trecho norte publicada no PNCP")
+	cases := []struct {
+		role string
+		want string
+	}{
+		{"Engenheiro Civil", "ENGINEERING"},
+		{"Analista Financeiro", "FINANCE"},
+		{"Advogada", "LEGAL"},
+		{"", "UNKNOWN"},
+	}
+	for _, tc := range cases {
+		st := PlanOutreachStrategy(pb, acc, testCand(tc.role), nil, 1)
+		if st.BuyerRole != tc.want {
+			t.Fatalf("role %q got %s want %s", tc.role, st.BuyerRole, tc.want)
+		}
+	}
+}
+
+func TestPlanStrategyNoScoreFields(t *testing.T) {
+	st := PlanOutreachStrategy(MustPlaybook(), testAccount("ADITIVOS", "ADITIVO_RECENTE", "termo aditivo nº 3"), testCand("Diretor"), nil, 1)
+	if st.Experiment == nil {
+		t.Fatal("expected experiment assignment")
+	}
+	if st.Experiment.VariantID != "champion" && st.Experiment.VariantID == "" {
+		t.Fatal("variant")
+	}
+	// same account stable
+	st2 := PlanOutreachStrategy(MustPlaybook(), testAccount("ADITIVOS", "ADITIVO_RECENTE", "termo aditivo nº 3"), testCand("Diretor"), nil, 1)
+	// different UUIDs so variants may differ — just ensure no panic and offer set
+	if st.MicroOfferCode == "" || st2.MicroOfferCode == "" {
+		t.Fatal("offer required")
+	}
+}

--- a/internal/app/confenge/strategy_test.go
+++ b/internal/app/confenge/strategy_test.go
@@ -61,6 +61,9 @@ func TestPlanStrategyAnnualidadeNoUnpaidClaim(t *testing.T) {
 	if st.CTAType != CTATypePermissionOffer {
 		t.Fatalf("cta %s", st.CTAType)
 	}
+	if strings.Contains(st.ImplicationHypothesis, "reconstituting") {
+		t.Fatalf("implication must be pure PT-BR: %q", st.ImplicationHypothesis)
+	}
 	// No score fields exist on struct — compile-time guarantee via JSON tags check
 	blob, _ := json.Marshal(st)
 	for _, banned := range []string{"lead_score", "priority_score", "commercial_score", "conversion_score"} {
@@ -87,6 +90,21 @@ func TestPlanStrategyAnnualidadeNoUnpaidClaim(t *testing.T) {
 		if !strings.Contains(low, "posso") {
 			t.Fatalf("expected verify/offer language: %s", out.BodyText)
 		}
+	}
+}
+
+func TestGenerationChannelForTouch(t *testing.T) {
+	if GenerationChannelForTouch(1, models.TouchpointPurposeInitial) != ChannelEmailInitial {
+		t.Fatal("touch 1")
+	}
+	if GenerationChannelForTouch(2, models.TouchpointPurposeFollowUp) != ChannelEmailFollowup {
+		t.Fatal("touch 2")
+	}
+	if GenerationChannelForTouch(5, models.TouchpointPurposeClose) != ChannelEmailFollowup {
+		t.Fatal("touch 5")
+	}
+	if SequencePositionForTouch(1, models.TouchpointPurposeFollowUp) < 2 {
+		t.Fatal("follow-up purpose elevates position")
 	}
 }
 

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -238,24 +238,23 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 	evidIDs := evidenceIDsFrom(evidence, acc)
 	factUsed := SanitizeText(firstNonEmpty(acc.FactToMention, tp.FactUsed), 2000)
 	pb, _ := LoadPlaybook()
-	pos := tp.Ordinal
-	if pos <= 0 {
-		pos = 1
-	}
+	pos := SequencePositionForTouch(tp.Ordinal, tp.Purpose)
+	genCh := GenerationChannelForTouch(tp.Ordinal, tp.Purpose)
 	st := PlanOutreachStrategy(pb, acc, cand, evidence, pos)
 	if factUsed != "" {
 		st.ObservedFact = factUsed
 	}
 	// Classify risk with the same validators as GenerateDraft. Policy-authorized
 	// deterministic templates may stay GREEN when AllowPolicyTemplateGREEN is set.
+	// Follow-up/close use EMAIL_FOLLOWUP so legitimate "Re:" subjects are not first-touch fakes.
 	synth := &DraftOutput{
 		Subject: subject, BodyText: body, ServiceCode: acc.ServiceCode,
 		FactUsed: factUsed, EvidenceIDs: evidIDs, Claims: claimsFromFact(factUsed, evidIDs),
-		Channel: ChannelEmailInitial, Rationale: "touchpoint strategy compose",
+		Channel: genCh, Rationale: "touchpoint strategy compose",
 		CTA: st.CTASuggested, Question: st.CTASuggested,
 	}
 	val := ValidateDraft(synth, acc, cand, ValidateOpts{
-		MaxWords: s.cfg.MaxInitialEmailWords, Evidence: evidence, Channel: ChannelEmailInitial,
+		MaxWords: s.cfg.MaxInitialEmailWords, Evidence: evidence, Channel: genCh,
 		Strategy: &st, Playbook: pb,
 	})
 	recipient := tp.Recipient
@@ -367,23 +366,13 @@ func jitCompose(tp *models.OutreachTouchpoint, acc *models.OutreachAccount, cand
 	}
 	// Strategy-first compose by ordinal (1=SIGNAL … 5=CLOSE). Signature applied at enroll/send.
 	pb, _ := LoadPlaybook()
-	pos := tp.Ordinal
-	if pos <= 0 {
-		pos = 1
-	}
-	switch tp.Purpose {
-	case models.TouchpointPurposeFollowUp:
-		if pos < 2 {
-			pos = 2
-		}
-	case models.TouchpointPurposeClose:
-		pos = 5
-	}
+	pos := SequencePositionForTouch(tp.Ordinal, tp.Purpose)
+	genCh := GenerationChannelForTouch(tp.Ordinal, tp.Purpose)
 	st := PlanOutreachStrategy(pb, acc, cand, evidence, pos)
 	if fact != "" {
 		st.ObservedFact = fact
 	}
-	out := ComposeFromStrategy(st, acc, cand, ChannelEmailInitial)
+	out := ComposeFromStrategy(st, acc, cand, genCh)
 	subject, body = out.Subject, out.BodyText
 	_ = greeting
 	_ = company
@@ -401,6 +390,7 @@ func (s *service) EditTouchpoint(ctx context.Context, orgID, userID, id uuid.UUI
 	if models.TouchpointTerminalStates[tp.State] || tp.State == models.TouchpointQueued || tp.State == models.TouchpointSent {
 		return nil, errx.New(errx.BadRequest, "cannot edit touchpoint in state "+tp.State)
 	}
+	origBody := tp.BodyText
 	ch, rec, sub, bod := tp.Channel, tp.Recipient, tp.Subject, tp.BodyText
 	if channel != nil && *channel != "" {
 		ch = strings.ToUpper(strings.TrimSpace(*channel))
@@ -446,6 +436,17 @@ func (s *service) EditTouchpoint(ctx context.Context, orgID, userID, id uuid.UUI
 			}
 			d.HumanEdited, d.Status = true, models.OutreachDraftNeedsReview
 			d.ApprovedBy, d.ApprovedAt = nil, nil
+			// Operator edit learning signal (accumulate only; no auto-train).
+			if sig := NewOperatorEditSignal(d.ID.String(), origBody, tp.BodyText); len(sig.Codes) > 0 {
+				var val ValidationResult
+				if len(d.ValidationJSON) > 0 {
+					_ = json.Unmarshal(d.ValidationJSON, &val)
+				}
+				val.OperatorEdit = &sig
+				if b, err := json.Marshal(val); err == nil {
+					d.ValidationJSON = b
+				}
+			}
 			_ = s.repo.UpsertDraft(ctx, d)
 			_ = s.repo.UpdateTouchpoint(ctx, tp)
 		}
@@ -517,6 +518,25 @@ func (s *service) RejectOrSkipTouchpointReason(ctx context.Context, orgID, userI
 	}
 	tp.State, tp.StopReason = state, stop
 	ClearApproval(tp)
+	// Persist operator rejection learning signal on the draft when present.
+	if (action == "reject" || action == "REJECTED") && tp.DraftID != nil {
+		if d, _ := s.repo.GetDraft(ctx, orgID, *tp.DraftID); d != nil {
+			rej := NewOperatorRejection(strings.TrimPrefix(stop, "REJECTED:"), d.ID.String(), tp.ServiceCode, "")
+			if rej.Reason == "REJECTED" || rej.Reason == "" {
+				rej.Reason = "other"
+			}
+			var val ValidationResult
+			if len(d.ValidationJSON) > 0 {
+				_ = json.Unmarshal(d.ValidationJSON, &val)
+			}
+			val.OperatorReject = &rej
+			if b, err := json.Marshal(val); err == nil {
+				d.ValidationJSON = b
+				d.Status = models.OutreachDraftRejected
+				_ = s.repo.UpsertDraft(ctx, d)
+			}
+		}
+	}
 	if err := s.repo.UpdateTouchpoint(ctx, tp); err != nil {
 		return nil, errx.New(errx.Internal, "update failed")
 	}

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -116,9 +116,48 @@ func (s *service) ListReviewTouchpoints(ctx context.Context, orgID uuid.UUID, li
 	if list == nil {
 		list = []models.OutreachTouchpoint{}
 	}
+	pb, _ := LoadPlaybook()
 	for i := range list {
 		if acc, err := s.repo.GetAccount(ctx, orgID, list[i].AccountID); err == nil && acc != nil {
 			list[i].Account = acc
+			pos := list[i].Ordinal
+			if pos <= 0 {
+				pos = 1
+			}
+			var cand *models.OutreachContactCandidate
+			if list[i].ContactCandidateID != nil {
+				cand, _ = s.repo.GetCandidate(ctx, orgID, *list[i].ContactCandidateID)
+			}
+			st := PlanOutreachStrategy(pb, acc, cand, nil, pos)
+			if list[i].FactUsed != "" {
+				st.ObservedFact = list[i].FactUsed
+			}
+			ex := ExplainStrategy(st, list[i].Recipient)
+			list[i].StrategyExplain = map[string]any{
+				"why_now": ex.WhyNow, "fact_used": ex.FactUsed, "hypothesis": ex.Hypothesis,
+				"service": ex.Service, "offer": ex.Offer, "recipient": ex.Recipient,
+				"sources": ex.Sources, "touch": ex.Touch, "experiment": ex.Experiment,
+				"doctrine_version": ex.Doctrine,
+			}
+			if list[i].DraftID != nil {
+				if d, _ := s.repo.GetDraft(ctx, orgID, *list[i].DraftID); d != nil {
+					list[i].Draft = d
+					var val ValidationResult
+					if len(d.ValidationJSON) > 0 {
+						_ = json.Unmarshal(d.ValidationJSON, &val)
+						list[i].DoctrineAlerts = val.DoctrineAlerts
+						if val.StrategyExplain != nil {
+							list[i].StrategyExplain = map[string]any{
+								"why_now": val.StrategyExplain.WhyNow, "fact_used": val.StrategyExplain.FactUsed,
+								"hypothesis": val.StrategyExplain.Hypothesis, "service": val.StrategyExplain.Service,
+								"offer": val.StrategyExplain.Offer, "recipient": val.StrategyExplain.Recipient,
+								"sources": val.StrategyExplain.Sources, "touch": val.StrategyExplain.Touch,
+								"experiment": val.StrategyExplain.Experiment, "doctrine_version": val.StrategyExplain.Doctrine,
+							}
+						}
+					}
+				}
+			}
 		}
 	}
 	return list, nil
@@ -198,18 +237,33 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 	// Prefer real evidence rows over opaque moment evidence ids for validators.
 	evidIDs := evidenceIDsFrom(evidence, acc)
 	factUsed := SanitizeText(firstNonEmpty(acc.FactToMention, tp.FactUsed), 2000)
+	pb, _ := LoadPlaybook()
+	pos := tp.Ordinal
+	if pos <= 0 {
+		pos = 1
+	}
+	st := PlanOutreachStrategy(pb, acc, cand, evidence, pos)
+	if factUsed != "" {
+		st.ObservedFact = factUsed
+	}
 	// Classify risk with the same validators as GenerateDraft. Policy-authorized
 	// deterministic templates may stay GREEN when AllowPolicyTemplateGREEN is set.
 	synth := &DraftOutput{
 		Subject: subject, BodyText: body, ServiceCode: acc.ServiceCode,
 		FactUsed: factUsed, EvidenceIDs: evidIDs, Claims: claimsFromFact(factUsed, evidIDs),
-		Channel: ChannelEmailInitial, Rationale: "touchpoint jit template",
+		Channel: ChannelEmailInitial, Rationale: "touchpoint strategy compose",
+		CTA: st.CTASuggested, Question: st.CTASuggested,
 	}
 	val := ValidateDraft(synth, acc, cand, ValidateOpts{
 		MaxWords: s.cfg.MaxInitialEmailWords, Evidence: evidence, Channel: ChannelEmailInitial,
+		Strategy: &st, Playbook: pb,
 	})
-	// Persist validation for green-autorun / review UI.
-	valJSON, _ := json.Marshal(val)
+	recipient := tp.Recipient
+	if cand != nil && recipient == "" {
+		recipient = cand.Email
+	}
+	// Persist validation + strategy explain for green-autorun / review UI.
+	valJSON := PackValidationWithStrategy(val, st, recipient)
 	risk, flags := ClassifyRisk(acc, cand, synth, val)
 	allowTemplateGREEN := false
 	if s.cfg.GreenAutorunEnabled && s.policyStore != nil {
@@ -246,7 +300,7 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 		draft = &models.OutreachDraft{
 			OrganizationID: orgID, AccountID: tp.AccountID, ContactCandidateID: tp.ContactCandidateID,
 			Channel: tp.Channel, Subject: subject, BodyText: body, ServiceCode: acc.ServiceCode,
-			FactUsed: factUsed, EvidenceIDs: evidIDs,
+			StrategyCode: StrategyCodeFor(st), FactUsed: factUsed, EvidenceIDs: evidIDs,
 			Provider: "template", Model: modelName, PromptVersion: PromptVersion + "+touch",
 			Status: models.OutreachDraftNeedsReview, RiskClass: risk, RiskFlags: flags,
 			ValidationJSON: valJSON,
@@ -256,6 +310,7 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 		draft.Channel = tp.Channel
 		draft.Subject, draft.BodyText = subject, body
 		draft.ServiceCode = acc.ServiceCode
+		draft.StrategyCode = StrategyCodeFor(st)
 		draft.FactUsed = factUsed
 		draft.EvidenceIDs = evidIDs
 		draft.Provider, draft.Model = "template", modelName
@@ -310,21 +365,28 @@ func jitCompose(tp *models.OutreachTouchpoint, acc *models.OutreachAccount, cand
 		}
 		return "", SanitizeText(body, 2000)
 	}
+	// Strategy-first compose by ordinal (1=SIGNAL … 5=CLOSE). Signature applied at enroll/send.
+	pb, _ := LoadPlaybook()
+	pos := tp.Ordinal
+	if pos <= 0 {
+		pos = 1
+	}
 	switch tp.Purpose {
 	case models.TouchpointPurposeFollowUp:
-		subject = "Re: " + company
-		body = greeting + ",\n\nRetomo com uma pergunta objetiva: quem na equipe acompanha " + firstNonEmpty(acc.ServiceName, "este tema") + "?\n\n"
-		if fact != "" {
-			body += "Contexto: " + fact + "\n\n"
+		if pos < 2 {
+			pos = 2
 		}
-		body += "Se fizer sentido, respondo em poucos minutos."
 	case models.TouchpointPurposeClose:
-		subject = "Re: " + company
-		body = greeting + ",\n\nEncerro por aqui para não ocupar sua caixa. Se fizer sentido no futuro, é só responder este fio."
-	default:
-		out := TemplateDraft(acc, cand)
-		subject, body = out.Subject, out.BodyText
+		pos = 5
 	}
+	st := PlanOutreachStrategy(pb, acc, cand, evidence, pos)
+	if fact != "" {
+		st.ObservedFact = fact
+	}
+	out := ComposeFromStrategy(st, acc, cand, ChannelEmailInitial)
+	subject, body = out.Subject, out.BodyText
+	_ = greeting
+	_ = company
 	return SanitizeText(subject, 200), SanitizeText(body, 8000)
 }
 
@@ -426,6 +488,11 @@ func (s *service) ApproveTouchpoint(ctx context.Context, orgID, userID, id uuid.
 // note: QueueTouchpoint + CanTransport accept CAMPAIGN_POLICY without approved_by.
 
 func (s *service) RejectOrSkipTouchpoint(ctx context.Context, orgID, userID, id uuid.UUID, action string) (*models.OutreachTouchpoint, *errx.Error) {
+	return s.RejectOrSkipTouchpointReason(ctx, orgID, userID, id, action, "")
+}
+
+// RejectOrSkipTouchpointReason records optional doctrine rejection reason for learning (one click).
+func (s *service) RejectOrSkipTouchpointReason(ctx context.Context, orgID, userID, id uuid.UUID, action, reason string) (*models.OutreachTouchpoint, *errx.Error) {
 	if xerr := s.requireEnabled(); xerr != nil {
 		return nil, xerr
 	}
@@ -441,6 +508,12 @@ func (s *service) RejectOrSkipTouchpoint(ctx context.Context, orgID, userID, id 
 		state, stop = models.TouchpointSkipped, "SKIPPED"
 	} else if action == "reject" || action == "REJECTED" {
 		state, stop = models.TouchpointRejected, "REJECTED"
+		if r := strings.TrimSpace(reason); r != "" {
+			pb, _ := LoadPlaybook()
+			if ValidRejectionReason(pb, r) {
+				stop = "REJECTED:" + r
+			}
+		}
 	}
 	tp.State, tp.StopReason = state, stop
 	ClearApproval(tp)

--- a/internal/app/confenge/validators.go
+++ b/internal/app/confenge/validators.go
@@ -10,7 +10,8 @@ import (
 )
 
 // PromptVersion tags generation prompt revisions (see docs/confenge/copy-generation.md).
-const PromptVersion = "confenge.draft.v2"
+// v3: strategy-first composition + outreach doctrine confenge-outreach-v1.
+const PromptVersion = "confenge.draft.v3"
 
 // DraftClaim is one auditable fact/phrase anchored to evidence ids.
 type DraftClaim struct {
@@ -47,13 +48,19 @@ type DraftFollowup struct {
 
 // ValidationResult is deterministic pre-send / pre-approve checks.
 type ValidationResult struct {
-	OK           bool         `json:"ok"`
-	Errors       []string     `json:"errors,omitempty"`
-	Warnings     []string     `json:"warnings,omitempty"`
-	Claims       []DraftClaim `json:"claims,omitempty"`
-	Rationale    string       `json:"rationale,omitempty"`
-	Channel      string       `json:"channel,omitempty"`
-	NearDupScore float64      `json:"near_dup_score,omitempty"`
+	OK              bool                `json:"ok"`
+	Errors          []string            `json:"errors,omitempty"`
+	Warnings        []string            `json:"warnings,omitempty"`
+	Claims          []DraftClaim        `json:"claims,omitempty"`
+	Rationale       string              `json:"rationale,omitempty"`
+	Channel         string              `json:"channel,omitempty"`
+	NearDupScore    float64             `json:"near_dup_score,omitempty"`
+	DoctrineVersion string              `json:"doctrine_version,omitempty"`
+	Strategy        *OutreachStrategy   `json:"strategy,omitempty"`
+	StrategyExplain *StrategyExplain    `json:"strategy_explain,omitempty"`
+	DoctrineAlerts  []string            `json:"doctrine_alerts,omitempty"`
+	OperatorEdit    *OperatorEditSignal `json:"operator_edit,omitempty"`
+	OperatorReject  *OperatorRejection  `json:"operator_reject,omitempty"`
 }
 
 // ValidateOpts configures deterministic validation for a channel.
@@ -64,6 +71,8 @@ type ValidateOpts struct {
 	RecentBodies           []string
 	ServiceOverrideAudited bool
 	SkipEmailRecipient     bool
+	Strategy               *OutreachStrategy
+	Playbook               *Playbook
 }
 
 var bannedPhrases = []string{
@@ -299,6 +308,20 @@ func ValidateDraft(out *DraftOutput, acc *models.OutreachAccount, cand *models.O
 			res.Errors = append(res.Errors, "internal rationale leaked into body_text")
 		}
 	}
+
+	// Doctrine QA (strategy-first commercial constraints).
+	st := opts.Strategy
+	pb := opts.Playbook
+	dqa := ValidateDoctrineCopy(out, st, pb, channel)
+	MergeDoctrineIntoValidation(&res, dqa)
+	res.DoctrineAlerts = append(res.DoctrineAlerts, dqa.Alerts...)
+	if st != nil {
+		res.DoctrineVersion = st.DoctrineVersion
+		res.Strategy = st
+	} else {
+		res.DoctrineVersion = OutreachDoctrineVersion
+	}
+
 	if !res.OK && len(res.Errors) == 0 {
 		res.Errors = append(res.Errors, "validation failed")
 	}

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -550,4 +550,7 @@ type OutreachTouchpoint struct {
 	Draft                *OutreachDraft   `json:"draft,omitempty"`
 	// ContextStale when GeneratedContextHash != account.MessageContextHash.
 	ContextStale bool `json:"context_stale,omitempty"`
+	// StrategyExplain is operator cockpit metadata (not prospect-facing; not a DB column).
+	StrategyExplain map[string]any `json:"strategy_explain,omitempty"`
+	DoctrineAlerts  []string       `json:"doctrine_alerts,omitempty"`
 }

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -89,7 +89,10 @@ export default function ConfengePage() {
       { label: "Ready", value: s?.ready_to_generate ?? 0 },
       { label: "Review", value: s?.needs_review ?? w?.needs_review ?? 0 },
       { label: "Sent", value: s?.sent ?? 0 },
-      { label: "Replied", value: s?.replied ?? 0 },
+      { label: "Human reply", value: s?.replied ?? 0 },
+      { label: "Meeting", value: s?.meeting ?? 0 },
+      { label: "Proposal", value: s?.proposal ?? 0 },
+      { label: "Won", value: s?.won ?? 0 },
       { label: "DNC", value: s?.do_not_contact ?? 0 },
     ];
     if (w) {
@@ -409,6 +412,40 @@ export default function ConfengePage() {
                     {current.channel} · {current.service_code || "—"}
                   </div>
                 </div>
+
+                {/* Operator strategy cockpit (not prospect-facing) */}
+                <div
+                  className="rounded-md border border-slate-200 bg-slate-50 p-2 space-y-1.5"
+                  data-testid="confenge-strategy-explain"
+                >
+                  <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">
+                    Strategy {current.strategy_explain?.doctrine_version || "confenge-outreach-v1"}
+                  </div>
+                  <StrategyRow label="Por que agora" value={current.strategy_explain?.why_now || current.account?.moment_summary} />
+                  <StrategyRow label="Fato usado" value={current.strategy_explain?.fact_used || current.fact_used} />
+                  <StrategyRow label="Hipótese" value={current.strategy_explain?.hypothesis} />
+                  <StrategyRow label="Serviço" value={current.strategy_explain?.service || current.service_code} />
+                  <StrategyRow label="Oferta" value={current.strategy_explain?.offer} />
+                  <StrategyRow label="Destinatário" value={current.strategy_explain?.recipient || current.recipient} />
+                  <StrategyRow
+                    label="Fontes"
+                    value={(current.strategy_explain?.sources || current.evidence_ids || []).join(", ")}
+                  />
+                  <StrategyRow label="Touch" value={current.strategy_explain?.touch || String(current.ordinal)} />
+                  <StrategyRow label="Experimento" value={current.strategy_explain?.experiment} />
+                </div>
+                {(current.doctrine_alerts?.length ?? 0) > 0 && (
+                  <div className="space-y-1" data-testid="confenge-doctrine-alerts">
+                    {current.doctrine_alerts!.map((a) => (
+                      <div
+                        key={a}
+                        className="text-[11px] text-amber-800 bg-amber-50 border border-amber-100 rounded px-2 py-1"
+                      >
+                        ⚠ {a}
+                      </div>
+                    ))}
+                  </div>
+                )}
                 <div>
                   <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">
                     Fact / evidence
@@ -517,6 +554,16 @@ export default function ConfengePage() {
         </section>
       </div>
     </Page>
+  );
+}
+
+function StrategyRow({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+  return (
+    <div>
+      <span className="text-[10px] uppercase tracking-[0.12em] text-slate-400">{label}</span>
+      <div className="text-slate-800 text-[12.5px] leading-snug">{value}</div>
+    </div>
   );
 }
 

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -20,6 +20,7 @@ import {
   usePauseConfengeDispatch,
   usePlanConfengeCadence,
   useResumeConfengeDispatch,
+  useRejectConfengeTouchpoint,
   useSkipConfengeTouchpoint,
 } from "@/lib/api/hooks/app/confenge/useConfenge";
 import type {
@@ -46,6 +47,7 @@ export default function ConfengePage() {
   const genTouch = useGenerateConfengeTouchpoint();
   const approveQueue = useApproveAndQueueTouchpoint();
   const skip = useSkipConfengeTouchpoint();
+  const reject = useRejectConfengeTouchpoint();
   const dnc = useDncConfengeAccount();
   const dispatchStatus = useConfengeDispatchStatus(enabled);
   const pauseDispatch = usePauseConfengeDispatch();
@@ -544,6 +546,45 @@ export default function ConfengePage() {
                     <Ban className="inline h-3.5 w-3.5 mr-1" />
                     DNC
                   </button>
+                </div>
+                <div
+                  className="flex flex-wrap gap-1 pt-1"
+                  data-testid="confenge-reject-reasons"
+                >
+                  <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400 w-full">
+                    Reject reason
+                  </span>
+                  {(
+                    [
+                      "factual_error",
+                      "too_generic",
+                      "too_salesy",
+                      "wrong_offer",
+                      "unsupported_claim",
+                      "creepy",
+                      "too_long",
+                      "tone",
+                      "other",
+                    ] as const
+                  ).map((reason) => (
+                    <button
+                      key={reason}
+                      type="button"
+                      disabled={reject.isPending}
+                      className="h-6 px-2 rounded border border-slate-200 text-[11px] text-slate-600 hover:bg-rose-50 hover:border-rose-200 hover:text-rose-700 disabled:opacity-50"
+                      onClick={() =>
+                        reject.mutate(
+                          { id: current.id, reason },
+                          {
+                            onSuccess: () =>
+                              setIdx((i) => Math.min(i, Math.max(0, queue.length - 2))),
+                          },
+                        )
+                      }
+                    >
+                      {reason.replace(/_/g, " ")}
+                    </button>
+                  ))}
                 </div>
                 <p className="text-[11px] text-slate-400">
                   Editing clears approval. No approve whole sequence.

--- a/web/src/lib/api/client/app/confenge/confenge.ts
+++ b/web/src/lib/api/client/app/confenge/confenge.ts
@@ -179,8 +179,17 @@ export async function queueConfengeTouchpoint(id: string): Promise<ConfengeTouch
   return res.data;
 }
 
-export async function decideConfengeTouchpoint(id: string, action: "skip" | "reject"): Promise<ConfengeTouchpoint> {
-  const res = await Request<{ data: ConfengeTouchpoint }>({ method: "POST", url: `/confenge/touchpoints/${id}/decision`, authorization: true, data: { action } });
+export async function decideConfengeTouchpoint(
+  id: string,
+  action: "skip" | "reject",
+  reason?: string,
+): Promise<ConfengeTouchpoint> {
+  const res = await Request<{ data: ConfengeTouchpoint }>({
+    method: "POST",
+    url: `/confenge/touchpoints/${id}/decision`,
+    authorization: true,
+    data: { action, reason: reason || undefined },
+  });
   return res.data;
 }
 

--- a/web/src/lib/api/hooks/app/confenge/useConfenge.ts
+++ b/web/src/lib/api/hooks/app/confenge/useConfenge.ts
@@ -257,6 +257,19 @@ export function useSkipConfengeTouchpoint() {
     });
 }
 
+export function useRejectConfengeTouchpoint() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: ({ id, reason }: { id: string; reason: string }) =>
+            decideConfengeTouchpoint(id, "reject", reason),
+        onSuccess: () => {
+            void qc.invalidateQueries({ queryKey: KEY });
+            toast.success("Rejected");
+        },
+        onError: (e: Error) => toast.error(e.message || "Reject failed"),
+    });
+}
+
 export function useDncConfengeAccount() {
     const qc = useQueryClient();
     return useMutation({

--- a/web/src/lib/api/models/app/confenge/Confenge.ts
+++ b/web/src/lib/api/models/app/confenge/Confenge.ts
@@ -205,6 +205,19 @@ export type ConfengeAttentionItem = {
 };
 
 
+export type ConfengeStrategyExplain = {
+  why_now?: string;
+  fact_used?: string;
+  hypothesis?: string;
+  service?: string;
+  offer?: string;
+  recipient?: string;
+  sources?: string[];
+  touch?: string;
+  experiment?: string;
+  doctrine_version?: string;
+};
+
 export type ConfengeTouchpoint = {
   id: string;
   organization_id: string;
@@ -223,6 +236,9 @@ export type ConfengeTouchpoint = {
   fact_used: string;
   evidence_ids?: string[];
   account?: ConfengeAccount;
+  strategy_explain?: ConfengeStrategyExplain;
+  doctrine_alerts?: string[];
+  draft?: ConfengeDraft;
 };
 
 export type ConfengeDispatchFailure = {


### PR DESCRIPTION
## Objective
Turn extra-cli intelligence into evidence-led, low-friction, measurable CONFENGE commercial conversations.

## Doctrine
- Predictable outbound process
- Insight-led Challenger messaging
- SPIN-informed post-engagement discovery
- ethical persuasion
- modern data-backed cold email defaults
- CONFENGE-specific B2G adaptation
- Version: `confenge-outreach-v1`
- Machine playbook: `internal/app/confenge/outreach_playbook/` (mirrored under `data/confenge/outreach_playbook/`)
- Docs: `docs/confenge/OUTREACH-DOCTRINE.md`, `docs/confenge/OUTREACH-RESEARCH-SYNTHESIS.md`

## Architectural boundary
extra-cli decides WHO/WHY NOW.
Warmbly decides HOW TO APPROACH.
No local commercial re-scoring.

Pipeline: intelligence → OutreachStrategy → constrained generation → deterministic doctrine QA → human approval.

## Safety
No unsupported claims.
No invented social proof.
No hidden authority claims.
No real sends.
Human approval unchanged.
GREEN autorun OFF (not activated).
WhatsApp OFF (runtime channel policy).
Annualidade is verify-now, never unpaid reajuste claim.

## Experiments
- Account-level champion/challenger assignment (single dimension)
- Primary metric: positive_reply_rate (not opens)
- Secondary: human_reply, qualified, meeting, proposal, won, revenue
- Small-n protection: minimum 50 delivered per arm before non-INCONCLUSIVE
- Metadata stamped on strategy / ValidationJSON

## Parallel work
Orthogonal to auth hardening and VPS execution plane.
Forbidden paths untouched in this PR (no green_autorun/policy_auth/governor core/Hostinger/VPS deploy changes).
Based on main at e1cda6eb.

## Tests
```
go test ./internal/app/confenge/ -count=1
# ok
```
HEAD: d60a6044d73312f3016f3096ebfb7683671518de
BASE: e1cda6ebb30cc18d9ee78bd9178d3c86e1f29d7c

## Definition of Done (ship bar)
- [x] Versioned doctrine + research synthesis
- [x] Strategy separated from copy generation
- [x] No activation re-scoring
- [x] WHY YOU / WHY NOW on first touches
- [x] Micro-offer library + fulfillment path
- [x] First CTA permission/offer not meeting-default
- [x] Deterministic copy QA (annualidade, empty follow-up, claims)
- [x] Experiment metadata + small-n
- [x] Operator strategy explain UI
- [x] Positive reply distinct from any reply
- [x] WhatsApp/GREEN/governor/VPS untouched