### PR TITLE
feat(confenge): GO-LIVE SHA table uses identity rule not hard-coded tip

### DIFF
--- a/docs/confenge/CONFENGE-GO-LIVE-2026-08-10.md
+++ b/docs/confenge/CONFENGE-GO-LIVE-2026-08-10.md
@@ -36,12 +36,12 @@ Clear (1) with one observed cadence cancel after Unibox ingest (or explicit oper
 | REPO | MAIN SHA | DEPLOYED / PRODUCTION | STATUS |
 | --- | --- | --- | --- |
 | extra-cli | `28a31a1bac44d250f6f9dd26bd9c30aa12ae1263` | feed `:8443` HTTP 200 (stock generated_at 2026-08-08) | PARTIAL stock |
-| warmbly | `283e78d2dac661da3677e6bc9e50fc106f508c26` (origin/main at last docs bind; rebind VPS after merge) | VPS: `.deployed_sha` **must equal** `git rev-parse HEAD` | **MATCH** when equal |
+| warmbly | `origin/main` tip (operator: `git rev-parse origin/main`) | VPS: `.deployed_sha` **equals** `git rev-parse HEAD` | **MATCH** when equal |
 | web-cfg | `88d72aeaa72c812fcff7e2bde9c2736f5f22515f` | live `/.well-known/build-info.json` commit match | **MATCH** |
 
 ---
 
-Live SHA bind note: after VPS `git checkout` of this tip, operator verifies `test "$(cat .deployed_sha)" = "$(git rev-parse HEAD)"` (expected `283e78d2dac661da3677e6bc9e50fc106f508c26` or newer main tip).
+Live SHA bind note: MATCH rule is deploy identity only — `test "$(cat /opt/warmbly-confenge/.deployed_sha)" = "$(git -C /opt/warmbly-confenge rev-parse HEAD)"` and equals `origin/main`. Concrete bind values live in implementer `evidence/shas.json` / `sha-audit.md` (not hardcoded in this table to avoid docs-tip skew).
 
 ## What already converged (keep; do not redo)
 


### PR DESCRIPTION
Avoids false-fail when docs tip advances: MATCH when VPS .deployed_sha == HEAD == origin/main. Concrete bind SHAs stay in evidence. NO_GO for reply-stop residual unchanged.