### PR TITLE
feat(confenge): normalize Hostinger From forms for live reply-stop handoff

### DIFF
--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"math/rand"
-	"net/mail"
 	"strings"
 	"time"
 
@@ -15,6 +14,7 @@ import (
 	warmupapp "github.com/warmbly/warmbly/internal/app/warmup"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/emailaddr"
 	"github.com/warmbly/warmbly/internal/repository"
 	"github.com/warmbly/warmbly/internal/tasks/proto"
 	"github.com/warmbly/warmbly/internal/tasksched"
@@ -699,17 +699,8 @@ func (s *service) SelectVariant(ctx context.Context, organizationID, campaignID,
 }
 
 func parseSenderEmail(addrs []string) string {
-	if len(addrs) == 0 {
-		return ""
-	}
-	primary := strings.TrimSpace(addrs[0])
-	if primary == "" {
-		return ""
-	}
-	if parsed, err := mail.ParseAddress(primary); err == nil {
-		return strings.ToLower(strings.TrimSpace(parsed.Address))
-	}
-	return strings.ToLower(strings.Trim(primary, "<>"))
+	// Normalize Hostinger/live Unibox forms (" (a@b)", "Name (a@b)") as well as RFC5322.
+	return emailaddr.ExtractFirst(addrs)
 }
 
 func cleanMessageID(mid string) string {

--- a/internal/app/consumer/event_new_email.go
+++ b/internal/app/consumer/event_new_email.go
@@ -13,6 +13,7 @@ import (
 	"github.com/warmbly/warmbly/internal/config"
 	"github.com/warmbly/warmbly/internal/infrastructure/pubsub"
 	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/pkg/emailaddr"
 )
 
 func (s *JobsService) HandleNewEmail(ctx context.Context, e *models.JobEventNewEmail) error {
@@ -77,10 +78,8 @@ func (s *JobsService) HandleNewEmail(ctx context.Context, e *models.JobEventNewE
 	// CONFENGE outcome loop: attribute human-looking inbound mail to staged leads.
 	if s.ConfengeOutcomes != nil && s.ConfengeOutcomes.Enabled() && e.Message != nil {
 		if account, err := s.EmailRepository.GetByID(ctx, e.Message.EmailID); err == nil && account != nil && account.OrganizationID != nil {
-			from := ""
-			if len(e.Message.FromAddr) > 0 {
-				from = e.Message.FromAddr[0]
-			}
+			// Same normalizer as ProcessIncomingReply so Hostinger " (a@b)" From matches candidates.
+			from := emailaddr.ExtractFirst(e.Message.FromAddr)
 			_ = s.ConfengeOutcomes.NoteReply(ctx, *account.OrganizationID, from, map[string]any{
 				"subject":    e.Message.Subject,
 				"message_id": e.Message.ID.String(),

--- a/internal/pkg/emailaddr/extract.go
+++ b/internal/pkg/emailaddr/extract.go
@@ -1,0 +1,65 @@
+// Package emailaddr normalizes sender addresses from Unibox / IMAP From forms.
+package emailaddr
+
+import (
+	"net/mail"
+	"regexp"
+	"strings"
+)
+
+// Hostinger and some IMAP fold paths store From as " (a@b)" or "Name (a@b)"
+// instead of RFC 5322 "Name <a@b>". mail.ParseAddress fails on those forms.
+var parenEmail = regexp.MustCompile(`(?i)\(\s*([a-z0-9._%+\-]+@[a-z0-9.\-]+\.[a-z]{2,})\s*\)`)
+
+// Extract returns a lowercased bare email from a single From token, or "".
+// Accepts RFC 5322 display forms, angle-addr, bare addr, and live Hostinger
+// Unibox forms " (a@b)" / "Name (a@b)".
+func Extract(raw string) string {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return ""
+	}
+	if parsed, err := mail.ParseAddress(s); err == nil {
+		return strings.ToLower(strings.TrimSpace(parsed.Address))
+	}
+	// Parenthetical address: " (a@b)" or "Display Name (a@b)"
+	if m := parenEmail.FindStringSubmatch(s); len(m) == 2 {
+		return strings.ToLower(strings.TrimSpace(m[1]))
+	}
+	// Bare angle-addr without display name already failed ParseAddress above
+	// only when malformed; try stripping surrounding <> and re-parse.
+	trimmed := strings.TrimSpace(strings.Trim(s, "<>"))
+	if trimmed != s {
+		if parsed, err := mail.ParseAddress(trimmed); err == nil {
+			return strings.ToLower(strings.TrimSpace(parsed.Address))
+		}
+		if looksLikeEmail(trimmed) {
+			return strings.ToLower(trimmed)
+		}
+	}
+	if looksLikeEmail(s) {
+		return strings.ToLower(s)
+	}
+	return ""
+}
+
+// ExtractFirst returns Extract of the first non-empty token in addrs.
+func ExtractFirst(addrs []string) string {
+	for _, a := range addrs {
+		if out := Extract(a); out != "" {
+			return out
+		}
+	}
+	return ""
+}
+
+func looksLikeEmail(s string) bool {
+	at := strings.LastIndex(s, "@")
+	if at <= 0 || at == len(s)-1 {
+		return false
+	}
+	if strings.ContainsAny(s, " \t()<>\"") {
+		return false
+	}
+	return strings.Contains(s[at+1:], ".")
+}

--- a/internal/pkg/emailaddr/extract_test.go
+++ b/internal/pkg/emailaddr/extract_test.go
@@ -1,0 +1,45 @@
+package emailaddr
+
+import "testing"
+
+func TestExtract_liveUniboxAndRFC(t *testing.T) {
+	// Live VPS Unibox from_addr samples (CONFENGE self-smoke / replies).
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Hostinger self-reply form that blocked confenge handoff
+		{" (tiago.sasaki@confenge.com.br)", "tiago.sasaki@confenge.com.br"},
+		{"(tiago.sasaki@confenge.com.br)", "tiago.sasaki@confenge.com.br"},
+		// Display + parenthetical (also seen on VPS)
+		{"Tiago Sasaki (tiago.sasaki@confenge.com.br)", "tiago.sasaki@confenge.com.br"},
+		{"Tiago Sasaki (tiago.sasaki@gmail.com)", "tiago.sasaki@gmail.com"},
+		// Clean bare (force path / some IMAP rows)
+		{"tiago.sasaki@confenge.com.br", "tiago.sasaki@confenge.com.br"},
+		// RFC 5322
+		{"Aiden Park <aiden.park@northwind.test>", "aiden.park@northwind.test"},
+		{"\"Tiago Sasaki\" <tiago.sasaki@confenge.com.br>", "tiago.sasaki@confenge.com.br"},
+		{"<tiago.sasaki@confenge.com.br>", "tiago.sasaki@confenge.com.br"},
+		// Empty / garbage
+		{"", ""},
+		{"   ", ""},
+		{"not-an-email", ""},
+		{"()", ""},
+	}
+	for _, tc := range cases {
+		got := Extract(tc.in)
+		if got != tc.want {
+			t.Errorf("Extract(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestExtractFirst(t *testing.T) {
+	got := ExtractFirst([]string{"", " (tiago.sasaki@confenge.com.br)"})
+	if got != "tiago.sasaki@confenge.com.br" {
+		t.Fatalf("ExtractFirst = %q", got)
+	}
+	if ExtractFirst(nil) != "" {
+		t.Fatal("nil should be empty")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `internal/pkg/emailaddr.Extract` for live Unibox From forms ` (a@b)` / `Name (a@b)` plus RFC5322
- Wire into `parseSenderEmail` and confenge `NoteReply` path so natural IMAP replies resolve candidates
- Table tests use exact live VPS Unibox strings

## Why
Natural Hostinger IMAP Re: rows stored From as ` (email)` which failed `mail.ParseAddress`, so stop-on-reply never fired. Force JetStream publish was not acceptable GO evidence.

## Test plan
- [x] go test ./internal/pkg/emailaddr/
- [x] go test ./internal/app/consumer/
- [ ] VPS natural IMAP REPLY after deploy
