### PR TITLE
feat: IMAP EXISTS/UIDNEXT fallback for Hostinger CONDSTORE stall

### DIFF
--- a/internal/app/worker/wmail/sync_imap.go
+++ b/internal/app/worker/wmail/sync_imap.go
@@ -19,16 +19,20 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 	}
 
 	for _, box := range folders {
-		befBox := w.SmtpImapData.FindPair(&box)
+		// copy for append / cursor update (range var is reused)
+		cur := box
+		befBox := w.SmtpImapData.FindPair(&cur)
+		plan := planMailboxSync(befBox, &cur)
+
 		if befBox == nil {
-			if err := w.mboxEvent(&box); err != nil {
+			if err := w.mboxEvent(&cur); err != nil {
 				return nil
 			}
 
 			// FETCH requires a selected mailbox; the select also arms
 			// CONDSTORE for the ChangedSince filtering. An empty mailbox is
 			// skipped: 1:* on zero messages is a server error.
-			count, err := w.SmtpImapData.ImapClient.SelectForSync(box.Name)
+			count, err := w.SmtpImapData.ImapClient.SelectForSync(cur.Name)
 			if err != nil {
 				return err
 			}
@@ -38,31 +42,55 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 				}
 			}
 
-			w.SmtpImapData.Mailboxes = append(w.SmtpImapData.Mailboxes, &box)
+			stored := cur
+			w.SmtpImapData.Mailboxes = append(w.SmtpImapData.Mailboxes, &stored)
 			continue
 		}
 
-		if befBox.HighestModSeq != box.HighestModSeq {
-			w.SmtpImapData.mailbox = box.UIDValidity
-			count, err := w.SmtpImapData.ImapClient.SelectForSync(box.Name)
+		if plan.Fetch {
+			w.SmtpImapData.mailbox = cur.UIDValidity
+			count, err := w.SmtpImapData.ImapClient.SelectForSync(cur.Name)
 			if err != nil {
 				return err
 			}
 			if count > 0 {
-				if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, befBox.HighestModSeq, count); err != nil {
-					return err
+				if plan.Full {
+					if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, plan.LastModSeq, count); err != nil {
+						return err
+					}
+				} else {
+					// Clamp window to actual SELECT EXISTS (server truth).
+					lo, hi := plan.Lo, plan.Hi
+					if hi > count {
+						hi = count
+					}
+					if lo < 1 {
+						lo = 1
+					}
+					if lo <= hi {
+						if err := w.SmtpImapData.ImapClient.FetchSeqWindow(ctx, plan.LastModSeq, lo, hi); err != nil {
+							return err
+						}
+					}
 				}
 			}
 		}
 
-		if befBox.HighestModSeq != box.HighestModSeq || befBox.Name != box.Name || !slices.Equal(befBox.Attrs, box.Attrs) {
-			w.mboxEvent(&box)
+		if plan.Fetch || befBox.Name != cur.Name || !slices.Equal(befBox.Attrs, cur.Attrs) ||
+			befBox.NumMessages != cur.NumMessages || befBox.UIDNext != cur.UIDNext ||
+			befBox.HighestModSeq != cur.HighestModSeq {
+			if plan.Fetch || befBox.Name != cur.Name || !slices.Equal(befBox.Attrs, cur.Attrs) ||
+				befBox.HighestModSeq != cur.HighestModSeq {
+				w.mboxEvent(&cur)
+			}
 
 			for _, ibox := range w.SmtpImapData.Mailboxes {
-				if ibox.UIDValidity == box.UIDValidity {
-					ibox.HighestModSeq = box.HighestModSeq
-					ibox.Name = box.Name
-					ibox.Attrs = box.Attrs
+				if ibox.UIDValidity == cur.UIDValidity {
+					ibox.HighestModSeq = cur.HighestModSeq
+					ibox.NumMessages = cur.NumMessages
+					ibox.UIDNext = cur.UIDNext
+					ibox.Name = cur.Name
+					ibox.Attrs = cur.Attrs
 				}
 			}
 		}

--- a/internal/app/worker/wmail/sync_imap_plan.go
+++ b/internal/app/worker/wmail/sync_imap_plan.go
@@ -1,0 +1,64 @@
+package wmail
+
+import "github.com/warmbly/warmbly/internal/models"
+
+// mailboxSyncPlan decides how to fetch when LIST-STATUS reports a change.
+// CONDSTORE HighestModSeq is preferred; when only EXISTS/UIDNEXT advances
+// (Hostinger CONDSTORE stall), walk the new sequence window with ChangedSince 0.
+type mailboxSyncPlan struct {
+	Fetch      bool
+	LastModSeq uint64
+	// Full walks 1:selectCount after SELECT. Otherwise Lo/Hi inclusive seqs.
+	Full bool
+	Lo   uint32
+	Hi   uint32
+}
+
+// planMailboxSync is pure so Hostinger stall cases stay unit-testable without IMAP.
+func planMailboxSync(bef, cur *models.Mailbox) mailboxSyncPlan {
+	if cur == nil {
+		return mailboxSyncPlan{}
+	}
+	if bef == nil {
+		return mailboxSyncPlan{Fetch: true, LastModSeq: 0, Full: true}
+	}
+
+	modseqAdv := cur.HighestModSeq != bef.HighestModSeq
+	existsGrew := cur.NumMessages > bef.NumMessages
+	uidNextGrew := cur.UIDNext > 0 && cur.UIDNext > bef.UIDNext
+
+	if !modseqAdv && !existsGrew && !uidNextGrew {
+		return mailboxSyncPlan{}
+	}
+
+	// Normal CONDSTORE path: full mailbox walk filtered by ChangedSince.
+	if modseqAdv {
+		return mailboxSyncPlan{
+			Fetch:      true,
+			LastModSeq: bef.HighestModSeq,
+			Full:       true,
+		}
+	}
+
+	// CONDSTORE stall: MODSEQ flat but EXISTS and/or UIDNEXT advanced.
+	// Prefer the new sequence window only (cheap). Fall back to full walk
+	// when we cannot bound the window (count missing or not grown).
+	if existsGrew && cur.NumMessages > 0 {
+		lo := bef.NumMessages + 1
+		if lo < 1 {
+			lo = 1
+		}
+		hi := cur.NumMessages
+		if lo <= hi {
+			return mailboxSyncPlan{
+				Fetch:      true,
+				LastModSeq: 0,
+				Full:       false,
+				Lo:         lo,
+				Hi:         hi,
+			}
+		}
+	}
+
+	return mailboxSyncPlan{Fetch: true, LastModSeq: 0, Full: true}
+}

--- a/internal/app/worker/wmail/sync_imap_plan_test.go
+++ b/internal/app/worker/wmail/sync_imap_plan_test.go
@@ -1,0 +1,71 @@
+package wmail
+
+import (
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestPlanMailboxSync_FirstSyncFull(t *testing.T) {
+	cur := &models.Mailbox{UIDValidity: 1, NumMessages: 10, HighestModSeq: 5, UIDNext: 11}
+	p := planMailboxSync(nil, cur)
+	if !p.Fetch || !p.Full || p.LastModSeq != 0 {
+		t.Fatalf("first sync want full Fetch lastMod=0, got %+v", p)
+	}
+}
+
+func TestPlanMailboxSync_NoChange(t *testing.T) {
+	bef := &models.Mailbox{UIDValidity: 1, NumMessages: 10, HighestModSeq: 5, UIDNext: 11}
+	cur := &models.Mailbox{UIDValidity: 1, NumMessages: 10, HighestModSeq: 5, UIDNext: 11}
+	p := planMailboxSync(bef, cur)
+	if p.Fetch {
+		t.Fatalf("unchanged STATUS must not fetch, got %+v", p)
+	}
+}
+
+func TestPlanMailboxSync_ModSeqAdvanceCONDSTORE(t *testing.T) {
+	bef := &models.Mailbox{UIDValidity: 1, NumMessages: 10, HighestModSeq: 5, UIDNext: 11}
+	cur := &models.Mailbox{UIDValidity: 1, NumMessages: 12, HighestModSeq: 9, UIDNext: 13}
+	p := planMailboxSync(bef, cur)
+	if !p.Fetch || !p.Full || p.LastModSeq != 5 {
+		t.Fatalf("modseq advance want full Fetch lastMod=5, got %+v", p)
+	}
+}
+
+func TestPlanMailboxSync_HostingerCondstoreStallExistsGrew(t *testing.T) {
+	// HighestModSeq flat, EXISTS grew: the Hostinger pilot failure mode.
+	bef := &models.Mailbox{UIDValidity: 1, NumMessages: 200, HighestModSeq: 42, UIDNext: 201}
+	cur := &models.Mailbox{UIDValidity: 1, NumMessages: 203, HighestModSeq: 42, UIDNext: 204}
+	p := planMailboxSync(bef, cur)
+	if !p.Fetch {
+		t.Fatal("exists growth must fetch despite flat modseq")
+	}
+	if p.Full {
+		t.Fatalf("exists-only growth should fetch new window only, got full %+v", p)
+	}
+	if p.LastModSeq != 0 {
+		t.Fatalf("stall fallback must use ChangedSince 0, got lastMod=%d", p.LastModSeq)
+	}
+	if p.Lo != 201 || p.Hi != 203 {
+		t.Fatalf("want seq window 201-203, got lo=%d hi=%d", p.Lo, p.Hi)
+	}
+}
+
+func TestPlanMailboxSync_UIDNextOnlyFullFallback(t *testing.T) {
+	// UIDNEXT advanced, EXISTS flat (e.g. expunge+append) → full walk.
+	bef := &models.Mailbox{UIDValidity: 1, NumMessages: 50, HighestModSeq: 7, UIDNext: 100}
+	cur := &models.Mailbox{UIDValidity: 1, NumMessages: 50, HighestModSeq: 7, UIDNext: 105}
+	p := planMailboxSync(bef, cur)
+	if !p.Fetch || !p.Full || p.LastModSeq != 0 {
+		t.Fatalf("uidnext-only want full Fetch lastMod=0, got %+v", p)
+	}
+}
+
+func TestPlanMailboxSync_ExistsDecreasedNoFetch(t *testing.T) {
+	bef := &models.Mailbox{UIDValidity: 1, NumMessages: 50, HighestModSeq: 7, UIDNext: 100}
+	cur := &models.Mailbox{UIDValidity: 1, NumMessages: 48, HighestModSeq: 7, UIDNext: 100}
+	p := planMailboxSync(bef, cur)
+	if p.Fetch {
+		t.Fatalf("exists shrink alone must not fetch, got %+v", p)
+	}
+}

--- a/internal/client/smtpimap/imap/client.go
+++ b/internal/client/smtpimap/imap/client.go
@@ -132,11 +132,14 @@ func (c *Client) Folders() ([]models.Mailbox, *errx.MailError) {
 	var resp []models.Mailbox
 
 	// LIST-STATUS: without requesting these, f.Status is nil for every
-	// folder and the sync loop sees an empty account.
+	// folder and the sync loop sees an empty account. NumMessages/UIDNext
+	// back the EXISTS/UIDNEXT fallback when CONDSTORE HighestModSeq stalls.
 	cmd := c.client.List("", "%", &imap.ListOptions{
 		ReturnStatus: &imap.StatusOptions{
 			UIDValidity:   true,
 			HighestModSeq: true,
+			NumMessages:   true,
+			UIDNext:       true,
 		},
 	})
 
@@ -155,11 +158,17 @@ func (c *Client) Folders() ([]models.Mailbox, *errx.MailError) {
 			continue
 		}
 
+		var num uint32
+		if f.Status.NumMessages != nil {
+			num = *f.Status.NumMessages
+		}
 		resp = append(resp, models.Mailbox{
 			Name:          f.Mailbox,
 			Attrs:         attrs,
 			UIDValidity:   f.Status.UIDValidity,
 			HighestModSeq: f.Status.HighestModSeq,
+			NumMessages:   num,
+			UIDNext:       uint32(f.Status.UIDNext),
 		})
 	}
 
@@ -199,17 +208,25 @@ func (c *Client) FetchChanges(ctx context.Context, lastModSeq uint64, count uint
 	if count == 0 {
 		return nil
 	}
+	return c.FetchSeqWindow(ctx, lastModSeq, 1, count)
+}
+
+// FetchSeqWindow walks inclusive sequence numbers [lo, hi] in bounded batches.
+// Used by the EXISTS/UIDNEXT fallback to fetch only newly appended messages
+// when CONDSTORE HighestModSeq does not advance.
+func (c *Client) FetchSeqWindow(ctx context.Context, lastModSeq uint64, lo, hi uint32) *errx.MailError {
+	if lo == 0 || hi == 0 || lo > hi {
+		return nil
+	}
 	const batch = uint32(config.ImapFetchBatchSize)
-	for lo := uint32(1); lo <= count; lo += batch {
-		hi := lo + batch - 1
-		if hi > count {
-			hi = count
+	for start := lo; start <= hi; start += batch {
+		end := start + batch - 1
+		if end > hi {
+			end = hi
 		}
-		if err := c.fetchRange(ctx, lastModSeq, lo, hi); err != nil {
+		if err := c.fetchRange(ctx, lastModSeq, start, end); err != nil {
 			return err
 		}
-		// The caller's context is the mailbox's sync context; abandon a long
-		// walk promptly when the mailbox is removed or the worker shuts down.
 		if ctx.Err() != nil {
 			return nil
 		}

--- a/internal/models/mailbox.go
+++ b/internal/models/mailbox.go
@@ -7,6 +7,10 @@ type Mailbox struct {
 	Attrs         []string `json:"attributes"`
 	UIDValidity   uint32   `json:"uid_validity"`
 	HighestModSeq uint64   `json:"highestmodseq"`
+	// NumMessages / UIDNext are LIST-STATUS EXISTS/UIDNEXT. Worker-only
+	// fallbacks when CONDSTORE HighestModSeq stalls (seen on Hostinger).
+	NumMessages uint32 `json:"num_messages,omitempty"`
+	UIDNext     uint32 `json:"uid_next,omitempty"`
 
 	UpdatedAt time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary
- LIST-STATUS now requests EXISTS + UIDNEXT alongside HighestModSeq
- When MODSEQ is flat but EXISTS/UIDNEXT advances (Hostinger CONDSTORE stall), fetch the new sequence window with ChangedSince 0
- Pure `planMailboxSync` unit tests cover first sync, no-op, CONDSTORE advance, Hostinger stall, and UIDNEXT-only paths

## Why
Continuous 1m IMAP poll missed Hostinger self-replies after the first full sync because `sync_imap` only called `FetchChanges` when `HighestModSeq` advanced. Reply-stop then depended on operator ADD_EMAIL reseed (unsafe for pilot cadence).

## Test plan
- [x] `go test ./internal/app/worker/wmail/`
- [x] `make lint` / gofmt
- [ ] Deploy worker to CONFENGE VPS; after first attach, send natural Re: and prove Unibox + PLANNED→REPLIED via continuous poll (no backend restart, no JetStream force)