### PR TITLE
feat: SELECT-based EXISTS/UIDNEXT for Hostinger continuous IMAP poll

### DIFF
--- a/internal/app/worker/wmail/sync_imap.go
+++ b/internal/app/worker/wmail/sync_imap.go
@@ -19,8 +19,23 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 	}
 
 	for _, box := range folders {
-		// copy for append / cursor update (range var is reused)
+		// SELECT is source of truth for EXISTS/UIDNEXT/HIGHESTMODSEQ. LIST-STATUS
+		// alone is insufficient on Hostinger (flat MODSEQ + empty LIST counts).
+		sel, serr := w.SmtpImapData.ImapClient.SelectForSyncInfo(box.Name)
+		if serr != nil {
+			return serr
+		}
+
 		cur := box
+		cur.NumMessages = sel.NumMessages
+		cur.UIDNext = sel.UIDNext
+		if sel.HighestModSeq != 0 {
+			cur.HighestModSeq = sel.HighestModSeq
+		}
+		if sel.UIDValidity != 0 {
+			cur.UIDValidity = sel.UIDValidity
+		}
+
 		befBox := w.SmtpImapData.FindPair(&cur)
 		plan := planMailboxSync(befBox, &cur)
 
@@ -28,20 +43,11 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 			if err := w.mboxEvent(&cur); err != nil {
 				return nil
 			}
-
-			// FETCH requires a selected mailbox; the select also arms
-			// CONDSTORE for the ChangedSince filtering. An empty mailbox is
-			// skipped: 1:* on zero messages is a server error.
-			count, err := w.SmtpImapData.ImapClient.SelectForSync(cur.Name)
-			if err != nil {
-				return err
-			}
-			if count > 0 {
-				if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, 0, count); err != nil {
+			if sel.NumMessages > 0 {
+				if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, 0, sel.NumMessages); err != nil {
 					return err
 				}
 			}
-
 			stored := cur
 			w.SmtpImapData.Mailboxes = append(w.SmtpImapData.Mailboxes, &stored)
 			continue
@@ -49,20 +55,15 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 
 		if plan.Fetch {
 			w.SmtpImapData.mailbox = cur.UIDValidity
-			count, err := w.SmtpImapData.ImapClient.SelectForSync(cur.Name)
-			if err != nil {
-				return err
-			}
-			if count > 0 {
+			if sel.NumMessages > 0 {
 				if plan.Full {
-					if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, plan.LastModSeq, count); err != nil {
+					if err := w.SmtpImapData.ImapClient.FetchChanges(ctx, plan.LastModSeq, sel.NumMessages); err != nil {
 						return err
 					}
 				} else {
-					// Clamp window to actual SELECT EXISTS (server truth).
 					lo, hi := plan.Lo, plan.Hi
-					if hi > count {
-						hi = count
+					if hi > sel.NumMessages {
+						hi = sel.NumMessages
 					}
 					if lo < 1 {
 						lo = 1
@@ -83,7 +84,6 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 				befBox.HighestModSeq != cur.HighestModSeq {
 				w.mboxEvent(&cur)
 			}
-
 			for _, ibox := range w.SmtpImapData.Mailboxes {
 				if ibox.UIDValidity == cur.UIDValidity {
 					ibox.HighestModSeq = cur.HighestModSeq
@@ -96,7 +96,6 @@ func (w *WMail) Sync(ctx context.Context) *errx.MailError {
 		}
 	}
 
-	// Collect deletions first to avoid modifying the slice during iteration
 	var deleted []uint32
 outer:
 	for _, box := range w.SmtpImapData.Mailboxes {
@@ -105,7 +104,6 @@ outer:
 				continue outer
 			}
 		}
-
 		if err := w.onEvent(models.JobEventTypeMailboxDelete, &models.JobEventMailboxDelete{
 			UserID:      w.UserID,
 			EmailID:     w.ID,

--- a/internal/app/worker/wmail/sync_imap_plan.go
+++ b/internal/app/worker/wmail/sync_imap_plan.go
@@ -2,7 +2,7 @@ package wmail
 
 import "github.com/warmbly/warmbly/internal/models"
 
-// mailboxSyncPlan decides how to fetch when LIST-STATUS reports a change.
+// mailboxSyncPlan decides how to fetch when SELECT status reports a change.
 // CONDSTORE HighestModSeq is preferred; when only EXISTS/UIDNEXT advances
 // (Hostinger CONDSTORE stall), walk the new sequence window with ChangedSince 0.
 type mailboxSyncPlan struct {

--- a/internal/client/smtpimap/imap/client.go
+++ b/internal/client/smtpimap/imap/client.go
@@ -187,17 +187,41 @@ func (c *Client) Mailbox(mailbox string, uidvali, opts *imap.SelectOptions) erro
 	return nil
 }
 
+// SyncMailboxStatus is SELECT/EXAMINE state used by the IMAP sync planner.
+// Prefer these over LIST-STATUS: some hosts (Hostinger) advertise CONDSTORE
+// but leave LIST-STATUS NumMessages/UIDNext empty while SELECT EXISTS works.
+type SyncMailboxStatus struct {
+	NumMessages   uint32
+	UIDNext       uint32
+	HighestModSeq uint64
+	UIDValidity   uint32
+}
+
 // SelectForSync opens a mailbox read-only with CONDSTORE enabled and returns
 // its message count. FETCH is only valid against a selected mailbox, so the
 // sync loop must call this before FetchChanges; CONDSTORE on the SELECT is
 // what arms ChangedSince. The count lets the caller skip the fetch entirely
 // for an empty mailbox, where a 1:* set is a server error.
 func (c *Client) SelectForSync(mailbox string) (uint32, *errx.MailError) {
+	st, err := c.SelectForSyncInfo(mailbox)
+	if err != nil {
+		return 0, err
+	}
+	return st.NumMessages, nil
+}
+
+// SelectForSyncInfo is SelectForSync plus UIDNEXT/HIGHESTMODSEQ for EXISTS fallback.
+func (c *Client) SelectForSyncInfo(mailbox string) (*SyncMailboxStatus, *errx.MailError) {
 	data, err := c.client.Select(mailbox, &imap.SelectOptions{ReadOnly: true, CondStore: true}).Wait()
 	if err != nil {
-		return 0, c.handleError(err)
+		return nil, c.handleError(err)
 	}
-	return data.NumMessages, nil
+	return &SyncMailboxStatus{
+		NumMessages:   data.NumMessages,
+		UIDNext:       uint32(data.UIDNext),
+		HighestModSeq: data.HighestModSeq,
+		UIDValidity:   data.UIDValidity,
+	}, nil
 }
 
 // FetchChanges walks the selected mailbox in bounded sequence windows, emitting


### PR DESCRIPTION
## Summary
Follow-up to #31: Hostinger LIST-STATUS can omit NumMessages/UIDNext while SELECT EXISTS works. Sync planner now reads status from SELECT (SelectForSyncInfo) so continuous 1m poll ingests new mail without ADD_EMAIL reseed.

## Test plan
- [x] go test ./internal/app/worker/wmail/ ./internal/client/smtpimap/imap/
- [ ] VPS continuous poll proof after deploy