### PR TITLE
feat: supersede stale CONFENGE send authorization after PR 45

### DIFF
--- a/docs/confenge/CONFENGE-GO-LIVE-2026-08-10.md
+++ b/docs/confenge/CONFENGE-GO-LIVE-2026-08-10.md
@@ -1,5 +1,11 @@
 # CONFENGE go-live card — 2026-08-10 09:00 America/Sao_Paulo
 
+> Historical card from 2026-08-10. Superseded by the PR #45 operational
+> validation on 2026-08-13. This file is not authorization to resume dispatch
+> or send. The current state is 8 generic recipients in `NEEDS_REVIEW`, 22
+> accounts blocked by `recipient_evidence_date_missing`, 0 approved, 0 sent,
+> and dispatch paused. Issues #39, #41, #42, and #43 remain the active gates.
+
 ## Verdict
 
 ```text

--- a/docs/confenge/FINAL-REPORT.md
+++ b/docs/confenge/FINAL-REPORT.md
@@ -1,5 +1,11 @@
 # CONFENGE FINAL PRODUCTION READINESS — FINAL-REPORT
 
+> Historical evidence from the earlier readiness cycle. Superseded by the PR
+> #45 operational validation on 2026-08-13. This file is not authorization to
+> send. The current state is 8 generic recipients in `NEEDS_REVIEW`, 22 accounts
+> blocked by `recipient_evidence_date_missing`, 0 approved, 0 sent, and dispatch
+> paused. Issues #39, #41, #42, and #43 remain the active gates.
+
 Sole-writer artifacts live in `data/confenge-evidence/` (gitignored runtime).  
 This file is a commit-friendly copy of the mechanical gate output.
 

--- a/docs/confenge/GO-NO-GO.md
+++ b/docs/confenge/GO-NO-GO.md
@@ -1,5 +1,12 @@
 # GO / NO-GO
 
+> Historical evidence from 2026-08-08. Superseded by the PR #45 operational
+> validation on 2026-08-13. This file is not authorization to send. The current
+> state is 8 generic recipients in `NEEDS_REVIEW`, 22 accounts blocked by
+> `recipient_evidence_date_missing`, 0 approved, 0 sent, and dispatch paused.
+> Human recipient validation, review, dispatch, and send GO/NO-GO remain tracked
+> in issues #39, #41, #42, and #43.
+
 ## Verdict
 
 ```text


### PR DESCRIPTION
Follow-up to #45. Marks three historical GO/NO-GO records as superseded so they cannot be mistaken for current send authorization. Records the verified post-merge state: 8 generic recipients in needs review, 22 blocked for missing recipient evidence dates, 0 approved, 0 sent, and dispatch paused. No runtime behavior changes.