### PR TITLE
feat: keep EXCEPTION out of NEEDS_REVIEW and make cockpit funnel plus manual cards honest

### DIFF
--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -48,6 +48,8 @@ Every target ends in `VALIDATED`, `EXCEPTION`, or `BLOCKED`. A generic mailbox i
 
 Copy is planned only after extra-cli intelligence is reduced to an internal `OutreachStrategy`. The messageability gate then decides `READY`, `NEEDS_ENRICHMENT`, or `BLOCKED`. Only a `READY` plan is rendered. `NEEDS_REVIEW` means the exact body is sendable if a human presses Approve. Unready items go to a separate exception or enrichment queue.
 
+`NEEDS_REVIEW` is assigned only when recipient resolution is `VALIDATED`, the contact tier is `DIRECT_EMAIL_VALIDATED`, messageability is `READY`, and the composed body is non-empty. An `EXCEPTION` never becomes `NEEDS_REVIEW`. Two individually valid named humans on the same account stay `EXCEPTION` and land in `MANUAL_OUTREACH` until a human picks one recipient.
+
 Human `APPROVE`, `EDIT`, `REJECT`, `RECIPIENT_CHANGE`, and `SKIP` persist as `HumanCorrection`. Edits keep before/after. AI never substitutes the human gate.
 
 ## Per-touch human approval (product invariant)
@@ -115,6 +117,8 @@ Target-fit is updated only by a current authoritative decision. A downgrade take
 | Endpoint | Purpose |
 | --- | --- |
 | `GET /confenge/status` | Whether the feature is on |
+| `GET /confenge/cockpit` | Contact funnel plus `NEEDS_REVIEW` and honest manual lanes |
+| `POST /confenge/manual-queue/:id/action` | Persist a `HumanCorrection` without auto-approve |
 | `GET /confenge/summary` | Queue counters |
 | `GET /confenge/accounts` | Staged companies |
 | `GET /confenge/accounts/:id` | Company with candidates and evidence |
@@ -139,7 +143,7 @@ The CONFENGE page is a PT-BR commercial operations center. It uses the CONFENGE 
 
 Feed freshness uses the upstream manifest's durable `source_generated_at`, not the time at which Warmbly downloaded it. The API retains `feed_last_success_at` as a backward-compatible alias for that authoritative source time and exposes `feed_synced_at` separately for operational diagnostics. The dashboard, API and VPS status script use the same `CONFENGE_FEED_MAX_AGE` threshold, which defaults to 24 hours. Missing, stale, corrupt, or rolled-back feed state blocks cohort preparation.
 
-The page also opens with the recommended next action, a three-step usage guide, operational readiness, and short descriptions for each work area. The per-message review queue shows company, exact recipient, channel, service, fact and evidence, stage number, short history, and the exact send preview. The operator can approve without dispatch, skip the stage, reject with a reason, or mark the account as do not contact.
+The page also opens with the recommended next action, a three-step usage guide, operational readiness, and short descriptions for each work area. The operational funnel counts imported tiers, `NEEDS_REVIEW`, the manual lanes, approvals, and post-send outcomes (`SENT` as contacted, `REPLIED`, `MEETING`) from `GET /confenge/cockpit`. Each manual-lane card shows why now, the factual hook, the recommended action, confidence, and a Copy text control. The per-message review queue shows company, exact recipient, channel, service, fact and evidence, stage number, short history, and the exact send preview. The operator can approve without dispatch, skip the stage, reject with a reason, or mark the account as do not contact.
 
 ## Global dispatch governor
 

--- a/internal/app/confenge/contact_cockpit.go
+++ b/internal/app/confenge/contact_cockpit.go
@@ -27,6 +27,14 @@ func humanQueueStates() []string {
 	}
 }
 
+func outcomeQueueStates() []string {
+	return []string{
+		models.OutreachQueueSent,
+		models.OutreachQueueReplied,
+		models.OutreachQueueMeeting,
+	}
+}
+
 func (s *service) CollectContactCockpit(ctx context.Context, orgID uuid.UUID) (*ContactCockpit, *errx.Error) {
 	if xerr := s.requireEnabled(); xerr != nil {
 		return nil, xerr
@@ -37,6 +45,20 @@ func (s *service) CollectContactCockpit(ctx context.Context, orgID uuid.UUID) (*
 	var manual []ManualQueueItem
 	var ready []ManualQueueItem
 	extras := ContactFunnel{}
+	for _, qs := range outcomeQueueStates() {
+		accs, err := s.repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{QueueState: qs, Limit: 200})
+		if err != nil {
+			return nil, errx.New(errx.Internal, "list outcome accounts: "+err.Error())
+		}
+		switch qs {
+		case models.OutreachQueueSent:
+			extras.Contacted += len(accs)
+		case models.OutreachQueueReplied:
+			extras.Replied += len(accs)
+		case models.OutreachQueueMeeting:
+			extras.Meeting += len(accs)
+		}
+	}
 	for _, qs := range humanQueueStates() {
 		accs, err := s.repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{QueueState: qs, Limit: 200})
 		if err != nil {
@@ -44,15 +66,8 @@ func (s *service) CollectContactCockpit(ctx context.Context, orgID uuid.UUID) (*
 		}
 		for i := range accs {
 			acc := accs[i]
-			switch acc.QueueState {
-			case models.OutreachQueueApproved:
+			if acc.QueueState == models.OutreachQueueApproved {
 				extras.Approved++
-			case models.OutreachQueueSent:
-				extras.Contacted++
-			case models.OutreachQueueReplied:
-				extras.Replied++
-			case models.OutreachQueueMeeting:
-				extras.Meeting++
 			}
 			cands, _ := s.repo.ListCandidates(ctx, orgID, acc.ID)
 			ev, _ := s.repo.ListEvidence(ctx, orgID, acc.ID)

--- a/internal/app/confenge/contact_tier.go
+++ b/internal/app/confenge/contact_tier.go
@@ -110,7 +110,8 @@ func ClassifyContactTier(acc *models.OutreachAccount, c *models.OutreachContactC
 	email := strings.TrimSpace(c.Email)
 	sendReady := c.EmailSendReady && email != "" && !generic && !roleBox
 	if sendReady && named && roleOK && validatePilotRecipient(c, now) == nil {
-		out.Tier, out.EmailValidated, out.RecipientState, out.Lane = ContactTierA, true, RecipientValidated, LaneNeedsReviewEmail
+		// TIER A is identity only. NEEDS_REVIEW is decided later by VALIDATED+READY+body.
+		out.Tier, out.EmailValidated, out.RecipientState = ContactTierA, true, RecipientValidated
 		out.RecommendedNext = "Gerar mensagem so se messageability for READY; autorizacao humana obrigatoria."
 		return out
 	}
@@ -136,11 +137,13 @@ func ClassifyContactTier(acc *models.OutreachAccount, c *models.OutreachContactC
 }
 
 func ClassifyActionLane(cls ContactClass, rec RecipientResolution, plan OutboundMessagePlan, body string) string {
+	// NEEDS_REVIEW is only sendable copy awaiting human authorization.
+	if rec.State == RecipientValidated && cls.Tier == ContactTierA &&
+		plan.Messageability == MessageabilityReady && strings.TrimSpace(body) != "" {
+		return LaneNeedsReviewEmail
+	}
 	if cls.Tier == ContactTierE || rec.State == RecipientBlocked {
 		return LaneBlockedExhausted
-	}
-	if cls.Tier == ContactTierA && rec.State == RecipientValidated && plan.Messageability == MessageabilityReady && strings.TrimSpace(body) != "" {
-		return LaneNeedsReviewEmail
 	}
 	switch cls.Tier {
 	case ContactTierB:
@@ -150,8 +153,9 @@ func ClassifyActionLane(cls ContactClass, rec RecipientResolution, plan Outbound
 	case ContactTierD:
 		return LaneLowConfidenceManual
 	}
-	if rec.State == RecipientException && cls.Lane != "" {
-		return cls.Lane
+	if rec.State == RecipientException {
+		// Conflict / ambiguous identity is an operator decision, never authorize.
+		return LaneManualOutreach
 	}
 	return LaneBlockedExhausted
 }

--- a/internal/app/confenge/contact_tier_test.go
+++ b/internal/app/confenge/contact_tier_test.go
@@ -262,3 +262,105 @@ func TestManualActionNeverApproves(t *testing.T) {
 		}
 	}
 }
+
+func TestTwoValidatedHumansNeverEnterNeedsReview(t *testing.T) {
+	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
+	repo := newMemRepo()
+	svc := testSvc(repo).(*service)
+	org := uuid.New()
+	acc := testAccount("REAJUSTE", "ANUALIDADE", "contrato 1149/2022 atingiu aniversário de reajuste em 2024")
+	acc.OrganizationID = org
+	acc.QueueState = models.OutreachQueueReadyToGenerate
+	acc.NomeFantasia = "Horizonte Sul"
+	if _, err := repo.UpsertAccount(context.Background(), acc); err != nil {
+		t.Fatal(err)
+	}
+	a := validatedCand("Ana Souza", "Diretora de Contratos", "ana.souza@horizontesul.com.br")
+	a.OrganizationID, a.AccountID, a.SourceContactID = org, acc.ID, "ct-ana"
+	b := validatedCand("Bruno Lima", "Gerente de Contratos", "bruno.lima@horizontesul.com.br")
+	b.OrganizationID, b.AccountID, b.SourceContactID = org, acc.ID, "ct-bruno"
+	if _, err := repo.UpsertCandidate(context.Background(), &a); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.UpsertCandidate(context.Background(), &b); err != nil {
+		t.Fatal(err)
+	}
+	cands := []models.OutreachContactCandidate{a, b}
+	rec := ResolveRecipient(acc, cands, now)
+	if rec.State != RecipientException {
+		t.Fatalf("two validated humans must be EXCEPTION, got %s %v", rec.State, rec.ReasonCodes)
+	}
+	cls := ClassifyContactTier(acc, &a, now)
+	_, plan := BuildOutboundPlan(MustPlaybook(), acc, &a, nil, 1)
+	out := ComposeFromPlan(plan, acc, &a, ChannelEmailInitial)
+	lane := ClassifyActionLane(cls, rec, plan, out.BodyText)
+	if lane == LaneNeedsReviewEmail {
+		t.Fatalf("EXCEPTION must never become NEEDS_REVIEW: tier=%s rec=%s lane=%s", cls.Tier, rec.State, lane)
+	}
+	cockpit, xerr := svc.CollectContactCockpit(context.Background(), org)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	for _, item := range cockpit.Ready {
+		if item.CanonicalTargetID == acc.ID.String() {
+			t.Fatalf("conflict account leaked into NEEDS_REVIEW: %+v", item)
+		}
+	}
+}
+
+func TestCollectContactCockpitLanesAndOutcomeFunnel(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo).(*service)
+	org, user := uuid.New(), uuid.New()
+	raw, err := os.ReadFile(filepath.Join("testdata", "contact_tiers_v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, &user, raw, ImportOptions{IdempotencyKey: "cockpit-lanes"}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	accs, err := repo.ListAccounts(context.Background(), org, repository.OutreachAccountFilter{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(accs) != 5 {
+		t.Fatalf("imported=%d", len(accs))
+	}
+	for i := range accs {
+		accs[i].QueueState = models.OutreachQueueReadyToGenerate
+		if _, err := repo.UpsertAccount(context.Background(), &accs[i]); err != nil {
+			t.Fatal(err)
+		}
+	}
+	sent := &models.OutreachAccount{OrganizationID: org, CNPJ14: "70000000000101", QueueState: models.OutreachQueueSent, NomeFantasia: "Enviada"}
+	replied := &models.OutreachAccount{OrganizationID: org, CNPJ14: "70000000000112", QueueState: models.OutreachQueueReplied, NomeFantasia: "Respondeu"}
+	meeting := &models.OutreachAccount{OrganizationID: org, CNPJ14: "70000000000123", QueueState: models.OutreachQueueMeeting, NomeFantasia: "Reuniao"}
+	for _, acc := range []*models.OutreachAccount{sent, replied, meeting} {
+		if _, err := repo.UpsertAccount(context.Background(), acc); err != nil {
+			t.Fatal(err)
+		}
+	}
+	cockpit, xerr := svc.CollectContactCockpit(context.Background(), org)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if cockpit.Funnel.Contacted < 1 || cockpit.Funnel.Replied < 1 || cockpit.Funnel.Meeting < 1 {
+		t.Fatalf("outcome funnel dead: %+v", cockpit.Funnel)
+	}
+	byLane := map[string]int{}
+	for _, item := range cockpit.Ready {
+		byLane[item.Lane]++
+		if item.Lane != LaneNeedsReviewEmail {
+			t.Fatalf("ready list must only hold NEEDS_REVIEW: %+v", item)
+		}
+	}
+	for _, item := range cockpit.Manual {
+		byLane[item.Lane]++
+		if item.Lane == LaneNeedsReviewEmail {
+			t.Fatalf("manual list must not hold NEEDS_REVIEW: %+v", item)
+		}
+	}
+	if byLane[LaneManualOutreach] < 1 || byLane[LaneRoleMailboxException] < 1 || byLane[LaneLowConfidenceManual] < 1 {
+		t.Fatalf("fixture lanes missing: %+v ready=%d manual=%d", byLane, len(cockpit.Ready), len(cockpit.Manual))
+	}
+}

--- a/internal/app/confenge/ui_presence_test.go
+++ b/internal/app/confenge/ui_presence_test.go
@@ -27,6 +27,12 @@ func TestConfengeUIAcceptanceAffordancesPresent(t *testing.T) {
 		`data-testid="confenge-body-input"`,
 		`data-testid="confenge-recipient"`,
 		`data-testid="confenge-recipient-input"`,
+		`data-testid="confenge-manual-queue"`,
+		`data-testid="confenge-manual-why-now"`,
+		`data-testid="confenge-manual-hook"`,
+		`data-testid="confenge-manual-next"`,
+		`data-testid="confenge-manual-confidence"`,
+		`data-testid="confenge-manual-copy-text"`,
 		`confenge-stat-`, // template for Sent/Review/etc.
 		"Aprovar mensagem",
 		"Precisa de atenção",

--- a/web/src/app/app/confenge/labels.test.ts
+++ b/web/src/app/app/confenge/labels.test.ts
@@ -10,6 +10,7 @@ describe("rótulos da Central comercial CONFENGE", () => {
     expect(stateLabel("EXCEPTION")).toBe("Exceção de destinatário");
     expect(stateLabel("ROLE_MAILBOX_EXCEPTION")).toBe("Exceção de caixa funcional");
     expect(stateLabel("MANUAL_OUTREACH")).toBe("Abordagem manual");
+    expect(stateLabel("COPY_TEXT")).toBe("Copiar texto");
     expect(reasonLabel("generic_mailbox")).toContain("genérica");
     expect(reasonLabel("missing_contract_event")).toContain("evento contratual");
     expect(stateLabel("DO_NOT_CONTACT")).toBe("Não contatar");

--- a/web/src/app/app/confenge/labels.ts
+++ b/web/src/app/app/confenge/labels.ts
@@ -36,6 +36,7 @@ const STATE_LABELS: Record<string, string> = {
   MANUAL_OUTREACH: "Abordagem manual",
   ROLE_MAILBOX_EXCEPTION: "Exceção de caixa funcional",
   LOW_CONFIDENCE_MANUAL: "Manual de baixa confiança",
+  COPY_TEXT: "Copiar texto",
   MARK_CONTACTED: "Marcar como contatado",
   CORRECT_CONTACT: "Corrigir contato",
   PROMOTE_AFTER_NEW_EVIDENCE: "Promover após nova evidência",

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -353,6 +353,9 @@ export default function ConfengePage() {
                 ["Prontas para revisar", cockpit.data.funnel.needs_review],
                 ["Fila manual", cockpit.data.funnel.manual_outreach_ready],
                 ["Aprovadas", cockpit.data.funnel.approved],
+                ["Contatadas", cockpit.data.funnel.contacted],
+                ["Respostas", cockpit.data.funnel.replied],
+                ["Reuniões", cockpit.data.funnel.meeting],
               ].map(([label, n]) => (
                 <ReadinessItem key={String(label)} label={String(label)} value={String(n)} />
               ))}
@@ -371,15 +374,31 @@ export default function ConfengePage() {
               <li key={`${item.canonical_target_id}-${item.lane}`} className="px-3 py-2.5 text-[12.5px] space-y-1">
                 <div className="font-medium text-slate-900">{item.company} <span className="text-[10px] uppercase tracking-[0.14em] text-slate-500">{stateLabel(item.contact_tier)}</span></div>
                 <div className="text-slate-600">{[item.person, item.role, item.channel, item.service].filter(Boolean).join(" · ") || "Sem pessoa nomeada"}</div>
+                {item.why_now && <div data-testid="confenge-manual-why-now" className="text-slate-500">Por que agora: {item.why_now}</div>}
+                {item.factual_hook && <div data-testid="confenge-manual-hook" className="text-slate-500">Gancho: {item.factual_hook}</div>}
+                {item.recommended_action && <div data-testid="confenge-manual-next" className="text-slate-500">Próxima ação: {item.recommended_action}</div>}
+                {item.confidence && <div data-testid="confenge-manual-confidence" className="text-[11px] text-slate-400">Confiança: {item.confidence}</div>}
                 {item.source && <div className="text-[11px] text-slate-400 break-all">Fonte: {item.source}</div>}
                 {item.suggested_text && <div className="rounded border border-slate-100 bg-slate-50 px-2 py-1 text-[11.5px] whitespace-pre-wrap">{item.suggested_text}</div>}
                 {item.blocking_warning && <div className="text-amber-800">{item.blocking_warning}</div>}
                 <div className="flex flex-wrap gap-1.5 pt-1">
                   {item.source && <a href={item.source} target="_blank" rel="noreferrer" className="h-7 px-2.5 inline-flex items-center rounded-md border border-slate-200 text-[12.5px]">Abrir fonte</a>}
-                  {(item.actions || []).filter((a) => a !== "OPEN_SOURCE" && a !== "COPY_TEXT" && a !== "APPROVE").map((action) => (
+                  {item.suggested_text && (
+                    <button
+                      type="button"
+                      data-testid="confenge-manual-copy-text"
+                      className="h-7 px-2.5 rounded-md border border-slate-200 text-[12.5px]"
+                      onClick={() => { void navigator.clipboard.writeText(item.suggested_text || ""); }}
+                    >
+                      {stateLabel("COPY_TEXT")}
+                    </button>
+                  )}
+                  {(item.actions || []).filter((a) => a !== "OPEN_SOURCE" && a !== "APPROVE").map((action) => (
+                    action === "COPY_TEXT" ? null : (
                     <button key={action} type="button" className="h-7 px-2.5 rounded-md border border-slate-200 text-[12.5px]" disabled={manualAction.isPending || !item.canonical_target_id} onClick={() => item.canonical_target_id && manualAction.mutate({ accountId: item.canonical_target_id, action })}>
                       {stateLabel(action)}
                     </button>
+                    )
                   ))}
                 </div>
               </li>


### PR DESCRIPTION
Closes the three fail-closed gaps on top of #51.

- `ClassifyActionLane` now requires `VALIDATED` + TIER A + `READY` + nonempty body before `NEEDS_REVIEW`. `EXCEPTION` (including two individually valid named humans) goes to `MANUAL_OUTREACH`, never authorize.
- `CollectContactCockpit` counts `SENT` / `REPLIED` / `MEETING` so the contacted → replied → meeting funnel is live.
- Manual cards show why now, factual hook, recommended action, confidence, and `COPY_TEXT`.

Does not enable send. Does not weaken #50 gates. Does not treat GenericRecipientAcknowledged as VALIDATED.

Verification: `make lint` pass; `go test ./internal/app/confenge -run 'TestTwoValidatedHumansNeverEnterNeedsReview|TestCollectContactCockpitLanesAndOutcomeFunnel|TestConfengeUIAcceptanceAffordancesPresent|TestContactTiersContractualFixture|TestContactTierGenericCannotApproveViaHumanPath|TestContactTierRoleMailboxGenerateNeverNeedsReview'` pass.