### PR TITLE
feat: persist extra-cli person_id through PG so QUALIDADE 17adca65031d71b21ebaac4c survives reload

### DIFF
--- a/internal/app/confenge/commercial_action_pg_test.go
+++ b/internal/app/confenge/commercial_action_pg_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,5 +71,100 @@ func TestPostgresR2InferredEmailSurvivesCandidateScan(t *testing.T) {
 	}
 	if planned.Action.EmailSendable || planned.Action.Dispatchable || planned.RecipientState == RecipientValidated {
 		t.Fatalf("R2 after PG reload must not be VALIDATED/sendable: %+v rec=%s", planned.Action, planned.RecipientState)
+	}
+}
+
+func postgresTestDSN() string {
+	if dsn := os.Getenv("WARMBLY_TEST_POSTGRES_DSN"); dsn != "" {
+		return dsn
+	}
+	return strings.TrimSpace(os.Getenv("PRIMARY_DB"))
+}
+
+func TestPostgresQualidadePersonIDSurvivesReload(t *testing.T) {
+	dsn := postgresTestDSN()
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN/PRIMARY_DB is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `ALTER TABLE outreach_contact_candidates ADD COLUMN IF NOT EXISTS person_id text NOT NULL DEFAULT ''`); err != nil {
+		t.Fatalf("candidate person_id column: %v", err)
+	}
+	if _, err := pool.Exec(ctx, `ALTER TABLE outreach_commercial_actions ADD COLUMN IF NOT EXISTS person_id text NOT NULL DEFAULT ''`); err != nil {
+		t.Fatalf("action person_id column: %v", err)
+	}
+	userID, orgID := uuid.New(), uuid.New()
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, first_name, last_name, email) VALUES ($1,'Qualidade','Person',$2)`, userID, "qualidade-"+userID.String()+"@example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name, slug, owner_user_id) VALUES ($1,'Qualidade Person',$2,$3)`, orgID, "qualidade-person-"+orgID.String(), userID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		defer pool.Close()
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM organizations WHERE id=$1`, orgID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM users WHERE id=$1`, userID)
+	})
+
+	raw, err := os.ReadFile(filepath.Join("testdata", "track_a_operator_projection_v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := repository.NewOutreachRepository(pool)
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true, MaxFeedPayloadBytes: DefaultMaxPayloadBytes}, repo, nil).(*service)
+	if _, xerr := svc.ImportFromBytes(ctx, orgID, &userID, raw, ImportOptions{IdempotencyKey: "qualidade-person-pg"}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	acc, err := repo.GetAccountByCNPJ(ctx, orgID, "00820854000114")
+	if err != nil || acc == nil {
+		t.Fatalf("qualidade account: %v", err)
+	}
+	cands, err := repo.ListCandidates(ctx, orgID, acc.ID)
+	if err != nil || len(cands) == 0 {
+		t.Fatalf("list candidates: n=%d err=%v", len(cands), err)
+	}
+	const wantPerson = "17adca65031d71b21ebaac4c"
+	const wantCandidate = "9f4676aa79d0cd5f5fedd7a7"
+	if cands[0].PersonID != wantPerson {
+		t.Fatalf("PG reload person_id=%q want extra-cli %q (source_contact_id=%q)", cands[0].PersonID, wantPerson, cands[0].SourceContactID)
+	}
+	if cands[0].SourceContactID != wantCandidate {
+		t.Fatalf("PG reload source_contact_id=%q want candidate_id %q", cands[0].SourceContactID, wantCandidate)
+	}
+	if cands[0].PersonID == cands[0].SourceContactID {
+		t.Fatal("PG stored person_id as source_contact_id")
+	}
+	planned := PlanCommercialAction(PlanInput{
+		Account: acc, Candidate: &cands[0], Candidates: cands,
+		Now: time.Date(2026, 8, 14, 16, 0, 0, 0, time.UTC),
+	})
+	if planned.Action.PersonID != wantPerson {
+		t.Fatalf("replan after PG scan dropped person_id: %q", planned.Action.PersonID)
+	}
+	if planned.Action.EmailSendable || planned.Action.Dispatchable {
+		t.Fatalf("routed call after PG reload must not send: %+v", planned.Action)
+	}
+	svc.persistPlannedAction(ctx, planned)
+	st := svc.actionStore()
+	if st == nil {
+		t.Fatal("commercial action store unavailable")
+	}
+	open, err := st.ListCommercialActions(ctx, orgID, acc.ID, true, 20)
+	if err != nil || len(open) == 0 {
+		t.Fatalf("list actions: n=%d err=%v", len(open), err)
+	}
+	if open[0].PersonID != wantPerson {
+		t.Fatalf("persisted action person_id=%q want %q", open[0].PersonID, wantPerson)
+	}
+	card := AssembleActionCard(open[0])
+	if card.PersonID != wantPerson {
+		t.Fatalf("card person_id=%q want %q", card.PersonID, wantPerson)
 	}
 }

--- a/internal/app/confenge/commercial_plan.go
+++ b/internal/app/confenge/commercial_plan.go
@@ -95,7 +95,7 @@ func PlanCommercialAction(in PlanInput) PlannedAction {
 			out.CandidateID = &id
 		}
 		out.Confidence = c.Confidence
-		out.PersonID = firstNonEmpty(c.PersonID, "")
+		out.PersonID = strings.TrimSpace(c.PersonID)
 		if provenPersonName(c) {
 			out.PersonName = strings.TrimSpace(c.Name)
 		}

--- a/internal/app/confenge/commercial_store.go
+++ b/internal/app/confenge/commercial_store.go
@@ -42,6 +42,7 @@ func (s *service) persistPlannedAction(ctx context.Context, planned PlannedActio
 			existing.WhyNow = a.WhyNow
 			existing.FactualHook = a.FactualHook
 			existing.CompanyName = a.CompanyName
+			existing.PersonID = firstNonEmpty(a.PersonID, existing.PersonID)
 			existing.UpdatedAt = time.Now().UTC()
 			_ = st.UpsertCommercialAction(ctx, existing)
 			return

--- a/internal/app/confenge/operator_pack_test.go
+++ b/internal/app/confenge/operator_pack_test.go
@@ -133,8 +133,14 @@ func TestTrackAOperatorProjectionImportIdempotent(t *testing.T) {
 	if first.Company.CNPJ14 != "00820854000114" || first.Contacts[0].Name != "EDUARDO SCHMITT ESPINDOLA" {
 		t.Fatalf("first card identity invented or lost: %+v", first)
 	}
-	if first.Contacts[0].PersonID == "" {
-		t.Fatal("person_id missing from extra-cli DUI account")
+	if first.Contacts[0].PersonID != "17adca65031d71b21ebaac4c" {
+		t.Fatalf("QUALIDADE person_id: %q", first.Contacts[0].PersonID)
+	}
+	if first.Contacts[0].SourceContactID != "9f4676aa79d0cd5f5fedd7a7" {
+		t.Fatalf("QUALIDADE source_contact_id/candidate_id: %q", first.Contacts[0].SourceContactID)
+	}
+	if first.Contacts[0].PersonID == first.Contacts[0].SourceContactID {
+		t.Fatal("person_id must not collapse into source_contact_id")
 	}
 	if first.Contacts[0].EmailSendReady != nil && *first.Contacts[0].EmailSendReady {
 		t.Fatal("Track A must not publish email_send_ready")
@@ -184,12 +190,25 @@ func TestTrackAOperatorProjectionImportIdempotent(t *testing.T) {
 			t.Fatalf("duplicate CNPJ %s", a.CNPJ14)
 		}
 	}
-	cands, err := repo.ListCandidates(context.Background(), org, accs[0].ID)
+	var qualidade models.OutreachAccount
+	for _, a := range accs {
+		if a.CNPJ14 == "00820854000114" {
+			qualidade = a
+			break
+		}
+	}
+	if qualidade.ID == uuid.Nil {
+		t.Fatal("QUALIDADE account missing after import")
+	}
+	cands, err := repo.ListCandidates(context.Background(), org, qualidade.ID)
 	if err != nil || len(cands) == 0 {
 		t.Fatalf("candidates: %v %#v", err, cands)
 	}
-	if cands[0].PersonID == "" && cands[0].SourceContactID == "" {
-		t.Fatal("imported person identity missing")
+	if cands[0].PersonID != "17adca65031d71b21ebaac4c" {
+		t.Fatalf("imported person_id=%q want extra-cli 17adca65031d71b21ebaac4c", cands[0].PersonID)
+	}
+	if cands[0].SourceContactID == cands[0].PersonID {
+		t.Fatal("person_id must not be stored as source_contact_id")
 	}
 	if strings.Contains(strings.ToLower(cands[0].Name), "invent") {
 		t.Fatal("invented name")

--- a/internal/infrastructure/db/migrations/000098_outreach_person_id.down.sql
+++ b/internal/infrastructure/db/migrations/000098_outreach_person_id.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE outreach_commercial_actions DROP COLUMN IF EXISTS person_id;
+ALTER TABLE outreach_contact_candidates DROP COLUMN IF EXISTS person_id;

--- a/internal/infrastructure/db/migrations/000098_outreach_person_id.up.sql
+++ b/internal/infrastructure/db/migrations/000098_outreach_person_id.up.sql
@@ -1,0 +1,12 @@
+-- extra-cli decision-unit person_id is distinct from source_contact_id
+-- (candidate_id). Persist it so CollectToday re-plan cannot drop identity.
+ALTER TABLE outreach_contact_candidates
+    ADD COLUMN IF NOT EXISTS person_id text NOT NULL DEFAULT '';
+
+ALTER TABLE outreach_commercial_actions
+    ADD COLUMN IF NOT EXISTS person_id text NOT NULL DEFAULT '';
+
+COMMENT ON COLUMN outreach_contact_candidates.person_id IS
+'Imported extra-cli decision-unit person_id. Never invent; never collapse into source_contact_id.';
+COMMENT ON COLUMN outreach_commercial_actions.person_id IS
+'Copied from the imported extra-cli person_id when published. Distinct from source_contact_id.';

--- a/internal/repository/person_id_persist_test.go
+++ b/internal/repository/person_id_persist_test.go
@@ -1,0 +1,90 @@
+package repository
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// extra-cli Track A QUALIDADE (00820854000114) publishes these as distinct ids.
+const (
+	qualidadeCandidateID = "9f4676aa79d0cd5f5fedd7a7"
+	qualidadePersonID    = "17adca65031d71b21ebaac4c"
+)
+
+type assignRow struct{ src []any }
+
+func (r assignRow) Scan(dest ...any) error {
+	if len(dest) != len(r.src) {
+		return fmt.Errorf("scan arity dest=%d src=%d", len(dest), len(r.src))
+	}
+	for i := range dest {
+		dv := reflect.ValueOf(dest[i])
+		sv := reflect.ValueOf(r.src[i])
+		if dv.Kind() != reflect.Ptr || sv.Kind() != reflect.Ptr {
+			return fmt.Errorf("scan dest/src %d not pointers", i)
+		}
+		if dv.Elem().Type() != sv.Elem().Type() {
+			return fmt.Errorf("scan type mismatch at %d: %s vs %s", i, dv.Elem().Type(), sv.Elem().Type())
+		}
+		dv.Elem().Set(sv.Elem())
+	}
+	return nil
+}
+
+func TestOutreachSQLKeepsPersonIDColumn(t *testing.T) {
+	if !strings.Contains(outreachCandidateSelect, "person_id") {
+		t.Fatal("outreachCandidateSelect dropped person_id")
+	}
+	if !strings.Contains(outreachActionSelect, "person_id") {
+		t.Fatal("outreachActionSelect dropped person_id")
+	}
+}
+
+func TestQualidadePersonIDSurvivesShippedCandidateScan(t *testing.T) {
+	in := models.OutreachContactCandidate{
+		SourceContactID: qualidadeCandidateID,
+		PersonID:        qualidadePersonID,
+		Name:            "EDUARDO SCHMITT ESPINDOLA",
+		Role:            "Sócio-Administrador",
+	}
+	got, err := scanCandidate(assignRow{src: candidateScanDest(&in)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PersonID != qualidadePersonID {
+		t.Fatalf("scan dropped extra-cli person_id: got %q want %q", got.PersonID, qualidadePersonID)
+	}
+	if got.SourceContactID != qualidadeCandidateID {
+		t.Fatalf("scan dropped candidate_id: got %q", got.SourceContactID)
+	}
+	if got.PersonID == got.SourceContactID {
+		t.Fatal("person_id must stay distinct from source_contact_id")
+	}
+	if got.Name != in.Name {
+		t.Fatalf("name: %q", got.Name)
+	}
+}
+
+func TestQualidadePersonIDSurvivesShippedActionScan(t *testing.T) {
+	in := models.OutreachCommercialAction{
+		PersonName: "EDUARDO SCHMITT ESPINDOLA",
+		PersonID:   qualidadePersonID,
+		ActionType: models.ActionRoutedCall,
+		Lane:       models.LaneRoutedCallQueue,
+	}
+	var ev, warn, content, corr []byte
+	got, err := scanCommercialAction(assignRow{src: commercialActionScanDest(&in, &ev, &warn, &content, &corr)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.PersonID != qualidadePersonID {
+		t.Fatalf("action scan dropped person_id: got %q want %q", got.PersonID, qualidadePersonID)
+	}
+	if got.PersonName != in.PersonName {
+		t.Fatalf("person name: %q", got.PersonName)
+	}
+}

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -1374,7 +1374,7 @@ func (r *outreachRepository) ListCandidates(ctx context.Context, orgID, accountI
 }
 
 const outreachCandidateSelect = `
-	SELECT id, organization_id, account_id, COALESCE(source_contact_id,''),
+	SELECT id, organization_id, account_id, COALESCE(source_contact_id,''), COALESCE(person_id,''),
 		COALESCE(name,''), COALESCE(role,''), COALESCE(email,''), COALESCE(phone,''),
 		COALESCE(phone_e164,''), COALESCE(phone_source,''), COALESCE(phone_source_url,''),
 		COALESCE(whatsapp_consent_status,'UNKNOWN'), COALESCE(whatsapp_consent_source,''),
@@ -1388,10 +1388,9 @@ const outreachCandidateSelect = `
 		COALESCE(channel_value,''), COALESCE(channel_display,''),
 		last_import_run_id, created_at, updated_at `
 
-func scanCandidate(row scannable) (*models.OutreachContactCandidate, error) {
-	var c models.OutreachContactCandidate
-	err := row.Scan(
-		&c.ID, &c.OrganizationID, &c.AccountID, &c.SourceContactID,
+func candidateScanDest(c *models.OutreachContactCandidate) []any {
+	return []any{
+		&c.ID, &c.OrganizationID, &c.AccountID, &c.SourceContactID, &c.PersonID,
 		&c.Name, &c.Role, &c.Email, &c.Phone,
 		&c.PhoneE164, &c.PhoneSource, &c.PhoneSourceURL,
 		&c.WhatsAppConsentStatus, &c.WhatsAppConsentSource,
@@ -1404,7 +1403,12 @@ func scanCandidate(row scannable) (*models.OutreachContactCandidate, error) {
 		&c.ReachabilityClass, &c.RouteType, &c.RouteRelation,
 		&c.ChannelValue, &c.ChannelDisplay,
 		&c.LastImportRunID, &c.CreatedAt, &c.UpdatedAt,
-	)
+	}
+}
+
+func scanCandidate(row scannable) (*models.OutreachContactCandidate, error) {
+	var c models.OutreachContactCandidate
+	err := row.Scan(candidateScanDest(&c)...)
 	if err != nil {
 		return nil, err
 	}
@@ -1438,7 +1442,7 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 		var created bool
 		err := r.db.QueryRow(ctx, `
 			INSERT INTO outreach_contact_candidates (
-				id, organization_id, account_id, source_contact_id,
+				id, organization_id, account_id, source_contact_id, person_id,
 				name, role, email, phone,
 				phone_e164, phone_source, phone_source_url,
 				whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_provenance_ok,
@@ -1450,17 +1454,17 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 				reachability_class, route_type, route_relation, channel_value, channel_display,
 				last_import_run_id, created_at, updated_at
 			) VALUES (
-				$1,$2,$3,$4,
-				$5,$6,$7,$8,
-				$9,$10,$11,
-				$12,$13,$14,$15,
-				$16,$17,$18,$19,
-				$20,$21,$22,
-				$23,$24,$25,$26,
-				$27,$28,$29,
-				$30,$31,
-				$32,$33,$34,$35,$36,
-				$37,$38,$39
+				$1,$2,$3,$4,$5,
+				$6,$7,$8,$9,
+				$10,$11,$12,
+				$13,$14,$15,$16,
+				$17,$18,$19,$20,
+				$21,$22,$23,
+				$24,$25,$26,$27,
+				$28,$29,$30,
+				$31,$32,
+				$33,$34,$35,$36,$37,
+				$38,$39,$40
 			)
 			ON CONFLICT (organization_id, account_id, source_contact_id) WHERE source_contact_id <> '' DO UPDATE SET
 				name = EXCLUDED.name,
@@ -1511,11 +1515,12 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 				route_relation = EXCLUDED.route_relation,
 				channel_value = EXCLUDED.channel_value,
 				channel_display = EXCLUDED.channel_display,
+				person_id = EXCLUDED.person_id,
 				last_import_run_id = EXCLUDED.last_import_run_id,
 				updated_at = EXCLUDED.updated_at,
 				id = outreach_contact_candidates.id
 			RETURNING (xmax = 0), id`,
-			c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
+			c.ID, c.OrganizationID, c.AccountID, c.SourceContactID, c.PersonID,
 			c.Name, c.Role, c.Email, c.Phone,
 			c.PhoneE164, c.PhoneSource, c.PhoneSourceURL,
 			c.WhatsAppConsentStatus, c.WhatsAppConsentSource, c.WhatsAppConsentAt, c.WhatsAppConsentProvenanceOK,
@@ -1532,7 +1537,7 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 	// No source id: insert only (cannot safely dedupe).
 	_, err := r.db.Exec(ctx, `
 		INSERT INTO outreach_contact_candidates (
-			id, organization_id, account_id, source_contact_id,
+			id, organization_id, account_id, source_contact_id, person_id,
 			name, role, email, phone,
 			phone_e164, phone_source, phone_source_url,
 			whatsapp_consent_status, whatsapp_consent_source, whatsapp_consent_at, whatsapp_consent_provenance_ok,
@@ -1544,9 +1549,9 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 			reachability_class, route_type, route_relation, channel_value, channel_display,
 			last_import_run_id, created_at, updated_at
 		) VALUES (
-			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40
 		)`,
-		c.ID, c.OrganizationID, c.AccountID, c.SourceContactID,
+		c.ID, c.OrganizationID, c.AccountID, c.SourceContactID, c.PersonID,
 		c.Name, c.Role, c.Email, c.Phone,
 		c.PhoneE164, c.PhoneSource, c.PhoneSourceURL,
 		c.WhatsAppConsentStatus, c.WhatsAppConsentSource, c.WhatsAppConsentAt, c.WhatsAppConsentProvenanceOK,

--- a/internal/repository/pg_outreach_actions.go
+++ b/internal/repository/pg_outreach_actions.go
@@ -15,7 +15,7 @@ import (
 
 const outreachActionSelect = `
 	SELECT id, organization_id, account_id, contact_candidate_id, parent_action_id, followup_action_id,
-		COALESCE(source_lead_id,''), COALESCE(person_name,''), COALESCE(observed_role,''), COALESCE(target_role,''),
+		COALESCE(source_lead_id,''), COALESCE(person_name,''), COALESCE(person_id,''), COALESCE(observed_role,''), COALESCE(target_role,''),
 		action_type, COALESCE(reachability_class,''), COALESCE(mapping_version,''),
 		COALESCE(route_type,''), COALESCE(route_relation,''), COALESCE(channel_value,''), COALESCE(channel_display,''),
 		COALESCE(why_now,''), COALESCE(factual_hook,''), COALESCE(recommended_action,''),
@@ -61,7 +61,7 @@ func (r *outreachRepository) UpsertCommercialAction(ctx context.Context, a *mode
 	_, err := r.db.Exec(ctx, `
 		INSERT INTO outreach_commercial_actions (
 			id, organization_id, account_id, contact_candidate_id, parent_action_id, followup_action_id,
-			source_lead_id, person_name, observed_role, target_role,
+			source_lead_id, person_name, person_id, observed_role, target_role,
 			action_type, reachability_class, mapping_version, route_type, route_relation,
 			channel_value, channel_display, why_now, factual_hook, recommended_action,
 			service_code, service_context, confidence, evidence_ids, warnings,
@@ -74,20 +74,21 @@ func (r *outreachRepository) UpsertCommercialAction(ctx context.Context, a *mode
 			created_at, updated_at, started_at, completed_at
 		) VALUES (
 			$1,$2,$3,$4,$5,$6,
-			$7,$8,$9,$10,
-			$11,$12,$13,$14,$15,
-			$16,$17,$18,$19,$20,
-			$21,$22,$23,$24,$25,
-			$26,$27,$28,$29,$30,$31,$32,
-			$33,$34,$35,$36,$37,
-			$38,$39,$40,$41,$42,$43,
-			$44,$45,$46,$47,
-			$48,$49,$50,$51,
-			$52,$53,$54,$55,$56,
-			$57,$58,$59,$60
+			$7,$8,$9,$10,$11,
+			$12,$13,$14,$15,$16,
+			$17,$18,$19,$20,$21,
+			$22,$23,$24,$25,$26,
+			$27,$28,$29,$30,$31,$32,$33,
+			$34,$35,$36,$37,$38,
+			$39,$40,$41,$42,$43,$44,
+			$45,$46,$47,$48,
+			$49,$50,$51,$52,
+			$53,$54,$55,$56,$57,
+			$58,$59,$60,$61
 		)
 		ON CONFLICT (id) DO UPDATE SET
 			person_name = EXCLUDED.person_name,
+			person_id = EXCLUDED.person_id,
 			observed_role = EXCLUDED.observed_role,
 			target_role = EXCLUDED.target_role,
 			action_type = EXCLUDED.action_type,
@@ -140,7 +141,7 @@ func (r *outreachRepository) UpsertCommercialAction(ctx context.Context, a *mode
 			completed_at = EXCLUDED.completed_at,
 			updated_at = EXCLUDED.updated_at`,
 		a.ID, a.OrganizationID, a.AccountID, a.CandidateID, a.ParentActionID, a.FollowupActionID,
-		a.SourceLeadID, a.PersonName, a.ObservedRole, a.TargetRole,
+		a.SourceLeadID, a.PersonName, a.PersonID, a.ObservedRole, a.TargetRole,
 		a.ActionType, a.ReachabilityClass, a.MappingVersion, a.RouteType, a.RouteRelation,
 		a.ChannelValue, a.ChannelDisplay, a.WhyNow, a.FactualHook, a.RecommendedAction,
 		a.ServiceCode, a.ServiceContext, a.Confidence, ev, warn,
@@ -200,23 +201,27 @@ func (r *outreachRepository) ListCommercialActions(ctx context.Context, orgID, a
 	return out, rows.Err()
 }
 
-func scanCommercialAction(row scannable) (*models.OutreachCommercialAction, error) {
-	var a models.OutreachCommercialAction
-	var ev, warn, content, corr []byte
-	err := row.Scan(
+func commercialActionScanDest(a *models.OutreachCommercialAction, ev, warn, content, corr *[]byte) []any {
+	return []any{
 		&a.ID, &a.OrganizationID, &a.AccountID, &a.CandidateID, &a.ParentActionID, &a.FollowupActionID,
-		&a.SourceLeadID, &a.PersonName, &a.ObservedRole, &a.TargetRole,
+		&a.SourceLeadID, &a.PersonName, &a.PersonID, &a.ObservedRole, &a.TargetRole,
 		&a.ActionType, &a.ReachabilityClass, &a.MappingVersion, &a.RouteType, &a.RouteRelation,
 		&a.ChannelValue, &a.ChannelDisplay, &a.WhyNow, &a.FactualHook, &a.RecommendedAction,
-		&a.ServiceCode, &a.ServiceContext, &a.Confidence, &ev, &warn,
+		&a.ServiceCode, &a.ServiceContext, &a.Confidence, ev, warn,
 		&a.State, &a.Lane, &a.PriorityRank, &a.PriorityScore, &a.Actionable, &a.EmailSendable, &a.Dispatchable,
 		&a.PersonFingerprint, &a.RouteFingerprint, &a.ContentHash, &a.SnapshotHash, &a.IdempotencyKey,
 		&a.HumanActor, &a.HumanNotes, &a.OutcomeCode, &a.OutcomeNotes, &a.TargetReached, &a.ConversationStarted,
 		&a.InterestState, &a.NextActionType, &a.NextActionAt, &a.RouteQualityFeedback,
-		&a.PersonRelevanceFeedback, &a.MessageFeedback, &content, &corr,
+		&a.PersonRelevanceFeedback, &a.MessageFeedback, content, corr,
 		&a.BlockedPerson, &a.BlockedRoute, &a.StaleWarning, &a.RequiresFresh, &a.CompanyName,
 		&a.CreatedAt, &a.UpdatedAt, &a.StartedAt, &a.CompletedAt,
-	)
+	}
+}
+
+func scanCommercialAction(row scannable) (*models.OutreachCommercialAction, error) {
+	var a models.OutreachCommercialAction
+	var ev, warn, content, corr []byte
+	err := row.Scan(commercialActionScanDest(&a, &ev, &warn, &content, &corr)...)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}


### PR DESCRIPTION
Follow-up to #53. extra-cli Track A QUALIDADE publishes `candidate_id=9f4676aa79d0cd5f5fedd7a7` and `person_id=17adca65031d71b21ebaac4c` as distinct ids. The previous store kept only `source_contact_id`, so CollectToday re-plan after PG reload dropped person identity.

This adds `person_id` on `outreach_contact_candidates` and `outreach_commercial_actions`, wires upsert/select, and proves reload via the shipped scan path plus a live PG import of the Track A projection. Email sendability is unchanged. No auto-send.