### PR TITLE
feat: surface prospect verification evidence

### DIFF
--- a/docs/confenge/commercial-actions.md
+++ b/docs/confenge/commercial-actions.md
@@ -54,8 +54,11 @@ A named person plus a company phone without `BELONGS_TO_NAMED_PERSON` is
 `confenge import` also accepts the extra-cli operator pack (`cards.json`) and
 `confenge.decision_unit_account.v1` accounts. Re-import is idempotent. Warmbly
 keeps extra-cli account id, person id, evidence ids, why-now, route class,
-confidence, recommended action, and service. It does not invent a person,
-role, email, or phone.
+confidence, recommended action, resolved company domain, and service. Passive
+email-verification reports are rendered as operator warnings with DNS, MX,
+catch-all, SMTP, and identity-proof dimensions kept separate. `MX_PRESENT`
+never becomes mailbox/identity proof, `VERIFIED`, or `email_send_ready=true`.
+It does not invent a person, role, email, or phone.
 
 After import the CLI prints an operator summary: actionable accounts, route
 distribution, manual-call count, email-safe count, unresolved blockers, and
@@ -78,10 +81,17 @@ Keep shipping `confenge.outreach.v1`. Optionally add, per lead or contact:
     "route_relation": "ROUTES_TO_NAMED_PERSON",
     "channel_value": "+554132220000",
     "channel_display": "telefone oficial da empresa",
-    "inferred_email": false
+    "inferred_email": false,
+    "verification_status": "CANDIDATE_UNVERIFIED",
+    "email_send_ready": false
   }]
 }
 ```
+
+Operator cards may also publish `domain_resolution`, `email_verification`, and
+`email_verification_reports`. These are visibility/provenance fields, not a
+send authorization. Legacy cards remain compatible and continue through the
+same recipient, messageability, approval, and transport gates.
 
 Do not invent a person when only a role is known. Warmbly will target the
 function, not a fabricated name.

--- a/internal/app/confenge/operator_pack.go
+++ b/internal/app/confenge/operator_pack.go
@@ -201,8 +201,14 @@ func operatorCardToLead(card, dui map[string]any, rank int) FeedLead {
 	if len(doNot) == 0 && dui != nil {
 		doNot = stringSlice(dui["warnings"])
 	}
+	if notice := operatorVerificationNotice(card); notice != "" {
+		doNot = appendUnique(doNot, notice)
+	}
 	evidenceIDs := collectOperatorEvidenceIDs(card, dui)
 	email, phone, site := splitChannel(channel, channelType)
+	if site == "" {
+		site = operatorDomainURL(card, dui)
+	}
 	// Operator projection is WHO/WHY NOW. Generic/role mailboxes stay unsendable.
 	sendReady := false
 	if class == models.ReachabilityR1Direct && email != "" && personName != "" {
@@ -221,7 +227,7 @@ func operatorCardToLead(card, dui map[string]any, rank int) FeedLead {
 		Email:              email,
 		Phone:              phone,
 		SourceURL:          firstNonEmpty(strField(card, "channel_source_url"), site),
-		VerificationStatus: "OFFICIAL_SOURCE",
+		VerificationStatus: operatorVerificationStatus(card, email),
 		Confidence:         firstNonEmpty(confidence, "MEDIUM"),
 		Recommended:        true,
 		EmailSendReady:     sendPtr,
@@ -273,6 +279,84 @@ func operatorCardToLead(card, dui map[string]any, rank int) FeedLead {
 		lead.CommercialState = "NEEDS_CONTACT"
 	}
 	return lead
+}
+
+func operatorVerificationStatus(card map[string]any, email string) string {
+	if strings.TrimSpace(email) == "" {
+		return models.OutreachVerifyOfficialSource
+	}
+	if explicit := strings.ToUpper(strField(card, "verification_status")); explicit != "" {
+		switch explicit {
+		case models.OutreachVerifyInstitutionalGeneric, models.OutreachVerifyCandidateUnverified,
+			models.OutreachVerifyNotFound:
+			return explicit
+		}
+	}
+	report, _ := card["email_verification"].(map[string]any)
+	switch strings.ToUpper(strField(report, "final_classification")) {
+	case "GENERIC_MAILBOX", "GENERIC_ROLE_MAILBOX":
+		return models.OutreachVerifyInstitutionalGeneric
+	case "UNVERIFIED_DIRECT_CANDIDATE", "UNVERIFIED":
+		return models.OutreachVerifyCandidateUnverified
+	}
+	// Legacy operator packs predate passive verification. Preserve their
+	// source-provenance label; readiness remains an independent, fail-closed gate.
+	return models.OutreachVerifyOfficialSource
+}
+
+func operatorVerificationNotice(card map[string]any) string {
+	report, _ := card["email_verification"].(map[string]any)
+	if report != nil {
+		return fmt.Sprintf(
+			"Verificacao tecnica do e-mail: DNS=%s; MX=%s; catch-all=%s; SMTP=%s. Isso nao prova caixa nem identidade.",
+			firstNonEmpty(strField(report, "dns"), "UNKNOWN"),
+			firstNonEmpty(strField(report, "mx"), "UNKNOWN"),
+			firstNonEmpty(strField(report, "catch_all"), "UNKNOWN_NOT_PROBED"),
+			firstNonEmpty(strField(report, "smtp"), "SKIPPED_POLICY"),
+		)
+	}
+	reports, err := asMapSlice(card["email_verification_reports"])
+	if err != nil || len(reports) == 0 {
+		return ""
+	}
+	mxPresent, smtpSkipped, identityProven := 0, 0, 0
+	for _, item := range reports {
+		if strings.EqualFold(strField(item, "mx"), "MX_PRESENT") {
+			mxPresent++
+		}
+		if strings.EqualFold(strField(item, "smtp"), "SKIPPED_POLICY") {
+			smtpSkipped++
+		}
+		if proven, ok := item["identity_proven"].(bool); ok && proven {
+			identityProven++
+		}
+	}
+	return fmt.Sprintf(
+		"Verificacao passiva de rotas de e-mail: candidatos=%d; MX_PRESENT=%d; SMTP_SKIPPED_POLICY=%d; identidade_provada=%d. MX nao prova caixa nem identidade.",
+		len(reports), mxPresent, smtpSkipped, identityProven,
+	)
+}
+
+func operatorDomainURL(card, dui map[string]any) string {
+	domain := ""
+	if resolution, ok := card["domain_resolution"].(map[string]any); ok {
+		domain = strField(resolution, "canonical_domain")
+	}
+	if domain == "" && dui != nil {
+		if extra, ok := dui["extra"].(map[string]any); ok {
+			if resolution, ok := extra["domain_resolution"].(map[string]any); ok {
+				domain = strField(resolution, "canonical_domain")
+			}
+		}
+	}
+	domain = strings.TrimSpace(strings.TrimSuffix(domain, "/"))
+	if domain == "" {
+		return ""
+	}
+	if strings.HasPrefix(domain, "http://") || strings.HasPrefix(domain, "https://") {
+		return domain
+	}
+	return "https://" + domain
 }
 
 func recString(dui map[string]any, key string) string {

--- a/internal/app/confenge/operator_pack_test.go
+++ b/internal/app/confenge/operator_pack_test.go
@@ -48,6 +48,52 @@ func TestMapActionModeTokens(t *testing.T) {
 	}
 }
 
+func TestOperatorProjectionPreservesVerificationDimensionsAndDomain(t *testing.T) {
+	card := map[string]any{
+		"cnpj":                         "00820854000114",
+		"empresa":                      "QUALIDADE MINERACAO LTDA",
+		"primary_decision_unit_target": "EDUARDO ESPINDOLA",
+		"primary_route":                "DIRECT_EMAIL",
+		"route_class":                  models.ReachabilityR1Direct,
+		"channel":                      "eduardo@qualidademineracao.com.br",
+		"verification_status":          models.OutreachVerifyCandidateUnverified,
+		"email_send_ready":             false,
+		"email_verification": map[string]any{
+			"dns": "RESOLVED", "mx": "MX_PRESENT",
+			"catch_all": "UNKNOWN_NOT_PROBED", "smtp": "SKIPPED_POLICY",
+			"final_classification": "UNVERIFIED_DIRECT_CANDIDATE",
+		},
+		"email_verification_reports": []any{map[string]any{
+			"dns": "RESOLVED", "mx": "MX_PRESENT", "smtp": "SKIPPED_POLICY",
+		}},
+		"domain_resolution": map[string]any{
+			"canonical_domain": "qualidademineracao.com.br",
+			"confidence":       "HIGH",
+		},
+	}
+
+	lead := operatorCardToLead(card, nil, 1)
+	contact := lead.Contacts[0]
+	if contact.VerificationStatus != models.OutreachVerifyCandidateUnverified {
+		t.Fatalf("MX must not verify mailbox or identity: %+v", contact)
+	}
+	if contact.EmailSendReady == nil || *contact.EmailSendReady {
+		t.Fatalf("passive verification must stay unsendable: %+v", contact)
+	}
+	if lead.Company.Website != "https://qualidademineracao.com.br" {
+		t.Fatalf("resolved domain missing from projection: %+v", lead.Company)
+	}
+	joined := strings.Join(lead.MessagingContext.ClaimsToAvoid, " ")
+	if !strings.Contains(joined, "MX=MX_PRESENT") || !strings.Contains(joined, "nao prova caixa nem identidade") {
+		t.Fatalf("operator verification notice missing: %q", joined)
+	}
+	delete(card, "email_verification")
+	if aggregate := operatorVerificationNotice(card); !strings.Contains(aggregate, "candidatos=1") ||
+		!strings.Contains(aggregate, "identidade_provada=0") {
+		t.Fatalf("alternative-route verification summary missing: %q", aggregate)
+	}
+}
+
 func TestActionModePlansWithoutEmailReadiness(t *testing.T) {
 	now := time.Date(2026, 8, 14, 16, 0, 0, 0, time.UTC)
 	acc := &models.OutreachAccount{


### PR DESCRIPTION
## O que mudou

- consome o domínio canônico publicado pelo operator pack como site da conta
- preserva CANDIDATE_UNVERIFIED e INSTITUTIONAL_GENERIC no import
- mostra ao operador DNS, MX, catch-all, SMTP e identidade-provada como dimensões separadas
- mantém email_send_ready falso e todos os gates existentes
- documenta o contrato aditivo com extra-cli

## Por quê

O parser legado rotulava o contato do operator pack como OFFICIAL_SOURCE mesmo quando a nova verificação passiva apenas confirmava plausibilidade de domínio. A mudança remove essa ambiguidade sem criar uma segunda fonte de verdade.

## Validação

- testes focais do pacote confenge passaram
- go vet ./internal/app/confenge passou
- gofmt aplicado
- lint global encontrou arquivos preexistentes fora do recorte com formatação incompatível
- suíte completa do pacote expôs três falhas preexistentes/de ambiente (hard-gate de workflow, /bin/bash e file:// do Windows)

Nenhum auto-send foi habilitado; aprovação humana, kill switch, suppression e transport gates permanecem inalterados.
