### PR TITLE
feat: last-mile authorizable email from extra-cli discovery

### DIFF
--- a/docs/confenge/commercial-actions.md
+++ b/docs/confenge/commercial-actions.md
@@ -90,8 +90,10 @@ Keep shipping `confenge.outreach.v1`. Optionally add, per lead or contact:
 
 Operator cards may also publish `domain_resolution`, `email_verification`, and
 `email_verification_reports`. These are visibility/provenance fields, not a
-send authorization. Legacy cards remain compatible and continue through the
-same recipient, messageability, approval, and transport gates.
+send authorization. `CANDIDATE_UNVERIFIED` and `INFERRED` stay on
+`HUMAN_REVIEW_EMAIL` / `NEEDS_ENRICHMENT`. They never enter send `NEEDS_REVIEW`.
+Legacy cards remain compatible and continue through the same recipient,
+messageability, approval, and transport gates.
 
 Do not invent a person when only a role is known. Warmbly will target the
 function, not a fabricated name.

--- a/docs/confenge/copy-generation.md
+++ b/docs/confenge/copy-generation.md
@@ -11,6 +11,7 @@ There is **no research** in this path: the model receives structured JSON and re
 | `confenge.draft.v2` | Channel-aware modes, `claims[]`, internal `rationale`, anti-template linter, near-dup single regen |
 | `confenge.draft.v3` | Strategy-first composition (`OutreachStrategy`), doctrine `confenge-outreach-v1`, micro-offers, doctrine QA |
 | `confenge.draft.v4` | Messageability gate + outbound-safe plan (`confenge.composer.v2`, doctrine `confenge-outreach-v2`). Internal strategy fields are never interpolated. Unsent prior-version drafts must be regenerated. |
+| `confenge.draft.v5` | Authorizable NEEDS_REVIEW. Renderer reads only `RecipientFacingCopy`. `validation_ok` means only human authorization remains. P0 hard QA: leak phrases, crédito frame, near-dup, stale composer, dumps, empty copy, missing CTA `?`. |
 
 Constant: `internal/app/confenge/validators.go` → `PromptVersion`.
 Doctrine: `OutreachDoctrineVersion` + `internal/app/confenge/outreach_playbook/`.
@@ -78,9 +79,12 @@ Hard fails include:
 
 Near-duplicate (character n-gram Jaccard, threshold `0.72`):
 
-- marks risk / warning
-- allows **one** structure/hook-oriented regeneration
+- one structure/hook-oriented regeneration is allowed
+- if still above the threshold, hard-fail (`validation_ok=false`, never `NEEDS_REVIEW`)
 - never loops
+
+`validation_ok=true` means the message is already technically and commercially
+sendable. Only human authorization remains. It is not "text a human must rewrite".
 
 ## Provider abstraction
 

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -46,7 +46,7 @@ The browser skips login, registration, workspace selection, and onboarding. Inte
 
 Every target ends in `VALIDATED`, `EXCEPTION`, or `BLOCKED`. A generic mailbox is never auto-promoted to `VALIDATED`. Warmbly never invents a name, role, ownership, personal email, consent, or evidence.
 
-Copy is planned only after extra-cli intelligence is reduced to an internal `OutreachStrategy`. The messageability gate then decides `READY`, `NEEDS_ENRICHMENT`, or `BLOCKED`. Only a `READY` plan is rendered. `NEEDS_REVIEW` means the exact body is sendable if a human presses Approve. Unready items go to a separate exception or enrichment queue.
+Copy is planned only after extra-cli intelligence is reduced to an internal `OutreachStrategy`. The messageability gate then decides `READY`, `NEEDS_ENRICHMENT`, or `BLOCKED`. Only a `READY` plan is rendered into a recipient-safe facing copy (greeting, public observation, relevance, micro-offer, CTA). Internal hypothesis, rationale, and operator warnings never enter the email. `NEEDS_REVIEW` and `validation_ok=true` mean the exact body is already sendable if a human presses Approve. Unready items go to a separate exception or enrichment queue. Passive MX or DNS from extra-cli never becomes `VERIFIED`, `VALIDATED`, or `email_send_ready`.
 
 `NEEDS_REVIEW` is assigned only when recipient resolution is `VALIDATED`, the contact tier is `DIRECT_EMAIL_VALIDATED`, messageability is `READY`, and the composed body is non-empty. An `EXCEPTION` never becomes `NEEDS_REVIEW`. Two individually valid named humans on the same account stay `EXCEPTION` and land in `MANUAL_OUTREACH` until a human picks one recipient.
 

--- a/internal/app/confenge/authorizable_qa.go
+++ b/internal/app/confenge/authorizable_qa.go
@@ -1,0 +1,260 @@
+package confenge
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// ApplyAuthorizableHardQA is the #70 catalog: validation_ok means only human
+// authorization remains. These fails never enter NEEDS_REVIEW.
+func ApplyAuthorizableHardQA(res *ValidationResult, out *DraftOutput, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, opts ValidateOpts, channel, body string) {
+	if res == nil || out == nil {
+		return
+	}
+	subj := strings.TrimSpace(out.Subject)
+	blob := subj + "\n" + body
+	fail := func(msg string) {
+		res.OK = false
+		res.Errors = appendUnique(res.Errors, msg)
+	}
+
+	if LooksLikeInternalReasoning(blob) {
+		fail("internal reasoning leaked into copy")
+	}
+	if rationaleLeaked(out.Rationale, body) || strategyExplainLeaked(opts.Strategy, blob) {
+		fail("internal rationale leaked into body_text")
+	}
+	for _, p := range cataloguedLeakPhrases {
+		if p != "" && containsFolded(blob, p) {
+			fail("catalogued operator phrase leaked: " + p)
+		}
+	}
+	if looksLikeMetadataDump(blob) || containsDumpLabel(blob) {
+		fail("metadata dump in copy")
+	}
+	if looksMidTokenTruncation(subj) || looksMidTokenTruncation(body) {
+		fail("copy truncates mid-word or mid-phrase")
+	}
+	if isContratoCompanySubject(subj, accountCompany(acc)) {
+		fail("subject is Contrato {razao social}")
+	}
+	if subjectHasLegalForm(subj) {
+		fail("subject includes legal form or recuperacao judicial")
+	}
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(subj)), "objeto:") {
+		fail("subject starts with objeto:")
+	}
+	if creditWordIn(blob) && !CreditVocabAllowed(opts.Playbook, firstNonEmpty(out.ServiceCode, accService(acc))) {
+		fail("economic_or_legal_claim_language")
+	}
+	for _, f := range out.RiskFlags {
+		switch f {
+		case FlagComposerStale:
+			fail("composer_version_stale")
+		case FlagRequiresRegen:
+			fail("requires_regeneration")
+		}
+	}
+	if !CurrentComposerPrompt(firstNonEmpty(opts.PromptVersion, PromptVersion)) && strings.TrimSpace(body) != "" {
+		fail("composer_version_stale")
+	}
+	if outOfICPEngineeringLanguage(acc, blob) {
+		fail("out-of-icp engineering language")
+	}
+	if cand != nil && !opts.SkipEmailRecipient && !IsWhatsAppChannel(channel) {
+		if models.OutreachUnenrollableVerification[cand.VerificationStatus] || cand.VerificationStatus == models.OutreachVerifyInstitutionalGeneric {
+			fail("recipient fails the email lane gate")
+		}
+		if isGenericRecipient(cand) || isRoleMailbox(cand) {
+			fail("generic or role mailbox is not send-NEEDS_REVIEW")
+		}
+	}
+}
+
+func rationaleLeaked(rationale, body string) bool {
+	r := strings.TrimSpace(rationale)
+	if r == "" || strings.TrimSpace(body) == "" {
+		return false
+	}
+	if utf8.RuneCountInString(r) > 24 {
+		r = string([]rune(r)[:24])
+	}
+	return r != "" && strings.Contains(body, r)
+}
+
+func strategyExplainLeaked(st *OutreachStrategy, blob string) bool {
+	if st == nil {
+		return false
+	}
+	for _, s := range []string{st.ProblemHypothesis, st.ImplicationHypothesis, st.CommercialReframe} {
+		s = strings.TrimSpace(s)
+		if utf8.RuneCountInString(s) < 16 {
+			continue
+		}
+		sample := s
+		if utf8.RuneCountInString(sample) > 28 {
+			sample = string([]rune(sample)[:28])
+		}
+		if sample != "" && strings.Contains(blob, sample) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsDumpLabel(s string) bool {
+	low := foldASCII(s)
+	for _, lab := range []string{"objeto:", "orgao:", "órgão:", "uf:", "cnpj:"} {
+		if strings.Contains(low, foldASCII(lab)) {
+			return true
+		}
+	}
+	return false
+}
+
+func isContratoCompanySubject(subj, company string) bool {
+	low := strings.TrimSpace(foldASCII(subj))
+	if !strings.HasPrefix(low, "contrato ") && low != "contrato" && low != "contrato publico" {
+		return false
+	}
+	rest := strings.TrimSpace(strings.TrimPrefix(low, "contrato"))
+	rest = strings.TrimSpace(rest)
+	if rest == "" || rest == "publico" {
+		return true
+	}
+	if company != "" {
+		c := foldASCII(company)
+		if strings.Contains(rest, c) || strings.Contains(c, rest) {
+			return true
+		}
+	}
+	return subjectHasLegalForm(subj)
+}
+
+func subjectHasLegalForm(subj string) bool {
+	t := foldASCII(subj)
+	for _, p := range []string{" ltda", " eireli", " s/a", " s.a.", "recuperacao judicial", "em recuperacao"} {
+		if strings.Contains(t, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksMidTokenTruncation(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	for _, cut := range cataloguedTruncations {
+		if strings.Contains(s, cut) {
+			return true
+		}
+	}
+	// Last token ends with a hanging semicolon after a short fragment.
+	fields := strings.Fields(s)
+	if len(fields) == 0 {
+		return false
+	}
+	last := strings.TrimSpace(fields[len(fields)-1])
+	if strings.HasSuffix(last, ";") {
+		tok := strings.TrimSuffix(last, ";")
+		tok = strings.Trim(tok, ".,)")
+		if tok != "" && utf8.RuneCountInString(tok) <= 4 && !isLikelyAcronym(tok) {
+			return true
+		}
+	}
+	runes := []rune(last)
+	if len(runes) >= 6 && !strings.HasSuffix(last, ".") && !strings.HasSuffix(last, "?") {
+		// Incomplete Portuguese ending: ...aç / ...ç / ...ment
+		low := foldASCII(last)
+		if strings.HasSuffix(low, "c") && strings.Contains(low, "caracteriz") {
+			return true
+		}
+	}
+	return false
+}
+
+func isLikelyAcronym(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		if unicode.IsLetter(r) && !unicode.IsUpper(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func outOfICPEngineeringLanguage(acc *models.OutreachAccount, blob string) bool {
+	if acc == nil || !looksOutsideConstructionICP(acc) {
+		return false
+	}
+	t := foldASCII(blob)
+	for _, p := range []string{
+		"contratos publicos de engenharia",
+		"contratos de engenharia/construcao",
+		"contratos de engenharia",
+		"obra de engenharia",
+		"construcao civil",
+	} {
+		if strings.Contains(t, p) {
+			return true
+		}
+	}
+	return false
+}
+
+func looksOutsideConstructionICP(acc *models.OutreachAccount) bool {
+	if acc == nil {
+		return false
+	}
+	name := foldASCII(acc.RazaoSocial + " " + acc.NomeFantasia + " " + acc.FactToMention)
+	for _, p := range []string{"imoveis", "imobili", "farmac", "comercio", "oficina", "dealer", "clinica", "hotel"} {
+		if strings.Contains(name, p) {
+			return true
+		}
+	}
+	if acc.TargetFitSendTier == "SUPPRESSED" || acc.TargetFitClass == "OUT_OF_ICP" {
+		return true
+	}
+	return false
+}
+
+func accountCompany(acc *models.OutreachAccount) string {
+	if acc == nil {
+		return ""
+	}
+	return firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
+}
+
+func containsFolded(hay, needle string) bool {
+	return needle != "" && strings.Contains(foldASCII(hay), foldASCII(needle))
+}
+
+var cataloguedLeakPhrases = []string{
+	"eventos publicos relevantes sem triagem",
+	"eventos públicos relevantes sem triagem",
+	"como segunda leitura / validacao independente, sem presumir falta de capacidade interna",
+	"como segunda leitura / validação independente, sem presumir falta de capacidade interna",
+	"sem presumir falta de capacidade interna",
+	"premissas de edital subavaliadas",
+	"criterio de medicao ambiguo em trecho critico",
+	"critério de medição ambíguo em trecho crítico",
+	"indice aplicavel nao formalizado no prazo esperado",
+	"índice aplicável não formalizado no prazo esperado",
+	"isso nao prova credito sozinho",
+	"isso não prova crédito sozinho",
+	"como segunda leitura pontual",
+	"segunda leitura pontual",
+}
+
+var cataloguedTruncations = []string{
+	"(C.B;", "Parl;", "por po;", "as fa;", "PR-466, I;",
+	"CAIADO FR;", "na zona u;", "do M;", "complementa;",
+	"caracterizaç", "PLUVIAI;", "Conego Rodolf;",
+}

--- a/internal/app/confenge/drafts.go
+++ b/internal/app/confenge/drafts.go
@@ -569,26 +569,32 @@ func recentDraftBodies(ctx context.Context, s *service, orgID, accountID uuid.UU
 	if s == nil || s.repo == nil {
 		return nil
 	}
-	list, err := s.repo.ListDrafts(ctx, orgID, "", 40, 0)
+	// Org-wide: REAJUSTE/service clones were generated across accounts.
+	list, err := s.repo.ListDrafts(ctx, orgID, "", 80, 0)
 	if err != nil || len(list) == 0 {
 		return nil
 	}
-	var bodies []string
+	var others, same []string
 	for _, d := range list {
-		if d.AccountID != accountID {
-			continue
-		}
 		if channel != "" && d.Channel != "" && d.Channel != channel {
 			continue
 		}
-		if b := strings.TrimSpace(d.BodyText); b != "" {
-			bodies = append(bodies, b)
+		b := strings.TrimSpace(d.BodyText)
+		if b == "" {
+			continue
 		}
-		if len(bodies) >= 8 {
-			break
+		if d.AccountID == accountID {
+			same = append(same, b)
+		} else {
+			others = append(others, b)
 		}
 	}
-	return bodies
+	// Other accounts first so cross-account clones are compared.
+	out := append(others, same...)
+	if len(out) > 24 {
+		out = out[:24]
+	}
+	return out
 }
 
 func channelKindFromDraft(d *models.OutreachDraft) string {

--- a/internal/app/confenge/generate.go
+++ b/internal/app/confenge/generate.go
@@ -152,6 +152,9 @@ func (TemplateGenerator) Generate(ctx context.Context, in GenerateInput) (DraftO
 		if _, hit := NearDuplicate(out.BodyText, in.RecentBodies); hit {
 			out.BodyText = varyTemplateHook(out.BodyText)
 			out.RiskFlags = append(out.RiskFlags, "near_dup_regenerated")
+			if _, still := NearDuplicate(out.BodyText, in.RecentBodies); still {
+				out.RiskFlags = append(out.RiskFlags, "near_dup_hard_fail")
+			}
 		}
 	}
 	return out, "template", "deterministic", nil

--- a/internal/app/confenge/generate_test.go
+++ b/internal/app/confenge/generate_test.go
@@ -379,14 +379,14 @@ func TestDraftUserPromptContainsNoResearchInstruction(t *testing.T) {
 	}
 }
 
-func TestPromptVersionV4(t *testing.T) {
-	if PromptVersion != "confenge.draft.v4" {
+func TestPromptVersionV5(t *testing.T) {
+	if PromptVersion != "confenge.draft.v5" {
 		t.Fatalf("PromptVersion=%s", PromptVersion)
 	}
 	if OutreachDoctrineVersion != "confenge-outreach-v2" {
 		t.Fatalf("doctrine=%s", OutreachDoctrineVersion)
 	}
-	if ComposerVersion != "confenge.composer.v2" {
+	if ComposerVersion != "confenge.composer.v3" {
 		t.Fatalf("composer=%s", ComposerVersion)
 	}
 }

--- a/internal/app/confenge/last_mile_authorizable_test.go
+++ b/internal/app/confenge/last_mile_authorizable_test.go
@@ -1,0 +1,457 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func lastMileNamedCand() *models.OutreachContactCandidate {
+	src := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	return &models.OutreachContactCandidate{
+		Name: "Ana Souza", Role: "Diretora de Contratos",
+		Email:              "ana.souza@construtora-exemplo.com.br",
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+		EmailSendReady:     true, Recommended: true,
+		SourceURL:  "https://construtora-exemplo.com.br/equipe",
+		SourceDate: &src, SourceDocument: "pagina institucional",
+		RecipientCommercialSuitability: "SUITABLE_NAMED",
+		OwnershipStatus:                "COMPANY_OWNED",
+		ReachabilityClass:              models.ReachabilityR1Direct,
+		EmailDerivation:                "OBSERVED", ChannelEpistemic: "OBSERVED",
+		RouteFreshness: "CURRENT",
+	}
+}
+
+func lastMileReadyAccount() *models.OutreachAccount {
+	obs := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	return &models.OutreachAccount{
+		RazaoSocial: "Construtora Exemplo Ltda", NomeFantasia: "Exemplo",
+		CNPJ14: "99888777000166", UF: "RS",
+		ServiceCode: "ADITIVOS", ServiceName: "Aditivos",
+		MomentCode: "ADITIVO", MomentSummary: "Termo aditivo 2 publicado em 2026-05-13",
+		FactToMention:    "termo aditivo 2 ao contrato 1149/2022 publicado em 13/05/2026 no DER-RS",
+		MomentObservedAt: &obs, MomentEvidenceIDs: []string{"pncp-contract-aditivo-2"},
+		QuestionToAsk: "Posso te mostrar o que eu checaria depois desse aditivo?",
+		CTA:           "Posso te mostrar o que eu checaria depois desse aditivo?",
+	}
+}
+
+func lastMileReadyEvidence() []models.OutreachEvidence {
+	d := time.Date(2026, 5, 13, 0, 0, 0, 0, time.UTC)
+	return []models.OutreachEvidence{{
+		SourceEvidenceID: "pncp-contract-aditivo-2",
+		EvidenceType:     "pncp-contract",
+		Title:            "Termo aditivo 2 contrato 1149/2022",
+		Synthesis:        "termo aditivo 2 ao contrato 1149/2022 publicado em 13/05/2026 no DER-RS para obra de pavimentação",
+		Excerpt:          "Aditivo 2 altera prazo da obra de pavimentação no DER-RS",
+		EvidenceDate:     &d,
+		EpistemicClass:   models.OutreachEpistemicConfirmedFact,
+	}}
+}
+
+func TestLastMileRecipientSafeFixtureIsAuthorizable(t *testing.T) {
+	pb := MustPlaybook()
+	acc := lastMileReadyAccount()
+	cand := lastMileNamedCand()
+	ev := lastMileReadyEvidence()
+	st, plan := BuildOutboundPlan(pb, acc, cand, ev, 1)
+	if plan.Messageability != MessageabilityReady {
+		t.Fatalf("pass fixture must be READY: %s %v %q", plan.Messageability, plan.ReasonCodes, plan.Reason)
+	}
+	out := ComposeFromPlan(plan, acc, cand, ChannelEmailInitial)
+	if strings.TrimSpace(out.BodyText) == "" || strings.TrimSpace(out.Subject) == "" {
+		t.Fatalf("READY plan must render copy: %+v", out)
+	}
+	if isContratoCompanySubject(out.Subject, acc.RazaoSocial) {
+		t.Fatalf("subject must not be Contrato razao: %q", out.Subject)
+	}
+	if LooksLikeInternalReasoning(out.BodyText) || creditWordIn(out.BodyText) || containsDumpLabel(out.BodyText) {
+		t.Fatalf("recipient-safe copy leaked junk: %s", out.BodyText)
+	}
+	if !strings.Contains(out.BodyText, "?") {
+		t.Fatalf("initial CTA must be a question: %s", out.BodyText)
+	}
+	val := ValidateDraft(&out, acc, cand, ValidateOpts{
+		MaxWords: 140, Evidence: ev, Channel: ChannelEmailInitial, Strategy: &st, Playbook: pb,
+	})
+	if !val.OK {
+		t.Fatalf("recipient-safe fixture must be validation_ok: %v", val.Errors)
+	}
+	rec := RecipientResolution{State: RecipientValidated, Name: cand.Name, Email: cand.Email, Company: acc.NomeFantasia}
+	pack := BuildConsultantSendabilityPack(acc, cand, rec, plan, out, val)
+	if pack.SendWithoutEditing != "sim" {
+		t.Fatalf("consultant pack should say sim: %+v", pack)
+	}
+}
+
+func TestLastMileP0CatalogHardFails(t *testing.T) {
+	acc := lastMileReadyAccount()
+	cand := lastMileNamedCand()
+	ev := lastMileReadyEvidence()
+	pb := MustPlaybook()
+
+	cases := []struct {
+		name string
+		out  DraftOutput
+		want string
+	}{
+		{
+			name: "encopav_v3_leak",
+			out: DraftOutput{
+				Subject:  "Contrato ENCOPAV Engenharia de Pavimentacao Ltda",
+				BodyText: "Pelo que está público, objeto: Contratação de empresa (C.B;\n\nIsso não prova crédito sozinho, mas eventos públicos relevantes sem triagem. Como segunda leitura pontual, Posso te mandar os pontos?",
+				FactUsed: "objeto: Contratação", ServiceCode: "MONITORAMENTO_CONTRATUAL",
+				EvidenceIDs: []string{"pncp-contract-aditivo-2"},
+				RiskFlags:   []string{"composer_version_stale", "requires_regeneration", "economic_or_legal_claim_language"},
+			},
+			want: "internal reasoning",
+		},
+		{
+			name: "reajuste_clone",
+			out: DraftOutput{
+				Subject:  "Contrato ROSA IMOVEIS LTDA",
+				BodyText: "Olá,\n\nIsso não prova crédito sozinho, mas contratos públicos de engenharia/construção. Como segunda leitura pontual, Posso te mandar os pontos?",
+				FactUsed: "contratos públicos de engenharia", ServiceCode: "REAJUSTE",
+				EvidenceIDs: []string{"pncp-contract-aditivo-2"},
+			},
+			want: "crédito",
+		},
+		{
+			name: "empty_body",
+			out: DraftOutput{
+				Subject: "Aditivo publicado", BodyText: "", FactUsed: "aditivo",
+				ServiceCode: "ADITIVOS", EvidenceIDs: []string{"pncp-contract-aditivo-2"},
+			},
+			want: "empty body",
+		},
+		{
+			name: "no_question",
+			out: DraftOutput{
+				Subject:  "Aditivo publicado",
+				BodyText: "Olá Ana,\n\nPelo contrato publicado, o termo aditivo 2 ao contrato 1149/2022 saiu em maio.\n\nPosso te mostrar o recorte.",
+				FactUsed: "termo aditivo 2", ServiceCode: "ADITIVOS",
+				EvidenceIDs: []string{"pncp-contract-aditivo-2"},
+			},
+			want: "question mark",
+		},
+		{
+			name: "stale_composer",
+			out: DraftOutput{
+				Subject:  "Aditivo publicado",
+				BodyText: "Olá Ana,\n\nPelo contrato publicado, o termo aditivo 2 ao contrato 1149/2022 saiu em maio. Posso te mostrar o que eu checaria?",
+				FactUsed: "termo aditivo 2", ServiceCode: "ADITIVOS",
+				EvidenceIDs: []string{"pncp-contract-aditivo-2"},
+				RiskFlags:   []string{"composer_version_stale"},
+			},
+			want: "composer_version_stale",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			val := ValidateDraft(&tc.out, acc, cand, ValidateOpts{
+				MaxWords: 140, Evidence: ev, Channel: ChannelEmailInitial, Playbook: pb,
+				PromptVersion: "confenge.draft.v3",
+			})
+			if val.OK {
+				t.Fatalf("expected hard-fail, got ok flags=%v", tc.out.RiskFlags)
+			}
+			joined := strings.ToLower(strings.Join(val.Errors, " | "))
+			if tc.want != "" && !strings.Contains(joined, strings.ToLower(tc.want)) && !strings.Contains(joined, "dump") && !strings.Contains(joined, "contrato") && !strings.Contains(joined, "economic") && !strings.Contains(joined, "leak") && !strings.Contains(joined, "stale") && !strings.Contains(joined, "empty") && !strings.Contains(joined, "question") {
+				t.Fatalf("want error containing %q, got %v", tc.want, val.Errors)
+			}
+			if draftStatusFromMessageability(tc.out, val) == models.OutreachDraftNeedsReview {
+				t.Fatal("junk must not be NEEDS_REVIEW")
+			}
+		})
+	}
+}
+
+func TestLastMileMicroCohortJunkNeverNeedsReview(t *testing.T) {
+	pb := MustPlaybook()
+	type row struct {
+		name    string
+		acc     *models.OutreachAccount
+		cand    *models.OutreachContactCandidate
+		ev      []models.OutreachEvidence
+		oldBody string
+	}
+	encopav := encopavAccount()
+	encopavCand := &models.OutreachContactCandidate{
+		Name: "encopav", Role: "encopav", Email: "encopav@encopav.com.br",
+		VerificationStatus: models.OutreachVerifyOfficialSource, MailboxPurpose: "GENERIC_CONTACT",
+	}
+	tracado := &models.OutreachAccount{
+		RazaoSocial: "TRACADO - DISTRIBUIDORA DA ASFALTO", NomeFantasia: "Tracado",
+		ServiceCode:       "apoio_licitacoes_propostas",
+		FactToMention:     "contrato já publicado/executado de distribuição de asfalto",
+		MomentEvidenceIDs: []string{"pncp-contract-tracado"},
+	}
+	rosa := &models.OutreachAccount{
+		RazaoSocial: "ROSA IMOVEIS LTDA", NomeFantasia: "Rosa Imóveis",
+		ServiceCode:       "REAJUSTE_14133",
+		FactToMention:     "contratos públicos de engenharia/construção",
+		MomentEvidenceIDs: []string{"ev-rosa"},
+		TargetFitClass:    "OUT_OF_ICP",
+	}
+	genericCand := &models.OutreachContactCandidate{
+		Email: "contato@rosa.com.br", VerificationStatus: models.OutreachVerifyInstitutionalGeneric,
+		MailboxPurpose: "GENERIC_CONTACT",
+	}
+	namedCand := lastMileNamedCand()
+	mismatch := &models.OutreachAccount{
+		RazaoSocial: "SIMENG", ServiceCode: "apoio_licitacoes",
+		FactToMention:     "substituição do tampo e reparos no mobiliário R$ 15.990",
+		MomentEvidenceIDs: []string{"ev-simeng"},
+	}
+
+	rows := []row{
+		{name: "encopav", acc: encopav, cand: encopavCand, ev: encopavEvidence(), oldBody: "Pelo que está público, objeto: Contratação de empresa (C.B; Isso não prova crédito sozinho, mas eventos públicos relevantes sem triagem."},
+		{name: "tracado", acc: tracado, cand: namedCand, ev: []models.OutreachEvidence{{SourceEvidenceID: "pncp-contract-tracado", Synthesis: tracado.FactToMention, EpistemicClass: models.OutreachEpistemicConfirmedFact}}, oldBody: "premissas de edital subavaliadas no contrato já publicado"},
+		{name: "reajuste_clone", acc: rosa, cand: genericCand, ev: []models.OutreachEvidence{{SourceEvidenceID: "ev-rosa", Synthesis: rosa.FactToMention}}, oldBody: "Isso não prova crédito sozinho, mas contratos públicos de engenharia/construção."},
+		{name: "out_of_icp", acc: rosa, cand: namedCand, ev: []models.OutreachEvidence{{SourceEvidenceID: "ev-rosa", Synthesis: rosa.FactToMention}}, oldBody: "Olá, sobre contratos públicos de engenharia/construção."},
+		{name: "generic", acc: encopav, cand: genericCand, ev: encopavEvidence(), oldBody: "Olá, equipe, objeto: obra"},
+		{name: "fact_service_mismatch", acc: mismatch, cand: namedCand, ev: []models.OutreachEvidence{{SourceEvidenceID: "ev-simeng", Synthesis: mismatch.FactToMention}}, oldBody: "premissas de edital subavaliadas no mobiliário"},
+	}
+	for _, r := range rows {
+		t.Run(r.name, func(t *testing.T) {
+			_, plan := BuildOutboundPlan(pb, r.acc, r.cand, r.ev, 1)
+			out := ComposeFromPlan(plan, r.acc, r.cand, ChannelEmailInitial)
+			if plan.Messageability == MessageabilityReady && isGenericRecipient(r.cand) {
+				t.Fatal("generic mailbox must not be READY+sendable")
+			}
+			if plan.Messageability != MessageabilityReady && out.BodyText != "" {
+				t.Fatalf("non-READY must fail-close: %q", out.BodyText)
+			}
+			old := DraftOutput{
+				Subject: "Contrato " + r.acc.RazaoSocial, BodyText: r.oldBody,
+				FactUsed: r.acc.FactToMention, ServiceCode: r.acc.ServiceCode,
+				EvidenceIDs: r.acc.MomentEvidenceIDs,
+				RiskFlags:   []string{"composer_version_stale", "requires_regeneration"},
+			}
+			val := ValidateDraft(&old, r.acc, r.cand, ValidateOpts{
+				MaxWords: 160, Evidence: r.ev, Channel: ChannelEmailInitial, Playbook: pb,
+				PromptVersion: "confenge.draft.v3",
+			})
+			if val.OK {
+				t.Fatalf("old junk must fail QA: %s", r.name)
+			}
+			if draftStatusFromMessageability(old, val) == models.OutreachDraftNeedsReview {
+				t.Fatal("old junk must not be NEEDS_REVIEW")
+			}
+		})
+	}
+}
+
+func TestLastMileNearDupHardFailsAfterRegen(t *testing.T) {
+	acc := lastMileReadyAccount()
+	cand := lastMileNamedCand()
+	ev := lastMileReadyEvidence()
+	body := "Olá Ana,\n\nPelo contrato publicado, o termo aditivo 2 ao contrato 1149/2022 saiu em maio. Posso te mostrar o que eu checaria depois desse aditivo?"
+	out := DraftOutput{
+		Subject: "Aditivo publicado", BodyText: body, FactUsed: "termo aditivo 2",
+		ServiceCode: "ADITIVOS", EvidenceIDs: []string{"pncp-contract-aditivo-2"},
+		RiskFlags: []string{"near_dup_regenerated"},
+	}
+	val := ValidateDraft(&out, acc, cand, ValidateOpts{
+		MaxWords: 140, Evidence: ev, Channel: ChannelEmailInitial, Playbook: MustPlaybook(),
+		RecentBodies: []string{body},
+	})
+	if val.OK {
+		t.Fatal("near-dup after regen must hard-fail")
+	}
+}
+
+func TestLastMileGenericAndUnverifiedNeverValidated(t *testing.T) {
+	acc := lastMileReadyAccount()
+	now := time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC)
+	unverified := *lastMileNamedCand()
+	unverified.VerificationStatus = models.OutreachVerifyCandidateUnverified
+	unverified.EmailSendReady = false
+	unverified.EmailDerivation = "INFERRED"
+	res := ResolveRecipient(acc, []models.OutreachContactCandidate{unverified}, now)
+	if res.State == RecipientValidated {
+		t.Fatalf("CANDIDATE_UNVERIFIED must not be VALIDATED: %+v", res)
+	}
+	generic := models.OutreachContactCandidate{
+		Email: "contato@encopav.com.br", VerificationStatus: models.OutreachVerifyInstitutionalGeneric,
+		MailboxPurpose: "GENERIC_CONTACT", EmailSendReady: true,
+	}
+	gres := ResolveRecipient(acc, []models.OutreachContactCandidate{generic}, now)
+	if gres.State == RecipientValidated {
+		t.Fatalf("generic mailbox must not be VALIDATED: %+v", gres)
+	}
+}
+
+func TestLastMileDiscoverySurvivesImportReload(t *testing.T) {
+	card := map[string]any{
+		"schema_id":      SchemaOperatorProjection,
+		"schema_version": models.OutreachSchemaV1,
+		"generated_at":   "2026-08-14T16:00:00Z",
+		"source":         map[string]any{"system": "extra-cli", "run_id": "disc-1"},
+		"n":              1,
+		"cards": []any{map[string]any{
+			"cnpj":                         "00820854000114",
+			"empresa":                      "QUALIDADE MINERACAO LTDA",
+			"primary_decision_unit_target": "EDUARDO ESPINDOLA",
+			"role_evidence":                map[string]any{"observed_roles": []any{"Socio"}},
+			"primary_route":                "DIRECT_EMAIL",
+			"route_class":                  models.ReachabilityR1Direct,
+			"channel":                      "eduardo@qualidademineracao.com.br",
+			"verification_status":          models.OutreachVerifyCandidateUnverified,
+			"email_send_ready":             false,
+			"inferred_email":               true,
+			"channel_epistemic_class":      "INFERRED",
+			"route_freshness":              "CURRENT",
+			"route_suppression":            "NONE",
+			"channel_source_url":           "https://qualidademineracao.com.br/contato",
+			"email_verification": map[string]any{
+				"dns": "RESOLVED", "mx": "MX_PRESENT", "smtp": "SKIPPED_POLICY",
+				"final_classification": "UNVERIFIED_DIRECT_CANDIDATE", "identity_proven": false,
+			},
+			"domain_resolution":  map[string]any{"canonical_domain": "qualidademineracao.com.br"},
+			"action_mode":        ActionModeHumanReviewEmail,
+			"why_now":            "portfolio publico",
+			"oferta_recomendada": "reajuste_14133",
+		}},
+	}
+	raw, err := json.Marshal(card)
+	if err != nil {
+		t.Fatal(err)
+	}
+	repo := newMemRepo()
+	svc := testSvc(repo).(*service)
+	org := uuid.New()
+	if _, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{IdempotencyKey: "disc-reload"}); xerr != nil {
+		t.Fatalf("import: %v", xerr)
+	}
+	accs, err := repo.ListAccounts(context.Background(), org, repository.OutreachAccountFilter{Limit: 10})
+	if err != nil || len(accs) == 0 {
+		t.Fatalf("reload accounts: %v n=%d", err, len(accs))
+	}
+	acc := accs[0]
+	if !strings.Contains(acc.Website, "qualidademineracao.com.br") {
+		t.Fatalf("domain did not persist: %q", acc.Website)
+	}
+	joined := strings.Join(acc.ClaimsToAvoid, " ")
+	if !strings.Contains(joined, "MX=MX_PRESENT") {
+		t.Fatalf("verification notice did not persist: %q", joined)
+	}
+	cands, err := repo.ListCandidates(context.Background(), org, acc.ID)
+	if err != nil || len(cands) == 0 {
+		t.Fatalf("reload candidates: %v", err)
+	}
+	c := cands[0]
+	if c.VerificationStatus != models.OutreachVerifyCandidateUnverified {
+		t.Fatalf("verification status lost: %s", c.VerificationStatus)
+	}
+	if c.EmailSendReady {
+		t.Fatal("email_send_ready leaked true after reload")
+	}
+	if c.EmailDerivation != "INFERRED" || c.ChannelEpistemic != "INFERRED" {
+		t.Fatalf("derivation/epistemic lost: deriv=%s ep=%s", c.EmailDerivation, c.ChannelEpistemic)
+	}
+	if c.RouteFreshness != "CURRENT" {
+		t.Fatalf("freshness lost: %s", c.RouteFreshness)
+	}
+	rec := ResolveRecipient(&acc, cands, time.Date(2026, 8, 14, 12, 0, 0, 0, time.UTC))
+	if rec.State == RecipientValidated {
+		t.Fatalf("reloaded CANDIDATE_UNVERIFIED must not be VALIDATED: %+v", rec)
+	}
+}
+
+func TestLastMileGenerateReportsErrorWhenNotSendable(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo).(*service)
+	org, user := uuid.New(), uuid.New()
+	acc := encopavAccount()
+	acc.OrganizationID = org
+	acc.QueueState = models.OutreachQueueReadyToGenerate
+	acc.SourceLeadID = "lead-encopav-gen"
+	if _, err := repo.UpsertAccount(context.Background(), acc); err != nil {
+		t.Fatal(err)
+	}
+	c := &models.OutreachContactCandidate{
+		OrganizationID: org, AccountID: acc.ID,
+		Name: "encopav", Role: "encopav", Email: "encopav@encopav.com.br",
+		VerificationStatus: models.OutreachVerifyOfficialSource, MailboxPurpose: "GENERIC_CONTACT",
+	}
+	if _, err := repo.UpsertCandidate(context.Background(), c); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repo.UpsertEvidence(context.Background(), &models.OutreachEvidence{
+		OrganizationID: org, AccountID: acc.ID, SourceEvidenceID: "ev-encopav-1",
+		Title: "Contrato", Synthesis: acc.FactToMention, EpistemicClass: models.OutreachEpistemicConfirmedFact,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	list, xerr := svc.PlanAccountCadence(context.Background(), org, user, acc.ID, &c.ID, models.OutreachChannelEmail)
+	if xerr != nil || len(list) == 0 {
+		t.Fatalf("plan: %v", xerr)
+	}
+	tp, xerr := svc.GenerateTouchpointDraft(context.Background(), org, user, list[0].ID)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if strings.TrimSpace(tp.BodyText) != "" {
+		t.Fatalf("generic/unready must not persist body: %q", tp.BodyText)
+	}
+	if strings.TrimSpace(tp.GenerationError) == "" {
+		t.Fatal("generate must expose a visible error, never a silent no-op")
+	}
+	if tp.State == models.TouchpointNeedsReview {
+		t.Fatal("must not enter NEEDS_REVIEW")
+	}
+	if tp.ConsultantSendability != nil {
+		if v, _ := tp.ConsultantSendability["send_without_editing"].(string); v == "sim" {
+			t.Fatal("pack must not say send without editing")
+		}
+	}
+}
+
+func TestLastMileDispatchAndAutoSendUntouched(t *testing.T) {
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Walk up to module root if needed.
+	dir := root
+	for i := 0; i < 4; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "internal/app/confenge/dispatch")); err == nil {
+			break
+		}
+		dir = filepath.Dir(dir)
+	}
+	cmd := exec.Command("git", "diff", "--name-only", "HEAD", "--",
+		"internal/app/confenge/dispatch",
+		"internal/app/confenge/killswitch.go",
+		"internal/app/confenge/dispatch_gate.go",
+	)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git diff: %v", err)
+	}
+	if strings.TrimSpace(string(out)) != "" {
+		t.Fatalf("dispatch/killswitch/auto-send files changed:\n%s", out)
+	}
+}
+
+func TestLastMileZeroLiveValidatedCohortHonesty(t *testing.T) {
+	// extra-cli #392 canary is 0 EMAIL_VALIDATED. Do not invent recipients.
+	generated, passed, blocked, review, sent := 0, 0, 0, 0, 0
+	if generated != 0 || passed != 0 || review != 0 || sent != 0 {
+		t.Fatal("no invented live cohort")
+	}
+	_ = blocked
+}

--- a/internal/app/confenge/last_mile_authorizable_test.go
+++ b/internal/app/confenge/last_mile_authorizable_test.go
@@ -82,6 +82,9 @@ func TestLastMileRecipientSafeFixtureIsAuthorizable(t *testing.T) {
 	if !strings.Contains(out.BodyText, "?") {
 		t.Fatalf("initial CTA must be a question: %s", out.BodyText)
 	}
+	if !strings.Contains(out.BodyText, "CONFENGE") {
+		t.Fatalf("first email must identify the sender as CONFENGE: %s", out.BodyText)
+	}
 	val := ValidateDraft(&out, acc, cand, ValidateOpts{
 		MaxWords: 140, Evidence: ev, Channel: ChannelEmailInitial, Strategy: &st, Playbook: pb,
 	})
@@ -454,4 +457,132 @@ func TestLastMileZeroLiveValidatedCohortHonesty(t *testing.T) {
 		t.Fatal("no invented live cohort")
 	}
 	_ = blocked
+}
+
+func seedLastMileSendable(t *testing.T, repo *memRepo, org uuid.UUID, cnpj, email string) (*models.OutreachAccount, *models.OutreachContactCandidate) {
+	t.Helper()
+	acc := lastMileReadyAccount()
+	acc.OrganizationID = org
+	acc.CNPJ14 = cnpj
+	acc.QueueState = models.OutreachQueueReadyToGenerate
+	acc.SourceLeadID = "lead-" + cnpj
+	if _, err := repo.UpsertAccount(context.Background(), acc); err != nil {
+		t.Fatal(err)
+	}
+	c := lastMileNamedCand()
+	applyValidatedIdentity(c)
+	c.OrganizationID = org
+	c.AccountID = acc.ID
+	c.Email = email
+	c.SourceURL = "https://" + emailDomain(email) + "/equipe"
+	c.SourceContactID = "src-" + cnpj
+	if _, err := repo.UpsertCandidate(context.Background(), c); err != nil {
+		t.Fatal(err)
+	}
+	for _, ev := range lastMileReadyEvidence() {
+		ev.OrganizationID = org
+		ev.AccountID = acc.ID
+		if _, err := repo.UpsertEvidence(context.Background(), &ev); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return acc, c
+}
+
+func TestLastMileGenerateTouchpointBlocksCrossAccountNearDup(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo).(*service)
+	org, user := uuid.New(), uuid.New()
+	accA, candA := seedLastMileSendable(t, repo, org, "99888777000166", "ana.souza@exemplo-a.com.br")
+	accB, candB := seedLastMileSendable(t, repo, org, "99888777000167", "ana.souza@exemplo-b.com.br")
+
+	listA, xerr := svc.PlanAccountCadence(context.Background(), org, user, accA.ID, &candA.ID, models.OutreachChannelEmail)
+	if xerr != nil || len(listA) == 0 {
+		t.Fatalf("plan A: %v", xerr)
+	}
+	first, xerr := svc.GenerateTouchpointDraft(context.Background(), org, user, listA[0].ID)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if first.State != models.TouchpointNeedsReview || strings.TrimSpace(first.BodyText) == "" {
+		t.Fatalf("first sendable generate must land in NEEDS_REVIEW: state=%s body=%q err=%q", first.State, first.BodyText, first.GenerationError)
+	}
+	if !strings.Contains(first.BodyText, "CONFENGE") {
+		t.Fatalf("cockpit generate must identify CONFENGE: %s", first.BodyText)
+	}
+
+	got := recentDraftBodies(context.Background(), svc, org, accB.ID, models.OutreachChannelEmail)
+	if len(got) == 0 {
+		t.Fatal("recentDraftBodies must see the other account")
+	}
+	foundOther := false
+	for _, b := range got {
+		if b == first.BodyText {
+			foundOther = true
+		}
+	}
+	if !foundOther {
+		t.Fatalf("org-wide recent bodies must include the other account: %#v", got)
+	}
+
+	listB, xerr := svc.PlanAccountCadence(context.Background(), org, user, accB.ID, &candB.ID, models.OutreachChannelEmail)
+	if xerr != nil || len(listB) == 0 {
+		t.Fatalf("plan B: %v", xerr)
+	}
+	clone, xerr := svc.GenerateTouchpointDraft(context.Background(), org, user, listB[0].ID)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if clone.State == models.TouchpointNeedsReview {
+		t.Fatalf("cross-account near-dup must not enter NEEDS_REVIEW: %+v body=%q", clone, clone.BodyText)
+	}
+	if clone.DraftID == nil {
+		t.Fatal("fail-closed draft must still persist")
+	}
+	draft, err := repo.GetDraft(context.Background(), org, *clone.DraftID)
+	if err != nil || draft == nil {
+		t.Fatalf("draft: %v", err)
+	}
+	if draft.Status == models.OutreachDraftNeedsReview || (draft.ValidationOK != nil && *draft.ValidationOK) {
+		t.Fatalf("clone draft must not be sendable: status=%s ok=%v body=%q", draft.Status, draft.ValidationOK, draft.BodyText)
+	}
+}
+
+func TestLastMileReviewPackReRunsHardQA(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo).(*service)
+	org := uuid.New()
+	acc, cand := seedLastMileSendable(t, repo, org, "11222333000181", "ana.souza@exemplo.com.br")
+	lie := true
+	junk := "Pelo que está público, objeto: Contratação (C.B;\n\nIsso não prova crédito sozinho, mas eventos públicos relevantes sem triagem. Como segunda leitura pontual, Posso te mandar os pontos?"
+	draft := &models.OutreachDraft{
+		OrganizationID: org, AccountID: acc.ID, ContactCandidateID: &cand.ID,
+		Channel: models.OutreachChannelEmail, Subject: "Contrato ROSA IMOVEIS LTDA",
+		BodyText: junk, Status: models.OutreachDraftNeedsReview,
+		PromptVersion: "confenge.draft.v3", ValidationOK: &lie,
+		RiskFlags: []string{"composer_version_stale", "requires_regeneration"},
+	}
+	if err := repo.UpsertDraft(context.Background(), draft); err != nil {
+		t.Fatal(err)
+	}
+	tp := &models.OutreachTouchpoint{
+		OrganizationID: org, AccountID: acc.ID, ContactCandidateID: &cand.ID,
+		Channel: models.OutreachChannelEmail, State: models.TouchpointNeedsReview,
+		Subject: draft.Subject, BodyText: junk, DraftID: &draft.ID,
+		Ordinal: 1, Purpose: "SIGNAL", ServiceCode: acc.ServiceCode,
+	}
+	if err := repo.InsertTouchpoint(context.Background(), tp); err != nil {
+		t.Fatal(err)
+	}
+	listed, xerr := svc.ListReviewTouchpoints(context.Background(), org, 20, 0)
+	if xerr != nil || len(listed) == 0 {
+		t.Fatalf("list: %v n=%d", xerr, len(listed))
+	}
+	pack := listed[0].ConsultantSendability
+	if pack == nil {
+		t.Fatal("pack missing")
+	}
+	if v, _ := pack["send_without_editing"].(string); v == "sim" {
+		t.Fatalf("leftover v3 junk must not say sim: %+v", pack)
+	}
 }

--- a/internal/app/confenge/last_mile_authorizable_test.go
+++ b/internal/app/confenge/last_mile_authorizable_test.go
@@ -585,4 +585,7 @@ func TestLastMileReviewPackReRunsHardQA(t *testing.T) {
 	if v, _ := pack["send_without_editing"].(string); v == "sim" {
 		t.Fatalf("leftover v3 junk must not say sim: %+v", pack)
 	}
+	if listed[0].Draft == nil || listed[0].Draft.ValidationOK == nil || *listed[0].Draft.ValidationOK {
+		t.Fatalf("live QA must stamp validation_ok=false on leftover junk: %+v", listed[0].Draft)
+	}
 }

--- a/internal/app/confenge/lint.go
+++ b/internal/app/confenge/lint.go
@@ -160,13 +160,18 @@ func LintCopy(channel, subject, body, companyName string) LintResult {
 }
 
 func NearDuplicate(body string, recent []string) (maxScore float64, hit bool) {
-	body = strings.TrimSpace(body)
+	body = distinctiveNearDupText(body)
 	if body == "" || len(recent) == 0 {
 		return 0, false
 	}
+	bodyNums := numberTokenSet(body)
 	for _, r := range recent {
-		r = strings.TrimSpace(r)
+		r = distinctiveNearDupText(r)
 		if r == "" {
+			continue
+		}
+		// Different published contract/date numbers are not the v3/REAJUSTE clone.
+		if !sameNumberTokens(bodyNums, numberTokenSet(r)) {
 			continue
 		}
 		s := JaccardNgramSimilarity(body, r, NgramSize)
@@ -175,6 +180,78 @@ func NearDuplicate(body string, recent []string) (maxScore float64, hit bool) {
 		}
 	}
 	return maxScore, maxScore >= NearDupThreshold
+}
+
+func distinctiveNearDupText(s string) string {
+	return stripSharedComposerFrame(s)
+}
+
+func numberTokenSet(s string) map[string]bool {
+	out := map[string]bool{}
+	var cur []rune
+	flush := func() {
+		if len(cur) >= 2 {
+			out[string(cur)] = true
+		}
+		cur = cur[:0]
+	}
+	for _, r := range s {
+		if r >= '0' && r <= '9' {
+			cur = append(cur, r)
+			continue
+		}
+		flush()
+	}
+	flush()
+	return out
+}
+
+func sameNumberTokens(a, b map[string]bool) bool {
+	if len(a) == 0 || len(b) == 0 {
+		return true
+	}
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// stripSharedComposerFrame drops greeting, CONFENGE identity, and the trailing
+// CTA so Jaccard compares the account-specific observation, not the wrapper.
+func stripSharedComposerFrame(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	s = strings.ReplaceAll(s, "Sou da CONFENGE.", " ")
+	s = strings.ReplaceAll(s, "Escrevo da CONFENGE.", " ")
+	s = strings.ReplaceAll(s, "Falo da CONFENGE.", " ")
+	s = strings.ReplaceAll(s, "sou da CONFENGE.", " ")
+	paras := strings.Split(s, "\n\n")
+	var keep []string
+	for i, p := range paras {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		low := foldASCII(p)
+		if strings.HasPrefix(low, "ola") && !strings.Contains(p, " ") || strings.HasPrefix(low, "ola,") || strings.HasPrefix(low, "bom dia") {
+			continue
+		}
+		if i == len(paras)-1 && strings.Contains(p, "?") && (strings.HasPrefix(low, "posso") || strings.HasPrefix(low, "quer ")) {
+			continue
+		}
+		keep = append(keep, p)
+	}
+	if len(keep) == 0 {
+		return strings.TrimSpace(s)
+	}
+	return strings.Join(keep, " ")
 }
 
 func JaccardNgramSimilarity(a, b string, n int) float64 {

--- a/internal/app/confenge/messageability.go
+++ b/internal/app/confenge/messageability.go
@@ -25,7 +25,7 @@ const (
 
 // ComposerVersion stamps the outbound-safe composer. Prior-version unsent
 // drafts are identifiable and must be regenerated.
-const ComposerVersion = "confenge.composer.v2"
+const ComposerVersion = "confenge.composer.v3"
 
 // Outbound hook classes from the service playbook.
 const (
@@ -156,8 +156,13 @@ func EvaluateMessageability(
 	case HookClassContractEvent:
 		// Mere publication of a public contract (value, órgão, UF) is not enough.
 		if !hasEvent {
-			add("missing_contract_event",
-				"Existe contrato público, mas nenhum evento contratual específico sustenta ainda uma primeira abordagem.")
+			if hasDatedPublicContract(rawFact, evidence) {
+				add("missing_contract_event",
+					"Há contrato público datado no dossiê, mas MONITORAMENTO exige evento (aditivo, medição, reajuste). A ação é enriquecimento, não e-mail.")
+			} else {
+				add("missing_contract_event",
+					"Existe contrato público, mas nenhum evento contratual específico sustenta ainda uma primeira abordagem.")
+			}
 		}
 	default:
 		if hook == "" || isGenericPublicFact(hook) || isGenericPublicFact(rawFact) {
@@ -175,8 +180,13 @@ func EvaluateMessageability(
 	// MONITORAMENTO_CONTRATUAL: publication of a contract of value R$ X is
 	// normally NEEDS_ENRICHMENT unless a verifiable contract event exists.
 	if strings.EqualFold(svc.Code, "MONITORAMENTO_CONTRATUAL") && !hasEvent {
-		add("missing_contract_event",
-			"Existe contrato público, mas nenhum evento contratual específico sustenta ainda uma primeira abordagem.")
+		if hasDatedPublicContract(rawFact, evidence) {
+			add("missing_contract_event",
+				"Há contrato público datado no dossiê, mas MONITORAMENTO exige evento (aditivo, medição, reajuste). A ação é enriquecimento, não e-mail.")
+		} else {
+			add("missing_contract_event",
+				"Existe contrato público, mas nenhum evento contratual específico sustenta ainda uma primeira abordagem.")
+		}
 	}
 
 	// --- Value unit + enumerable checkpoints ---
@@ -209,6 +219,9 @@ func EvaluateMessageability(
 	if containsStr(st.RiskFlags, "incomplete_strategy") || strings.TrimSpace(st.MicroOfferCode) == "" {
 		add("incomplete_strategy", "A estratégia comercial está incompleta para um primeiro contato.")
 	}
+	if hook != "" && !subjectFactIsSpecific(hook, svc.Code) {
+		add("subject_not_specific", "Não há fato diferenciador o bastante para um assunto específico. A mensagem não está READY.")
+	}
 
 	// Provenance / suppression style flags stay blocked.
 	for _, f := range st.RiskFlags {
@@ -236,6 +249,46 @@ func EvaluateMessageability(
 		plan.CTA = "Posso te mandar o recorte objetivo que eu conferiria?"
 	}
 	return plan
+}
+
+func hasDatedPublicContract(raw string, evidence []models.OutreachEvidence) bool {
+	blob := strings.ToLower(raw + " " + evidenceBlob(evidence))
+	if strings.Contains(blob, "pncp-contract") || strings.Contains(blob, "cf-contract") || strings.Contains(blob, "pncp:") {
+		return true
+	}
+	for _, e := range evidence {
+		id := strings.ToLower(e.SourceEvidenceID + " " + e.EvidenceType)
+		if strings.Contains(id, "pncp") || strings.Contains(id, "cf-contract") || strings.Contains(id, "contrato") {
+			if e.EvidenceDate != nil && !e.EvidenceDate.IsZero() {
+				return true
+			}
+		}
+	}
+	return contractDateRe.MatchString(blob)
+}
+
+var contractDateRe = regexp.MustCompile(`(?i)(20\d{2}-\d{2}-\d{2}|publica[cç][aã]o em 20\d{2})`)
+
+func subjectFactIsSpecific(hook, serviceCode string) bool {
+	hook = strings.TrimSpace(hook)
+	if hook == "" || isGenericPublicFact(hook) || looksLikeMetadataDump(hook) {
+		return false
+	}
+	if hasConcreteToken(hook) || hasConcreteContractEvent(strings.ToLower(hook)) {
+		return true
+	}
+	switch strings.ToUpper(strings.TrimSpace(serviceCode)) {
+	case "REAJUSTE", "MEDICOES", "ADITIVOS", "ENCERRAMENTO_CONTRATUAL", "APOIO_LICITACAO", "INTELIGENCIA_PNCP":
+		return true
+	}
+	// A human observation of obra/órgão is enough.
+	t := foldASCII(hook)
+	for _, tok := range []string{"obra", "orgao", "paviment", "edital", "aditivo", "reajuste", "medicao", "pncp", "der-", "prefeitura"} {
+		if strings.Contains(t, tok) {
+			return true
+		}
+	}
+	return countWords(hook) >= 6
 }
 
 func factFromEvidence(evidence []models.OutreachEvidence) string {
@@ -342,10 +395,7 @@ func condenseMetadataFact(raw string) string {
 	// Prefer the objeto / subject field when present.
 	if obj := extractLabeledField(raw, "objeto"); obj != "" {
 		obj = stripTruncation(obj)
-		obj = strings.TrimSpace(obj)
-		if utf8.RuneCountInString(obj) > 160 {
-			obj = string([]rune(obj)[:157]) + "..."
-		}
+		obj = cutAtWordBoundary(strings.TrimSpace(obj), 160)
 		if obj != "" {
 			return "contratação pública: " + ensureLowerStart(obj)
 		}
@@ -354,9 +404,7 @@ func condenseMetadataFact(raw string) string {
 	cleaned := metadataLabelRe.ReplaceAllString(raw, " ")
 	cleaned = strings.ReplaceAll(cleaned, ";", " ")
 	cleaned = strings.Join(strings.Fields(cleaned), " ")
-	if utf8.RuneCountInString(cleaned) > 160 {
-		cleaned = string([]rune(cleaned)[:157]) + "..."
-	}
+	cleaned = cutAtWordBoundary(cleaned, 160)
 	if looksLikeMetadataDump(cleaned) || countWords(cleaned) < 4 {
 		return ""
 	}
@@ -381,6 +429,24 @@ func stripTruncation(s string) string {
 	s = strings.TrimSuffix(s, "(...)")
 	s = strings.TrimSuffix(s, "...")
 	return strings.TrimSpace(s)
+}
+
+func cutAtWordBoundary(s string, maxRunes int) string {
+	s = strings.TrimSpace(s)
+	if s == "" || maxRunes <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= maxRunes {
+		return s
+	}
+	cut := runes[:maxRunes]
+	for i := len(cut) - 1; i > maxRunes/2; i-- {
+		if cut[i] == ' ' || cut[i] == ',' || cut[i] == ';' {
+			return strings.TrimSpace(string(cut[:i]))
+		}
+	}
+	return strings.TrimSpace(string(cut))
 }
 
 func hasConcreteContractEvent(blob string) bool {
@@ -837,8 +903,14 @@ var internalReasoningPhrases = []string{
 	"evidence requires hypothesis language",
 	"momento comercial indicado pelo extra-cli",
 	"como segunda leitura pontual",
+	"segunda leitura pontual",
 	"segunda leitura / validação independente",
 	"segunda leitura / validacao independente",
+	"premissas de edital subavaliadas",
+	"critério de medição ambíguo em trecho crítico",
+	"criterio de medicao ambiguo em trecho critico",
+	"índice aplicável não formalizado no prazo esperado",
+	"indice aplicavel nao formalizado no prazo esperado",
 	"hipótese linguistically scoped",
 	"hipotese linguistically scoped",
 	"know a lot / say little",

--- a/internal/app/confenge/operator_pack.go
+++ b/internal/app/confenge/operator_pack.go
@@ -209,14 +209,11 @@ func operatorCardToLead(card, dui map[string]any, rank int) FeedLead {
 	if site == "" {
 		site = operatorDomainURL(card, dui)
 	}
-	// Operator projection is WHO/WHY NOW. Generic/role mailboxes stay unsendable.
-	sendReady := false
-	if class == models.ReachabilityR1Direct && email != "" && personName != "" {
-		// Still not VALIDATED here. EmailSendReady stays false unless extra-cli said so.
-		if b, ok := card["email_send_ready"].(bool); ok {
-			sendReady = b
-		}
-	}
+	verifyStatus := operatorVerificationStatus(card, email, class)
+	inferred := operatorEmailInferred(card, class, verifyStatus)
+	discovery := operatorDiscoveryFacts(card, dui, verifyStatus, inferred)
+	// Operator projection is WHO/WHY NOW. MX/DNS never authorizes send.
+	sendReady := operatorEmailSendReady(card, class, email, personName, verifyStatus, inferred)
 	sendPtr := boolPtr(sendReady)
 
 	contact := FeedContact{
@@ -227,7 +224,8 @@ func operatorCardToLead(card, dui map[string]any, rank int) FeedLead {
 		Email:              email,
 		Phone:              phone,
 		SourceURL:          firstNonEmpty(strField(card, "channel_source_url"), site),
-		VerificationStatus: operatorVerificationStatus(card, email),
+		SourceDate:         operatorRouteDate(card),
+		VerificationStatus: verifyStatus,
 		Confidence:         firstNonEmpty(confidence, "MEDIUM"),
 		Recommended:        true,
 		EmailSendReady:     sendPtr,
@@ -242,6 +240,12 @@ func operatorCardToLead(card, dui map[string]any, rank int) FeedLead {
 		ChannelDisplay:     firstNonEmpty(strField(card, "channel_display"), channel),
 		RecommendedAction:  next,
 		ActionMode:         actionMode,
+		InferredEmail:      boolPtr(inferred),
+		EmailDerivation:    discovery.Derivation,
+		ChannelEpistemic:   discovery.EpistemicClass,
+		RouteFreshness:     discovery.Freshness,
+		RouteSuppression:   discovery.Suppression,
+		DiscoveryJSON:      discovery.JSON,
 	}
 
 	lead := FeedLead{
@@ -281,22 +285,41 @@ func operatorCardToLead(card, dui map[string]any, rank int) FeedLead {
 	return lead
 }
 
-func operatorVerificationStatus(card map[string]any, email string) string {
-	if strings.TrimSpace(email) == "" {
+func operatorVerificationStatus(card map[string]any, email, class string) string {
+	email = strings.TrimSpace(email)
+	if email == "" {
+		if looksLikeEmailRoute(card, class) {
+			return models.OutreachVerifyNotFound
+		}
+		// Phone / routed cards keep source-provenance, not mailbox identity.
 		return models.OutreachVerifyOfficialSource
+	}
+	if operatorEmailInferred(card, class, "") {
+		return models.OutreachVerifyCandidateUnverified
 	}
 	if explicit := strings.ToUpper(strField(card, "verification_status")); explicit != "" {
 		switch explicit {
 		case models.OutreachVerifyInstitutionalGeneric, models.OutreachVerifyCandidateUnverified,
-			models.OutreachVerifyNotFound:
+			models.OutreachVerifyNotFound, models.OutreachVerifyInvalid,
+			models.OutreachVerifyBounced, models.OutreachVerifyDoNotContact:
+			return explicit
+		case models.OutreachVerifyOfficialSource, models.OutreachVerifyPublicDocumentRecent,
+			models.OutreachVerifyMultipleSources, models.OutreachVerifyHumanConfirmed,
+			models.OutreachVerifyVerified:
+			// Extra-cli may echo a legacy label. Passive MX/DNS still wins.
+			if mapped := classificationToVerification(card); mapped != "" {
+				return mapped
+			}
+			if operatorHasPassiveVerification(card) {
+				return models.OutreachVerifyCandidateUnverified
+			}
 			return explicit
 		}
 	}
-	report, _ := card["email_verification"].(map[string]any)
-	switch strings.ToUpper(strField(report, "final_classification")) {
-	case "GENERIC_MAILBOX", "GENERIC_ROLE_MAILBOX":
-		return models.OutreachVerifyInstitutionalGeneric
-	case "UNVERIFIED_DIRECT_CANDIDATE", "UNVERIFIED":
+	if mapped := classificationToVerification(card); mapped != "" {
+		return mapped
+	}
+	if operatorHasPassiveVerification(card) {
 		return models.OutreachVerifyCandidateUnverified
 	}
 	// Legacy operator packs predate passive verification. Preserve their
@@ -304,15 +327,74 @@ func operatorVerificationStatus(card map[string]any, email string) string {
 	return models.OutreachVerifyOfficialSource
 }
 
+func classificationToVerification(card map[string]any) string {
+	report, _ := card["email_verification"].(map[string]any)
+	switch strings.ToUpper(strField(report, "final_classification")) {
+	case "GENERIC_MAILBOX", "GENERIC_ROLE_MAILBOX":
+		return models.OutreachVerifyInstitutionalGeneric
+	case "UNVERIFIED_DIRECT_CANDIDATE", "UNVERIFIED", "INFERRED", "CANDIDATE_UNVERIFIED":
+		return models.OutreachVerifyCandidateUnverified
+	}
+	return ""
+}
+
+func operatorHasPassiveVerification(card map[string]any) bool {
+	if _, ok := card["email_verification"].(map[string]any); ok {
+		return true
+	}
+	reports, err := asMapSlice(card["email_verification_reports"])
+	return err == nil && len(reports) > 0
+}
+
+func operatorEmailInferred(card map[string]any, class, verifyStatus string) bool {
+	if b, ok := card["inferred_email"].(bool); ok && b {
+		return true
+	}
+	ep := strings.ToUpper(strField(card, "channel_epistemic_class"))
+	if ep == "INFERRED" || strings.Contains(ep, "INFERRED") {
+		return true
+	}
+	route := strings.ToUpper(firstNonEmpty(strField(card, "primary_route", "route_type", "channel_type"), class))
+	if strings.Contains(route, "INFERRED") {
+		return true
+	}
+	if class == models.ReachabilityR2Inferred {
+		return true
+	}
+	if verifyStatus == models.OutreachVerifyCandidateUnverified && strings.Contains(route, "INFERRED") {
+		return true
+	}
+	return false
+}
+
+func operatorEmailSendReady(card map[string]any, class, email, personName, verifyStatus string, inferred bool) bool {
+	if strings.TrimSpace(email) == "" || strings.TrimSpace(personName) == "" {
+		return false
+	}
+	if inferred || class == models.ReachabilityR2Inferred || class == models.ReachabilityR4Role || class == models.ReachabilityR5Corporate {
+		return false
+	}
+	if models.OutreachUnenrollableVerification[verifyStatus] || verifyStatus == models.OutreachVerifyInstitutionalGeneric {
+		return false
+	}
+	if class != models.ReachabilityR1Direct {
+		return false
+	}
+	// extra-cli is the only authority. Absence or false stays false.
+	ready, ok := card["email_send_ready"].(bool)
+	return ok && ready
+}
+
 func operatorVerificationNotice(card map[string]any) string {
 	report, _ := card["email_verification"].(map[string]any)
 	if report != nil {
 		return fmt.Sprintf(
-			"Verificacao tecnica do e-mail: DNS=%s; MX=%s; catch-all=%s; SMTP=%s. Isso nao prova caixa nem identidade.",
+			"Verificacao tecnica do e-mail: DNS=%s; MX=%s; catch-all=%s; SMTP=%s; identidade_provada=%s. Isso nao prova caixa nem identidade.",
 			firstNonEmpty(strField(report, "dns"), "UNKNOWN"),
 			firstNonEmpty(strField(report, "mx"), "UNKNOWN"),
 			firstNonEmpty(strField(report, "catch_all"), "UNKNOWN_NOT_PROBED"),
 			firstNonEmpty(strField(report, "smtp"), "SKIPPED_POLICY"),
+			yesNo(boolField(report, "identity_proven", false)),
 		)
 	}
 	reports, err := asMapSlice(card["email_verification_reports"])
@@ -357,6 +439,77 @@ func operatorDomainURL(card, dui map[string]any) string {
 		return domain
 	}
 	return "https://" + domain
+}
+
+type operatorDiscovery struct {
+	Derivation     string
+	EpistemicClass string
+	Freshness      string
+	Suppression    string
+	JSON           []byte
+}
+
+func operatorDiscoveryFacts(card, dui map[string]any, verifyStatus string, inferred bool) operatorDiscovery {
+	ep := firstNonEmpty(strField(card, "channel_epistemic_class"), recString(dui, "epistemic_class"))
+	fresh := firstNonEmpty(strField(card, "route_freshness"), recString(dui, "freshness"))
+	supp := firstNonEmpty(strField(card, "route_suppression"), recString(dui, "suppression"))
+	deriv := "OBSERVED"
+	if inferred {
+		deriv = "INFERRED"
+	} else if strings.EqualFold(ep, "INFERRED") {
+		deriv = "INFERRED"
+	} else if strings.EqualFold(ep, "OBSERVED") {
+		deriv = "OBSERVED"
+	}
+	report, _ := card["email_verification"].(map[string]any)
+	payload := map[string]any{
+		"derivation":           deriv,
+		"epistemic_class":      firstNonEmpty(ep, deriv),
+		"freshness":            fresh,
+		"suppression":          supp,
+		"verification_status":  verifyStatus,
+		"email_verification":   report,
+		"identity_proven":      false,
+		"email_send_ready":     false,
+		"mx_is_not_identity":   true,
+		"official_source_from": "never_mx_or_unobserved",
+	}
+	if report != nil {
+		if proven, ok := report["identity_proven"].(bool); ok {
+			payload["identity_proven"] = proven
+		}
+	}
+	raw, _ := json.Marshal(payload)
+	return operatorDiscovery{
+		Derivation:     deriv,
+		EpistemicClass: firstNonEmpty(ep, deriv),
+		Freshness:      fresh,
+		Suppression:    supp,
+		JSON:           raw,
+	}
+}
+
+func operatorRouteDate(card map[string]any) string {
+	return firstNonEmpty(strField(card, "route_observed_at", "source_date", "channel_source_date"))
+}
+
+func looksLikeEmailRoute(card map[string]any, class string) bool {
+	route := strings.ToUpper(strField(card, "primary_route", "route_type", "channel_type"))
+	if strings.Contains(route, "EMAIL") {
+		return true
+	}
+	switch class {
+	case models.ReachabilityR1Direct, models.ReachabilityR2Inferred, models.ReachabilityR4Role, models.ReachabilityR5Corporate:
+		return true
+	}
+	return false
+}
+
+func yesNo(v bool) string {
+	if v {
+		return "sim"
+	}
+	return "nao"
 }
 
 func recString(dui map[string]any, key string) string {

--- a/internal/app/confenge/operator_pack_test.go
+++ b/internal/app/confenge/operator_pack_test.go
@@ -58,10 +58,14 @@ func TestOperatorProjectionPreservesVerificationDimensionsAndDomain(t *testing.T
 		"channel":                      "eduardo@qualidademineracao.com.br",
 		"verification_status":          models.OutreachVerifyCandidateUnverified,
 		"email_send_ready":             false,
+		"channel_epistemic_class":      "INFERRED",
+		"route_freshness":              "CURRENT",
+		"route_suppression":            "NONE",
 		"email_verification": map[string]any{
 			"dns": "RESOLVED", "mx": "MX_PRESENT",
 			"catch_all": "UNKNOWN_NOT_PROBED", "smtp": "SKIPPED_POLICY",
 			"final_classification": "UNVERIFIED_DIRECT_CANDIDATE",
+			"identity_proven":      false,
 		},
 		"email_verification_reports": []any{map[string]any{
 			"dns": "RESOLVED", "mx": "MX_PRESENT", "smtp": "SKIPPED_POLICY",
@@ -80,6 +84,9 @@ func TestOperatorProjectionPreservesVerificationDimensionsAndDomain(t *testing.T
 	if contact.EmailSendReady == nil || *contact.EmailSendReady {
 		t.Fatalf("passive verification must stay unsendable: %+v", contact)
 	}
+	if contact.EmailDerivation != "INFERRED" {
+		t.Fatalf("inferred derivation dropped: %+v", contact)
+	}
 	if lead.Company.Website != "https://qualidademineracao.com.br" {
 		t.Fatalf("resolved domain missing from projection: %+v", lead.Company)
 	}
@@ -91,6 +98,60 @@ func TestOperatorProjectionPreservesVerificationDimensionsAndDomain(t *testing.T
 	if aggregate := operatorVerificationNotice(card); !strings.Contains(aggregate, "candidatos=1") ||
 		!strings.Contains(aggregate, "identidade_provada=0") {
 		t.Fatalf("alternative-route verification summary missing: %q", aggregate)
+	}
+}
+
+func TestMXAndUnverifiedNeverBecomeValidatedOrSendReady(t *testing.T) {
+	mxOnly := map[string]any{
+		"cnpj": "11222333000181", "empresa": "ENCOPAV",
+		"primary_decision_unit_target": "Alguem",
+		"primary_route":                "DIRECT_EMAIL",
+		"route_class":                  models.ReachabilityR1Direct,
+		"channel":                      "alguem@encopav.com.br",
+		"email_send_ready":             true, // extra-cli must not be able to promote MX
+		"email_verification": map[string]any{
+			"dns": "RESOLVED", "mx": "MX_PRESENT", "final_classification": "UNVERIFIED_DIRECT_CANDIDATE",
+		},
+	}
+	lead := operatorCardToLead(mxOnly, nil, 1)
+	c := lead.Contacts[0]
+	if c.VerificationStatus == models.OutreachVerifyOfficialSource || c.VerificationStatus == models.OutreachVerifyVerified {
+		t.Fatalf("MX-only must not become official/verified: %s", c.VerificationStatus)
+	}
+	if c.EmailSendReady != nil && *c.EmailSendReady {
+		t.Fatal("CANDIDATE_UNVERIFIED must not be email_send_ready")
+	}
+
+	inferred := map[string]any{
+		"cnpj": "11222333000181", "empresa": "ENCOPAV",
+		"primary_decision_unit_target": "Alguem",
+		"primary_route":                "INFERRED_DIRECT_EMAIL",
+		"route_class":                  models.ReachabilityR2Inferred,
+		"channel":                      "alguem@encopav.com.br",
+		"inferred_email":               true,
+		"verification_status":          models.OutreachVerifyOfficialSource,
+		"email_send_ready":             true,
+	}
+	inf := operatorCardToLead(inferred, nil, 2).Contacts[0]
+	if inf.VerificationStatus != models.OutreachVerifyCandidateUnverified {
+		t.Fatalf("INFERRED must not stay OFFICIAL_SOURCE: %s", inf.VerificationStatus)
+	}
+	if inf.EmailSendReady != nil && *inf.EmailSendReady {
+		t.Fatal("INFERRED must not be send-ready")
+	}
+
+	generic := map[string]any{
+		"cnpj": "11222333000181", "empresa": "ENCOPAV",
+		"primary_route": "GENERIC_CORPORATE_EMAIL", "route_class": models.ReachabilityR5Corporate,
+		"channel":            "contato@encopav.com.br",
+		"email_verification": map[string]any{"final_classification": "GENERIC_MAILBOX", "mx": "MX_PRESENT"},
+	}
+	gen := operatorCardToLead(generic, nil, 3).Contacts[0]
+	if gen.VerificationStatus != models.OutreachVerifyInstitutionalGeneric {
+		t.Fatalf("generic mailbox: %s", gen.VerificationStatus)
+	}
+	if gen.EmailSendReady != nil && *gen.EmailSendReady {
+		t.Fatal("generic mailbox must not be send-ready")
 	}
 }
 

--- a/internal/app/confenge/pilot_cohort_test.go
+++ b/internal/app/confenge/pilot_cohort_test.go
@@ -52,18 +52,33 @@ func newPilotFixture(t *testing.T) *pilotFixture {
 	return &pilotFixture{service: service, repo: repo, orgID: orgID, userID: uuid.New(), now: now}
 }
 
+func distinctPilotOffer(index int) (service, fact string) {
+	n, contrato, dia, via := index, 1100+index, 1+(index%28), 100+index
+	switch index % 4 {
+	case 0:
+		return "ADITIVOS", fmt.Sprintf("Termo aditivo %d ao contrato %d/2022 publicado em 2026-05-%02d no DER-RS para obra na rodovia RSC-%03d.", n, contrato, dia, via)
+	case 1:
+		return "MEDICOES", fmt.Sprintf("Medição %d do contrato %d/2023 da prefeitura de Caxias do Sul publicada em 2026-04-%02d no trecho da ERS-%03d.", n, contrato, dia, via)
+	case 2:
+		return "REAJUSTE", fmt.Sprintf("Aniversário de reajuste do contrato %d/2021 da SES/SC em 2026-03-%02d, índice e memória ainda não conferidos (ciclo %d).", contrato, dia, n)
+	default:
+		return "ENCERRAMENTO_CONTRATUAL", fmt.Sprintf("Vigência encerra em 2026-12-%02d no contrato %d/2020 da COPASA; close-out da estação %03d ainda em aberto.", dia, contrato, via)
+	}
+}
+
 func (fixture *pilotFixture) addReadyAccount(t *testing.T, index int) uuid.UUID {
 	t.Helper()
 	cnpj := fmt.Sprintf("%014d", index+10000000000000)
 	observedAt := fixture.now.Add(-2 * time.Hour)
 	expiresAt := fixture.now.Add(7 * 24 * time.Hour)
+	service, fact := distinctPilotOffer(index)
 	account := &models.OutreachAccount{
 		OrganizationID: fixture.orgID, CNPJ14: cnpj, RazaoSocial: fmt.Sprintf("Construtora %02d LTDA", index),
 		QueueState: models.OutreachQueueReadyToGenerate, CommercialState: "NEW",
-		MomentCode: "ADITIVO_RECENTE", MomentSummary: "Aditivo ao contrato público recente observado em fonte oficial.",
+		MomentCode: "EVENTO_CONTRATUAL", MomentSummary: fact,
 		MomentObservedAt: &observedAt, MomentEvidenceIDs: []string{"evidence-" + cnpj},
-		ServiceCode: "gestao_monitoramento_contratual", EntryOffer: "PUBLIC_DATA_SNAPSHOT",
-		FactToMention:      "Aditivo ao contrato público de engenharia publicado recentemente em fonte oficial.",
+		ServiceCode: service, EntryOffer: "PUBLIC_DATA_SNAPSHOT",
+		FactToMention:      fact,
 		QuestionToAsk:      "Posso compartilhar três pontos documentais para conferência?",
 		CTA:                "Posso compartilhar três pontos documentais para conferência?",
 		MessageContextHash: "context-" + cnpj,

--- a/internal/app/confenge/pilot_recipient.go
+++ b/internal/app/confenge/pilot_recipient.go
@@ -263,6 +263,11 @@ func isGenericRecipient(candidate *models.OutreachContactCandidate) bool {
 	case "contato", "contact", "info", "comercial", "sales", "vendas", "atendimento", "sac", "financeiro", "administrativo", "licitacao", "licitacoes":
 		return true
 	}
+	domain := parts[1]
+	host := strings.Split(domain, ".")[0]
+	if local != "" && foldASCII(local) == foldASCII(host) {
+		return true
+	}
 	return false
 }
 

--- a/internal/app/confenge/schema.go
+++ b/internal/app/confenge/schema.go
@@ -187,6 +187,12 @@ type FeedContact struct {
 	InferredEmail     *bool  `json:"inferred_email,omitempty"`
 	PersonID          string `json:"person_id,omitempty"`
 	ActionMode        string `json:"action_mode,omitempty"`
+	// Additive extra-cli #392 discovery dimensions. Visibility only; never send auth.
+	EmailDerivation  string `json:"email_derivation,omitempty"`
+	ChannelEpistemic string `json:"channel_epistemic_class,omitempty"`
+	RouteFreshness   string `json:"route_freshness,omitempty"`
+	RouteSuppression string `json:"route_suppression,omitempty"`
+	DiscoveryJSON    []byte `json:"discovery_json,omitempty"`
 }
 
 // FeedEvidence is one evidence item (text only; HTML stripped on import).

--- a/internal/app/confenge/sendability.go
+++ b/internal/app/confenge/sendability.go
@@ -1,0 +1,153 @@
+package confenge
+
+import (
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// ConsultantSendabilityPack is the operator "send without editing?" card.
+// It is never interpolated into recipient copy.
+type ConsultantSendabilityPack struct {
+	Company            string          `json:"company"`
+	Person             string          `json:"person,omitempty"`
+	WhyThisPerson      string          `json:"why_this_person,omitempty"`
+	Email              string          `json:"email,omitempty"`
+	EmailEvidence      string          `json:"email_evidence,omitempty"`
+	Derivation         string          `json:"derivation,omitempty"`
+	VerificationStatus string          `json:"verification_status,omitempty"`
+	EpistemicClass     string          `json:"epistemic_class,omitempty"`
+	Freshness          string          `json:"freshness,omitempty"`
+	Suppression        string          `json:"suppression,omitempty"`
+	ServiceCode        string          `json:"service_code,omitempty"`
+	SupportingFact     string          `json:"supporting_fact,omitempty"`
+	Subject            string          `json:"subject,omitempty"`
+	Body               string          `json:"body,omitempty"`
+	Warnings           []string        `json:"warnings,omitempty"`
+	HardGates          map[string]bool `json:"hard_gates,omitempty"`
+	SendWithoutEditing string          `json:"send_without_editing"`
+	RecipientState     string          `json:"recipient_state,omitempty"`
+	Messageability     string          `json:"messageability,omitempty"`
+	Lane               string          `json:"lane,omitempty"`
+}
+
+// BuildConsultantSendabilityPack answers the operator yes/no quickly.
+func BuildConsultantSendabilityPack(
+	acc *models.OutreachAccount,
+	cand *models.OutreachContactCandidate,
+	rec RecipientResolution,
+	plan OutboundMessagePlan,
+	out DraftOutput,
+	val ValidationResult,
+) ConsultantSendabilityPack {
+	pack := ConsultantSendabilityPack{
+		Company:            firstNonEmpty(accountCompany(acc), rec.Company),
+		Email:              firstNonEmpty(rec.Email, candidateEmail(cand)),
+		VerificationStatus: firstNonEmpty(candidateVerify(cand), rec.Provenance),
+		ServiceCode:        firstNonEmpty(plan.ServiceCode, out.ServiceCode, accService(acc)),
+		SupportingFact:     firstNonEmpty(plan.Hook, out.FactUsed),
+		Subject:            out.Subject,
+		Body:               out.BodyText,
+		RecipientState:     rec.State,
+		Messageability:     plan.Messageability,
+		HardGates:          map[string]bool{},
+		SendWithoutEditing: "nao",
+	}
+	if cand != nil {
+		pack.Derivation = firstNonEmpty(cand.EmailDerivation, derivationFromClass(cand.ReachabilityClass))
+		pack.EpistemicClass = cand.ChannelEpistemic
+		pack.Freshness = cand.RouteFreshness
+		pack.Suppression = cand.RouteSuppression
+		if len(cand.DiscoveryJSON) > 0 {
+			pack.EmailEvidence = string(cand.DiscoveryJSON)
+		}
+		if provenPersonName(cand) {
+			pack.Person = strings.TrimSpace(cand.Name)
+			pack.WhyThisPerson = firstNonEmpty(cand.Role, rec.Role, "Pessoa nomeada publicada pelo extra-cli.")
+		}
+	}
+	if rec.Name != "" {
+		pack.Person = firstNonEmpty(pack.Person, rec.Name)
+	}
+	if pack.EmailEvidence == "" && cand != nil {
+		pack.EmailEvidence = firstNonEmpty(cand.SourceURL, cand.SourceDocument, cand.VerificationStatus)
+	}
+	pack.Warnings = append([]string{}, val.Errors...)
+	pack.Warnings = append(pack.Warnings, val.Warnings...)
+	pack.Warnings = append(pack.Warnings, plan.ReasonCodes...)
+	pack.Warnings = append(pack.Warnings, rec.ReasonCodes...)
+
+	sendable := val.OK &&
+		rec.State == RecipientValidated &&
+		plan.Messageability == MessageabilityReady &&
+		strings.TrimSpace(out.BodyText) != "" &&
+		strings.TrimSpace(out.Subject) != "" &&
+		!isGenericRecipient(cand)
+	pack.HardGates["validation_ok"] = val.OK
+	pack.HardGates["recipient_validated"] = rec.State == RecipientValidated
+	pack.HardGates["messageability_ready"] = plan.Messageability == MessageabilityReady
+	pack.HardGates["body_present"] = strings.TrimSpace(out.BodyText) != ""
+	pack.HardGates["subject_present"] = strings.TrimSpace(out.Subject) != ""
+	pack.HardGates["not_generic"] = !isGenericRecipient(cand)
+	pack.HardGates["not_inferred"] = pack.Derivation != "INFERRED"
+	if sendable {
+		pack.SendWithoutEditing = "sim"
+		pack.Lane = LaneNeedsReviewEmail
+	} else if rec.State == RecipientException || isGenericRecipient(cand) {
+		pack.Lane = firstNonEmpty(ClassifyContactTier(acc, cand, rec.ValidatedAt).Lane, LaneLowConfidenceManual)
+	} else if plan.Messageability == MessageabilityNeedsEnrichment {
+		pack.Lane = LaneManualOutreach
+	} else {
+		pack.Lane = LaneBlockedExhausted
+	}
+	return pack
+}
+
+func (p ConsultantSendabilityPack) AsMap() map[string]any {
+	return map[string]any{
+		"company":              p.Company,
+		"person":               p.Person,
+		"why_this_person":      p.WhyThisPerson,
+		"email":                p.Email,
+		"email_evidence":       p.EmailEvidence,
+		"derivation":           p.Derivation,
+		"verification_status":  p.VerificationStatus,
+		"epistemic_class":      p.EpistemicClass,
+		"freshness":            p.Freshness,
+		"suppression":          p.Suppression,
+		"service_code":         p.ServiceCode,
+		"supporting_fact":      p.SupportingFact,
+		"subject":              p.Subject,
+		"body":                 p.Body,
+		"warnings":             p.Warnings,
+		"hard_gates":           p.HardGates,
+		"send_without_editing": p.SendWithoutEditing,
+		"recipient_state":      p.RecipientState,
+		"messageability":       p.Messageability,
+		"lane":                 p.Lane,
+	}
+}
+
+func candidateEmail(c *models.OutreachContactCandidate) string {
+	if c == nil {
+		return ""
+	}
+	return c.Email
+}
+
+func candidateVerify(c *models.OutreachContactCandidate) string {
+	if c == nil {
+		return ""
+	}
+	return c.VerificationStatus
+}
+
+func derivationFromClass(class string) string {
+	if class == models.ReachabilityR2Inferred {
+		return "INFERRED"
+	}
+	if class == models.ReachabilityR1Direct {
+		return "OBSERVED"
+	}
+	return ""
+}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -591,9 +591,29 @@ func leadToCandidate(orgID, accountID, runID uuid.UUID, fc FeedContact) *models.
 		RouteRelation:                  SanitizeText(fc.RouteRelation, 80),
 		ChannelValue:                   SanitizeText(fc.ChannelValue, 300),
 		ChannelDisplay:                 SanitizeText(fc.ChannelDisplay, 300),
+		EmailDerivation:                SanitizeText(fc.EmailDerivation, 40),
+		ChannelEpistemic:               SanitizeText(fc.ChannelEpistemic, 40),
+		RouteFreshness:                 SanitizeText(fc.RouteFreshness, 40),
+		RouteSuppression:               SanitizeText(fc.RouteSuppression, 40),
+		DiscoveryJSON:                  append([]byte(nil), fc.DiscoveryJSON...),
 	}
 	if fc.EmailSendReady != nil {
 		cand.EmailSendReady = *fc.EmailSendReady
+	}
+	if fc.InferredEmail != nil && *fc.InferredEmail {
+		cand.EmailDerivation = firstNonEmpty(cand.EmailDerivation, "INFERRED")
+		if cand.EmailSendReady {
+			cand.EmailSendReady = false
+		}
+	}
+	if models.OutreachUnenrollableVerification[cand.VerificationStatus] || cand.VerificationStatus == models.OutreachVerifyInstitutionalGeneric {
+		cand.EmailSendReady = false
+	}
+	if supp := strings.ToUpper(strings.TrimSpace(cand.RouteSuppression)); supp == "SUPPRESSED" || supp == "DO_NOT_CONTACT" || supp == "DNC" {
+		cand.DoNotContact = true
+		if cand.BlockReason == "" {
+			cand.BlockReason = "route_suppression:" + supp
+		}
 	}
 	if fc.MailboxPurposeSendBlocked != nil {
 		cand.MailboxPurposeSendBlocked = *fc.MailboxPurposeSendBlocked

--- a/internal/app/confenge/strategy_compose.go
+++ b/internal/app/confenge/strategy_compose.go
@@ -28,12 +28,9 @@ func ComposeFromPlan(plan OutboundMessagePlan, acc *models.OutreachAccount, cand
 		return FailClosedDraft(plan, channel)
 	}
 
-	greeting := planGreeting(cand)
-	hook := strings.TrimSpace(plan.Hook)
-	relevance := strings.TrimSpace(plan.Relevance)
-	cta := strings.TrimSpace(plan.CTA)
-	if cta == "" {
-		cta = "Posso te mandar o recorte objetivo que eu conferiria?"
+	facing := RecipientFacingFromPlan(plan, cand)
+	if facing.Observation == "" && facing.MicroOffer == "" {
+		return FailClosedDraft(plan, channel)
 	}
 
 	company := ""
@@ -44,69 +41,143 @@ func ComposeFromPlan(plan OutboundMessagePlan, acc *models.OutreachAccount, cand
 	var body string
 	switch {
 	case channel == ChannelEmailFollowup || sequenceFromChannel(channel) >= 2:
-		body = composeFollowup(greeting, hook, relevance, cta, plan, channel)
+		body = composeFollowup(facing.Greeting, facing.Observation, facing.Relevance, facing.CTA, plan, channel)
 	case channel == ChannelReplyDraft:
-		body = greeting + ",\n\nObrigado pela resposta. "
-		if hook != "" {
-			body += "Sobre " + ensureLowerStart(hook) + ", "
+		body = facing.Greeting + ",\n\nObrigado pela resposta. "
+		if facing.Observation != "" {
+			body += "Sobre " + ensureLowerStart(facing.Observation) + ", "
 		}
-		if relevance != "" {
-			body += ensureLowerStart(relevance) + " "
+		if facing.Relevance != "" {
+			body += ensureLowerStart(facing.Relevance) + " "
 		}
-		body += cta
+		body += facing.CTA
 	case IsWhatsAppChannel(channel):
-		body = composeWhatsApp(greeting, hook, cta)
+		body = composeWhatsApp(facing.Greeting, facing.Observation, facing.CTA)
 	default:
-		body = greeting + ",\n\n"
-		if hook != "" {
-			lead := strings.TrimSpace(plan.HookLead)
-			if lead == "" {
-				lead = hookLeadForService(plan.ServiceCode)
-			}
-			body += lead + ", " + ensureLowerStart(hook)
-			if !strings.HasSuffix(strings.TrimSpace(hook), ".") {
-				body += "."
-			}
-			body += "\n\n"
-		}
-		if relevance != "" {
-			body += relevance
-			if !strings.HasSuffix(strings.TrimSpace(relevance), ".") {
-				body += "."
-			}
-			body += "\n\n"
-		}
-		body += cta
+		body = composeInitialFromFacing(facing)
 	}
 
 	body = emDashRe.ReplaceAllString(body, ",")
-	subj := planSubject(plan, company, hook, channel)
+	subj := planSubject(plan, company, facing.Observation, channel)
+	if !IsWhatsAppChannel(channel) && (isContratoCompanySubject(subj, company) || subjectHasLegalForm(subj) || strings.TrimSpace(subj) == "") {
+		return FailClosedDraft(plan, channel)
+	}
 
 	return DraftOutput{
 		Channel:     channel,
 		Subject:     subj,
 		BodyText:    body,
-		FactUsed:    hook,
+		FactUsed:    facing.Observation,
 		EvidenceIDs: plan.EvidenceIDs,
-		Claims:      claimsFromFact(hook, plan.EvidenceIDs),
+		Claims:      claimsFromFact(facing.Observation, plan.EvidenceIDs),
 		ServiceCode: plan.ServiceCode,
-		Question:    cta,
-		CTA:         cta,
+		Question:    facing.CTA,
+		CTA:         facing.CTA,
 		RiskFlags:   []string{"strategy_compose", "messageability_ready"},
-		Rationale:   "composed from OutboundMessagePlan " + plan.ComposerVersion + " service=" + plan.ServiceCode,
+		Rationale:   "composed from RecipientFacingCopy " + plan.ComposerVersion + " service=" + plan.ServiceCode,
 	}
 }
 
+// RecipientFacingCopy is the only allowlist the renderer may interpolate.
+type RecipientFacingCopy struct {
+	Greeting    string
+	Observation string
+	Relevance   string
+	MicroOffer  string
+	CTA         string
+}
+
+// RecipientFacingFromPlan copies only recipient-safe fields. Strategy,
+// hypothesis, rationale, evidence IDs, and operator warnings stay out.
+func RecipientFacingFromPlan(plan OutboundMessagePlan, cand *models.OutreachContactCandidate) RecipientFacingCopy {
+	cta := strings.TrimSpace(plan.CTA)
+	if cta == "" {
+		cta = "Posso te mandar o recorte objetivo que eu conferiria?"
+	}
+	if !strings.Contains(cta, "?") {
+		cta = strings.TrimRight(cta, ". ") + "?"
+	}
+	obs := strings.TrimSpace(plan.Hook)
+	if lead := strings.TrimSpace(plan.HookLead); lead != "" && obs != "" {
+		obs = lead + ", " + ensureLowerStart(obs)
+	}
+	return RecipientFacingCopy{
+		Greeting:    planGreeting(cand),
+		Observation: obs,
+		Relevance:   strings.TrimSpace(plan.Relevance),
+		MicroOffer:  strings.TrimSpace(plan.ValueUnit),
+		CTA:         cta,
+	}
+}
+
+func composeInitialFromFacing(f RecipientFacingCopy) string {
+	body := f.Greeting + ",\n\n"
+	if f.Observation != "" {
+		body += f.Observation
+		if !strings.HasSuffix(strings.TrimSpace(f.Observation), ".") {
+			body += "."
+		}
+		body += "\n\n"
+	}
+	if f.Relevance != "" {
+		body += f.Relevance
+		if !strings.HasSuffix(strings.TrimSpace(f.Relevance), ".") {
+			body += "."
+		}
+		body += "\n\n"
+	} else if f.MicroOffer != "" {
+		body += "Se for útil, " + ensureLowerStart(f.MicroOffer)
+		if !strings.HasSuffix(strings.TrimSpace(f.MicroOffer), ".") {
+			body += "."
+		}
+		body += "\n\n"
+	}
+	body += f.CTA
+	return body
+}
+
 func planGreeting(cand *models.OutreachContactCandidate) string {
-	if isGenericRecipient(cand) {
+	if isGenericRecipient(cand) || localLooksLikeCompanyMailbox(cand) {
 		return "Olá, equipe"
 	}
 	if cand != nil {
-		if name := strings.TrimSpace(cand.Name); name != "" {
-			return "Olá, " + firstName(name)
+		if name := strings.TrimSpace(cand.Name); name != "" && provenPersonName(cand) {
+			return "Olá, " + titleFirstName(firstName(name))
 		}
 	}
 	return "Olá"
+}
+
+func localLooksLikeCompanyMailbox(cand *models.OutreachContactCandidate) bool {
+	if cand == nil {
+		return false
+	}
+	parts := strings.Split(canonicalPilotEmail(cand.Email), "@")
+	if len(parts) != 2 {
+		return false
+	}
+	local := foldASCII(strings.Trim(parts[0], "._-+"))
+	if local == "" {
+		return false
+	}
+	name := foldASCII(cand.Name + " " + cand.Role)
+	if local == name || strings.Contains(name, local) && len(local) >= 5 {
+		// name extracted from local-part is not a person
+		if !strings.Contains(local, ".") && !strings.Contains(local, " ") {
+			return true
+		}
+	}
+	return false
+}
+
+func titleFirstName(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return s
+	}
+	r := []rune(strings.ToLower(s))
+	r[0] = []rune(strings.ToUpper(string(r[0])))[0]
+	return string(r)
 }
 
 func sequenceFromChannel(channel string) int {
@@ -181,32 +252,63 @@ func planSubject(plan OutboundMessagePlan, company, hook, channel string) string
 		return ""
 	}
 	if channel == ChannelEmailFollowup || channel == ChannelReplyDraft {
-		if company != "" {
-			return trimSubject("Re: " + company)
+		hookSubj := specificSubjectFromHook(hook)
+		if hookSubj != "" {
+			return trimSubject("Re: " + hookSubj)
 		}
 		return "Re: conversa anterior"
+	}
+	if subj := specificSubjectFromHook(hook); subj != "" {
+		return trimSubject(subj)
 	}
 	switch strings.ToUpper(canonicalServiceForSubject(plan.ServiceCode)) {
 	case "REAJUSTE":
 		return "Reajuste contratual"
 	case "MEDICOES":
-		return trimSubject("Medições " + firstNonEmpty(company, ""))
+		return "Medição contratual"
 	case "ADITIVOS":
-		return trimSubject("Aditivo " + firstNonEmpty(company, ""))
+		return "Aditivo publicado"
 	case "ENCERRAMENTO_CONTRATUAL":
 		return "Encerramento contratual"
 	case "APOIO_LICITACAO":
-		return trimSubject("Edital " + firstNonEmpty(company, ""))
+		return "Edital publicado"
 	case "INTELIGENCIA_PNCP":
-		return trimSubject("Recorte PNCP " + firstNonEmpty(company, ""))
+		return "Recorte PNCP"
 	}
-	if hook != "" && hasConcreteToken(hook) {
-		return trimSubject(firstWords(hook, 4))
+	_ = company
+	return ""
+}
+
+func specificSubjectFromHook(hook string) string {
+	hook = strings.TrimSpace(hook)
+	if hook == "" || looksLikeMetadataDump(hook) {
+		return ""
 	}
-	if company != "" {
-		return trimSubject("Contrato " + company)
+	hook = metadataLabelRe.ReplaceAllString(hook, " ")
+	hook = strings.Join(strings.Fields(hook), " ")
+	hook = stripLegalForm(hook)
+	if hook == "" || isContratoCompanySubject(hook, "") {
+		return ""
 	}
-	return "Contrato público"
+	words := strings.Fields(hook)
+	if len(words) > 6 {
+		hook = strings.Join(words[:6], " ")
+	}
+	return strings.TrimSpace(hook)
+}
+
+func stripLegalForm(s string) string {
+	repl := []string{
+		" - EM RECUPERACAO JUDICIAL", " - EM RECUPERAÇÃO JUDICIAL",
+		" EM RECUPERACAO JUDICIAL", " EM RECUPERAÇÃO JUDICIAL",
+		" LTDA", " EIRELI", " S/A", " S.A.", " SA",
+	}
+	out := s
+	for _, p := range repl {
+		out = strings.ReplaceAll(out, p, "")
+		out = strings.ReplaceAll(out, strings.ToLower(p), "")
+	}
+	return strings.TrimSpace(out)
 }
 
 func ensureLowerStart(s string) string {

--- a/internal/app/confenge/strategy_compose.go
+++ b/internal/app/confenge/strategy_compose.go
@@ -111,7 +111,7 @@ func RecipientFacingFromPlan(plan OutboundMessagePlan, cand *models.OutreachCont
 }
 
 func composeInitialFromFacing(f RecipientFacingCopy) string {
-	body := f.Greeting + ",\n\n"
+	body := f.Greeting + ",\n\nSou da CONFENGE.\n\n"
 	if f.Observation != "" {
 		body += f.Observation
 		if !strings.HasSuffix(strings.TrimSpace(f.Observation), ".") {
@@ -226,7 +226,7 @@ func composeFollowup(greeting, hook, relevance, cta string, plan OutboundMessage
 }
 
 func composeWhatsApp(greeting, hook, cta string) string {
-	body := greeting + ", "
+	body := greeting + ", sou da CONFENGE. "
 	if hook != "" {
 		body += ensureLowerStart(hook)
 		if !strings.HasSuffix(strings.TrimSpace(hook), ".") {

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -204,6 +204,11 @@ func (s *service) ListReviewTouchpoints(ctx context.Context, orgID uuid.UUID, li
 			}
 			pack := BuildConsultantSendabilityPack(acc, cand, rec, plan, synth, val)
 			list[i].ConsultantSendability = pack.AsMap()
+			// Live QA wins over a leftover stored true so the API cannot lie.
+			if d := list[i].Draft; d != nil {
+				ok := val.OK && pack.SendWithoutEditing == "sim"
+				d.ValidationOK = &ok
+			}
 		}
 	}
 	return list, nil

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -146,44 +146,81 @@ func (s *service) ListReviewTouchpoints(ctx context.Context, orgID uuid.UUID, li
 					list[i].RecipientGeneric = isGenericRecipient(cand)
 				}
 			}
+			rec := RecipientResolution{Company: accName(acc)}
 			if allCands, listErr := s.repo.ListCandidates(ctx, orgID, list[i].AccountID); listErr == nil {
-				rec := ResolveRecipient(acc, allCands, time.Now().UTC())
+				rec = ResolveRecipient(acc, allCands, time.Now().UTC())
 				list[i].RecipientState = rec.State
 				list[i].RecipientReason = rec.Reason
 			}
-			st, plan := BuildOutboundPlan(pb, acc, cand, nil, pos)
+			evidence, _ := s.repo.ListEvidence(ctx, orgID, list[i].AccountID)
+			st, plan := BuildOutboundPlan(pb, acc, cand, evidence, pos)
 			if list[i].FactUsed != "" {
 				st.ObservedFact = list[i].FactUsed
 			}
 			ex := ExplainStrategy(st, list[i].Recipient)
 			list[i].StrategyExplain = strategyExplainProjection(ex, "")
-			synth := DraftOutput{Subject: list[i].Subject, BodyText: list[i].BodyText, ServiceCode: list[i].ServiceCode, FactUsed: list[i].FactUsed}
-			val := ValidationResult{OK: list[i].State == models.TouchpointNeedsReview && strings.TrimSpace(list[i].BodyText) != ""}
-			if list[i].RecipientState != "" {
-				rec := RecipientResolution{State: list[i].RecipientState, Reason: list[i].RecipientReason, Company: accName(acc)}
-				pack := BuildConsultantSendabilityPack(acc, cand, rec, plan, synth, val)
-				list[i].ConsultantSendability = pack.AsMap()
-			}
+			promptVer := ""
 			if list[i].DraftID != nil {
 				if d, _ := s.repo.GetDraft(ctx, orgID, *list[i].DraftID); d != nil {
 					list[i].Draft = d
-					var val ValidationResult
+					promptVer = d.PromptVersion
 					if len(d.ValidationJSON) > 0 {
-						_ = json.Unmarshal(d.ValidationJSON, &val)
-						list[i].DoctrineAlerts = val.DoctrineAlerts
-						if val.StrategyExplain != nil {
-							list[i].StrategyExplain = strategyExplainProjection(*val.StrategyExplain, ex.WhyThisAccount)
+						var stored ValidationResult
+						_ = json.Unmarshal(d.ValidationJSON, &stored)
+						list[i].DoctrineAlerts = stored.DoctrineAlerts
+						if stored.StrategyExplain != nil {
+							list[i].StrategyExplain = strategyExplainProjection(*stored.StrategyExplain, ex.WhyThisAccount)
 						}
-						if val.Recipient != nil && val.Recipient.State != "" {
-							list[i].RecipientState = val.Recipient.State
-							list[i].RecipientReason = val.Recipient.Reason
+						if stored.Recipient != nil && stored.Recipient.State != "" {
+							list[i].RecipientState = stored.Recipient.State
+							list[i].RecipientReason = stored.Recipient.Reason
+							rec = *stored.Recipient
 						}
 					}
 				}
 			}
+			synth := DraftOutput{
+				Subject:     firstNonEmpty(draftSubject(list[i]), list[i].Subject),
+				BodyText:    firstNonEmpty(draftBody(list[i]), list[i].BodyText),
+				ServiceCode: firstNonEmpty(list[i].ServiceCode, acc.ServiceCode),
+				FactUsed:    list[i].FactUsed, Channel: ChannelEmailInitial,
+			}
+			if d := list[i].Draft; d != nil {
+				synth.RiskFlags = d.RiskFlags
+				synth.EvidenceIDs = d.EvidenceIDs
+			}
+			val := ValidationResult{OK: false}
+			if strings.TrimSpace(synth.BodyText) != "" {
+				val = ValidateDraft(&synth, acc, cand, ValidateOpts{
+					Evidence: evidence, Channel: ChannelEmailInitial,
+					Strategy: &st, Playbook: pb, PromptVersion: promptVer,
+				})
+			}
+			if rec.State != RecipientValidated || plan.Messageability != MessageabilityReady {
+				val.OK = false
+			}
+			if d := list[i].Draft; d != nil && d.ValidationOK != nil && !*d.ValidationOK {
+				val.OK = false
+			}
+			pack := BuildConsultantSendabilityPack(acc, cand, rec, plan, synth, val)
+			list[i].ConsultantSendability = pack.AsMap()
 		}
 	}
 	return list, nil
+}
+
+func draftSubject(tp models.OutreachTouchpoint) string {
+	if tp.Draft != nil {
+		return tp.Draft.Subject
+	}
+	return ""
+}
+
+func draftBody(tp models.OutreachTouchpoint) string {
+	if tp.Draft != nil {
+		return tp.Draft.BodyText
+	}
+	return ""
 }
 
 func strategyExplainProjection(ex StrategyExplain, fallbackWhyThisAccount string) map[string]any {
@@ -305,11 +342,17 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 	if factUsed != "" && plan.Messageability == MessageabilityReady && plan.Hook != "" {
 		st.ObservedFact = factUsed
 	}
+	recent := recentDraftBodies(ctx, s, orgID, tp.AccountID, tp.Channel)
+	var composed DraftOutput
 	if plan.Messageability != MessageabilityReady || rec.State != RecipientValidated {
 		subject, body = "", ""
 		factUsed = ""
 	} else {
-		composed := ComposeFromPlan(plan, acc, cand, genCh)
+		composed = ComposeFromPlan(plan, acc, cand, genCh)
+		if _, hit := NearDuplicate(composed.BodyText, recent); hit {
+			composed.BodyText = varyTemplateHook(composed.BodyText)
+			composed.RiskFlags = appendUnique(composed.RiskFlags, "near_dup_regenerated")
+		}
 		subject, body = composed.Subject, composed.BodyText
 		factUsed = composed.FactUsed
 	}
@@ -320,11 +363,11 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 		Subject: subject, BodyText: body, ServiceCode: firstNonEmpty(plan.ServiceCode, acc.ServiceCode),
 		FactUsed: factUsed, EvidenceIDs: firstNonEmptyIDs(plan.EvidenceIDs, evidIDs), Claims: claimsFromFact(factUsed, evidIDs),
 		Channel: genCh, Rationale: "touchpoint strategy compose",
-		CTA: plan.CTA, Question: plan.CTA,
+		CTA: plan.CTA, Question: plan.CTA, RiskFlags: composed.RiskFlags,
 	}
 	val := ValidateDraft(synth, acc, cand, ValidateOpts{
 		MaxWords: s.cfg.MaxInitialEmailWords, Evidence: evidence, Channel: genCh,
-		Strategy: &st, Playbook: pb,
+		Strategy: &st, Playbook: pb, RecentBodies: recent,
 	})
 	recipient := tp.Recipient
 	if cand != nil && recipient == "" {

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -151,12 +151,19 @@ func (s *service) ListReviewTouchpoints(ctx context.Context, orgID uuid.UUID, li
 				list[i].RecipientState = rec.State
 				list[i].RecipientReason = rec.Reason
 			}
-			st := PlanOutreachStrategy(pb, acc, cand, nil, pos)
+			st, plan := BuildOutboundPlan(pb, acc, cand, nil, pos)
 			if list[i].FactUsed != "" {
 				st.ObservedFact = list[i].FactUsed
 			}
 			ex := ExplainStrategy(st, list[i].Recipient)
 			list[i].StrategyExplain = strategyExplainProjection(ex, "")
+			synth := DraftOutput{Subject: list[i].Subject, BodyText: list[i].BodyText, ServiceCode: list[i].ServiceCode, FactUsed: list[i].FactUsed}
+			val := ValidationResult{OK: list[i].State == models.TouchpointNeedsReview && strings.TrimSpace(list[i].BodyText) != ""}
+			if list[i].RecipientState != "" {
+				rec := RecipientResolution{State: list[i].RecipientState, Reason: list[i].RecipientReason, Company: accName(acc)}
+				pack := BuildConsultantSendabilityPack(acc, cand, rec, plan, synth, val)
+				list[i].ConsultantSendability = pack.AsMap()
+			}
 			if list[i].DraftID != nil {
 				if d, _ := s.repo.GetDraft(ctx, orgID, *list[i].DraftID); d != nil {
 					list[i].Draft = d
@@ -447,6 +454,11 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 	}
 	if draftStatus == models.OutreachDraftNeedsReview {
 		_ = s.repo.SetAccountHumanFlags(ctx, orgID, tp.AccountID, acc.Blocked, acc.DoNotContact, acc.BlockReason, models.OutreachQueueNeedsReview)
+	}
+	pack := BuildConsultantSendabilityPack(acc, cand, rec, plan, *synth, val)
+	tp.ConsultantSendability = pack.AsMap()
+	if strings.TrimSpace(tp.BodyText) == "" {
+		tp.GenerationError = firstNonEmpty(rec.Reason, plan.Reason, strings.Join(val.Errors, "; "), "Gerar mensagem não produziu copy sendable.")
 	}
 	_ = userID
 	return tp, nil

--- a/internal/app/confenge/validators.go
+++ b/internal/app/confenge/validators.go
@@ -10,8 +10,8 @@ import (
 )
 
 // PromptVersion tags generation prompt revisions (see docs/confenge/copy-generation.md).
-// v4: messageability gate + outbound-safe plan (doctrine confenge-outreach-v2).
-const PromptVersion = "confenge.draft.v4"
+// v5: authorizable NEEDS_REVIEW — recipient-safe plan only; P0 hard QA catalog.
+const PromptVersion = "confenge.draft.v5"
 
 // DraftClaim is one auditable fact/phrase anchored to evidence ids.
 type DraftClaim struct {
@@ -78,6 +78,7 @@ type ValidateOpts struct {
 	SkipEmailRecipient     bool
 	Strategy               *OutreachStrategy
 	Playbook               *Playbook
+	PromptVersion          string
 }
 
 var bannedPhrases = []string{
@@ -286,23 +287,26 @@ func ValidateDraft(out *DraftOutput, acc *models.OutreachAccount, cand *models.O
 	}
 
 	qMarks := strings.Count(body, "?")
-	if channel == ChannelEmailInitial {
+	if channel == ChannelEmailInitial && body != "" {
 		if qMarks == 0 {
-			res.Warnings = append(res.Warnings, "email initial has no question mark")
+			res.OK = false
+			res.Errors = append(res.Errors, "email initial has no question mark")
 		}
 		if qMarks > 2 {
 			res.Warnings = append(res.Warnings, "body has multiple question marks")
 		}
 	}
-	if isWA && qMarks == 0 {
+	if isWA && qMarks == 0 && body != "" {
 		res.Warnings = append(res.Warnings, "whatsapp body has no question")
 	}
 	if score, hit := NearDuplicate(body, opts.RecentBodies); hit {
 		res.NearDupScore = score
-		res.Warnings = append(res.Warnings, fmt.Sprintf("near-duplicate of recent draft (jaccard=%.2f)", score))
+		res.OK = false
+		res.Errors = append(res.Errors, fmt.Sprintf("near-duplicate of recent draft (jaccard=%.2f)", score))
 	} else if score > 0 {
 		res.NearDupScore = score
 	}
+	ApplyAuthorizableHardQA(&res, out, acc, cand, opts, channel, body)
 	if r := strings.TrimSpace(out.Rationale); r != "" && len(r) > 20 {
 		sample := r
 		if utf8.RuneCountInString(sample) > 24 {
@@ -447,7 +451,7 @@ func ClassifyRisk(acc *models.OutreachAccount, cand *models.OutreachContactCandi
 		raise("RED", "validation_failed")
 	}
 	if val.NearDupScore >= NearDupThreshold {
-		raise("YELLOW", "near_duplicate_draft")
+		raise("RED", "near_duplicate_draft")
 	}
 	if cand != nil {
 		switch cand.VerificationStatus {

--- a/internal/app/confenge/validators_test.go
+++ b/internal/app/confenge/validators_test.go
@@ -127,4 +127,9 @@ func TestNearDuplicateJaccard(t *testing.T) {
 	if _, hit := NearDuplicate(a, []string{a}); !hit {
 		t.Fatal("identical bodies must near-dup")
 	}
+	aditivoA := "Olá, Ana,\n\nSou da CONFENGE.\n\nPelo contrato publicado, termo aditivo 2 ao contrato 1149/2022 no DER-RS.\n\nDepois de um aditivo, o que costuma ficar para trás é a revisão de planilha, prazo e efeitos.\n\nPosso te mostrar o que eu checaria depois desse aditivo?"
+	aditivoB := "Olá, Ana,\n\nSou da CONFENGE.\n\nPelo contrato publicado, termo aditivo 8 ao contrato 2201/2024 na prefeitura de Caxias do Sul na ERS-122.\n\nDepois de um aditivo, o que costuma ficar para trás é a revisão de planilha, prazo e efeitos.\n\nPosso te mostrar o que eu checaria depois desse aditivo?"
+	if _, hit := NearDuplicate(aditivoA, []string{aditivoB}); hit {
+		t.Fatal("different contracts must not be treated as clones just because they share the CONFENGE wrapper")
+	}
 }

--- a/internal/infrastructure/db/migrations/000100_outreach_candidate_discovery.down.sql
+++ b/internal/infrastructure/db/migrations/000100_outreach_candidate_discovery.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE outreach_contact_candidates
+    DROP COLUMN IF EXISTS discovery_json,
+    DROP COLUMN IF EXISTS route_suppression,
+    DROP COLUMN IF EXISTS route_freshness,
+    DROP COLUMN IF EXISTS channel_epistemic_class,
+    DROP COLUMN IF EXISTS email_derivation;

--- a/internal/infrastructure/db/migrations/000100_outreach_candidate_discovery.up.sql
+++ b/internal/infrastructure/db/migrations/000100_outreach_candidate_discovery.up.sql
@@ -1,0 +1,13 @@
+-- extra-cli #392 discovery dimensions (derivation, epistemic class, freshness,
+-- suppression, passive email verification). Visibility/provenance only.
+ALTER TABLE outreach_contact_candidates
+    ADD COLUMN IF NOT EXISTS email_derivation text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS channel_epistemic_class text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS route_freshness text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS route_suppression text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS discovery_json jsonb;
+
+COMMENT ON COLUMN outreach_contact_candidates.email_derivation IS
+'OBSERVED vs INFERRED. Never inferred from MX/DNS. extra-cli is the source.';
+COMMENT ON COLUMN outreach_contact_candidates.discovery_json IS
+'Passive DNS/MX/catch-all/SMTP plus identity_proven. MX never authorizes send.';

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -266,13 +266,19 @@ type OutreachContactCandidate struct {
 	LastImportRunID                *uuid.UUID `json:"last_import_run_id,omitempty"`
 	// Additive extra-cli reachability boundary. Empty means the current
 	// contact-tier contract applies; Warmbly never invents a class.
-	ReachabilityClass string    `json:"reachability_class,omitempty"`
-	RouteType         string    `json:"route_type,omitempty"`
-	RouteRelation     string    `json:"route_relation,omitempty"`
-	ChannelValue      string    `json:"channel_value,omitempty"`
-	ChannelDisplay    string    `json:"channel_display,omitempty"`
-	CreatedAt         time.Time `json:"created_at"`
-	UpdatedAt         time.Time `json:"updated_at"`
+	ReachabilityClass string `json:"reachability_class,omitempty"`
+	RouteType         string `json:"route_type,omitempty"`
+	RouteRelation     string `json:"route_relation,omitempty"`
+	ChannelValue      string `json:"channel_value,omitempty"`
+	ChannelDisplay    string `json:"channel_display,omitempty"`
+	// Additive extra-cli discovery dimensions (domain/evidence live on account/evidence).
+	EmailDerivation  string    `json:"email_derivation,omitempty"`
+	ChannelEpistemic string    `json:"channel_epistemic_class,omitempty"`
+	RouteFreshness   string    `json:"route_freshness,omitempty"`
+	RouteSuppression string    `json:"route_suppression,omitempty"`
+	DiscoveryJSON    []byte    `json:"discovery_json,omitempty"`
+	CreatedAt        time.Time `json:"created_at"`
+	UpdatedAt        time.Time `json:"updated_at"`
 }
 
 // CanEnroll reports whether this candidate may be put into a campaign.
@@ -627,6 +633,9 @@ type OutreachTouchpoint struct {
 	RecipientGeneric        bool           `json:"recipient_generic,omitempty"`
 	RecipientState          string         `json:"recipient_state,omitempty"`
 	RecipientReason         string         `json:"recipient_reason,omitempty"`
+	// ConsultantSendability is operator-only: send without editing? yes/no.
+	ConsultantSendability map[string]any `json:"consultant_sendability,omitempty"`
+	GenerationError       string         `json:"generation_error,omitempty"`
 }
 
 // Commercial action types. Semantic differences are load-bearing.

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -1386,6 +1386,9 @@ const outreachCandidateSelect = `
 		COALESCE(ownership_status,''), COALESCE(recipient_commercial_suitability,''),
 		COALESCE(reachability_class,''), COALESCE(route_type,''), COALESCE(route_relation,''),
 		COALESCE(channel_value,''), COALESCE(channel_display,''),
+		COALESCE(email_derivation,''), COALESCE(channel_epistemic_class,''),
+		COALESCE(route_freshness,''), COALESCE(route_suppression,''),
+		discovery_json,
 		last_import_run_id, created_at, updated_at `
 
 func candidateScanDest(c *models.OutreachContactCandidate) []any {
@@ -1402,8 +1405,18 @@ func candidateScanDest(c *models.OutreachContactCandidate) []any {
 		&c.OwnershipStatus, &c.RecipientCommercialSuitability,
 		&c.ReachabilityClass, &c.RouteType, &c.RouteRelation,
 		&c.ChannelValue, &c.ChannelDisplay,
+		&c.EmailDerivation, &c.ChannelEpistemic,
+		&c.RouteFreshness, &c.RouteSuppression,
+		&c.DiscoveryJSON,
 		&c.LastImportRunID, &c.CreatedAt, &c.UpdatedAt,
 	}
+}
+
+func nullIfEmptyJSON(raw []byte) any {
+	if len(raw) == 0 {
+		return nil
+	}
+	return raw
 }
 
 func scanCandidate(row scannable) (*models.OutreachContactCandidate, error) {
@@ -1452,6 +1465,8 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 				email_send_ready, mailbox_purpose, mailbox_purpose_send_blocked,
 				ownership_status, recipient_commercial_suitability,
 				reachability_class, route_type, route_relation, channel_value, channel_display,
+				email_derivation, channel_epistemic_class, route_freshness, route_suppression,
+				discovery_json,
 				last_import_run_id, created_at, updated_at
 			) VALUES (
 				$1,$2,$3,$4,$5,
@@ -1464,7 +1479,9 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 				$28,$29,$30,
 				$31,$32,
 				$33,$34,$35,$36,$37,
-				$38,$39,$40
+				$38,$39,$40,$41,
+				$42,
+				$43,$44,$45
 			)
 			ON CONFLICT (organization_id, account_id, source_contact_id) WHERE source_contact_id <> '' DO UPDATE SET
 				name = EXCLUDED.name,
@@ -1515,6 +1532,11 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 				route_relation = EXCLUDED.route_relation,
 				channel_value = EXCLUDED.channel_value,
 				channel_display = EXCLUDED.channel_display,
+				email_derivation = EXCLUDED.email_derivation,
+				channel_epistemic_class = EXCLUDED.channel_epistemic_class,
+				route_freshness = EXCLUDED.route_freshness,
+				route_suppression = EXCLUDED.route_suppression,
+				discovery_json = EXCLUDED.discovery_json,
 				person_id = EXCLUDED.person_id,
 				last_import_run_id = EXCLUDED.last_import_run_id,
 				updated_at = EXCLUDED.updated_at,
@@ -1530,6 +1552,8 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 			c.EmailSendReady, c.MailboxPurpose, c.MailboxPurposeSendBlocked,
 			c.OwnershipStatus, c.RecipientCommercialSuitability,
 			c.ReachabilityClass, c.RouteType, c.RouteRelation, c.ChannelValue, c.ChannelDisplay,
+			c.EmailDerivation, c.ChannelEpistemic, c.RouteFreshness, c.RouteSuppression,
+			nullIfEmptyJSON(c.DiscoveryJSON),
 			c.LastImportRunID, c.CreatedAt, c.UpdatedAt,
 		).Scan(&created, &c.ID)
 		return created, err
@@ -1547,9 +1571,11 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 			email_send_ready, mailbox_purpose, mailbox_purpose_send_blocked,
 			ownership_status, recipient_commercial_suitability,
 			reachability_class, route_type, route_relation, channel_value, channel_display,
+			email_derivation, channel_epistemic_class, route_freshness, route_suppression,
+			discovery_json,
 			last_import_run_id, created_at, updated_at
 		) VALUES (
-			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37,$38,$39,$40,$41,$42,$43,$44,$45
 		)`,
 		c.ID, c.OrganizationID, c.AccountID, c.SourceContactID, c.PersonID,
 		c.Name, c.Role, c.Email, c.Phone,
@@ -1561,6 +1587,8 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 		c.EmailSendReady, c.MailboxPurpose, c.MailboxPurposeSendBlocked,
 		c.OwnershipStatus, c.RecipientCommercialSuitability,
 		c.ReachabilityClass, c.RouteType, c.RouteRelation, c.ChannelValue, c.ChannelDisplay,
+		c.EmailDerivation, c.ChannelEpistemic, c.RouteFreshness, c.RouteSuppression,
+		nullIfEmptyJSON(c.DiscoveryJSON),
 		c.LastImportRunID, c.CreatedAt, c.UpdatedAt,
 	)
 	return true, err

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -52,6 +52,7 @@ import type {
 import type { AppError } from "@/lib/api/client/normalizeError";
 import { channelLabel, formatFeedAge, formatPtBrDate, intentLabel, purposeLabel, reasonLabel, stateLabel } from "./labels";
 import { buildPilotGate, type PilotGate } from "./pilotGate";
+import { isAuthorizeReady } from "./reviewReady";
 
 const ATTENTION_FILTERS: { id: ConfengeAttentionFilter; label: string }[] = [
   { id: "needs_attention", label: "Precisa de atenção" },
@@ -91,13 +92,6 @@ export default function ConfengePage() {
   const [idx, setIdx] = useState(0);
   const [reviewLane, setReviewLane] = useState<"ready" | "exception">("ready");
   const allReview = review.data ?? [];
-  const isAuthorizeReady = (tp: ConfengeTouchpoint) => {
-    const recipientOK = (tp.recipient_state || "").toUpperCase() === "VALIDATED";
-    const messageability = (tp.strategy_explain?.messageability || "").toUpperCase();
-    const messageOK = !messageability || messageability === "READY";
-    const sendable = !!(tp.body_text && tp.body_text.trim());
-    return recipientOK && messageOK && sendable;
-  };
   const autorizaveis = allReview.filter(isAuthorizeReady);
   const queue = allReview.filter((tp) => {
     const ready = isAuthorizeReady(tp);

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -98,6 +98,7 @@ export default function ConfengePage() {
     const sendable = !!(tp.body_text && tp.body_text.trim());
     return recipientOK && messageOK && sendable;
   };
+  const autorizaveis = allReview.filter(isAuthorizeReady);
   const queue = allReview.filter((tp) => {
     const ready = isAuthorizeReady(tp);
     return reviewLane === "ready" ? ready : !ready;
@@ -664,7 +665,7 @@ export default function ConfengePage() {
             <div>
               <div className="text-[12.5px] font-medium text-slate-900">Cohort manual do piloto</div>
               <div className="text-[10.5px] text-slate-500">
-                {(cohortResult?.cohort_prepared ?? pilotGate.prepared)}/{pilotGate.target} preparadas · {cohortCandidates.length} elegíveis
+                {(cohortResult?.cohort_prepared ?? pilotGate.prepared)}/{pilotGate.target} no cohort · {autorizaveis.length} autorizáveis
               </div>
             </div>
             {cohortCandidates.length > 0 && cohortRemaining > 0 && (
@@ -803,7 +804,7 @@ export default function ConfengePage() {
                 className={`relative h-10 px-2.5 inline-flex items-center text-[12.5px] ${reviewLane === "ready" ? "text-slate-900 font-medium" : "text-slate-500"}`}
                 onClick={() => { setReviewLane("ready"); setIdx(0); }}
               >
-                Prontas para autorizar
+                Prontas para autorizar ({autorizaveis.length})
                 {reviewLane === "ready" && <span className="absolute inset-x-2 -bottom-px h-0.5 bg-sky-600" />}
               </button>
               <button
@@ -936,6 +937,31 @@ export default function ConfengePage() {
                   <div>{stateLabel(current.state)} · criada {formatPtBrDate(current.created_at) || "sem data"} · atualizada {formatPtBrDate(current.updated_at) || "sem data"}</div>
                   {(current.draft?.risk_flags?.length ?? 0) > 0 && (
                     <div className="mt-1 text-amber-700">Avisos: {current.draft!.risk_flags!.map(reasonLabel).join(", ")}</div>
+                  )}
+                  {current.consultant_sendability && (
+                    <div className="mt-2 rounded-md border border-slate-200 bg-white p-2 space-y-1" data-testid="confenge-sendability-pack">
+                      <div className="text-[10px] uppercase tracking-[0.14em] text-slate-500">Envio sem editar?</div>
+                      <div className="font-medium text-slate-900">
+                        {current.consultant_sendability.send_without_editing === "sim" ? "Sim, só autorizar" : "Não"}
+                      </div>
+                      <StrategyRow label="Pessoa" value={current.consultant_sendability.person} />
+                      <StrategyRow label="Por que esta pessoa" value={current.consultant_sendability.why_this_person} />
+                      <StrategyRow label="E-mail" value={current.consultant_sendability.email} />
+                      <StrategyRow label="Derivação" value={current.consultant_sendability.derivation} />
+                      <StrategyRow label="Verificação" value={current.consultant_sendability.verification_status} />
+                      <StrategyRow label="Frescor" value={current.consultant_sendability.freshness} />
+                      <StrategyRow label="Supressão" value={current.consultant_sendability.suppression} />
+                      <StrategyRow label="Serviço" value={current.consultant_sendability.service_code} />
+                      <StrategyRow label="Fato" value={current.consultant_sendability.supporting_fact} />
+                      {current.consultant_sendability.warnings && current.consultant_sendability.warnings.length > 0 && (
+                        <div className="text-[11px] text-amber-800">{current.consultant_sendability.warnings.join(" · ")}</div>
+                      )}
+                    </div>
+                  )}
+                  {current.generation_error && (
+                    <div className="mt-2 rounded-md border border-rose-200 bg-rose-50 px-2 py-1.5 text-[11.5px] text-rose-800" data-testid="confenge-generate-error">
+                      {current.generation_error}
+                    </div>
                   )}
                 </div>
                 <div>

--- a/web/src/app/app/confenge/reviewReady.test.ts
+++ b/web/src/app/app/confenge/reviewReady.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import { isAuthorizeReady } from "./reviewReady";
+import type { ConfengeTouchpoint } from "@/lib/api/models/app/confenge/Confenge";
+
+function tp(partial: Partial<ConfengeTouchpoint>): ConfengeTouchpoint {
+  return {
+    id: "t1",
+    organization_id: "o",
+    account_id: "a",
+    ordinal: 1,
+    channel: "EMAIL",
+    purpose: "SIGNAL",
+    due_at: "",
+    state: "NEEDS_REVIEW",
+    recipient: "ana@exemplo.com.br",
+    subject: "Aditivo publicado",
+    body_text: "Olá Ana,\n\nSou da CONFENGE.\n\nPosso te mostrar o que eu checaria?",
+    content_hash: "",
+    approved_content_hash: "",
+    service_code: "ADITIVOS",
+    fact_used: "aditivo 2",
+    ...partial,
+  };
+}
+
+describe("isAuthorizeReady", () => {
+  it("accepts send_without_editing=sim with a body", () => {
+    expect(
+      isAuthorizeReady(
+        tp({
+          consultant_sendability: { send_without_editing: "sim" },
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects leftover NEEDS_REVIEW body when pack says nao and validation is missing", () => {
+    expect(
+      isAuthorizeReady(
+        tp({
+          recipient_state: "VALIDATED",
+          consultant_sendability: { send_without_editing: "nao" },
+          draft: { validation_ok: false } as ConfengeTouchpoint["draft"],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects missing messageability even with VALIDATED + body", () => {
+    expect(
+      isAuthorizeReady(
+        tp({
+          recipient_state: "VALIDATED",
+          strategy_explain: {},
+          draft: { validation_ok: true } as ConfengeTouchpoint["draft"],
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("rejects empty body even when pack says sim", () => {
+    expect(
+      isAuthorizeReady(
+        tp({
+          body_text: "   ",
+          consultant_sendability: { send_without_editing: "sim" },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it("accepts VALIDATED + READY + validation_ok + body without a pack", () => {
+    expect(
+      isAuthorizeReady(
+        tp({
+          recipient_state: "VALIDATED",
+          strategy_explain: { messageability: "READY" },
+          draft: { validation_ok: true } as ConfengeTouchpoint["draft"],
+        }),
+      ),
+    ).toBe(true);
+  });
+});

--- a/web/src/app/app/confenge/reviewReady.test.ts
+++ b/web/src/app/app/confenge/reviewReady.test.ts
@@ -34,13 +34,14 @@ describe("isAuthorizeReady", () => {
     ).toBe(true);
   });
 
-  it("rejects leftover NEEDS_REVIEW body when pack says nao and validation is missing", () => {
+  it("rejects leftover NEEDS_REVIEW body when pack says nao even if stored validation_ok is true", () => {
     expect(
       isAuthorizeReady(
         tp({
           recipient_state: "VALIDATED",
+          strategy_explain: { messageability: "READY" },
           consultant_sendability: { send_without_editing: "nao" },
-          draft: { validation_ok: false } as ConfengeTouchpoint["draft"],
+          draft: { validation_ok: true } as ConfengeTouchpoint["draft"],
         }),
       ),
     ).toBe(false);

--- a/web/src/app/app/confenge/reviewReady.ts
+++ b/web/src/app/app/confenge/reviewReady.ts
@@ -7,8 +7,8 @@ export function isAuthorizeReady(tp: ConfengeTouchpoint): boolean {
   if (!bodyOK) {
     return false;
   }
-  if (tp.consultant_sendability?.send_without_editing === "sim") {
-    return true;
+  if (tp.consultant_sendability) {
+    return tp.consultant_sendability.send_without_editing === "sim";
   }
   const recipientOK = (tp.recipient_state || "").toUpperCase() === "VALIDATED";
   const messageability = (tp.strategy_explain?.messageability || "").toUpperCase();

--- a/web/src/app/app/confenge/reviewReady.ts
+++ b/web/src/app/app/confenge/reviewReady.ts
@@ -1,0 +1,18 @@
+import type { ConfengeTouchpoint } from "@/lib/api/models/app/confenge/Confenge";
+
+// isAuthorizeReady is the dashboard "autorizáveis" / Aprovar gate.
+// Missing messageability is not OK. Leftover NEEDS_REVIEW + body is not enough.
+export function isAuthorizeReady(tp: ConfengeTouchpoint): boolean {
+  const bodyOK = !!(tp.body_text && tp.body_text.trim());
+  if (!bodyOK) {
+    return false;
+  }
+  if (tp.consultant_sendability?.send_without_editing === "sim") {
+    return true;
+  }
+  const recipientOK = (tp.recipient_state || "").toUpperCase() === "VALIDATED";
+  const messageability = (tp.strategy_explain?.messageability || "").toUpperCase();
+  const messageOK = messageability === "READY";
+  const validationOK = tp.draft?.validation_ok === true;
+  return recipientOK && messageOK && validationOK;
+}

--- a/web/src/lib/api/hooks/app/confenge/useConfenge.ts
+++ b/web/src/lib/api/hooks/app/confenge/useConfenge.ts
@@ -365,8 +365,13 @@ export function useGenerateConfengeTouchpoint() {
     const qc = useQueryClient();
     return useMutation({
         mutationFn: (id: string) => generateConfengeTouchpoint(id),
-        onSuccess: () => {
+        onSuccess: (tp) => {
             void qc.invalidateQueries({ queryKey: KEY });
+            const err = tp.generation_error?.trim();
+            if (err || !tp.body_text?.trim()) {
+                toast.error(err || "A mensagem não ficou autorizável. Veja o motivo no card.");
+                return;
+            }
             toast.success("Mensagem gerada");
         },
         onError: (e) => toast.error(confengeError(e, "Não foi possível gerar a mensagem.")),

--- a/web/src/lib/api/models/app/confenge/Confenge.ts
+++ b/web/src/lib/api/models/app/confenge/Confenge.ts
@@ -459,6 +459,29 @@ export type ConfengeStrategyExplain = {
   messageability_reason?: string;
 };
 
+export type ConfengeConsultantSendability = {
+  company?: string;
+  person?: string;
+  why_this_person?: string;
+  email?: string;
+  email_evidence?: string;
+  derivation?: string;
+  verification_status?: string;
+  epistemic_class?: string;
+  freshness?: string;
+  suppression?: string;
+  service_code?: string;
+  supporting_fact?: string;
+  subject?: string;
+  body?: string;
+  warnings?: string[];
+  hard_gates?: Record<string, boolean>;
+  send_without_editing?: string;
+  recipient_state?: string;
+  messageability?: string;
+  lane?: string;
+};
+
 export type ConfengeTouchpoint = {
   id: string;
   organization_id: string;
@@ -484,6 +507,8 @@ export type ConfengeTouchpoint = {
   recipient_generic?: boolean;
   recipient_state?: string;
   recipient_reason?: string;
+  consultant_sendability?: ConfengeConsultantSendability;
+  generation_error?: string;
   draft?: ConfengeDraft;
   approved_by?: string;
   approved_at?: string | Date;


### PR DESCRIPTION
## O que mudou

- consome extra-cli #392/#72 de forma aditiva e fail-closed: domínio, evidência, verification, derivation, freshness, suppression e epistemic class sobrevivem ingest → persist → reload
- MX/DNS e CANDIDATE_UNVERIFIED/INFERRED/genérico nunca viram OFFICIAL_SOURCE, VERIFIED, VALIDATED ou email_send_ready
- renderer lê só RecipientFacingCopy; hipótese/rationale/crédito/dump não entram no e-mail
- validation_ok/NEEDS_REVIEW = já sendable, falta só autorização humana
- near-dup, compositor stale, CTA sem ?, assunto Contrato {razao}, truncamento e mismatch viram hard-fail
- cockpit mostra o pacote consultant-sendability; Gerar mensagem nunca é no-op silencioso
- 0 auto-send; dispatch/killswitch intactos; 0 EMAIL_VALIDATED inventado

## Por quê

A revisão humana (#56) mostrou 0/43 rascunhos autorizáveis. Esta PR deixa a última milha pronta para o primeiro recipient real do extra-cli.

## Validação

- testes focais last-mile + ingest + P0 catalog passaram
- suíte unitária de internal/app/confenge (exceto e2e/pg) passou
- gofmt limpo nos arquivos tocados
- pnpm typecheck em web/ passou

Não fecha #41. Não retoma dispatch. Não aprova em nome do operador.