### PR TITLE
feat: add commercial-intelligence join, exception queue, and monthly executive view

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1100,6 +1100,7 @@ func main() {
 		if confengeServiceForHandler != nil {
 			// Global dispatch governor: ~10 outbound/hour shared email+WhatsApp.
 			confengeServiceForHandler.WireDispatch(primaryDB.Pool)
+			confengeServiceForHandler.WireIntel(primaryDB.Pool)
 			// CAMPAIGN_POLICY_AUTHORIZATION store for GREEN autorun (no fake approved_by).
 			confengeServiceForHandler.WirePolicyAuth(repository.NewConfengePolicyRepository(primaryDB.Pool))
 		}

--- a/docs/confenge/README.md
+++ b/docs/confenge/README.md
@@ -18,8 +18,9 @@ Product acceptance matrix (email + WhatsApp sum, human approval, governor,
 outcomes): [PRODUCT-ACCEPTANCE.md](./PRODUCT-ACCEPTANCE.md).
 
 This tree also covers feed contract, import, staging models, review, WhatsApp
-orchestration, per-touch approval, dispatch governor, reply cockpit, and
-local-first ops.
+orchestration, per-touch approval, dispatch governor, reply cockpit,
+commercial intelligence (join / exception queue / executive view), and
+local-first ops. See [commercial-intelligence.md](./commercial-intelligence.md).
 
 ## Separation of concerns
 

--- a/docs/confenge/commercial-intelligence.md
+++ b/docs/confenge/commercial-intelligence.md
@@ -1,0 +1,71 @@
+# Commercial intelligence `confenge.commercial_intel.v1`
+
+Warmbly closes the commercial learning loop without becoming a CRM or a
+second ledger.
+
+```
+source/query/asset
+  → inbound lead_id / receipt_id / correlation_id
+  → extra-cli account / event / person / version
+  → Warmbly action_id / outcome_id / outbox event_id
+  → observed association
+  → LEARNING CANDIDATE (local only)
+```
+
+## Authority
+
+| Plane | Owns |
+| --- | --- |
+| web-cfg | source, query, asset, CTA, consent, lead attribution |
+| extra-cli | facts, entity, person, event, target-fit / activation versions |
+| Warmbly | approved action, delivery, human outcome, next action |
+
+UNKNOWN stays UNKNOWN. WON is never inferred. "Came via page X" plus
+"won contract Y" is an observed association, not causal proof.
+
+## Join keys
+
+Idempotent identity prefers `lead_id`, then `receipt_id`, then
+`action_id`, then outbox `idempotency_key`. Replay of the same IDs
+returns the first chain.
+
+Metric keys are SHA-256 of those IDs. Email, phone, name, and company
+never enter a metric key.
+
+## Exception queue
+
+`orphan`, `duplicate`, `conflicting_account`, `missing_version`,
+`stale_attribution`, plus `out_of_order` (held, not reordered) and
+`unconfirmed_won` (stays UNKNOWN). Store unavailable is fail-closed.
+
+## Executive view
+
+`GET /confenge/intel/executive?month=YYYY-MM&include_synthetic=0`
+
+Monthly payload, families kept separate (`inbound` / `outbound` /
+`partner` / `expansion`):
+
+- `inbound_qualified_pipeline`
+- `qco`
+- `conversations`
+- `meetings`
+- `proposals`
+- `pipeline`
+- `won` / `lost` / `unknown`
+- breakdowns by `source` / `asset` / `trigger` / `offer` / `route`
+- denominators, latency stamps, freshness / version watermarks
+
+`include_synthetic=1` is the labeled fixture path. Real metrics stay
+empty/UNKNOWN until a human-approved action exists.
+
+## Learning candidates
+
+Corrections and recorded outcomes emit a local `LEARNING CANDIDATE` for
+demand / asset / offer / content / distribution. Status is `PENDING`.
+This capability never writes extra-cli, web-cfg, or SmartLic.
+
+## What this is not
+
+No CRM board, forecast, magic score, auto-send, or second truth plane.
+The execution ledger (`MemoryLedger`) and the outcome outbox stay where
+they are. This module reads their IDs.

--- a/docs/confenge/commercial-intelligence.md
+++ b/docs/confenge/commercial-intelligence.md
@@ -36,7 +36,10 @@ never enter a metric key.
 
 `orphan`, `duplicate`, `conflicting_account`, `missing_version`,
 `stale_attribution`, plus `out_of_order` (held, not reordered) and
-`unconfirmed_won` (stays UNKNOWN). Store unavailable is fail-closed.
+`unconfirmed_won` / `unconfirmed_lost` (stay UNKNOWN). Store unavailable
+is fail-closed. Additive IDs (action, then outcome) merge onto the first
+chain. Outcomes join only by `lead_id` / `receipt_id` / `action_id` /
+`outcome_id`, never by email or CNPJ.
 
 ## Executive view
 

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -83,9 +83,14 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | GET | `/confenge/cockpit` | `READ_CONTACTS` |
 | GET | `/confenge/inbound` | `READ_CONTACTS` |
 | POST | `/confenge/inbound/:leadId/outcome` | `WRITE_CONTACTS` |
+| GET | `/confenge/intel/executive` | `READ_CONTACTS` |
+| GET | `/confenge/intel/exceptions` | `READ_CONTACTS` |
+| POST | `/confenge/intel/learning` | `WRITE_CONTACTS` |
 | POST | `/confenge/manual-queue/:id/action` | `WRITE_CONTACTS` |
 
 `GET /contacts/custom-fields` lists the distinct custom-field keys used across your contacts (frequency-ranked), for building personalization pickers. It returns a flat string array under `data`, capped at 200 keys.
+
+`GET /confenge/intel/executive` is the monthly commercial-intelligence query (not a CRM board). Families stay separate. Real counts stay empty or `UNKNOWN` until a human-approved action exists. `include_synthetic=1` is the labeled fixture path. WON is never inferred.
 
 AI contact research charges credits (2 per run, billable even when it finds nothing) and only saves cited findings. See the [AI contact research](/guides/ai-contact-research/) guide. The batch endpoint accepts up to 500 contact ids and drains in the background.
 

--- a/internal/api/handler/confenge_intel.go
+++ b/internal/api/handler/confenge_intel.go
@@ -1,0 +1,61 @@
+package handler
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+// GetConfengeExecutiveIntel — GET /confenge/intel/executive
+// Monthly commercial-intelligence query. Not a CRM board.
+func (h *Handler) GetConfengeExecutiveIntel(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	month := strings.TrimSpace(c.Query("month"))
+	includeSynthetic := queryBool(c, "include_synthetic")
+	view, xerr := h.ConfengeService.CommercialExecutiveView(c.Request.Context(), orgID, month, includeSynthetic)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": view})
+}
+
+// ListConfengeIntelExceptions — GET /confenge/intel/exceptions
+func (h *Handler) ListConfengeIntelExceptions(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	xs, xerr := h.ConfengeService.ListIntelExceptions(c.Request.Context(), orgID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": xs})
+}
+
+// RecordConfengeIntelLearning — POST /confenge/intel/learning
+func (h *Handler) RecordConfengeIntelLearning(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	var body intel.LearningInput
+	if err := c.ShouldBindJSON(&body); err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid body"))
+		return
+	}
+	cand, xerr := h.ConfengeService.RecordIntelLearning(c.Request.Context(), orgID, body)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{"data": cand})
+}

--- a/internal/api/handler/confenge_intel_test.go
+++ b/internal/api/handler/confenge_intel_test.go
@@ -1,0 +1,86 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/api/middleware"
+	"github.com/warmbly/warmbly/internal/app/confenge"
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+type intelHTTPStub struct {
+	confenge.Service
+	view intel.ExecutiveView
+}
+
+func (s *intelHTTPStub) Enabled() bool { return true }
+func (s *intelHTTPStub) CommercialExecutiveView(_ context.Context, _ uuid.UUID, month string, includeSynthetic bool) (*intel.ExecutiveView, *errx.Error) {
+	v := s.view
+	if month != "" {
+		v.Month = month
+	}
+	v.IncludeSynthetic = includeSynthetic
+	return &v, nil
+}
+
+func TestGetConfengeExecutiveIntelBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+	st := intel.NewMemoryStore()
+	intel.LoadSynthetic(st, org.String())
+	chains, _ := st.ListChains(org.String())
+	view := intel.Rollup(chains, intel.SyntheticMonth, true)
+	h := &Handler{ConfengeService: &intelHTTPStub{view: view}}
+
+	req := httptest.NewRequest(http.MethodGet, "/confenge/intel/executive?month=2026-08&include_synthetic=1", nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	c.Set(middleware.OrganizationIDKey, org)
+	h.GetConfengeExecutiveIntel(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	var wrap struct {
+		Data intel.ExecutiveView `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &wrap); err != nil {
+		t.Fatal(err)
+	}
+	body := w.Body.String()
+	for _, field := range []string{
+		"inbound_qualified_pipeline", "qco", "conversations", "meetings",
+		"proposals", "pipeline", "won", "lost", "unknown",
+	} {
+		if !jsonHasKey(body, field) {
+			t.Fatalf("body missing %s: %s", field, body)
+		}
+	}
+	if wrap.Data.InboundQualifiedPipeline == 0 || wrap.Data.QCO == 0 {
+		t.Fatalf("monthly fields empty: %+v", wrap.Data)
+	}
+	if wrap.Data.CausalProof {
+		t.Fatal("HTTP payload claimed causal proof")
+	}
+	fmt.Printf("HTTP_EXEC status=%d iqp=%d qco=%d won=%d lost=%d unknown=%d\n",
+		w.Code, wrap.Data.InboundQualifiedPipeline, wrap.Data.QCO, wrap.Data.Won, wrap.Data.Lost, wrap.Data.Unknown)
+}
+
+func jsonHasKey(body, key string) bool {
+	needle := `"` + key + `"`
+	for i := 0; i+len(needle) <= len(body); i++ {
+		if body[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -522,6 +522,8 @@ func Run(
 				confengeGroup.GET("/cockpit", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeContactCockpit)
 				confengeGroup.GET("/today", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeToday)
 				confengeGroup.GET("/inbound", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeInboundNow)
+				confengeGroup.GET("/intel/executive", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeExecutiveIntel)
+				confengeGroup.GET("/intel/exceptions", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeIntelExceptions)
 				confengeGroup.GET("/attention", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeAttention)
 				confengeGroup.GET("/attention/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeAttention)
 				confengeGroup.GET("/accounts", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeAccounts)
@@ -569,6 +571,7 @@ func Run(
 					confengeWrite.POST("/actions/:id/start", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.StartConfengeCommercialAction)
 					confengeWrite.POST("/actions/:id/outcome", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.RecordConfengeCommercialOutcome)
 					confengeWrite.POST("/inbound/:leadId/outcome", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.RecordConfengeInboundOutcome)
+					confengeWrite.POST("/intel/learning", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.RecordConfengeIntelLearning)
 					confengeWrite.POST("/dispatch/pause", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.PauseConfengeDispatch)
 					confengeWrite.POST("/dispatch/resume", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ResumeConfengeDispatch)
 				}

--- a/internal/app/confenge/intel/empty_real_test.go
+++ b/internal/app/confenge/intel/empty_real_test.go
@@ -1,0 +1,45 @@
+package intel
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestRealEmptyStoreNotFilledFromFixtures(t *testing.T) {
+	st := NewMemoryStore()
+	org := "33333333-3333-4333-8333-333333333333"
+	// Fixtures exist as a function but are not loaded into this store.
+	_ = SyntheticFacts(org)
+	chains, _ := st.ListChains(org)
+	view := Rollup(chains, SyntheticMonth, false)
+	if view.ChainCount != 0 || !view.RealEmpty {
+		t.Fatalf("empty store not empty: count=%d real_empty=%v", view.ChainCount, view.RealEmpty)
+	}
+	if view.InboundQualifiedPipeline != 0 || view.QCO != 0 || view.Conversations != 0 || view.Meetings != 0 || view.Proposals != 0 || view.Pipeline != 0 || view.Won != 0 || view.Lost != 0 {
+		t.Fatalf("real rollup invented counts: %+v", view)
+	}
+	if view.Unknown != 0 {
+		t.Fatalf("unknown count should be zero on an empty store, got %d", view.Unknown)
+	}
+	if view.AttributionKind != AssociationObserved || view.CausalProof {
+		t.Fatal("empty view claimed causation")
+	}
+
+	// Loading synthetics must not leak into includeSynthetic=false.
+	LoadSynthetic(st, org)
+	realOnly := Rollup(mustList(st, org), SyntheticMonth, false)
+	if realOnly.ChainCount != 0 || !realOnly.RealEmpty {
+		t.Fatalf("synthetic leaked into real rollup: %+v", realOnly)
+	}
+	labeled := Rollup(mustList(st, org), SyntheticMonth, true)
+	if labeled.ChainCount == 0 || labeled.RealEmpty {
+		t.Fatal("synthetic include path empty")
+	}
+	fmt.Printf("REAL_EMPTY iqp=%d qco=%d won=%d lost=%d unknown=%d real_empty=%v synthetic_count=%d\n",
+		realOnly.InboundQualifiedPipeline, realOnly.QCO, realOnly.Won, realOnly.Lost, realOnly.Unknown, realOnly.RealEmpty, labeled.ChainCount)
+}
+
+func mustList(st Store, org string) []Chain {
+	ch, _ := st.ListChains(org)
+	return ch
+}

--- a/internal/app/confenge/intel/exceptions.go
+++ b/internal/app/confenge/intel/exceptions.go
@@ -1,0 +1,112 @@
+package intel
+
+import (
+	"strings"
+	"time"
+)
+
+// ClassifyExceptions inspects one observed record against an optional
+// existing chain. It never invents a causal order.
+func ClassifyExceptions(in ObservedFacts, existing *Chain) []Exception {
+	now := time.Now().UTC()
+	identity := ChainIdentity(in.Keys)
+	metric := MetricKey(in.Keys)
+	base := Exception{
+		OrganizationID: strings.TrimSpace(in.Keys.OrganizationID),
+		Identity:       identity,
+		MetricKey:      metric,
+		ActionID:       strings.TrimSpace(in.Keys.ActionID),
+		OutcomeID:      strings.TrimSpace(in.Keys.OutcomeID),
+		AccountID:      strings.TrimSpace(in.Keys.AccountID),
+		LeadID:         strings.TrimSpace(in.Keys.LeadID),
+		Synthetic:      in.Synthetic,
+		At:             now,
+	}
+
+	var out []Exception
+	add := func(code, reason, next string, held bool) {
+		ex := base
+		ex.Code = code
+		ex.Reason = reason
+		ex.NextAction = next
+		ex.Held = held
+		out = append(out, ex)
+	}
+
+	if identity == "" {
+		add(ExceptionOrphan, "no lead_id, receipt_id, action_id, or idempotency_key", "hold until a durable ID arrives", true)
+	}
+
+	hasOutcome := strings.TrimSpace(in.Keys.OutcomeID) != "" || strings.TrimSpace(in.OutcomeType) != ""
+	hasAction := strings.TrimSpace(in.Keys.ActionID) != ""
+	if hasOutcome && !hasAction {
+		add(ExceptionOrphan, "outcome without action", "hold on exception queue until action arrives", true)
+	}
+	if normalizeFamily(in.Keys.RouteFamily) == FamilyInbound && strings.TrimSpace(in.Keys.LeadID) == "" && strings.TrimSpace(in.Keys.ReceiptID) == "" {
+		add(ExceptionOrphan, "inbound family missing lead_id/receipt_id", "hold until the web-cfg receipt IDs arrive", true)
+	}
+
+	if existing != nil && identity != "" {
+		add(ExceptionDuplicate, "same join IDs already have a chain", "return the first chain; do not insert a second", false)
+		if conflictAccount(existing.Keys, in.Keys) {
+			add(ExceptionConflictingAccount, "incoming account_id disagrees with the first chain", "keep the first extra-cli account; do not overwrite", false)
+		}
+	}
+
+	if strings.TrimSpace(in.Keys.AccountID) != "" || strings.TrimSpace(in.Keys.SourceLeadID) != "" {
+		if strings.TrimSpace(in.Keys.TargetFitVersion) == "" || strings.TrimSpace(in.Keys.ActivationPolicyVersion) == "" {
+			add(ExceptionMissingVersion, "extra-cli account present without target_fit or activation policy version", "leave version UNKNOWN; do not invent a watermark", false)
+		}
+	} else if strings.TrimSpace(in.Keys.TargetFitVersion) == "" && strings.TrimSpace(in.Keys.ActivationPolicyVersion) == "" && (hasAction || strings.TrimSpace(in.Keys.LeadID) != "") {
+		// Observed path with no extra-cli versions: record missing, stay UNKNOWN.
+		add(ExceptionMissingVersion, "no extra-cli version on the observed path", "leave version UNKNOWN", false)
+	}
+
+	if in.AttributionStale || in.RequiresFresh {
+		add(ExceptionStaleAttribution, "attribution or target-fit freshness is stale", "keep the observed IDs; do not invent a newer source/asset", false)
+	}
+
+	if outOfOrder(in) {
+		add(ExceptionOutOfOrder, "outcome timestamp precedes action or inbound; order is not invented", "hold; do not reorder into a fake chain", true)
+	}
+
+	if isWonType(in.OutcomeType) && !in.HumanConfirmed {
+		add(ExceptionUnconfirmedWon, "WON cannot be inferred", "require human or document confirmation; keep UNKNOWN", true)
+	}
+
+	return out
+}
+
+func conflictAccount(a, b JoinKeys) bool {
+	left := firstNonEmpty(a.AccountID, a.SourceLeadID)
+	right := firstNonEmpty(b.AccountID, b.SourceLeadID)
+	if left == "" || right == "" {
+		return false
+	}
+	return left != right
+}
+
+func outOfOrder(in ObservedFacts) bool {
+	if in.OutcomeOccurredAt.IsZero() {
+		return false
+	}
+	if !in.ActionOccurredAt.IsZero() && in.OutcomeOccurredAt.Before(in.ActionOccurredAt) {
+		return true
+	}
+	if !in.LeadCreatedAt.IsZero() && in.OutcomeOccurredAt.Before(in.LeadCreatedAt) {
+		return true
+	}
+	if !in.IngestedAt.IsZero() && in.OutcomeOccurredAt.Before(in.IngestedAt) && strings.TrimSpace(in.Keys.ActionID) == "" {
+		return true
+	}
+	return false
+}
+
+func firstNonEmpty(vs ...string) string {
+	for _, v := range vs {
+		if s := strings.TrimSpace(v); s != "" {
+			return s
+		}
+	}
+	return ""
+}

--- a/internal/app/confenge/intel/exceptions.go
+++ b/internal/app/confenge/intel/exceptions.go
@@ -37,8 +37,8 @@ func ClassifyExceptions(in ObservedFacts, existing *Chain) []Exception {
 		add(ExceptionOrphan, "no lead_id, receipt_id, action_id, or idempotency_key", "hold until a durable ID arrives", true)
 	}
 
-	hasOutcome := strings.TrimSpace(in.Keys.OutcomeID) != "" || strings.TrimSpace(in.OutcomeType) != ""
-	hasAction := strings.TrimSpace(in.Keys.ActionID) != ""
+	hasOutcome := knownID(in.Keys.OutcomeID) != "" || strings.TrimSpace(in.OutcomeType) != ""
+	hasAction := knownID(in.Keys.ActionID) != "" || chainHasAction(existing)
 	if hasOutcome && !hasAction {
 		add(ExceptionOrphan, "outcome without action", "hold on exception queue until action arrives", true)
 	}
@@ -47,9 +47,11 @@ func ClassifyExceptions(in ObservedFacts, existing *Chain) []Exception {
 	}
 
 	if existing != nil && identity != "" {
-		add(ExceptionDuplicate, "same join IDs already have a chain", "return the first chain; do not insert a second", false)
 		if conflictAccount(existing.Keys, in.Keys) {
 			add(ExceptionConflictingAccount, "incoming account_id disagrees with the first chain", "keep the first extra-cli account; do not overwrite", false)
+		}
+		if !additiveIDs(existing, in) {
+			add(ExceptionDuplicate, "same join IDs already have a chain", "return the first chain; do not insert a second", false)
 		}
 	}
 
@@ -73,8 +75,45 @@ func ClassifyExceptions(in ObservedFacts, existing *Chain) []Exception {
 	if isWonType(in.OutcomeType) && !in.HumanConfirmed {
 		add(ExceptionUnconfirmedWon, "WON cannot be inferred", "require human or document confirmation; keep UNKNOWN", true)
 	}
+	if isLostType(in.OutcomeType) && !in.HumanConfirmed {
+		add(ExceptionUnconfirmedLost, "LOST cannot be inferred", "require human or document confirmation; keep UNKNOWN", true)
+	}
 
 	return out
+}
+
+func chainHasAction(existing *Chain) bool {
+	if existing == nil {
+		return false
+	}
+	return knownID(existing.ActionID) != "" || knownID(existing.Keys.ActionID) != ""
+}
+
+func additiveIDs(existing *Chain, in ObservedFacts) bool {
+	if existing == nil {
+		return false
+	}
+	if inc := knownID(in.Keys.ActionID); inc != "" && knownID(existing.ActionID) == "" && knownID(existing.Keys.ActionID) == "" {
+		return true
+	}
+	if inc := knownID(in.Keys.OutcomeID); inc != "" && knownID(existing.OutcomeID) == "" && knownID(existing.Keys.OutcomeID) == "" {
+		return true
+	}
+	if inc := knownID(in.Keys.OutboxEventID); inc != "" && knownID(existing.OutboxEventID) == "" && knownID(existing.Keys.OutboxEventID) == "" {
+		return true
+	}
+	if inc := knownID(in.Keys.ReceiptID); inc != "" && knownID(existing.ReceiptID) == "" && knownID(existing.Keys.ReceiptID) == "" {
+		return true
+	}
+	return false
+}
+
+func knownID(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" || v == Unknown {
+		return ""
+	}
+	return v
 }
 
 func conflictAccount(a, b JoinKeys) bool {

--- a/internal/app/confenge/intel/exceptions_test.go
+++ b/internal/app/confenge/intel/exceptions_test.go
@@ -1,0 +1,131 @@
+package intel
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestClassifyNamedExceptions(t *testing.T) {
+	base := testFacts("org", "lead-ex", "rcpt-ex", "acc-ex", "act-ex", "out-ex")
+
+	orphan := base
+	orphan.Keys.LeadID = ""
+	orphan.Keys.ReceiptID = ""
+	orphan.Keys.ActionID = ""
+	orphan.Keys.IdempotencyKey = ""
+	orphan.Keys.OutcomeID = "out-orphan"
+	orphan.OutcomeType = OutcomeMeeting
+
+	dupExisting := &Chain{Keys: base.Keys, Identity: ChainIdentity(base.Keys)}
+
+	conflict := base
+	conflict.Keys.AccountID = "other-acc"
+	conflict.Keys.SourceLeadID = "other-acc"
+
+	missing := base
+	missing.Keys.TargetFitVersion = ""
+	missing.Keys.ActivationPolicyVersion = ""
+
+	stale := base
+	stale.AttributionStale = true
+
+	codes := map[string][]Exception{
+		ExceptionOrphan:             ClassifyExceptions(orphan, nil),
+		ExceptionDuplicate:          ClassifyExceptions(base, dupExisting),
+		ExceptionConflictingAccount: ClassifyExceptions(conflict, dupExisting),
+		ExceptionMissingVersion:     ClassifyExceptions(missing, nil),
+		ExceptionStaleAttribution:   ClassifyExceptions(stale, nil),
+	}
+	for want, got := range codes {
+		if !hasCode(got, want) {
+			t.Fatalf("code %s missing in %+v", want, codesOf(got))
+		}
+		fmt.Printf("EXCEPTION code=%s persisted_classifier=true\n", want)
+	}
+
+	st := NewMemoryStore()
+	for _, in := range []ObservedFacts{orphan, missing, stale} {
+		res := Reconcile(st, in)
+		if len(res.Exceptions) == 0 {
+			t.Fatalf("reconcile dropped exceptions for %+v", in.Keys)
+		}
+	}
+	// Duplicate + conflict persist when a first chain exists.
+	first := Reconcile(st, base)
+	if !first.Created && first.Chain.Identity == "" && !hasCode(first.Exceptions, ExceptionOrphan) {
+		// base has IDs; should create unless earlier orphan identity collided.
+	}
+	dup := Reconcile(st, base)
+	if !hasCode(dup.Exceptions, ExceptionDuplicate) {
+		t.Fatalf("duplicate not persisted on replay: %+v", codesOf(dup.Exceptions))
+	}
+	conf := Reconcile(st, conflict)
+	if !hasCode(conf.Exceptions, ExceptionConflictingAccount) && conflict.Keys.LeadID == base.Keys.LeadID {
+		t.Fatalf("conflicting_account not persisted: %+v", codesOf(conf.Exceptions))
+	}
+	stored, _ := st.ListExceptions("")
+	seen := map[string]bool{}
+	for _, ex := range stored {
+		seen[ex.Code] = true
+	}
+	for _, code := range []string{ExceptionOrphan, ExceptionDuplicate, ExceptionMissingVersion, ExceptionStaleAttribution} {
+		if !seen[code] {
+			t.Fatalf("store missing exception %s (have %v)", code, seen)
+		}
+	}
+	fmt.Printf("EXCEPTION_STORE codes=%d\n", len(stored))
+}
+
+func TestOutOfOrderHeldNotReordered(t *testing.T) {
+	st := NewMemoryStore()
+	in := testFacts("org", "lead-oo", "rcpt-oo", "acc-oo", "act-oo", "out-oo")
+	in.ActionOccurredAt = time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	in.OutcomeOccurredAt = time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	res := Reconcile(st, in)
+	if !hasCode(res.Exceptions, ExceptionOutOfOrder) {
+		t.Fatalf("out_of_order missing: %+v", codesOf(res.Exceptions))
+	}
+	if !res.Held && !res.Chain.Held {
+		t.Fatal("out-of-order must be held")
+	}
+	if !res.Chain.LeadCreatedAt.Equal(in.LeadCreatedAt) {
+		t.Fatalf("lead_created_at rewritten: %v vs %v", res.Chain.LeadCreatedAt, in.LeadCreatedAt)
+	}
+	fmt.Printf("OUT_OF_ORDER held=%v reordered=false\n", res.Held || res.Chain.Held)
+}
+
+func TestUnconfirmedWonStaysUnknown(t *testing.T) {
+	st := NewMemoryStore()
+	in := testFacts("org", "lead-won", "rcpt-won", "acc-won", "act-won", "out-won")
+	in.OutcomeType = OutcomeWon
+	in.HumanConfirmed = false
+	res := Reconcile(st, in)
+	if !hasCode(res.Exceptions, ExceptionUnconfirmedWon) {
+		t.Fatalf("unconfirmed WON not classified: %+v", codesOf(res.Exceptions))
+	}
+	if res.Chain.OutcomeType == OutcomeWon {
+		t.Fatal("unconfirmed WON must not land on the chain")
+	}
+	if res.Chain.OutcomeType != OutcomeUnknown {
+		t.Fatalf("outcome=%s want UNKNOWN", res.Chain.OutcomeType)
+	}
+	fmt.Printf("UNCONFIRMED_WON chain_outcome=%s rejected=true\n", res.Chain.OutcomeType)
+}
+
+func hasCode(xs []Exception, code string) bool {
+	for _, ex := range xs {
+		if ex.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func codesOf(xs []Exception) []string {
+	var out []string
+	for _, ex := range xs {
+		out = append(out, ex.Code)
+	}
+	return out
+}

--- a/internal/app/confenge/intel/exceptions_test.go
+++ b/internal/app/confenge/intel/exceptions_test.go
@@ -113,6 +113,24 @@ func TestUnconfirmedWonStaysUnknown(t *testing.T) {
 	fmt.Printf("UNCONFIRMED_WON chain_outcome=%s rejected=true\n", res.Chain.OutcomeType)
 }
 
+func TestUnconfirmedLostStaysUnknown(t *testing.T) {
+	st := NewMemoryStore()
+	in := testFacts("org", "lead-lost", "rcpt-lost", "acc-lost", "act-lost", "out-lost")
+	in.OutcomeType = OutcomeLost
+	in.HumanConfirmed = false
+	res := Reconcile(st, in)
+	if !hasCode(res.Exceptions, ExceptionUnconfirmedLost) {
+		t.Fatalf("unconfirmed LOST not classified: %+v", codesOf(res.Exceptions))
+	}
+	if res.Chain.OutcomeType == OutcomeLost {
+		t.Fatal("unconfirmed LOST must not land on the chain")
+	}
+	if res.Chain.OutcomeType != OutcomeUnknown {
+		t.Fatalf("outcome=%s want UNKNOWN", res.Chain.OutcomeType)
+	}
+	fmt.Printf("UNCONFIRMED_LOST chain_outcome=%s rejected=true\n", res.Chain.OutcomeType)
+}
+
 func hasCode(xs []Exception, code string) bool {
 	for _, ex := range xs {
 		if ex.Code == code {

--- a/internal/app/confenge/intel/fixtures.go
+++ b/internal/app/confenge/intel/fixtures.go
@@ -1,0 +1,125 @@
+package intel
+
+import "time"
+
+// SyntheticMonth is the fixture window used by tests and the labeled demo.
+const SyntheticMonth = "2026-08"
+
+// SyntheticFacts returns clearly labeled SYNTHETIC observed records.
+// Real rollups must call Rollup(..., includeSynthetic=false).
+func SyntheticFacts(orgID string) []ObservedFacts {
+	base := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	ts := func(days, hours int) time.Time { return base.AddDate(0, 0, days).Add(time.Duration(hours) * time.Hour) }
+	ptr := func(t time.Time) *time.Time { return &t }
+
+	return []ObservedFacts{
+		{
+			Keys: JoinKeys{
+				OrganizationID: orgID, Source: "web-cfg", Query: "segunda-leitura",
+				AssetID: "landing-segunda-leitura", CTAID: "segunda-leitura-contrato",
+				CorrelationID: "corr-syn-in-1", LeadID: "webcfg-syn-in-1", ReceiptID: "rcpt-syn-in-1",
+				AccountID: "extra-acc-norte", SourceLeadID: "extra-acc-norte", PersonID: "person-ana",
+				EventIDs: []string{"ev-contract-margin"}, TargetFitVersion: "tf-v1",
+				ActivationPolicyVersion: "ap-v1", TargetFitWatermark: "wm-2026-08-01",
+				TargetFitFresh: true, ActionID: "act-syn-in-1", OutcomeID: "out-syn-in-1",
+				OutboxEventID: "evt-syn-in-1", IdempotencyKey: "idem-syn-in-1",
+				RouteFamily: FamilyInbound, Trigger: "CONTRACT_MARGIN_EVENT",
+				OfferID: "segunda-leitura", Route: "R3_ROUTED_TO_NAMED_PERSON",
+			},
+			LeadCreatedAt: ts(0, 0), IngestedAt: ts(0, 1), EnrichmentAt: ptr(ts(0, 2)),
+			FirstActionAt: ptr(ts(0, 4)), ConversationAt: ptr(ts(1, 2)),
+			ProposalAt: ptr(ts(5, 0)), CloseAt: ptr(ts(12, 0)),
+			ActionOccurredAt: ts(0, 4), OutcomeOccurredAt: ts(12, 0),
+			OutcomeType: OutcomeWon, HumanConfirmed: true, Qualified: true,
+			Conversation: true, PipelineOpen: false, Synthetic: true, Label: LabelSynthetic,
+		},
+		{
+			Keys: JoinKeys{
+				OrganizationID: orgID, Source: "web-cfg", Query: "diagnostico",
+				AssetID: "landing-diagnostico", CTAID: "cta-diag",
+				CorrelationID: "corr-syn-in-2", LeadID: "webcfg-syn-in-2", ReceiptID: "rcpt-syn-in-2",
+				AccountID: "extra-acc-sul", SourceLeadID: "extra-acc-sul", PersonID: "person-bruno",
+				EventIDs: []string{"ev-public-notice"}, TargetFitVersion: "tf-v1",
+				ActivationPolicyVersion: "ap-v1", TargetFitWatermark: "wm-2026-08-01",
+				TargetFitFresh: true, ActionID: "act-syn-in-2", OutcomeID: "out-syn-in-2",
+				OutboxEventID: "evt-syn-in-2", IdempotencyKey: "idem-syn-in-2",
+				RouteFamily: FamilyInbound, Trigger: "PUBLIC_NOTICE",
+				OfferID: "diagnostico", Route: "R1_DIRECT",
+			},
+			LeadCreatedAt: ts(2, 0), IngestedAt: ts(2, 1), EnrichmentAt: ptr(ts(2, 2)),
+			FirstActionAt: ptr(ts(2, 5)), ConversationAt: ptr(ts(3, 1)),
+			ActionOccurredAt: ts(2, 5), OutcomeOccurredAt: ts(3, 1),
+			OutcomeType: OutcomeQualifiedConversation, Qualified: true,
+			Conversation: true, PipelineOpen: true, Synthetic: true, Label: LabelSynthetic,
+		},
+		{
+			Keys: JoinKeys{
+				OrganizationID: orgID, Source: "web-cfg", Query: "segunda-leitura",
+				AssetID: "landing-segunda-leitura", LeadID: "webcfg-syn-in-3", ReceiptID: "rcpt-syn-in-3",
+				AccountID: "extra-acc-oeste", SourceLeadID: "extra-acc-oeste",
+				EventIDs: []string{"ev-addendum"}, TargetFitVersion: "tf-v1",
+				ActivationPolicyVersion: "ap-v1", TargetFitFresh: true,
+				ActionID: "act-syn-in-3", OutcomeID: "out-syn-in-3",
+				IdempotencyKey: "idem-syn-in-3", RouteFamily: FamilyInbound,
+				Trigger: "ADDENDUM", OfferID: "segunda-leitura", Route: "CALL",
+			},
+			LeadCreatedAt: ts(3, 0), IngestedAt: ts(3, 1), FirstActionAt: ptr(ts(3, 6)),
+			ProposalAt: ptr(ts(8, 0)), ActionOccurredAt: ts(3, 6), OutcomeOccurredAt: ts(8, 0),
+			OutcomeType: OutcomeProposal, Qualified: true, Conversation: true,
+			PipelineOpen: true, Synthetic: true, Label: LabelSynthetic,
+		},
+		{
+			Keys: JoinKeys{
+				OrganizationID: orgID, Source: "extra-cli", Query: "outbound-pilot",
+				AssetID: "playbook-v1", AccountID: "extra-acc-leste", SourceLeadID: "extra-acc-leste",
+				PersonID: "person-carla", EventIDs: []string{"ev-moment-leste"},
+				TargetFitVersion: "tf-v1", ActivationPolicyVersion: "ap-v1",
+				TargetFitFresh: true, ActionID: "act-syn-out-1", OutcomeID: "out-syn-out-1",
+				IdempotencyKey: "idem-syn-out-1", RouteFamily: FamilyOutbound,
+				Trigger: "CONTRACT_MARGIN_EVENT", OfferID: "segunda-leitura", Route: "EMAIL",
+			},
+			LeadCreatedAt: ts(1, 0), IngestedAt: ts(1, 0), FirstActionAt: ptr(ts(1, 3)),
+			ConversationAt: ptr(ts(4, 0)), ActionOccurredAt: ts(1, 3), OutcomeOccurredAt: ts(4, 0),
+			OutcomeType: OutcomeMeeting, Qualified: true, Conversation: true,
+			PipelineOpen: true, Synthetic: true, Label: LabelSynthetic,
+		},
+		{
+			Keys: JoinKeys{
+				OrganizationID: orgID, Source: "partner", Query: "indicacao",
+				AssetID: "partner-kit", AccountID: "extra-acc-partner", SourceLeadID: "extra-acc-partner",
+				PersonID: "person-diego", TargetFitVersion: "tf-v1",
+				ActivationPolicyVersion: "ap-v1", TargetFitFresh: true,
+				ActionID: "act-syn-pt-1", OutcomeID: "out-syn-pt-1",
+				IdempotencyKey: "idem-syn-pt-1", RouteFamily: FamilyPartner,
+				Trigger: "PARTNER_REFERRAL", OfferID: "diagnostico", Route: "ROUTED_CALL",
+			},
+			LeadCreatedAt: ts(6, 0), IngestedAt: ts(6, 0), FirstActionAt: ptr(ts(6, 2)),
+			ActionOccurredAt: ts(6, 2), OutcomeOccurredAt: ts(10, 0),
+			OutcomeType: OutcomeLost, HumanConfirmed: true, PipelineOpen: false,
+			Synthetic: true, Label: LabelSynthetic,
+		},
+		{
+			Keys: JoinKeys{
+				OrganizationID: orgID, Source: "expansion", Query: "renewal",
+				AssetID: "client-review", AccountID: "extra-acc-client", SourceLeadID: "extra-acc-client",
+				PersonID: "person-eva", TargetFitVersion: "tf-v1",
+				ActivationPolicyVersion: "ap-v1", TargetFitFresh: true,
+				ActionID: "act-syn-ex-1", OutcomeID: "out-syn-ex-1",
+				IdempotencyKey: "idem-syn-ex-1", RouteFamily: FamilyExpansion,
+				Trigger: "RENEWAL_WINDOW", OfferID: "annualidade", Route: "CALL",
+			},
+			LeadCreatedAt: ts(7, 0), IngestedAt: ts(7, 0), FirstActionAt: ptr(ts(7, 2)),
+			ActionOccurredAt: ts(7, 2), OutcomeType: OutcomeUnknown,
+			PipelineOpen: true, Synthetic: true, Label: LabelSynthetic,
+		},
+	}
+}
+
+// LoadSynthetic joins every labeled fixture into store. Idempotent.
+func LoadSynthetic(store Store, orgID string) []JoinResult {
+	var out []JoinResult
+	for _, f := range SyntheticFacts(orgID) {
+		out = append(out, Reconcile(store, f))
+	}
+	return out
+}

--- a/internal/app/confenge/intel/join.go
+++ b/internal/app/confenge/intel/join.go
@@ -92,11 +92,11 @@ func Reconcile(store Store, in ObservedFacts) JoinResult {
 	existing, _ := store.GetChain(in.Keys.OrganizationID, identity)
 	exceptions := ClassifyExceptions(in, existing)
 
-	wonBlocked := false
+	closeBlocked := false
 	held := false
 	for _, ex := range exceptions {
-		if ex.Code == ExceptionUnconfirmedWon {
-			wonBlocked = true
+		if ex.Code == ExceptionUnconfirmedWon || ex.Code == ExceptionUnconfirmedLost {
+			closeBlocked = true
 		}
 		if ex.Held {
 			held = true
@@ -110,16 +110,41 @@ func Reconcile(store Store, in ObservedFacts) JoinResult {
 
 	if existing != nil {
 		persistExceptions(store, exceptions)
+		merged, changed := mergeIntoChain(*existing, in, closeBlocked, held)
+		if !changed {
+			return JoinResult{
+				Chain:      *existing,
+				Exceptions: exceptions,
+				Created:    false,
+				Replay:     true,
+				Held:       existing.Held || held,
+			}
+		}
+		if err := store.UpdateChain(merged); err != nil {
+			ex := Exception{
+				Code:       ExceptionUnavailable,
+				Reason:     "update chain failed: " + err.Error(),
+				NextAction: "retry with the same IDs",
+				Identity:   identity,
+				MetricKey:  metric,
+				At:         now,
+			}
+			return JoinResult{Chain: *existing, Exceptions: []Exception{ex}, Held: true}
+		}
+		saved, _ := store.GetChain(in.Keys.OrganizationID, identity)
+		if saved == nil {
+			saved = &merged
+		}
 		return JoinResult{
-			Chain:      *existing,
+			Chain:      *saved,
 			Exceptions: exceptions,
 			Created:    false,
-			Replay:     true,
-			Held:       existing.Held || held,
+			Replay:     false,
+			Held:       saved.Held,
 		}
 	}
 
-	chain := buildChain(in, identity, metric, now, wonBlocked, held)
+	chain := buildChain(in, identity, metric, now, closeBlocked, held)
 	saved, created, err := store.PutChain(chain)
 	if err != nil {
 		ex := Exception{
@@ -142,7 +167,7 @@ func Reconcile(store Store, in ObservedFacts) JoinResult {
 	}
 }
 
-func buildChain(in ObservedFacts, identity, metric string, now time.Time, wonBlocked, held bool) Chain {
+func buildChain(in ObservedFacts, identity, metric string, now time.Time, closeBlocked, held bool) Chain {
 	k := in.Keys
 	label := strings.TrimSpace(in.Label)
 	if in.Synthetic {
@@ -151,10 +176,10 @@ func buildChain(in ObservedFacts, identity, metric string, now time.Time, wonBlo
 		label = LabelReal
 	}
 	outcome := strings.ToUpper(strings.TrimSpace(in.OutcomeType))
-	if outcome == "" || wonBlocked {
+	if outcome == "" || closeBlocked {
 		outcome = OutcomeUnknown
 	}
-	if isWonType(outcome) && !in.HumanConfirmed {
+	if (isWonType(outcome) || isLostType(outcome)) && !in.HumanConfirmed {
 		outcome = OutcomeUnknown
 	}
 	qualified := in.Qualified || outcome == OutcomeQualifiedConversation
@@ -203,7 +228,7 @@ func buildChain(in ObservedFacts, identity, metric string, now time.Time, wonBlo
 		ProposalAt:      in.ProposalAt,
 		CloseAt:         in.CloseAt,
 		OutcomeType:     outcome,
-		HumanConfirmed:  in.HumanConfirmed && isWonType(strings.ToUpper(strings.TrimSpace(in.OutcomeType))),
+		HumanConfirmed:  in.HumanConfirmed && (isWonType(strings.ToUpper(strings.TrimSpace(in.OutcomeType))) || isLostType(strings.ToUpper(strings.TrimSpace(in.OutcomeType)))),
 		Qualified:       qualified,
 		Conversation:    conversation,
 		PipelineOpen:    pipeline,
@@ -214,6 +239,136 @@ func buildChain(in ObservedFacts, identity, metric string, now time.Time, wonBlo
 		Label:           label,
 		CreatedAt:       now,
 	}
+}
+
+func mergeIntoChain(existing Chain, in ObservedFacts, closeBlocked, held bool) (Chain, bool) {
+	merged := existing
+	changed := false
+	fill := func(dst *string, incoming string) {
+		inc := knownID(incoming)
+		if inc == "" {
+			return
+		}
+		if knownID(*dst) == "" {
+			*dst = inc
+			changed = true
+		}
+	}
+	fill(&merged.Keys.ActionID, in.Keys.ActionID)
+	fill(&merged.ActionID, in.Keys.ActionID)
+	fill(&merged.Keys.OutcomeID, in.Keys.OutcomeID)
+	fill(&merged.OutcomeID, in.Keys.OutcomeID)
+	fill(&merged.Keys.OutboxEventID, in.Keys.OutboxEventID)
+	fill(&merged.OutboxEventID, in.Keys.OutboxEventID)
+	fill(&merged.Keys.IdempotencyKey, in.Keys.IdempotencyKey)
+	fill(&merged.IdempotencyKey, in.Keys.IdempotencyKey)
+	fill(&merged.Keys.ReceiptID, in.Keys.ReceiptID)
+	fill(&merged.ReceiptID, in.Keys.ReceiptID)
+	fill(&merged.Keys.CorrelationID, in.Keys.CorrelationID)
+	fill(&merged.CorrelationID, in.Keys.CorrelationID)
+	fill(&merged.Keys.PersonID, in.Keys.PersonID)
+	fill(&merged.PersonID, in.Keys.PersonID)
+	fill(&merged.Keys.AssetID, in.Keys.AssetID)
+	fill(&merged.AssetID, in.Keys.AssetID)
+	fill(&merged.Keys.Query, in.Keys.Query)
+	fill(&merged.Query, in.Keys.Query)
+	fill(&merged.Keys.Trigger, in.Keys.Trigger)
+	fill(&merged.Trigger, in.Keys.Trigger)
+	fill(&merged.Keys.OfferID, in.Keys.OfferID)
+	fill(&merged.OfferID, in.Keys.OfferID)
+	fill(&merged.Keys.Route, in.Keys.Route)
+	fill(&merged.Route, in.Keys.Route)
+	if !conflictAccount(existing.Keys, in.Keys) {
+		fill(&merged.Keys.AccountID, in.Keys.AccountID)
+		fill(&merged.AccountID, in.Keys.AccountID)
+		fill(&merged.Keys.SourceLeadID, in.Keys.SourceLeadID)
+	}
+	for _, ev := range in.Keys.EventIDs {
+		if knownID(ev) == "" {
+			continue
+		}
+		found := false
+		for _, have := range merged.Keys.EventIDs {
+			if have == ev {
+				found = true
+				break
+			}
+		}
+		if !found {
+			merged.Keys.EventIDs = append(merged.Keys.EventIDs, ev)
+			changed = true
+		}
+	}
+
+	incoming := strings.ToUpper(strings.TrimSpace(in.OutcomeType))
+	if closeBlocked || ((isWonType(incoming) || isLostType(incoming)) && !in.HumanConfirmed) {
+		incoming = OutcomeUnknown
+	}
+	if (merged.OutcomeType == "" || merged.OutcomeType == OutcomeUnknown) && incoming != "" && incoming != OutcomeUnknown {
+		merged.OutcomeType = incoming
+		changed = true
+	}
+	if in.HumanConfirmed && (isWonType(in.OutcomeType) || isLostType(in.OutcomeType)) && !merged.HumanConfirmed {
+		merged.HumanConfirmed = true
+		changed = true
+	}
+	if in.Qualified && !merged.Qualified {
+		merged.Qualified = true
+		changed = true
+	}
+	if in.Conversation && !merged.Conversation {
+		merged.Conversation = true
+		changed = true
+	}
+	if in.FirstActionAt != nil && merged.FirstActionAt == nil {
+		merged.FirstActionAt = in.FirstActionAt
+		changed = true
+	}
+	if in.ConversationAt != nil && merged.ConversationAt == nil {
+		merged.ConversationAt = in.ConversationAt
+		changed = true
+	}
+	if in.ProposalAt != nil && merged.ProposalAt == nil {
+		merged.ProposalAt = in.ProposalAt
+		changed = true
+	}
+	if in.CloseAt != nil && merged.CloseAt == nil && merged.HumanConfirmed {
+		merged.CloseAt = in.CloseAt
+		changed = true
+	}
+	if in.EnrichmentAt != nil && merged.EnrichmentAt == nil {
+		merged.EnrichmentAt = in.EnrichmentAt
+		changed = true
+	}
+	if held && !merged.Held {
+		merged.Held = true
+		changed = true
+	}
+
+	qualified := merged.Qualified || merged.OutcomeType == OutcomeQualifiedConversation
+	conversation := merged.Conversation || merged.ConversationAt != nil || qualified || merged.OutcomeType == OutcomeReplied
+	pipeline := merged.PipelineOpen
+	if !isWonType(merged.OutcomeType) && !isLostType(merged.OutcomeType) && merged.OutcomeType != OutcomeDoNotContact {
+		if qualified || conversation || merged.OutcomeType == OutcomeMeeting || merged.OutcomeType == OutcomeProposal || merged.OutcomeType == OutcomeContacted {
+			pipeline = true
+		}
+	}
+	if isWonType(merged.OutcomeType) || isLostType(merged.OutcomeType) {
+		pipeline = false
+	}
+	if qualified != merged.Qualified || conversation != merged.Conversation || pipeline != merged.PipelineOpen {
+		merged.Qualified = qualified
+		merged.Conversation = conversation
+		merged.PipelineOpen = pipeline
+		changed = true
+	}
+
+	if changed {
+		merged.MetricKey = MetricKey(merged.Keys)
+		merged.AttributionKind = AssociationObserved
+		merged.CausalProof = false
+	}
+	return merged, changed
 }
 
 func persistExceptions(store Store, xs []Exception) {

--- a/internal/app/confenge/intel/join.go
+++ b/internal/app/confenge/intel/join.go
@@ -1,0 +1,226 @@
+package intel
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+	"time"
+)
+
+// ChainIdentity is the durable idempotency key for one observed path.
+// lead_id wins when present so a replay of the same inbound receipt
+// cannot open a second chain.
+func ChainIdentity(k JoinKeys) string {
+	if id := strings.TrimSpace(k.LeadID); id != "" {
+		return "lead:" + id
+	}
+	if id := strings.TrimSpace(k.ReceiptID); id != "" {
+		return "receipt:" + id
+	}
+	if id := strings.TrimSpace(k.ActionID); id != "" {
+		return "action:" + id
+	}
+	if id := strings.TrimSpace(k.IdempotencyKey); id != "" {
+		return "idem:" + id
+	}
+	return ""
+}
+
+// MetricKey hashes join IDs only. Email, phone, name, and company are
+// never part of the material.
+func MetricKey(k JoinKeys) string {
+	events := append([]string{}, k.EventIDs...)
+	sort.Strings(events)
+	parts := []string{
+		strings.TrimSpace(k.OrganizationID),
+		strings.TrimSpace(k.Source),
+		strings.TrimSpace(k.Query),
+		strings.TrimSpace(k.AssetID),
+		strings.TrimSpace(k.CTAID),
+		strings.TrimSpace(k.CorrelationID),
+		strings.TrimSpace(k.LeadID),
+		strings.TrimSpace(k.ReceiptID),
+		strings.TrimSpace(k.AccountID),
+		strings.TrimSpace(k.SourceLeadID),
+		strings.TrimSpace(k.PersonID),
+		strings.Join(events, ","),
+		strings.TrimSpace(k.TargetFitVersion),
+		strings.TrimSpace(k.ActivationPolicyVersion),
+		strings.TrimSpace(k.ActionID),
+		strings.TrimSpace(k.OutcomeID),
+		strings.TrimSpace(k.OutboxEventID),
+		strings.TrimSpace(k.IdempotencyKey),
+		strings.TrimSpace(k.RouteFamily),
+		strings.TrimSpace(k.Trigger),
+		strings.TrimSpace(k.OfferID),
+		strings.TrimSpace(k.Route),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return hex.EncodeToString(sum[:])
+}
+
+// MetricKeyContainsPII reports whether a metric key string (or the raw
+// join material) carries obvious PII tokens. Shipped keys are hashes.
+func MetricKeyContainsPII(key string) bool {
+	low := strings.ToLower(key)
+	for _, tok := range []string{"@", "email=", "phone=", "nome=", "name=", "cnpj=", "tel:"} {
+		if strings.Contains(low, tok) {
+			return true
+		}
+	}
+	return strings.Contains(key, " ")
+}
+
+// Reconcile joins one observed record into the store. Same IDs return
+// the first chain. The store is fail-closed when nil.
+func Reconcile(store Store, in ObservedFacts) JoinResult {
+	now := time.Now().UTC()
+	if store == nil {
+		ex := Exception{
+			Code:       ExceptionUnavailable,
+			Reason:     "commercial intelligence store unavailable",
+			NextAction: "retry with the same IDs; do not invent a chain",
+			At:         now,
+		}
+		return JoinResult{Exceptions: []Exception{ex}, Held: true}
+	}
+
+	in.Keys.RouteFamily = normalizeFamily(in.Keys.RouteFamily)
+	identity := ChainIdentity(in.Keys)
+	metric := MetricKey(in.Keys)
+	existing, _ := store.GetChain(in.Keys.OrganizationID, identity)
+	exceptions := ClassifyExceptions(in, existing)
+
+	wonBlocked := false
+	held := false
+	for _, ex := range exceptions {
+		if ex.Code == ExceptionUnconfirmedWon {
+			wonBlocked = true
+		}
+		if ex.Held {
+			held = true
+		}
+	}
+
+	if identity == "" {
+		persistExceptions(store, exceptions)
+		return JoinResult{Exceptions: exceptions, Held: true}
+	}
+
+	if existing != nil {
+		persistExceptions(store, exceptions)
+		return JoinResult{
+			Chain:      *existing,
+			Exceptions: exceptions,
+			Created:    false,
+			Replay:     true,
+			Held:       existing.Held || held,
+		}
+	}
+
+	chain := buildChain(in, identity, metric, now, wonBlocked, held)
+	saved, created, err := store.PutChain(chain)
+	if err != nil {
+		ex := Exception{
+			Code:       ExceptionUnavailable,
+			Reason:     "put chain failed: " + err.Error(),
+			NextAction: "retry with the same IDs",
+			Identity:   identity,
+			MetricKey:  metric,
+			At:         now,
+		}
+		return JoinResult{Exceptions: []Exception{ex}, Held: true}
+	}
+	persistExceptions(store, exceptions)
+	return JoinResult{
+		Chain:      saved,
+		Exceptions: exceptions,
+		Created:    created,
+		Replay:     !created,
+		Held:       saved.Held,
+	}
+}
+
+func buildChain(in ObservedFacts, identity, metric string, now time.Time, wonBlocked, held bool) Chain {
+	k := in.Keys
+	label := strings.TrimSpace(in.Label)
+	if in.Synthetic {
+		label = LabelSynthetic
+	} else if label == "" {
+		label = LabelReal
+	}
+	outcome := strings.ToUpper(strings.TrimSpace(in.OutcomeType))
+	if outcome == "" || wonBlocked {
+		outcome = OutcomeUnknown
+	}
+	if isWonType(outcome) && !in.HumanConfirmed {
+		outcome = OutcomeUnknown
+	}
+	qualified := in.Qualified || outcome == OutcomeQualifiedConversation
+	conversation := in.Conversation || in.ConversationAt != nil || qualified || outcome == OutcomeReplied
+	pipeline := in.PipelineOpen
+	if !isWonType(outcome) && !isLostType(outcome) && outcome != OutcomeDoNotContact {
+		if qualified || conversation || outcome == OutcomeMeeting || outcome == OutcomeProposal || outcome == OutcomeContacted {
+			pipeline = true
+		}
+	}
+	if isWonType(outcome) || isLostType(outcome) {
+		pipeline = false
+	}
+	return Chain{
+		SchemaVersion:  SchemaV1,
+		Identity:       identity,
+		MetricKey:      metric,
+		Keys:           k,
+		Source:         idOrUnknown(k.Source),
+		Query:          idOrUnknown(k.Query),
+		AssetID:        idOrUnknown(k.AssetID),
+		LeadID:         idOrUnknown(k.LeadID),
+		ReceiptID:      idOrUnknown(k.ReceiptID),
+		CorrelationID:  idOrUnknown(k.CorrelationID),
+		AccountID:      idOrUnknown(k.AccountID),
+		PersonID:       idOrUnknown(k.PersonID),
+		ActionID:       idOrUnknown(k.ActionID),
+		OutcomeID:      idOrUnknown(k.OutcomeID),
+		OutboxEventID:  idOrUnknown(k.OutboxEventID),
+		IdempotencyKey: idOrUnknown(k.IdempotencyKey),
+		RouteFamily:    idOrUnknown(k.RouteFamily),
+		Trigger:        idOrUnknown(k.Trigger),
+		OfferID:        idOrUnknown(k.OfferID),
+		Route:          idOrUnknown(k.Route),
+		Versions: Versions{
+			TargetFit:          idOrUnknown(k.TargetFitVersion),
+			ActivationPolicy:   idOrUnknown(k.ActivationPolicyVersion),
+			TargetFitWatermark: idOrUnknown(k.TargetFitWatermark),
+			Fresh:              k.TargetFitFresh && !in.AttributionStale && !in.RequiresFresh,
+		},
+		LeadCreatedAt:   in.LeadCreatedAt,
+		IngestedAt:      in.IngestedAt,
+		EnrichmentAt:    in.EnrichmentAt,
+		FirstActionAt:   in.FirstActionAt,
+		ConversationAt:  in.ConversationAt,
+		ProposalAt:      in.ProposalAt,
+		CloseAt:         in.CloseAt,
+		OutcomeType:     outcome,
+		HumanConfirmed:  in.HumanConfirmed && isWonType(strings.ToUpper(strings.TrimSpace(in.OutcomeType))),
+		Qualified:       qualified,
+		Conversation:    conversation,
+		PipelineOpen:    pipeline,
+		Held:            held,
+		AttributionKind: AssociationObserved,
+		CausalProof:     false,
+		Synthetic:       in.Synthetic || label == LabelSynthetic,
+		Label:           label,
+		CreatedAt:       now,
+	}
+}
+
+func persistExceptions(store Store, xs []Exception) {
+	if store == nil {
+		return
+	}
+	for i := range xs {
+		_ = store.PutException(xs[i])
+	}
+}

--- a/internal/app/confenge/intel/join_test.go
+++ b/internal/app/confenge/intel/join_test.go
@@ -121,6 +121,58 @@ func TestMissingVersionStaysUnknown(t *testing.T) {
 		res.Chain.Versions.TargetFit, res.Chain.Versions.ActivationPolicy)
 }
 
+func TestReconcileMergesAdditiveActionThenOutcome(t *testing.T) {
+	st := NewMemoryStore()
+	org := "44444444-4444-4444-8444-444444444444"
+	lead := testFacts(org, "webcfg-merge-1", "rcpt-merge-1", "acc-merge", "act-merge-1", "")
+	lead.Keys.OutcomeID = ""
+	lead.Keys.OutboxEventID = ""
+	lead.OutcomeType = ""
+	lead.Qualified = false
+	first := Reconcile(st, lead)
+	if !first.Created {
+		t.Fatal("lead+action should create")
+	}
+	if first.Chain.ActionID != "act-merge-1" {
+		t.Fatalf("action_id=%s", first.Chain.ActionID)
+	}
+	if knownID(first.Chain.OutcomeID) != "" {
+		t.Fatalf("outcome invented on first write: %s", first.Chain.OutcomeID)
+	}
+
+	secondIn := lead
+	secondIn.Keys.ActionID = ""
+	secondIn.Keys.OutcomeID = "out-merge-1"
+	secondIn.Keys.OutboxEventID = "evt-merge-1"
+	secondIn.OutcomeType = OutcomeQualifiedConversation
+	secondIn.Qualified = true
+	second := Reconcile(st, secondIn)
+	if second.Created {
+		t.Fatal("second reconcile opened another chain")
+	}
+	if second.Chain.ActionID != "act-merge-1" {
+		t.Fatalf("merged action_id lost: %s", second.Chain.ActionID)
+	}
+	if second.Chain.OutcomeID != "out-merge-1" {
+		t.Fatalf("outcome_id not merged: %s", second.Chain.OutcomeID)
+	}
+	if second.Chain.OutboxEventID != "evt-merge-1" {
+		t.Fatalf("outbox event_id not merged: %s", second.Chain.OutboxEventID)
+	}
+	if second.Chain.OutcomeType != OutcomeQualifiedConversation {
+		t.Fatalf("outcome type=%s", second.Chain.OutcomeType)
+	}
+	chains, _ := st.ListChains(org)
+	if len(chains) != 1 {
+		t.Fatalf("chains=%d want 1", len(chains))
+	}
+	if hasCode(second.Exceptions, ExceptionDuplicate) {
+		t.Fatal("additive merge must not be classified as duplicate")
+	}
+	fmt.Printf("JOIN_MERGE identity=%s action=%s outcome=%s chains=1\n",
+		second.Chain.Identity, second.Chain.ActionID, second.Chain.OutcomeID)
+}
+
 func TestNilStoreFailClosed(t *testing.T) {
 	res := Reconcile(nil, testFacts("org", "l", "r", "a", "act", "out"))
 	if len(res.Exceptions) == 0 || res.Exceptions[0].Code != ExceptionUnavailable {

--- a/internal/app/confenge/intel/join_test.go
+++ b/internal/app/confenge/intel/join_test.go
@@ -1,0 +1,132 @@
+package intel
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func testFacts(org, lead, receipt, account, action, outcome string) ObservedFacts {
+	return ObservedFacts{
+		Keys: JoinKeys{
+			OrganizationID:          org,
+			Source:                  "web-cfg",
+			Query:                   "segunda-leitura",
+			AssetID:                 "landing-segunda-leitura",
+			CTAID:                   "cta-1",
+			CorrelationID:           "corr-1",
+			LeadID:                  lead,
+			ReceiptID:               receipt,
+			AccountID:               account,
+			SourceLeadID:            account,
+			PersonID:                "person-1",
+			EventIDs:                []string{"ev-1"},
+			TargetFitVersion:        "tf-v1",
+			ActivationPolicyVersion: "ap-v1",
+			TargetFitWatermark:      "wm-1",
+			TargetFitFresh:          true,
+			ActionID:                action,
+			OutcomeID:               outcome,
+			OutboxEventID:           "evt-1",
+			IdempotencyKey:          "idem-" + lead,
+			RouteFamily:             FamilyInbound,
+			Trigger:                 "CONTRACT_MARGIN_EVENT",
+			OfferID:                 "segunda-leitura",
+			Route:                   "R3",
+		},
+		LeadCreatedAt:     time.Date(2026, 8, 4, 10, 0, 0, 0, time.UTC),
+		IngestedAt:        time.Date(2026, 8, 4, 10, 5, 0, 0, time.UTC),
+		ActionOccurredAt:  time.Date(2026, 8, 4, 11, 0, 0, 0, time.UTC),
+		OutcomeOccurredAt: time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC),
+		OutcomeType:       OutcomeQualifiedConversation,
+		Qualified:         true,
+		Label:             LabelReal,
+	}
+}
+
+func TestReconcileIdempotentSameIDs(t *testing.T) {
+	st := NewMemoryStore()
+	org := "11111111-1111-4111-8111-111111111111"
+	in := testFacts(org, "webcfg-1", "rcpt-1", "acc-1", "act-1", "out-1")
+	first := Reconcile(st, in)
+	if !first.Created {
+		t.Fatalf("first join should create a chain")
+	}
+	second := Reconcile(st, in)
+	if second.Created {
+		t.Fatal("replay created a second chain")
+	}
+	if !second.Replay {
+		t.Fatal("replay flag unset")
+	}
+	if first.Chain.Identity != second.Chain.Identity {
+		t.Fatalf("identity mismatch %s vs %s", first.Chain.Identity, second.Chain.Identity)
+	}
+	chains, _ := st.ListChains(org)
+	if len(chains) != 1 {
+		t.Fatalf("chains=%d want 1", len(chains))
+	}
+	if MetricKeyContainsPII(first.Chain.MetricKey) {
+		t.Fatalf("metric key looks like PII: %s", first.Chain.MetricKey)
+	}
+	if first.Chain.CausalProof {
+		t.Fatal("join must not claim causal proof")
+	}
+	fmt.Printf("JOIN identity=%s replay=%v chains=%d metric_pii=%v\n",
+		first.Chain.Identity, second.Replay, len(chains), MetricKeyContainsPII(first.Chain.MetricKey))
+}
+
+func TestMetricKeyOmitsPII(t *testing.T) {
+	k := JoinKeys{
+		LeadID: "lead-1", ReceiptID: "rcpt-1", AccountID: "acc-1",
+		PersonID: "person-1", ActionID: "act-1", OutcomeID: "out-1",
+		AssetID: "asset-1", Source: "web-cfg",
+	}
+	key := MetricKey(k)
+	blob := key + k.LeadID + k.AccountID
+	if strings.Contains(strings.ToLower(blob), "@") || strings.Contains(key, "ana") {
+		t.Fatalf("pii leaked into metric material: %s", key)
+	}
+	if MetricKeyContainsPII(key) {
+		t.Fatalf("hashed key flagged as PII: %s", key)
+	}
+	if MetricKeyContainsPII("lead@empresa.com") {
+		// sanity: detector works
+	} else {
+		t.Fatal("detector missed email")
+	}
+	fmt.Printf("METRIC_KEY hash=%s pii=false\n", key[:16])
+}
+
+func TestMissingVersionStaysUnknown(t *testing.T) {
+	st := NewMemoryStore()
+	in := testFacts("org", "lead-mv", "rcpt-mv", "acc-mv", "act-mv", "out-mv")
+	in.Keys.TargetFitVersion = ""
+	in.Keys.ActivationPolicyVersion = ""
+	res := Reconcile(st, in)
+	if res.Chain.Versions.TargetFit != Unknown || res.Chain.Versions.ActivationPolicy != Unknown {
+		t.Fatalf("versions invented: %+v", res.Chain.Versions)
+	}
+	found := false
+	for _, ex := range res.Exceptions {
+		if ex.Code == ExceptionMissingVersion {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("missing_version not classified: %+v", res.Exceptions)
+	}
+	fmt.Printf("VERSION target_fit=%s activation=%s missing_version=true\n",
+		res.Chain.Versions.TargetFit, res.Chain.Versions.ActivationPolicy)
+}
+
+func TestNilStoreFailClosed(t *testing.T) {
+	res := Reconcile(nil, testFacts("org", "l", "r", "a", "act", "out"))
+	if len(res.Exceptions) == 0 || res.Exceptions[0].Code != ExceptionUnavailable {
+		t.Fatalf("want fail-closed unavailable, got %+v", res.Exceptions)
+	}
+	if res.Created {
+		t.Fatal("nil store must not create a chain")
+	}
+}

--- a/internal/app/confenge/intel/learning.go
+++ b/internal/app/confenge/intel/learning.go
@@ -1,0 +1,112 @@
+package intel
+
+import (
+	"strings"
+	"time"
+)
+
+// EmitLearning records a LEARNING CANDIDATE from a human correction or
+// a recorded outcome. It never writes extra-cli, web-cfg, or SmartLic.
+func EmitLearning(store Store, in LearningInput) LearningCandidate {
+	now := time.Now().UTC()
+	target := inferLearningTarget(in)
+	reason := strings.TrimSpace(in.Reason)
+	if reason == "" {
+		reason = Unknown
+	}
+	if target == "" {
+		target = Unknown
+	}
+	cand := LearningCandidate{
+		OrganizationID:  strings.TrimSpace(in.Keys.OrganizationID),
+		Kind:            LearningKind,
+		Target:          target,
+		Source:          normalizeLearningFrom(in.From),
+		Reason:          reason,
+		Status:          LearningPending,
+		Identity:        ChainIdentity(in.Keys),
+		MetricKey:       MetricKey(in.Keys),
+		AssetID:         strings.TrimSpace(in.Keys.AssetID),
+		OfferID:         strings.TrimSpace(in.Keys.OfferID),
+		ActionID:        strings.TrimSpace(in.Keys.ActionID),
+		OutcomeID:       strings.TrimSpace(in.Keys.OutcomeID),
+		LeadID:          strings.TrimSpace(in.Keys.LeadID),
+		CorrectionCodes: append([]string{}, in.CorrectionCodes...),
+		OutcomeType:     strings.ToUpper(strings.TrimSpace(in.OutcomeType)),
+		UpstreamWrites:  []string{},
+		Synthetic:       in.Synthetic,
+		At:              now,
+	}
+	if isWonType(in.OutcomeType) && !in.HumanConfirmed {
+		cand.OutcomeType = OutcomeUnknown
+		cand.Reason = "WON without human confirmation stays UNKNOWN"
+		if cand.Target == TargetOffer {
+			cand.Target = Unknown
+		}
+	}
+	if store == nil {
+		return cand
+	}
+	saved, _ := store.PutLearning(cand)
+	return saved
+}
+
+func normalizeLearningFrom(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case LearningFromCorrection, "human_correction", "edit", "reject":
+		return LearningFromCorrection
+	case LearningFromOutcome:
+		return LearningFromOutcome
+	default:
+		return Unknown
+	}
+}
+
+func inferLearningTarget(in LearningInput) string {
+	codes := append([]string{}, in.CorrectionCodes...)
+	if in.Reason != "" {
+		codes = append(codes, in.Reason)
+	}
+	for _, c := range codes {
+		switch strings.ToLower(strings.TrimSpace(c)) {
+		case "wrong_service", "wrong_offer", "offer", "unclear_value", "bad_cta":
+			return TargetOffer
+		case "weak_hook", "generic_copy", "awkward_tone", "unsupported_claim", "content":
+			return TargetContent
+		case "invalid_route", "channel_preference", "preferred_channel", "distribution":
+			return TargetDistribution
+		case "wrong_person", "wrong_recipient", "wrong_hook", "demand":
+			return TargetDemand
+		case "asset", "wrong_asset":
+			return TargetAsset
+		}
+	}
+	if strings.TrimSpace(in.Keys.OfferID) != "" && normalizeLearningFrom(in.From) == LearningFromOutcome {
+		switch strings.ToUpper(strings.TrimSpace(in.OutcomeType)) {
+		case OutcomeLost, OutcomeWon, OutcomeClient, OutcomeProposal:
+			return TargetOffer
+		case OutcomeQualifiedConversation, OutcomeMeeting:
+			return TargetDemand
+		}
+	}
+	if strings.TrimSpace(in.Keys.AssetID) != "" && normalizeLearningFrom(in.From) == LearningFromCorrection {
+		return TargetAsset
+	}
+	if normalizeLearningFrom(in.From) == LearningFromOutcome {
+		switch strings.ToUpper(strings.TrimSpace(in.OutcomeType)) {
+		case OutcomeLost, OutcomeNoResponse:
+			return TargetOffer
+		case OutcomeQualifiedConversation, OutcomeMeeting, OutcomeReplied:
+			return TargetDemand
+		case OutcomeWon, OutcomeClient:
+			if in.HumanConfirmed {
+				return TargetOffer
+			}
+			return Unknown
+		}
+	}
+	if strings.TrimSpace(in.Keys.AssetID) == "" && strings.TrimSpace(in.Keys.OfferID) == "" && len(in.CorrectionCodes) == 0 && strings.TrimSpace(in.Reason) == "" {
+		return Unknown
+	}
+	return Unknown
+}

--- a/internal/app/confenge/intel/learning.go
+++ b/internal/app/confenge/intel/learning.go
@@ -37,9 +37,9 @@ func EmitLearning(store Store, in LearningInput) LearningCandidate {
 		Synthetic:       in.Synthetic,
 		At:              now,
 	}
-	if isWonType(in.OutcomeType) && !in.HumanConfirmed {
+	if (isWonType(in.OutcomeType) || isLostType(in.OutcomeType)) && !in.HumanConfirmed {
 		cand.OutcomeType = OutcomeUnknown
-		cand.Reason = "WON without human confirmation stays UNKNOWN"
+		cand.Reason = "WON/LOST without human confirmation stays UNKNOWN"
 		if cand.Target == TargetOffer {
 			cand.Target = Unknown
 		}

--- a/internal/app/confenge/intel/learning_test.go
+++ b/internal/app/confenge/intel/learning_test.go
@@ -1,0 +1,85 @@
+package intel
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestLearningCandidateFromCorrectionAndOutcome(t *testing.T) {
+	st := NewMemoryStore()
+	keys := JoinKeys{
+		OrganizationID: "org",
+		LeadID:         "lead-learn",
+		AssetID:        "landing-segunda-leitura",
+		OfferID:        "segunda-leitura",
+		ActionID:       "act-learn",
+		OutcomeID:      "out-learn",
+	}
+	fromCorr := EmitLearning(st, LearningInput{
+		From:            LearningFromCorrection,
+		Reason:          "wrong_service",
+		CorrectionCodes: []string{"wrong_service"},
+		Keys:            keys,
+		Synthetic:       true,
+	})
+	if fromCorr.Kind != LearningKind {
+		t.Fatalf("kind=%s", fromCorr.Kind)
+	}
+	if fromCorr.Target != TargetOffer {
+		t.Fatalf("correction target=%s want offer", fromCorr.Target)
+	}
+	if len(fromCorr.UpstreamWrites) != 0 {
+		t.Fatalf("upstream writes attempted: %v", fromCorr.UpstreamWrites)
+	}
+	if fromCorr.Status != LearningPending {
+		t.Fatalf("status=%s", fromCorr.Status)
+	}
+
+	fromOut := EmitLearning(st, LearningInput{
+		From:        LearningFromOutcome,
+		OutcomeType: OutcomeQualifiedConversation,
+		Keys:        keys,
+		Synthetic:   true,
+	})
+	if fromOut.Target != TargetDemand {
+		t.Fatalf("outcome target=%s want demand", fromOut.Target)
+	}
+	if len(fromOut.UpstreamWrites) != 0 {
+		t.Fatalf("outcome attempted upstream write: %v", fromOut.UpstreamWrites)
+	}
+
+	unknown := EmitLearning(st, LearningInput{From: LearningFromOutcome, OutcomeType: OutcomeUnknown})
+	if unknown.Target != Unknown && unknown.OutcomeType != OutcomeUnknown {
+		t.Fatalf("UNKNOWN input invented target=%s outcome=%s", unknown.Target, unknown.OutcomeType)
+	}
+
+	unconfirmed := EmitLearning(st, LearningInput{
+		From: LearningFromOutcome, OutcomeType: OutcomeWon, HumanConfirmed: false, Keys: keys,
+	})
+	if unconfirmed.OutcomeType == OutcomeWon && unconfirmed.Target == TargetOffer {
+		t.Fatal("unconfirmed WON must not become an offer learning fact")
+	}
+
+	got, _ := st.ListLearning("")
+	if len(got) < 2 {
+		t.Fatalf("learning rows=%d", len(got))
+	}
+	fmt.Printf("LEARNING correction_target=%s outcome_target=%s upstream_writes=%d unknown_stays=%s\n",
+		fromCorr.Target, fromOut.Target, len(fromCorr.UpstreamWrites)+len(fromOut.UpstreamWrites), unknown.Target)
+}
+
+func TestLearningDoesNotCallOtherRepos(t *testing.T) {
+	// EmitLearning only talks to Store. A nil store still returns a local
+	// candidate and performs no extra-cli / web-cfg / SmartLic write.
+	cand := EmitLearning(nil, LearningInput{
+		From:            LearningFromCorrection,
+		CorrectionCodes: []string{"weak_hook"},
+		Keys:            JoinKeys{AssetID: "landing-x"},
+	})
+	if cand.Kind != LearningKind || cand.Target != TargetContent {
+		t.Fatalf("nil-store candidate broken: %+v", cand)
+	}
+	if len(cand.UpstreamWrites) != 0 {
+		t.Fatalf("nil-store wrote upstream: %v", cand.UpstreamWrites)
+	}
+}

--- a/internal/app/confenge/intel/observe.go
+++ b/internal/app/confenge/intel/observe.go
@@ -85,12 +85,15 @@ func ObserveFromInbound(lead models.OutreachInboundLead, acc *models.OutreachAcc
 		if action.CompletedAt != nil {
 			in.OutcomeOccurredAt = *action.CompletedAt
 		}
-		if isWonType(action.OutcomeCode) && strings.TrimSpace(action.HumanActor) != "" {
+		if (isWonType(action.OutcomeCode) || isLostType(action.OutcomeCode)) && strings.TrimSpace(action.HumanActor) != "" {
 			in.HumanConfirmed = true
 		}
 		if action.RequiresFresh || strings.TrimSpace(action.StaleWarning) != "" {
 			in.RequiresFresh = true
 		}
+	}
+	if outcome != nil && !outcomeMatchesJoinIDs(lead, action, outcome) {
+		outcome = nil
 	}
 	if outcome != nil {
 		if outcome.EventID != uuid.Nil {
@@ -144,7 +147,7 @@ func ObserveFromAction(action models.OutreachCommercialAction, acc *models.Outre
 	if action.CompletedAt != nil {
 		in.OutcomeOccurredAt = *action.CompletedAt
 	}
-	if isWonType(action.OutcomeCode) && strings.TrimSpace(action.HumanActor) != "" {
+	if (isWonType(action.OutcomeCode) || isLostType(action.OutcomeCode)) && strings.TrimSpace(action.HumanActor) != "" {
 		in.HumanConfirmed = true
 	}
 	if acc != nil {
@@ -180,4 +183,21 @@ func utmQuery(raw []byte) string {
 		}
 	}
 	return ""
+}
+
+func outcomeMatchesJoinIDs(lead models.OutreachInboundLead, action *models.OutreachCommercialAction, ev *models.OutreachOutcome) bool {
+	if ev == nil {
+		return false
+	}
+	src := strings.TrimSpace(ev.SourceLeadID)
+	if src == "" {
+		return false
+	}
+	if src == strings.TrimSpace(lead.LeadID) || src == strings.TrimSpace(lead.ReceiptID) {
+		return true
+	}
+	if action != nil && src == strings.TrimSpace(action.SourceLeadID) && (src == strings.TrimSpace(lead.LeadID) || src == strings.TrimSpace(lead.ReceiptID)) {
+		return true
+	}
+	return false
 }

--- a/internal/app/confenge/intel/observe.go
+++ b/internal/app/confenge/intel/observe.go
@@ -1,0 +1,183 @@
+package intel
+
+import (
+	"strings"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// ObserveFromInbound copies durable IDs from an inbound receipt plus
+// optional extra-cli / Warmbly rows. Empty fields stay empty.
+func ObserveFromInbound(lead models.OutreachInboundLead, acc *models.OutreachAccount, action *models.OutreachCommercialAction, outcome *models.OutreachOutcome) ObservedFacts {
+	in := ObservedFacts{
+		Keys: JoinKeys{
+			OrganizationID: lead.OrganizationID.String(),
+			Source:         strings.TrimSpace(lead.Source),
+			Query:          utmQuery(lead.UTMJSON),
+			AssetID:        strings.TrimSpace(lead.AssetID),
+			CTAID:          strings.TrimSpace(lead.CTAID),
+			CorrelationID:  strings.TrimSpace(lead.CorrelationID),
+			LeadID:         strings.TrimSpace(lead.LeadID),
+			ReceiptID:      strings.TrimSpace(lead.ReceiptID),
+			AccountID:      strings.TrimSpace(lead.EntityID),
+			PersonID:       strings.TrimSpace(lead.PersonID),
+			EventIDs:       append([]string{}, lead.Evidence...),
+			RouteFamily:    strings.TrimSpace(lead.RouteFamily),
+		},
+		LeadCreatedAt:  lead.LeadCreatedAt,
+		IngestedAt:     lead.WarmblyIngestedAt,
+		EnrichmentAt:   lead.EnrichmentCompletedAt,
+		FirstActionAt:  lead.FirstActionAt,
+		ConversationAt: lead.ConversationAt,
+		ProposalAt:     lead.ProposalAt,
+		CloseAt:        lead.CloseAt,
+		Label:          LabelReal,
+	}
+	if acc != nil {
+		if in.Keys.AccountID == "" {
+			in.Keys.AccountID = strings.TrimSpace(acc.SourceLeadID)
+		}
+		in.Keys.SourceLeadID = strings.TrimSpace(acc.SourceLeadID)
+		in.Keys.TargetFitVersion = strings.TrimSpace(acc.TargetFitVersion)
+		in.Keys.ActivationPolicyVersion = strings.TrimSpace(acc.ActivationPolicyVersion)
+		in.Keys.TargetFitWatermark = strings.TrimSpace(acc.TargetFitSourceWatermark)
+		in.Keys.TargetFitFresh = acc.TargetFitFresh
+		if in.Keys.Trigger == "" {
+			in.Keys.Trigger = strings.TrimSpace(acc.MomentCode)
+		}
+		if in.Keys.OfferID == "" {
+			in.Keys.OfferID = strings.TrimSpace(acc.EntryOffer)
+		}
+		if len(in.Keys.EventIDs) == 0 {
+			in.Keys.EventIDs = append([]string{}, acc.MomentEvidenceIDs...)
+		}
+		if !acc.TargetFitFresh && strings.TrimSpace(acc.TargetFitFreshnessReason) != "" {
+			in.RequiresFresh = true
+		}
+	}
+	if action != nil {
+		in.Keys.ActionID = action.ID.String()
+		if in.Keys.IdempotencyKey == "" {
+			in.Keys.IdempotencyKey = strings.TrimSpace(action.IdempotencyKey)
+		}
+		if in.Keys.PersonID == "" {
+			in.Keys.PersonID = strings.TrimSpace(action.PersonID)
+		}
+		if in.Keys.Route == "" {
+			in.Keys.Route = firstNonEmpty(action.ReachabilityClass, action.RouteType, action.ActionType)
+		}
+		if in.Keys.OfferID == "" {
+			in.Keys.OfferID = strings.TrimSpace(action.ServiceCode)
+		}
+		if action.StartedAt != nil {
+			in.ActionOccurredAt = *action.StartedAt
+		} else if !action.CreatedAt.IsZero() {
+			in.ActionOccurredAt = action.CreatedAt
+		}
+		if in.FirstActionAt == nil && !in.ActionOccurredAt.IsZero() {
+			t := in.ActionOccurredAt
+			in.FirstActionAt = &t
+		}
+		in.Conversation = action.ConversationStarted
+		in.OutcomeType = strings.TrimSpace(action.OutcomeCode)
+		if action.CompletedAt != nil {
+			in.OutcomeOccurredAt = *action.CompletedAt
+		}
+		if isWonType(action.OutcomeCode) && strings.TrimSpace(action.HumanActor) != "" {
+			in.HumanConfirmed = true
+		}
+		if action.RequiresFresh || strings.TrimSpace(action.StaleWarning) != "" {
+			in.RequiresFresh = true
+		}
+	}
+	if outcome != nil {
+		if outcome.EventID != uuid.Nil {
+			in.Keys.OutboxEventID = outcome.EventID.String()
+		}
+		if in.Keys.IdempotencyKey == "" {
+			in.Keys.IdempotencyKey = strings.TrimSpace(outcome.IdempotencyKey)
+		}
+		if in.Keys.OutcomeID == "" {
+			in.Keys.OutcomeID = outcome.ID.String()
+		}
+		if in.OutcomeType == "" {
+			in.OutcomeType = strings.TrimSpace(outcome.EventType)
+		}
+		if in.OutcomeOccurredAt.IsZero() {
+			in.OutcomeOccurredAt = outcome.OccurredAt
+		}
+	}
+	in.Qualified = in.OutcomeType == OutcomeQualifiedConversation
+	in.PipelineOpen = lead.Status == models.InboundStatusOpen
+	return in
+}
+
+// ObserveFromAction copies an outbound/partner/expansion action with no
+// inbound receipt. Route family stays UNKNOWN unless the caller sets it.
+func ObserveFromAction(action models.OutreachCommercialAction, acc *models.OutreachAccount, family string) ObservedFacts {
+	in := ObservedFacts{
+		Keys: JoinKeys{
+			OrganizationID: action.OrganizationID.String(),
+			ActionID:       action.ID.String(),
+			IdempotencyKey: strings.TrimSpace(action.IdempotencyKey),
+			PersonID:       strings.TrimSpace(action.PersonID),
+			SourceLeadID:   strings.TrimSpace(action.SourceLeadID),
+			LeadID:         strings.TrimSpace(action.SourceLeadID),
+			AccountID:      action.AccountID.String(),
+			OfferID:        strings.TrimSpace(action.ServiceCode),
+			Route:          firstNonEmpty(action.ReachabilityClass, action.RouteType, action.ActionType),
+			RouteFamily:    family,
+		},
+		OutcomeType:   strings.TrimSpace(action.OutcomeCode),
+		Conversation:  action.ConversationStarted,
+		Label:         LabelReal,
+		RequiresFresh: action.RequiresFresh || strings.TrimSpace(action.StaleWarning) != "",
+	}
+	if !action.CreatedAt.IsZero() {
+		in.ActionOccurredAt = action.CreatedAt
+		in.LeadCreatedAt = action.CreatedAt
+		t := action.CreatedAt
+		in.FirstActionAt = &t
+	}
+	if action.CompletedAt != nil {
+		in.OutcomeOccurredAt = *action.CompletedAt
+	}
+	if isWonType(action.OutcomeCode) && strings.TrimSpace(action.HumanActor) != "" {
+		in.HumanConfirmed = true
+	}
+	if acc != nil {
+		in.Keys.AccountID = firstNonEmpty(acc.SourceLeadID, in.Keys.AccountID)
+		in.Keys.SourceLeadID = firstNonEmpty(acc.SourceLeadID, in.Keys.SourceLeadID)
+		in.Keys.TargetFitVersion = acc.TargetFitVersion
+		in.Keys.ActivationPolicyVersion = acc.ActivationPolicyVersion
+		in.Keys.TargetFitWatermark = acc.TargetFitSourceWatermark
+		in.Keys.TargetFitFresh = acc.TargetFitFresh
+		in.Keys.Trigger = firstNonEmpty(in.Keys.Trigger, acc.MomentCode)
+		in.Keys.OfferID = firstNonEmpty(in.Keys.OfferID, acc.EntryOffer)
+		in.Keys.EventIDs = append([]string{}, acc.MomentEvidenceIDs...)
+	}
+	in.Qualified = in.OutcomeType == OutcomeQualifiedConversation
+	in.PipelineOpen = !isWonType(in.OutcomeType) && !isLostType(in.OutcomeType)
+	return in
+}
+
+func utmQuery(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	s := string(raw)
+	for _, key := range []string{`"query"`, `"utm_campaign"`, `"campaign"`, `"utm_source"`} {
+		if i := strings.Index(s, key); i >= 0 {
+			rest := s[i+len(key):]
+			if j := strings.Index(rest, `"`); j >= 0 {
+				rest = rest[j+1:]
+				if k := strings.Index(rest, `"`); k >= 0 {
+					return rest[:k]
+				}
+			}
+		}
+	}
+	return ""
+}

--- a/internal/app/confenge/intel/observe_test.go
+++ b/internal/app/confenge/intel/observe_test.go
@@ -1,0 +1,39 @@
+package intel
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestObserveFromInboundRejectsEmailCNPJOutcome(t *testing.T) {
+	lead := models.OutreachInboundLead{
+		LeadID: "webcfg-a", ReceiptID: "rcpt-a", EntityID: "acc-a",
+		LeadEmail: "shared@empresa.com", CNPJ14: "11222333000181",
+	}
+	foreign := &models.OutreachOutcome{
+		ID:           uuid.MustParse("55555555-5555-4555-8555-555555555555"),
+		SourceLeadID: "webcfg-b", EventType: OutcomeMeeting,
+		ContactEmail: "shared@empresa.com", CNPJ14: "11222333000181",
+	}
+	facts := ObserveFromInbound(lead, nil, nil, foreign)
+	if facts.Keys.OutcomeID != "" {
+		t.Fatalf("foreign meeting attached via email/cnpj: %s", facts.Keys.OutcomeID)
+	}
+	if facts.OutcomeType == OutcomeMeeting {
+		t.Fatal("foreign MEETING leaked onto the lead")
+	}
+
+	own := &models.OutreachOutcome{
+		ID:           uuid.MustParse("66666666-6666-4666-8666-666666666666"),
+		SourceLeadID: "webcfg-a", EventType: OutcomeWon,
+	}
+	ownFacts := ObserveFromInbound(lead, nil, nil, own)
+	if ownFacts.Keys.OutcomeID != own.ID.String() {
+		t.Fatalf("same lead_id outcome not joined: %s", ownFacts.Keys.OutcomeID)
+	}
+	fmt.Printf("OBSERVE_JOIN own_outcome=%s foreign_rejected=true\n", ownFacts.Keys.OutcomeID)
+}

--- a/internal/app/confenge/intel/pg.go
+++ b/internal/app/confenge/intel/pg.go
@@ -78,6 +78,24 @@ func (s *PGStore) PutChain(c Chain) (Chain, bool, error) {
 	return c, true, nil
 }
 
+func (s *PGStore) UpdateChain(c Chain) error {
+	if s == nil || s.db == nil {
+		return errors.New("intel pg store unavailable")
+	}
+	org := firstNonEmpty(c.Keys.OrganizationID, s.orgID)
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(context.Background(), `
+		UPDATE outreach_intel_chains
+		SET metric_key = $3, route_family = $4, payload = $5::jsonb
+		WHERE organization_id = $1::uuid AND identity = $2`,
+		org, c.Identity, c.MetricKey, c.RouteFamily, raw,
+	)
+	return err
+}
+
 func (s *PGStore) ListChains(orgID string) ([]Chain, error) {
 	if s == nil || s.db == nil {
 		return nil, nil

--- a/internal/app/confenge/intel/pg.go
+++ b/internal/app/confenge/intel/pg.go
@@ -1,0 +1,205 @@
+package intel
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PGStore persists this capability's own tables. It does not write
+// extra-cli, web-cfg, or SmartLic, and it is not the execution ledger.
+type PGStore struct {
+	db    *pgxpool.Pool
+	orgID string
+}
+
+func NewPGStore(db *pgxpool.Pool, orgID string) *PGStore {
+	return &PGStore{db: db, orgID: strings.TrimSpace(orgID)}
+}
+
+func (s *PGStore) GetChain(orgID, identity string) (*Chain, error) {
+	if s == nil || s.db == nil || strings.TrimSpace(identity) == "" {
+		return nil, nil
+	}
+	org := firstNonEmpty(orgID, s.orgID)
+	var raw []byte
+	err := s.db.QueryRow(context.Background(), `
+		SELECT payload FROM outreach_intel_chains
+		WHERE organization_id = $1::uuid AND identity = $2`, org, identity).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var c Chain
+	if err := json.Unmarshal(raw, &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func (s *PGStore) PutChain(c Chain) (Chain, bool, error) {
+	if s == nil || s.db == nil {
+		return c, false, errors.New("intel pg store unavailable")
+	}
+	org := firstNonEmpty(c.Keys.OrganizationID, s.orgID)
+	if existing, err := s.GetChain(org, c.Identity); err != nil {
+		return c, false, err
+	} else if existing != nil {
+		return *existing, false, nil
+	}
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = time.Now().UTC()
+	}
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return c, false, err
+	}
+	_, err = s.db.Exec(context.Background(), `
+		INSERT INTO outreach_intel_chains (
+			id, organization_id, identity, metric_key, route_family, label, synthetic, payload, created_at
+		) VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7, $8::jsonb, $9)
+		ON CONFLICT (organization_id, identity) DO NOTHING`,
+		uuid.New(), org, c.Identity, c.MetricKey, c.RouteFamily, c.Label, c.Synthetic, raw, c.CreatedAt,
+	)
+	if err != nil {
+		return c, false, err
+	}
+	if existing, gerr := s.GetChain(org, c.Identity); gerr == nil && existing != nil {
+		return *existing, existing.MetricKey == c.MetricKey && existing.CreatedAt.Equal(c.CreatedAt), nil
+	}
+	return c, true, nil
+}
+
+func (s *PGStore) ListChains(orgID string) ([]Chain, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	org := firstNonEmpty(orgID, s.orgID)
+	rows, err := s.db.Query(context.Background(), `
+		SELECT payload FROM outreach_intel_chains WHERE organization_id = $1::uuid`, org)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Chain
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var c Chain
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}
+
+func (s *PGStore) PutException(ex Exception) error {
+	if s == nil || s.db == nil {
+		return errors.New("intel pg store unavailable")
+	}
+	if strings.TrimSpace(ex.ID) == "" {
+		ex.ID = uuid.NewString()
+	}
+	if ex.At.IsZero() {
+		ex.At = time.Now().UTC()
+	}
+	org := firstNonEmpty(ex.OrganizationID, s.orgID)
+	raw, err := json.Marshal(ex)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(context.Background(), `
+		INSERT INTO outreach_intel_exceptions (
+			id, organization_id, code, identity, metric_key, held, payload, created_at
+		) VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7::jsonb, $8)`,
+		ex.ID, org, ex.Code, ex.Identity, ex.MetricKey, ex.Held, raw, ex.At,
+	)
+	return err
+}
+
+func (s *PGStore) ListExceptions(orgID string) ([]Exception, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	org := firstNonEmpty(orgID, s.orgID)
+	rows, err := s.db.Query(context.Background(), `
+		SELECT payload FROM outreach_intel_exceptions WHERE organization_id = $1::uuid ORDER BY created_at`, org)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Exception
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var ex Exception
+		if err := json.Unmarshal(raw, &ex); err != nil {
+			return nil, err
+		}
+		out = append(out, ex)
+	}
+	return out, rows.Err()
+}
+
+func (s *PGStore) PutLearning(c LearningCandidate) (LearningCandidate, error) {
+	if s == nil || s.db == nil {
+		return c, errors.New("intel pg store unavailable")
+	}
+	if strings.TrimSpace(c.ID) == "" {
+		c.ID = uuid.NewString()
+	}
+	if c.At.IsZero() {
+		c.At = time.Now().UTC()
+	}
+	raw, err := json.Marshal(c)
+	if err != nil {
+		return c, err
+	}
+	org := firstNonEmpty(c.OrganizationID, s.orgID)
+	_, err = s.db.Exec(context.Background(), `
+		INSERT INTO outreach_intel_learning_candidates (
+			id, organization_id, target, source, status, identity, payload, created_at
+		) VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7::jsonb, $8)`,
+		c.ID, org, c.Target, c.Source, c.Status, c.Identity, raw, c.At,
+	)
+	return c, err
+}
+
+func (s *PGStore) ListLearning(orgID string) ([]LearningCandidate, error) {
+	if s == nil || s.db == nil {
+		return nil, nil
+	}
+	org := firstNonEmpty(orgID, s.orgID)
+	rows, err := s.db.Query(context.Background(), `
+		SELECT payload FROM outreach_intel_learning_candidates WHERE organization_id = $1::uuid ORDER BY created_at`, org)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []LearningCandidate
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var c LearningCandidate
+		if err := json.Unmarshal(raw, &c); err != nil {
+			return nil, err
+		}
+		out = append(out, c)
+	}
+	return out, rows.Err()
+}

--- a/internal/app/confenge/intel/rollup.go
+++ b/internal/app/confenge/intel/rollup.go
@@ -1,0 +1,269 @@
+package intel
+
+import (
+	"sort"
+	"strings"
+	"time"
+)
+
+// Rollup builds the monthly executive view from already-joined chains.
+// includeSynthetic=false drops SYNTHETIC fixtures so real metrics stay
+// empty/UNKNOWN when nothing live has arrived.
+func Rollup(chains []Chain, month string, includeSynthetic bool) ExecutiveView {
+	month = strings.TrimSpace(month)
+	if month == "" {
+		month = time.Now().UTC().Format("2006-01")
+	}
+	view := ExecutiveView{
+		SchemaVersion:    SchemaV1,
+		Month:            month,
+		IncludeSynthetic: includeSynthetic,
+		AttributionKind:  AssociationObserved,
+		CausalProof:      false,
+		Families: []FamilyCounts{
+			{Family: FamilyInbound},
+			{Family: FamilyOutbound},
+			{Family: FamilyPartner},
+			{Family: FamilyExpansion},
+		},
+	}
+
+	familyIdx := map[string]int{
+		FamilyInbound:   0,
+		FamilyOutbound:  1,
+		FamilyPartner:   2,
+		FamilyExpansion: 3,
+	}
+	bySource := map[string]int{}
+	byAsset := map[string]int{}
+	byTrigger := map[string]int{}
+	byOffer := map[string]int{}
+	byRoute := map[string]int{}
+	tfVers := map[string]struct{}{}
+	apVers := map[string]struct{}{}
+	marks := map[string]struct{}{}
+
+	var latSum LatencyMS
+	var latN int
+
+	for _, c := range chains {
+		if !includeSynthetic && (c.Synthetic || c.Label == LabelSynthetic) {
+			continue
+		}
+		if !inMonth(c, month) {
+			continue
+		}
+		view.ChainCount++
+		incBreakdown(bySource, c.Source)
+		incBreakdown(byAsset, c.AssetID)
+		incBreakdown(byTrigger, c.Trigger)
+		incBreakdown(byOffer, c.OfferID)
+		incBreakdown(byRoute, c.Route)
+		if c.Versions.TargetFit != "" {
+			tfVers[c.Versions.TargetFit] = struct{}{}
+		}
+		if c.Versions.ActivationPolicy != "" {
+			apVers[c.Versions.ActivationPolicy] = struct{}{}
+		}
+		if c.Versions.TargetFitWatermark != "" {
+			marks[c.Versions.TargetFitWatermark] = struct{}{}
+		}
+		if !c.Versions.Fresh {
+			view.Freshness.StaleChains++
+		}
+		if c.Versions.TargetFit == Unknown || c.Versions.ActivationPolicy == Unknown {
+			view.Freshness.MissingVersionChains++
+		}
+
+		if strings.TrimSpace(c.LeadID) != "" && c.LeadID != Unknown {
+			view.Denominators.Leads++
+		}
+		if strings.TrimSpace(c.ActionID) != "" && c.ActionID != Unknown {
+			view.Denominators.Actions++
+		}
+		if c.OutcomeType != "" && c.OutcomeType != OutcomeUnknown {
+			view.Denominators.Outcomes++
+		}
+
+		fi, ok := familyIdx[c.RouteFamily]
+		if !ok {
+			// UNKNOWN family is counted in totals only; it is not folded
+			// into inbound/outbound/partner/expansion.
+			fi = -1
+		}
+
+		qco := c.Qualified || c.OutcomeType == OutcomeQualifiedConversation
+		if qco {
+			view.QCO++
+			view.Denominators.Qualified++
+			if fi >= 0 {
+				view.Families[fi].QCO++
+			}
+		}
+		if c.RouteFamily == FamilyInbound && qco {
+			view.InboundQualifiedPipeline++
+			if fi >= 0 {
+				view.Families[fi].InboundQualifiedPipeline++
+			}
+		}
+		if c.Conversation || c.ConversationAt != nil || qco {
+			view.Conversations++
+			view.Denominators.Conversations++
+			if fi >= 0 {
+				view.Families[fi].Conversations++
+			}
+		}
+		if c.OutcomeType == OutcomeMeeting {
+			view.Meetings++
+			view.Denominators.Meetings++
+			if fi >= 0 {
+				view.Families[fi].Meetings++
+			}
+		}
+		if c.OutcomeType == OutcomeProposal || c.ProposalAt != nil {
+			view.Proposals++
+			view.Denominators.Proposals++
+			if fi >= 0 {
+				view.Families[fi].Proposals++
+			}
+		}
+		if c.PipelineOpen {
+			view.Pipeline++
+			if fi >= 0 {
+				view.Families[fi].Pipeline++
+			}
+		}
+
+		switch {
+		case isWonType(c.OutcomeType) && c.HumanConfirmed:
+			view.Won++
+			view.Denominators.Closed++
+			if fi >= 0 {
+				view.Families[fi].Won++
+			}
+		case isLostType(c.OutcomeType):
+			view.Lost++
+			view.Denominators.Closed++
+			if fi >= 0 {
+				view.Families[fi].Lost++
+			}
+		default:
+			view.Unknown++
+			if fi >= 0 {
+				view.Families[fi].Unknown++
+			}
+		}
+
+		if n := latencySample(c); n.SampledChains == 1 {
+			latN++
+			latSum.LeadToIngest += n.LeadToIngest
+			latSum.IngestToEnrichment += n.IngestToEnrichment
+			latSum.EnrichmentToAction += n.EnrichmentToAction
+			latSum.ActionToConversation += n.ActionToConversation
+			latSum.ConversationToProposal += n.ConversationToProposal
+			latSum.ProposalToClose += n.ProposalToClose
+		}
+	}
+
+	if latN > 0 {
+		view.Latency = LatencyMS{
+			LeadToIngest:           latSum.LeadToIngest / int64(latN),
+			IngestToEnrichment:     latSum.IngestToEnrichment / int64(latN),
+			EnrichmentToAction:     latSum.EnrichmentToAction / int64(latN),
+			ActionToConversation:   latSum.ActionToConversation / int64(latN),
+			ConversationToProposal: latSum.ConversationToProposal / int64(latN),
+			ProposalToClose:        latSum.ProposalToClose / int64(latN),
+			SampledChains:          latN,
+		}
+	}
+	view.BySource = mapBreakdown(bySource)
+	view.ByAsset = mapBreakdown(byAsset)
+	view.ByTrigger = mapBreakdown(byTrigger)
+	view.ByOffer = mapBreakdown(byOffer)
+	view.ByRoute = mapBreakdown(byRoute)
+	view.Freshness.TargetFitVersions = mapKeys(tfVers)
+	view.Freshness.ActivationPolicyVersions = mapKeys(apVers)
+	view.Freshness.Watermarks = mapKeys(marks)
+	view.RealEmpty = view.ChainCount == 0
+	return view
+}
+
+func inMonth(c Chain, month string) bool {
+	ts := c.LeadCreatedAt
+	if ts.IsZero() {
+		ts = c.IngestedAt
+	}
+	if ts.IsZero() {
+		ts = c.CreatedAt
+	}
+	if ts.IsZero() {
+		return true
+	}
+	return ts.UTC().Format("2006-01") == month
+}
+
+func incBreakdown(m map[string]int, key string) {
+	key = idOrUnknown(key)
+	m[key]++
+}
+
+func mapBreakdown(m map[string]int) []Breakdown {
+	out := make([]Breakdown, 0, len(m))
+	for k, n := range m {
+		out = append(out, Breakdown{Key: k, Count: n})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count == out[j].Count {
+			return out[i].Key < out[j].Key
+		}
+		return out[i].Count > out[j].Count
+	})
+	return out
+}
+
+func mapKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func latencySample(c Chain) LatencyMS {
+	ms := func(a, b time.Time) int64 {
+		if a.IsZero() || b.IsZero() || b.Before(a) {
+			return 0
+		}
+		return b.Sub(a).Milliseconds()
+	}
+	var firstAction time.Time
+	if c.FirstActionAt != nil {
+		firstAction = *c.FirstActionAt
+	}
+	var enrich time.Time
+	if c.EnrichmentAt != nil {
+		enrich = *c.EnrichmentAt
+	}
+	var conv time.Time
+	if c.ConversationAt != nil {
+		conv = *c.ConversationAt
+	}
+	var prop time.Time
+	if c.ProposalAt != nil {
+		prop = *c.ProposalAt
+	}
+	var closeT time.Time
+	if c.CloseAt != nil {
+		closeT = *c.CloseAt
+	}
+	return LatencyMS{
+		LeadToIngest:           ms(c.LeadCreatedAt, c.IngestedAt),
+		IngestToEnrichment:     ms(c.IngestedAt, enrich),
+		EnrichmentToAction:     ms(enrich, firstAction),
+		ActionToConversation:   ms(firstAction, conv),
+		ConversationToProposal: ms(conv, prop),
+		ProposalToClose:        ms(prop, closeT),
+		SampledChains:          1,
+	}
+}

--- a/internal/app/confenge/intel/rollup.go
+++ b/internal/app/confenge/intel/rollup.go
@@ -141,7 +141,7 @@ func Rollup(chains []Chain, month string, includeSynthetic bool) ExecutiveView {
 			if fi >= 0 {
 				view.Families[fi].Won++
 			}
-		case isLostType(c.OutcomeType):
+		case isLostType(c.OutcomeType) && c.HumanConfirmed:
 			view.Lost++
 			view.Denominators.Closed++
 			if fi >= 0 {

--- a/internal/app/confenge/intel/rollup_test.go
+++ b/internal/app/confenge/intel/rollup_test.go
@@ -1,0 +1,117 @@
+package intel
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+)
+
+func TestExecutiveViewSyntheticSeparated(t *testing.T) {
+	st := NewMemoryStore()
+	org := "22222222-2222-4222-8222-222222222222"
+	LoadSynthetic(st, org)
+	chains, _ := st.ListChains(org)
+	view := Rollup(chains, SyntheticMonth, true)
+
+	if view.InboundQualifiedPipeline == 0 {
+		t.Fatalf("INBOUND QUALIFIED PIPELINE empty: %+v", view)
+	}
+	if view.QCO == 0 || view.Conversations == 0 || view.Meetings == 0 || view.Proposals == 0 {
+		t.Fatalf("missing monthly fields qco=%d conv=%d meet=%d prop=%d", view.QCO, view.Conversations, view.Meetings, view.Proposals)
+	}
+	if view.Won == 0 || view.Lost == 0 || view.Unknown == 0 {
+		t.Fatalf("won/lost/UNKNOWN missing won=%d lost=%d unknown=%d", view.Won, view.Lost, view.Unknown)
+	}
+	if view.Pipeline == 0 {
+		t.Fatalf("pipeline empty")
+	}
+	if view.AttributionKind != AssociationObserved || view.CausalProof {
+		t.Fatalf("causal claim leaked: kind=%s proof=%v", view.AttributionKind, view.CausalProof)
+	}
+	if view.Denominators.Leads == 0 || view.Latency.SampledChains == 0 {
+		t.Fatalf("denominators/latency missing: %+v %+v", view.Denominators, view.Latency)
+	}
+	if len(view.Freshness.TargetFitVersions) == 0 {
+		t.Fatal("freshness versions missing")
+	}
+	if len(view.BySource) == 0 || len(view.ByAsset) == 0 || len(view.ByTrigger) == 0 || len(view.ByOffer) == 0 || len(view.ByRoute) == 0 {
+		t.Fatalf("breakdowns missing src=%d asset=%d trig=%d offer=%d route=%d",
+			len(view.BySource), len(view.ByAsset), len(view.ByTrigger), len(view.ByOffer), len(view.ByRoute))
+	}
+
+	var inbound, outbound, partner, expansion FamilyCounts
+	for _, f := range view.Families {
+		switch f.Family {
+		case FamilyInbound:
+			inbound = f
+		case FamilyOutbound:
+			outbound = f
+		case FamilyPartner:
+			partner = f
+		case FamilyExpansion:
+			expansion = f
+		}
+	}
+	if inbound.InboundQualifiedPipeline == 0 {
+		t.Fatal("inbound family has no qualified pipeline")
+	}
+	if outbound.Meetings == 0 {
+		t.Fatal("outbound meeting mixed away")
+	}
+	if partner.Lost == 0 {
+		t.Fatal("partner lost mixed away")
+	}
+	if expansion.Unknown == 0 {
+		t.Fatal("expansion UNKNOWN mixed away")
+	}
+	if outbound.InboundQualifiedPipeline != 0 || partner.InboundQualifiedPipeline != 0 || expansion.InboundQualifiedPipeline != 0 {
+		t.Fatalf("INBOUND QUALIFIED PIPELINE leaked into other families: out=%d pt=%d ex=%d",
+			outbound.InboundQualifiedPipeline, partner.InboundQualifiedPipeline, expansion.InboundQualifiedPipeline)
+	}
+
+	raw, _ := json.Marshal(view)
+	body := string(raw)
+	for _, field := range []string{
+		"inbound_qualified_pipeline", "qco", "conversations", "meetings",
+		"proposals", "pipeline", "won", "lost", "unknown", "by_source",
+		"by_asset", "by_trigger", "by_offer", "by_route",
+	} {
+		if !containsJSONKey(body, field) {
+			t.Fatalf("payload missing %s: %s", field, body)
+		}
+	}
+	if _, ok := rawField(body, "forecast"); ok {
+		t.Fatal("forecast field must not be required")
+	}
+	if _, ok := rawField(body, "score"); ok {
+		t.Fatal("score field must not be required")
+	}
+	fmt.Printf("EXEC month=%s iqp=%d qco=%d conv=%d meet=%d prop=%d pipe=%d won=%d lost=%d unknown=%d families=4 causal_proof=%v\n",
+		view.Month, view.InboundQualifiedPipeline, view.QCO, view.Conversations, view.Meetings, view.Proposals, view.Pipeline, view.Won, view.Lost, view.Unknown, view.CausalProof)
+}
+
+func containsJSONKey(body, key string) bool {
+	return len(body) > 0 && (stringIndex(body, `"`+key+`"`) >= 0)
+}
+
+func rawField(body, key string) (string, bool) {
+	needle := `"` + key + `"`
+	i := stringIndex(body, needle)
+	if i < 0 {
+		return "", false
+	}
+	return needle, true
+}
+
+func stringIndex(s, sub string) int {
+	return len([]byte(s[:]))*0 + indexOf(s, sub)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/app/confenge/intel/rollup_test.go
+++ b/internal/app/confenge/intel/rollup_test.go
@@ -90,6 +90,27 @@ func TestExecutiveViewSyntheticSeparated(t *testing.T) {
 		view.Month, view.InboundQualifiedPipeline, view.QCO, view.Conversations, view.Meetings, view.Proposals, view.Pipeline, view.Won, view.Lost, view.Unknown, view.CausalProof)
 }
 
+func TestRollupUnconfirmedLostIsUnknown(t *testing.T) {
+	st := NewMemoryStore()
+	in := testFacts("org-lost", "lead-lost-r", "rcpt-lost-r", "acc-lost-r", "act-lost-r", "out-lost-r")
+	in.OutcomeType = OutcomeLost
+	in.HumanConfirmed = false
+	in.Synthetic = true
+	in.Label = LabelSynthetic
+	res := Reconcile(st, in)
+	if res.Chain.OutcomeType != OutcomeUnknown {
+		t.Fatalf("chain stored LOST without confirmation: %s", res.Chain.OutcomeType)
+	}
+	view := Rollup([]Chain{res.Chain}, "2026-08", true)
+	if view.Lost != 0 {
+		t.Fatalf("unconfirmed LOST counted as lost=%d", view.Lost)
+	}
+	if view.Unknown == 0 {
+		t.Fatal("unconfirmed LOST should land in UNKNOWN")
+	}
+	fmt.Printf("ROLLUP_UNCONFIRMED_LOST lost=%d unknown=%d\n", view.Lost, view.Unknown)
+}
+
 func containsJSONKey(body, key string) bool {
 	return len(body) > 0 && (stringIndex(body, `"`+key+`"`) >= 0)
 }

--- a/internal/app/confenge/intel/store.go
+++ b/internal/app/confenge/intel/store.go
@@ -1,0 +1,145 @@
+package intel
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Store is this capability's own rows. It is not the execution ledger
+// and it never writes extra-cli, web-cfg, or SmartLic.
+type Store interface {
+	GetChain(orgID, identity string) (*Chain, error)
+	PutChain(c Chain) (Chain, bool, error)
+	ListChains(orgID string) ([]Chain, error)
+	PutException(ex Exception) error
+	ListExceptions(orgID string) ([]Exception, error)
+	PutLearning(c LearningCandidate) (LearningCandidate, error)
+	ListLearning(orgID string) ([]LearningCandidate, error)
+}
+
+// MemoryStore is the shipped in-process store. Tests drive Reconcile
+// and Rollup through this type.
+type MemoryStore struct {
+	mu         sync.Mutex
+	chains     map[string]Chain
+	exceptions []Exception
+	learning   []LearningCandidate
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{chains: map[string]Chain{}}
+}
+
+func chainKey(orgID, identity string) string {
+	return strings.TrimSpace(orgID) + "\x00" + strings.TrimSpace(identity)
+}
+
+func (m *MemoryStore) GetChain(orgID, identity string) (*Chain, error) {
+	if m == nil {
+		return nil, nil
+	}
+	if strings.TrimSpace(identity) == "" {
+		return nil, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	c, ok := m.chains[chainKey(orgID, identity)]
+	if !ok {
+		return nil, nil
+	}
+	cp := c
+	return &cp, nil
+}
+
+func (m *MemoryStore) PutChain(c Chain) (Chain, bool, error) {
+	if m == nil {
+		return c, false, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.chains == nil {
+		m.chains = map[string]Chain{}
+	}
+	key := chainKey(c.Keys.OrganizationID, c.Identity)
+	if existing, ok := m.chains[key]; ok {
+		return existing, false, nil
+	}
+	if c.CreatedAt.IsZero() {
+		c.CreatedAt = time.Now().UTC()
+	}
+	m.chains[key] = c
+	return c, true, nil
+}
+
+func (m *MemoryStore) ListChains(orgID string) ([]Chain, error) {
+	if m == nil {
+		return nil, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	orgID = strings.TrimSpace(orgID)
+	out := make([]Chain, 0, len(m.chains))
+	for _, c := range m.chains {
+		if orgID == "" || c.Keys.OrganizationID == orgID {
+			out = append(out, c)
+		}
+	}
+	return out, nil
+}
+
+func (m *MemoryStore) PutException(ex Exception) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if strings.TrimSpace(ex.ID) == "" {
+		ex.ID = uuid.NewString()
+	}
+	if ex.At.IsZero() {
+		ex.At = time.Now().UTC()
+	}
+	m.exceptions = append(m.exceptions, ex)
+	return nil
+}
+
+func (m *MemoryStore) ListExceptions(orgID string) ([]Exception, error) {
+	if m == nil {
+		return nil, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]Exception, len(m.exceptions))
+	copy(out, m.exceptions)
+	return out, nil
+}
+
+func (m *MemoryStore) PutLearning(c LearningCandidate) (LearningCandidate, error) {
+	if m == nil {
+		return c, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if strings.TrimSpace(c.ID) == "" {
+		c.ID = uuid.NewString()
+	}
+	if c.At.IsZero() {
+		c.At = time.Now().UTC()
+	}
+	m.learning = append(m.learning, c)
+	return c, nil
+}
+
+func (m *MemoryStore) ListLearning(orgID string) ([]LearningCandidate, error) {
+	if m == nil {
+		return nil, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]LearningCandidate, len(m.learning))
+	copy(out, m.learning)
+	return out, nil
+}

--- a/internal/app/confenge/intel/store.go
+++ b/internal/app/confenge/intel/store.go
@@ -13,6 +13,7 @@ import (
 type Store interface {
 	GetChain(orgID, identity string) (*Chain, error)
 	PutChain(c Chain) (Chain, bool, error)
+	UpdateChain(c Chain) error
 	ListChains(orgID string) ([]Chain, error)
 	PutException(ex Exception) error
 	ListExceptions(orgID string) ([]Exception, error)
@@ -72,6 +73,23 @@ func (m *MemoryStore) PutChain(c Chain) (Chain, bool, error) {
 	}
 	m.chains[key] = c
 	return c, true, nil
+}
+
+func (m *MemoryStore) UpdateChain(c Chain) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.chains == nil {
+		m.chains = map[string]Chain{}
+	}
+	key := chainKey(c.Keys.OrganizationID, c.Identity)
+	if _, ok := m.chains[key]; !ok {
+		return nil
+	}
+	m.chains[key] = c
+	return nil
 }
 
 func (m *MemoryStore) ListChains(orgID string) ([]Chain, error) {

--- a/internal/app/confenge/intel/types.go
+++ b/internal/app/confenge/intel/types.go
@@ -1,0 +1,361 @@
+// Package intel is CONFENGE commercial intelligence: join, exception queue,
+// executive rollup, and LEARNING CANDIDATE records. It is not a CRM and
+// not a second ledger. extra-cli stays facts; web-cfg stays attribution;
+// Warmbly stays human action and outcomes.
+package intel
+
+import (
+	"strings"
+	"time"
+)
+
+const (
+	SchemaV1 = "confenge.commercial_intel.v1"
+
+	LabelSynthetic = "SYNTHETIC"
+	LabelReal      = "REAL"
+
+	Unknown = "UNKNOWN"
+
+	FamilyInbound   = "inbound"
+	FamilyOutbound  = "outbound"
+	FamilyPartner   = "partner"
+	FamilyExpansion = "expansion"
+
+	ExceptionOrphan             = "orphan"
+	ExceptionDuplicate          = "duplicate"
+	ExceptionConflictingAccount = "conflicting_account"
+	ExceptionMissingVersion     = "missing_version"
+	ExceptionStaleAttribution   = "stale_attribution"
+	ExceptionOutOfOrder         = "out_of_order"
+	ExceptionUnconfirmedWon     = "unconfirmed_won"
+	ExceptionUnavailable        = "ledger_unavailable"
+
+	OutcomeWon                   = "WON"
+	OutcomeLost                  = "LOST"
+	OutcomeUnknown               = "UNKNOWN"
+	OutcomeMeeting               = "MEETING"
+	OutcomeProposal              = "PROPOSAL"
+	OutcomeQualifiedConversation = "QUALIFIED_CONVERSATION"
+	OutcomeContacted             = "CONTACTED"
+	OutcomeReplied               = "REPLIED"
+	OutcomeClient                = "CLIENT"
+	OutcomeNoResponse            = "NO_RESPONSE"
+	OutcomeDoNotContact          = "DO_NOT_CONTACT"
+
+	LearningKind = "LEARNING_CANDIDATE"
+
+	TargetDemand           = "demand"
+	TargetAsset            = "asset"
+	TargetOffer            = "offer"
+	TargetContent          = "content"
+	TargetDistribution     = "distribution"
+	LearningFromCorrection = "correction"
+	LearningFromOutcome    = "outcome"
+	LearningPending        = "PENDING"
+
+	AssociationObserved = "observed_association"
+)
+
+// JoinKeys is the typed, idempotent join contract. Metric keys use these
+// IDs only. Email, phone, name, and company never enter a metric key.
+type JoinKeys struct {
+	OrganizationID string `json:"organization_id,omitempty"`
+
+	// web-cfg attribution authority.
+	Source        string `json:"source,omitempty"`
+	Query         string `json:"query,omitempty"`
+	AssetID       string `json:"asset_id,omitempty"`
+	CTAID         string `json:"cta_id,omitempty"`
+	CorrelationID string `json:"correlation_id,omitempty"`
+
+	// Inbound durable receipt (PR #71).
+	LeadID    string `json:"lead_id,omitempty"`
+	ReceiptID string `json:"receipt_id,omitempty"`
+
+	// extra-cli fact / identity / version authority.
+	AccountID               string   `json:"account_id,omitempty"`
+	SourceLeadID            string   `json:"source_lead_id,omitempty"`
+	PersonID                string   `json:"person_id,omitempty"`
+	EventIDs                []string `json:"event_ids,omitempty"`
+	TargetFitVersion        string   `json:"target_fit_version,omitempty"`
+	ActivationPolicyVersion string   `json:"activation_policy_version,omitempty"`
+	TargetFitWatermark      string   `json:"target_fit_watermark,omitempty"`
+	TargetFitFresh          bool     `json:"target_fit_fresh,omitempty"`
+
+	// Warmbly action / outcome / outbox authority.
+	ActionID       string `json:"action_id,omitempty"`
+	OutcomeID      string `json:"outcome_id,omitempty"`
+	OutboxEventID  string `json:"outbox_event_id,omitempty"`
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+
+	RouteFamily string `json:"route_family,omitempty"`
+	Trigger     string `json:"trigger,omitempty"`
+	OfferID     string `json:"offer_id,omitempty"`
+	Route       string `json:"route,omitempty"`
+}
+
+// ObservedFacts is one observed commercial record. Missing optional IDs
+// stay empty and render as UNKNOWN. Nothing is invented.
+type ObservedFacts struct {
+	Keys JoinKeys `json:"keys"`
+
+	LeadCreatedAt  time.Time  `json:"lead_created_at,omitempty"`
+	IngestedAt     time.Time  `json:"warmbly_ingested_at,omitempty"`
+	EnrichmentAt   *time.Time `json:"enrichment_completed_at,omitempty"`
+	FirstActionAt  *time.Time `json:"first_action_at,omitempty"`
+	ConversationAt *time.Time `json:"conversation_at,omitempty"`
+	ProposalAt     *time.Time `json:"proposal_at,omitempty"`
+	CloseAt        *time.Time `json:"close_at,omitempty"`
+
+	ActionOccurredAt  time.Time `json:"action_occurred_at,omitempty"`
+	OutcomeOccurredAt time.Time `json:"outcome_occurred_at,omitempty"`
+
+	OutcomeType    string `json:"outcome_type,omitempty"`
+	HumanConfirmed bool   `json:"human_confirmed,omitempty"`
+	Qualified      bool   `json:"qualified,omitempty"`
+	Conversation   bool   `json:"conversation,omitempty"`
+	PipelineOpen   bool   `json:"pipeline_open,omitempty"`
+
+	AttributionStale bool `json:"attribution_stale,omitempty"`
+	RequiresFresh    bool `json:"requires_fresh,omitempty"`
+
+	Synthetic bool   `json:"synthetic,omitempty"`
+	Label     string `json:"label,omitempty"`
+}
+
+// Chain is one reconstructed observed path. Replay of the same IDs
+// returns this row; it does not create a second chain.
+type Chain struct {
+	SchemaVersion string   `json:"schema_version"`
+	Identity      string   `json:"identity"`
+	MetricKey     string   `json:"metric_key"`
+	Keys          JoinKeys `json:"keys"`
+
+	Source         string `json:"source"`
+	Query          string `json:"query"`
+	AssetID        string `json:"asset_id"`
+	LeadID         string `json:"lead_id"`
+	ReceiptID      string `json:"receipt_id"`
+	CorrelationID  string `json:"correlation_id"`
+	AccountID      string `json:"account_id"`
+	PersonID       string `json:"person_id"`
+	ActionID       string `json:"action_id"`
+	OutcomeID      string `json:"outcome_id"`
+	OutboxEventID  string `json:"outbox_event_id"`
+	IdempotencyKey string `json:"idempotency_key"`
+
+	RouteFamily string `json:"route_family"`
+	Trigger     string `json:"trigger"`
+	OfferID     string `json:"offer_id"`
+	Route       string `json:"route"`
+
+	Versions Versions `json:"versions"`
+
+	LeadCreatedAt  time.Time  `json:"lead_created_at,omitempty"`
+	IngestedAt     time.Time  `json:"warmbly_ingested_at,omitempty"`
+	EnrichmentAt   *time.Time `json:"enrichment_completed_at,omitempty"`
+	FirstActionAt  *time.Time `json:"first_action_at,omitempty"`
+	ConversationAt *time.Time `json:"conversation_at,omitempty"`
+	ProposalAt     *time.Time `json:"proposal_at,omitempty"`
+	CloseAt        *time.Time `json:"close_at,omitempty"`
+
+	OutcomeType    string `json:"outcome_type"`
+	HumanConfirmed bool   `json:"human_confirmed"`
+	Qualified      bool   `json:"qualified"`
+	Conversation   bool   `json:"conversation"`
+	PipelineOpen   bool   `json:"pipeline_open"`
+	Held           bool   `json:"held"`
+
+	AttributionKind string `json:"attribution_kind"`
+	CausalProof     bool   `json:"causal_proof"`
+
+	Synthetic bool      `json:"synthetic"`
+	Label     string    `json:"label"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+// Versions are extra-cli watermarks copied, never invented.
+type Versions struct {
+	TargetFit          string `json:"target_fit_version"`
+	ActivationPolicy   string `json:"activation_policy_version"`
+	TargetFitWatermark string `json:"target_fit_watermark"`
+	Fresh              bool   `json:"target_fit_fresh"`
+}
+
+// Exception is a durable queue item. Out-of-order items are held.
+type Exception struct {
+	ID             string    `json:"id"`
+	OrganizationID string    `json:"organization_id,omitempty"`
+	Code           string    `json:"code"`
+	Reason         string    `json:"reason"`
+	NextAction     string    `json:"next_action"`
+	Identity       string    `json:"identity,omitempty"`
+	MetricKey      string    `json:"metric_key,omitempty"`
+	ActionID       string    `json:"action_id,omitempty"`
+	OutcomeID      string    `json:"outcome_id,omitempty"`
+	AccountID      string    `json:"account_id,omitempty"`
+	LeadID         string    `json:"lead_id,omitempty"`
+	Held           bool      `json:"held"`
+	Synthetic      bool      `json:"synthetic,omitempty"`
+	At             time.Time `json:"at"`
+}
+
+// JoinResult is the shipped reconcile outcome.
+type JoinResult struct {
+	Chain      Chain       `json:"chain"`
+	Exceptions []Exception `json:"exceptions,omitempty"`
+	Created    bool        `json:"created"`
+	Replay     bool        `json:"replay"`
+	Held       bool        `json:"held"`
+}
+
+// LearningCandidate stays inside this capability. It never writes extra-cli,
+// web-cfg, or SmartLic.
+type LearningCandidate struct {
+	ID              string    `json:"id"`
+	OrganizationID  string    `json:"organization_id,omitempty"`
+	Kind            string    `json:"kind"`
+	Target          string    `json:"target"`
+	Source          string    `json:"source"`
+	Reason          string    `json:"reason"`
+	Status          string    `json:"status"`
+	Identity        string    `json:"identity,omitempty"`
+	MetricKey       string    `json:"metric_key,omitempty"`
+	AssetID         string    `json:"asset_id,omitempty"`
+	OfferID         string    `json:"offer_id,omitempty"`
+	ActionID        string    `json:"action_id,omitempty"`
+	OutcomeID       string    `json:"outcome_id,omitempty"`
+	LeadID          string    `json:"lead_id,omitempty"`
+	CorrectionCodes []string  `json:"correction_codes,omitempty"`
+	OutcomeType     string    `json:"outcome_type,omitempty"`
+	UpstreamWrites  []string  `json:"upstream_writes"`
+	Synthetic       bool      `json:"synthetic,omitempty"`
+	At              time.Time `json:"at"`
+}
+
+// LearningInput is a human correction or a recorded outcome.
+type LearningInput struct {
+	From            string   `json:"from"`
+	Reason          string   `json:"reason,omitempty"`
+	CorrectionCodes []string `json:"correction_codes,omitempty"`
+	OutcomeType     string   `json:"outcome_type,omitempty"`
+	HumanConfirmed  bool     `json:"human_confirmed,omitempty"`
+	Keys            JoinKeys `json:"keys"`
+	Synthetic       bool     `json:"synthetic,omitempty"`
+}
+
+// FamilyCounts is one route-family slice of the executive view.
+type FamilyCounts struct {
+	Family                   string `json:"route_family"`
+	InboundQualifiedPipeline int    `json:"inbound_qualified_pipeline"`
+	QCO                      int    `json:"qco"`
+	Conversations            int    `json:"conversations"`
+	Meetings                 int    `json:"meetings"`
+	Proposals                int    `json:"proposals"`
+	Pipeline                 int    `json:"pipeline"`
+	Won                      int    `json:"won"`
+	Lost                     int    `json:"lost"`
+	Unknown                  int    `json:"unknown"`
+}
+
+// Breakdown is one ID-keyed rollup. Keys are IDs, never PII.
+type Breakdown struct {
+	Key   string `json:"key"`
+	Count int    `json:"count"`
+}
+
+// Denominators keep rates honest. Zero stays zero.
+type Denominators struct {
+	Leads         int `json:"leads"`
+	Actions       int `json:"actions"`
+	Outcomes      int `json:"outcomes"`
+	Qualified     int `json:"qualified"`
+	Conversations int `json:"conversations"`
+	Meetings      int `json:"meetings"`
+	Proposals     int `json:"proposals"`
+	Closed        int `json:"closed"`
+}
+
+// LatencyMS is observed elapsed time between stamps. Missing stamps stay 0.
+type LatencyMS struct {
+	LeadToIngest           int64 `json:"lead_to_ingest_ms"`
+	IngestToEnrichment     int64 `json:"ingest_to_enrichment_ms"`
+	EnrichmentToAction     int64 `json:"enrichment_to_action_ms"`
+	ActionToConversation   int64 `json:"action_to_conversation_ms"`
+	ConversationToProposal int64 `json:"conversation_to_proposal_ms"`
+	ProposalToClose        int64 `json:"proposal_to_close_ms"`
+	SampledChains          int   `json:"sampled_chains"`
+}
+
+// Freshness is the version/watermark surface. Empty stays UNKNOWN.
+type Freshness struct {
+	TargetFitVersions        []string `json:"target_fit_versions"`
+	ActivationPolicyVersions []string `json:"activation_policy_versions"`
+	Watermarks               []string `json:"watermarks"`
+	StaleChains              int      `json:"stale_chains"`
+	MissingVersionChains     int      `json:"missing_version_chains"`
+}
+
+// ExecutiveView is the monthly query payload. Not a CRM board.
+type ExecutiveView struct {
+	SchemaVersion            string         `json:"schema_version"`
+	Month                    string         `json:"month"`
+	IncludeSynthetic         bool           `json:"include_synthetic"`
+	InboundQualifiedPipeline int            `json:"inbound_qualified_pipeline"`
+	QCO                      int            `json:"qco"`
+	Conversations            int            `json:"conversations"`
+	Meetings                 int            `json:"meetings"`
+	Proposals                int            `json:"proposals"`
+	Pipeline                 int            `json:"pipeline"`
+	Won                      int            `json:"won"`
+	Lost                     int            `json:"lost"`
+	Unknown                  int            `json:"unknown"`
+	Families                 []FamilyCounts `json:"families"`
+	BySource                 []Breakdown    `json:"by_source"`
+	ByAsset                  []Breakdown    `json:"by_asset"`
+	ByTrigger                []Breakdown    `json:"by_trigger"`
+	ByOffer                  []Breakdown    `json:"by_offer"`
+	ByRoute                  []Breakdown    `json:"by_route"`
+	Denominators             Denominators   `json:"denominators"`
+	Latency                  LatencyMS      `json:"latency"`
+	Freshness                Freshness      `json:"freshness"`
+	AttributionKind          string         `json:"attribution_kind"`
+	CausalProof              bool           `json:"causal_proof"`
+	RealEmpty                bool           `json:"real_empty"`
+	ChainCount               int            `json:"chain_count"`
+}
+
+func idOrUnknown(v string) string {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return Unknown
+	}
+	return v
+}
+
+func normalizeFamily(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case FamilyInbound:
+		return FamilyInbound
+	case FamilyOutbound:
+		return FamilyOutbound
+	case FamilyPartner, "parceiro":
+		return FamilyPartner
+	case FamilyExpansion, "expansao", "expansão":
+		return FamilyExpansion
+	case "":
+		return Unknown
+	default:
+		return Unknown
+	}
+}
+
+func isWonType(t string) bool {
+	u := strings.ToUpper(strings.TrimSpace(t))
+	return u == OutcomeWon || u == OutcomeClient
+}
+
+func isLostType(t string) bool {
+	return strings.EqualFold(strings.TrimSpace(t), OutcomeLost)
+}

--- a/internal/app/confenge/intel/types.go
+++ b/internal/app/confenge/intel/types.go
@@ -29,6 +29,7 @@ const (
 	ExceptionStaleAttribution   = "stale_attribution"
 	ExceptionOutOfOrder         = "out_of_order"
 	ExceptionUnconfirmedWon     = "unconfirmed_won"
+	ExceptionUnconfirmedLost    = "unconfirmed_lost"
 	ExceptionUnavailable        = "ledger_unavailable"
 
 	OutcomeWon                   = "WON"

--- a/internal/app/confenge/intel_service.go
+++ b/internal/app/confenge/intel_service.go
@@ -1,0 +1,126 @@
+package confenge
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// WireIntel attaches the commercial-intelligence store. Nil db uses memory.
+func (s *service) WireIntel(db *pgxpool.Pool) {
+	if db != nil {
+		s.intel = intel.NewPGStore(db, "")
+		return
+	}
+	s.intel = intel.NewMemoryStore()
+}
+
+func (s *service) intelStore() intel.Store {
+	if s.intel == nil {
+		s.intel = intel.NewMemoryStore()
+	}
+	return s.intel
+}
+
+// ReconcileCommercialIntel joins one observed ID record. Replay is a no-op.
+func (s *service) ReconcileCommercialIntel(_ context.Context, orgID uuid.UUID, in intel.ObservedFacts) (intel.JoinResult, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return intel.JoinResult{}, xerr
+	}
+	if in.Keys.OrganizationID == "" {
+		in.Keys.OrganizationID = orgID.String()
+	}
+	return intel.Reconcile(s.intelStore(), in), nil
+}
+
+// CommercialExecutiveView reconciles known inbound/action IDs then rolls up
+// the month. includeSynthetic=false keeps real metrics empty/UNKNOWN.
+func (s *service) CommercialExecutiveView(ctx context.Context, orgID uuid.UUID, month string, includeSynthetic bool) (*intel.ExecutiveView, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	s.observeExisting(ctx, orgID)
+	chains, err := s.intelStore().ListChains(orgID.String())
+	if err != nil {
+		return nil, errx.New(errx.Internal, "commercial intel list: "+err.Error())
+	}
+	view := intel.Rollup(chains, month, includeSynthetic)
+	return &view, nil
+}
+
+// RecordIntelLearning emits a LEARNING CANDIDATE. No upstream write.
+func (s *service) RecordIntelLearning(_ context.Context, orgID uuid.UUID, in intel.LearningInput) (intel.LearningCandidate, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return intel.LearningCandidate{}, xerr
+	}
+	if in.Keys.OrganizationID == "" {
+		in.Keys.OrganizationID = orgID.String()
+	}
+	return intel.EmitLearning(s.intelStore(), in), nil
+}
+
+// ListIntelExceptions returns the durable exception queue.
+func (s *service) ListIntelExceptions(_ context.Context, orgID uuid.UUID) ([]intel.Exception, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	xs, err := s.intelStore().ListExceptions(orgID.String())
+	if err != nil {
+		return nil, errx.New(errx.Internal, "commercial intel exceptions: "+err.Error())
+	}
+	return xs, nil
+}
+
+func (s *service) observeExisting(ctx context.Context, orgID uuid.UUID) {
+	st := s.intelStore()
+	seenActions := map[string]bool{}
+	if inb := s.inboundStore(); inb != nil {
+		leads, err := inb.ListInboundLeads(ctx, orgID, false, 500)
+		if err == nil {
+			for i := range leads {
+				var acc *models.OutreachAccount
+				var action *models.OutreachCommercialAction
+				var outcome *models.OutreachOutcome
+				if leads[i].AccountID != nil {
+					acc, _ = s.repo.GetAccount(ctx, orgID, *leads[i].AccountID)
+				}
+				if leads[i].ActionID != nil {
+					if ast := s.actionStore(); ast != nil {
+						action, _ = ast.GetCommercialAction(ctx, orgID, *leads[i].ActionID)
+					}
+				}
+				outcome, _ = s.repo.GetLatestOutcomeForLead(ctx, orgID, leads[i].CNPJ14, leads[i].LeadID, leads[i].LeadEmail)
+				facts := intel.ObserveFromInbound(leads[i], acc, action, outcome)
+				intel.Reconcile(st, facts)
+				if action != nil {
+					seenActions[action.ID.String()] = true
+				}
+			}
+		}
+	}
+	if ast := s.actionStore(); ast != nil {
+		actions, err := ast.ListCommercialActions(ctx, orgID, uuid.Nil, false, 500)
+		if err == nil {
+			for i := range actions {
+				if seenActions[actions[i].ID.String()] {
+					continue
+				}
+				var acc *models.OutreachAccount
+				if actions[i].AccountID != uuid.Nil {
+					acc, _ = s.repo.GetAccount(ctx, orgID, actions[i].AccountID)
+				}
+				family := intel.Unknown
+				if strings.HasPrefix(actions[i].IdempotencyKey, "inbound:") {
+					family = intel.FamilyInbound
+				}
+				intel.Reconcile(st, intel.ObserveFromAction(actions[i], acc, family))
+			}
+		}
+	}
+}

--- a/internal/app/confenge/intel_service.go
+++ b/internal/app/confenge/intel_service.go
@@ -95,7 +95,7 @@ func (s *service) observeExisting(ctx context.Context, orgID uuid.UUID) {
 						action, _ = ast.GetCommercialAction(ctx, orgID, *leads[i].ActionID)
 					}
 				}
-				outcome, _ = s.repo.GetLatestOutcomeForLead(ctx, orgID, leads[i].CNPJ14, leads[i].LeadID, leads[i].LeadEmail)
+				outcome = outcomeByJoinIDs(ctx, s.repo, orgID, leads[i], action)
 				facts := intel.ObserveFromInbound(leads[i], acc, action, outcome)
 				intel.Reconcile(st, facts)
 				if action != nil {
@@ -123,4 +123,39 @@ func (s *service) observeExisting(ctx context.Context, orgID uuid.UUID) {
 			}
 		}
 	}
+}
+
+// intelOutboxByID looks up outbox rows by durable IDs only. Email/CNPJ
+// must not be used as a join key.
+type intelOutboxByID interface {
+	GetOutcomeBySourceLeadID(ctx context.Context, orgID uuid.UUID, sourceLeadID string) (*models.OutreachOutcome, error)
+}
+
+func outcomeByJoinIDs(ctx context.Context, repo any, orgID uuid.UUID, lead models.OutreachInboundLead, action *models.OutreachCommercialAction) *models.OutreachOutcome {
+	st, ok := repo.(intelOutboxByID)
+	if !ok {
+		return nil
+	}
+	for _, id := range []string{strings.TrimSpace(lead.LeadID), strings.TrimSpace(lead.ReceiptID)} {
+		if id == "" {
+			continue
+		}
+		ev, err := st.GetOutcomeBySourceLeadID(ctx, orgID, id)
+		if err != nil || ev == nil {
+			continue
+		}
+		src := strings.TrimSpace(ev.SourceLeadID)
+		if src != "" && (src == strings.TrimSpace(lead.LeadID) || src == strings.TrimSpace(lead.ReceiptID)) {
+			return ev
+		}
+	}
+	if action != nil {
+		if id := strings.TrimSpace(action.SourceLeadID); id != "" && (id == strings.TrimSpace(lead.LeadID) || id == strings.TrimSpace(lead.ReceiptID)) {
+			ev, err := st.GetOutcomeBySourceLeadID(ctx, orgID, id)
+			if err == nil && ev != nil && strings.TrimSpace(ev.SourceLeadID) == id {
+				return ev
+			}
+		}
+	}
+	return nil
 }

--- a/internal/app/confenge/intel_service_test.go
+++ b/internal/app/confenge/intel_service_test.go
@@ -1,0 +1,115 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+)
+
+func TestCommercialExecutiveViewEmptyReal(t *testing.T) {
+	svc, _, org := inboundTestService(t)
+	view, xerr := svc.CommercialExecutiveView(context.Background(), org, intel.SyntheticMonth, false)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if view.InboundQualifiedPipeline != 0 || view.QCO != 0 || view.Won != 0 || !view.RealEmpty {
+		t.Fatalf("empty real view invented data: %+v", view)
+	}
+	fmt.Printf("SERVICE_REAL_EMPTY iqp=%d qco=%d real_empty=%v\n", view.InboundQualifiedPipeline, view.QCO, view.RealEmpty)
+}
+
+func TestCommercialIntelJoinAndLearningViaService(t *testing.T) {
+	svc, _, org := inboundTestService(t)
+	facts := intel.SyntheticFacts(org.String())[1]
+	res, xerr := svc.ReconcileCommercialIntel(context.Background(), org, facts)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if !res.Created {
+		t.Fatal("first service join should create")
+	}
+	again, xerr := svc.ReconcileCommercialIntel(context.Background(), org, facts)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if again.Created || !again.Replay {
+		t.Fatal("service replay must return the first chain")
+	}
+	view, xerr := svc.CommercialExecutiveView(context.Background(), org, intel.SyntheticMonth, true)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if view.QCO == 0 {
+		t.Fatalf("synthetic QCO missing: %+v", view)
+	}
+	cand, xerr := svc.RecordIntelLearning(context.Background(), org, intel.LearningInput{
+		From: intel.LearningFromCorrection, CorrectionCodes: []string{"wrong_service"},
+		Keys: facts.Keys, Synthetic: true,
+	})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if cand.Target != intel.TargetOffer || len(cand.UpstreamWrites) != 0 {
+		t.Fatalf("learning via service: %+v", cand)
+	}
+	fmt.Printf("SERVICE_JOIN identity=%s replay=%v qco=%d learning_target=%s\n",
+		res.Chain.Identity, again.Replay, view.QCO, cand.Target)
+}
+
+func TestObserveFromInboundKeepsIDsOnly(t *testing.T) {
+	svc, repo, org := inboundTestService(t)
+	now := parseFlexibleTime("2026-08-14T14:55:00Z")
+	body := []byte(`{
+		"lead_id":"webcfg-obs-1","receipt_id":"rcpt-obs-1","created_at":"2026-08-14T14:55:00Z",
+		"source":"web-cfg","route_family":"inbound","asset_id":"landing-segunda-leitura",
+		"cta_id":"segunda-leitura-contrato","entity_public_id":"extra-obs",
+		"company":"Construtora Norte","name":"Ana Souza","email":"ana.souza@norte.example",
+		"phone":"+5541999887766","correlation_id":"corr-obs-1",
+		"utm":{"source":"google","campaign":"segunda-leitura"}
+	}`)
+	ing, xerr := svc.IngestInboundLead(context.Background(), org, body, IngestOptions{Now: now})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if ing.Lead == nil {
+		t.Fatal("ingest dropped lead")
+	}
+	facts := intel.ObserveFromInbound(*ing.Lead, nil, ing.Action, nil)
+	if facts.Keys.LeadID != "webcfg-obs-1" || facts.Keys.ReceiptID != "rcpt-obs-1" {
+		t.Fatalf("inbound IDs not copied: %+v", facts.Keys)
+	}
+	if facts.Keys.AssetID != "landing-segunda-leitura" || facts.Keys.CorrelationID != "corr-obs-1" {
+		t.Fatalf("web-cfg attribution not copied: %+v", facts.Keys)
+	}
+	key := intel.MetricKey(facts.Keys)
+	if intel.MetricKeyContainsPII(key) {
+		t.Fatalf("observe metric key has PII: %s", key)
+	}
+	raw, _ := json.Marshal(facts.Keys)
+	if containsAny(string(raw), "ana.souza@norte.example", "+5541999887766", "Ana Souza") {
+		t.Fatalf("PII entered join keys: %s", raw)
+	}
+	fmt.Printf("OBSERVE lead=%s receipt=%s asset=%s metric_pii=false\n",
+		facts.Keys.LeadID, facts.Keys.ReceiptID, facts.Keys.AssetID)
+	_ = repo
+}
+
+func containsAny(s string, parts ...string) bool {
+	for _, p := range parts {
+		if len(p) > 0 && indexOfStr(s, p) >= 0 {
+			return true
+		}
+	}
+	return false
+}
+func indexOfStr(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/app/confenge/intel_service_test.go
+++ b/internal/app/confenge/intel_service_test.go
@@ -5,8 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"testing"
+	"time"
+
+	"github.com/google/uuid"
 
 	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/models"
 )
 
 func TestCommercialExecutiveViewEmptyReal(t *testing.T) {
@@ -95,6 +99,72 @@ func TestObserveFromInboundKeepsIDsOnly(t *testing.T) {
 	fmt.Printf("OBSERVE lead=%s receipt=%s asset=%s metric_pii=false\n",
 		facts.Keys.LeadID, facts.Keys.ReceiptID, facts.Keys.AssetID)
 	_ = repo
+}
+
+func TestObserveExistingJoinsOutcomeByLeadIDOnly(t *testing.T) {
+	svc, repo, org := inboundTestService(t)
+	now := time.Date(2026, 8, 14, 15, 0, 0, 0, time.UTC)
+	sharedEmail := "shared@empresa.com"
+	sharedCNPJ := "11222333000181"
+	leadA := &models.OutreachInboundLead{
+		OrganizationID: org, LeadID: "webcfg-join-a", ReceiptID: "rcpt-a",
+		LeadCreatedAt: now, WarmblyIngestedAt: now,
+		LeadEmail: sharedEmail, CNPJ14: sharedCNPJ,
+		RouteFamily: "inbound", Status: models.InboundStatusOpen,
+		EnrichmentStatus: models.InboundEnrichmentUnknown, Owner: models.InboundOwnerUnknown,
+	}
+	leadB := &models.OutreachInboundLead{
+		OrganizationID: org, LeadID: "webcfg-join-b", ReceiptID: "rcpt-b",
+		LeadCreatedAt: now, WarmblyIngestedAt: now,
+		LeadEmail: sharedEmail, CNPJ14: sharedCNPJ,
+		RouteFamily: "inbound", Status: models.InboundStatusOpen,
+		EnrichmentStatus: models.InboundEnrichmentUnknown, Owner: models.InboundOwnerUnknown,
+	}
+	if _, _, err := repo.InsertInboundLead(context.Background(), leadA); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := repo.InsertInboundLead(context.Background(), leadB); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.EnqueueOutcome(context.Background(), &models.OutreachOutcome{
+		OrganizationID: org, SourceLeadID: "webcfg-join-a", EventType: intel.OutcomeQualifiedConversation,
+		ContactEmail: sharedEmail, CNPJ14: sharedCNPJ, OccurredAt: now, IdempotencyKey: "out-a",
+		EventID: uuid.MustParse("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.EnqueueOutcome(context.Background(), &models.OutreachOutcome{
+		OrganizationID: org, SourceLeadID: "webcfg-join-b", EventType: intel.OutcomeMeeting,
+		ContactEmail: sharedEmail, CNPJ14: sharedCNPJ, OccurredAt: now.Add(time.Hour), IdempotencyKey: "out-b",
+		EventID: uuid.MustParse("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc.observeExisting(context.Background(), org)
+	chains, err := svc.intelStore().ListChains(org.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	byLead := map[string]intel.Chain{}
+	for _, c := range chains {
+		byLead[c.LeadID] = c
+	}
+	a, okA := byLead["webcfg-join-a"]
+	b, okB := byLead["webcfg-join-b"]
+	if !okA || !okB {
+		t.Fatalf("missing chains a=%v b=%v have=%d", okA, okB, len(chains))
+	}
+	if a.OutcomeType == intel.OutcomeMeeting {
+		t.Fatal("lead A absorbed lead B meeting via email/cnpj")
+	}
+	if a.OutcomeType != intel.OutcomeQualifiedConversation {
+		t.Fatalf("lead A outcome=%s want QCO (old outbox filter would drop it)", a.OutcomeType)
+	}
+	if b.OutcomeType != intel.OutcomeMeeting {
+		t.Fatalf("lead B outcome=%s want MEETING", b.OutcomeType)
+	}
+	fmt.Printf("OBSERVE_EXISTING a=%s b=%s email_or_rejected=true qco_visible=true\n", a.OutcomeType, b.OutcomeType)
 }
 
 func containsAny(s string, parts ...string) bool {

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
 	"github.com/warmbly/warmbly/internal/app/whatsapp"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
@@ -115,6 +116,13 @@ type Service interface {
 	GetActiveCampaignPolicy(ctx context.Context, orgID, campaignID uuid.UUID) (*models.CampaignPolicyAuthorization, *errx.Error)
 	TryGreenAutorun(ctx context.Context, orgID, actorID, touchpointID uuid.UUID) (*models.OutreachTouchpoint, GreenAutorunDecision, *errx.Error)
 	RunGreenAutorunBatch(ctx context.Context, orgID, actorID uuid.UUID, limit int) (queued, skipped int, details []map[string]any, xerr *errx.Error)
+
+	// Commercial intelligence (join / exception queue / executive view).
+	WireIntel(db *pgxpool.Pool)
+	ReconcileCommercialIntel(ctx context.Context, orgID uuid.UUID, in intel.ObservedFacts) (intel.JoinResult, *errx.Error)
+	CommercialExecutiveView(ctx context.Context, orgID uuid.UUID, month string, includeSynthetic bool) (*intel.ExecutiveView, *errx.Error)
+	RecordIntelLearning(ctx context.Context, orgID uuid.UUID, in intel.LearningInput) (intel.LearningCandidate, *errx.Error)
+	ListIntelExceptions(ctx context.Context, orgID uuid.UUID) ([]intel.Exception, *errx.Error)
 }
 
 // ImportOptions controls dry-run, idempotency, and source tracking.
@@ -141,6 +149,7 @@ type service struct {
 	waStore     WhatsAppStateStore
 	governor    *dispatch.Governor
 	policyStore repository.ConfengePolicyRepository
+	intel       intel.Store
 }
 
 // NewService wires confenge outreach. When cfg.Enabled is false, mutators return 404-style disabled errors.

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -798,6 +798,30 @@ func (m *memRepo) GetLatestOutcomeForLead(ctx context.Context, orgID uuid.UUID, 
 	return best, nil
 }
 
+func (m *memRepo) GetOutcomeBySourceLeadID(_ context.Context, orgID uuid.UUID, sourceLeadID string) (*models.OutreachOutcome, error) {
+	sourceLeadID = strings.TrimSpace(sourceLeadID)
+	if sourceLeadID == "" {
+		return nil, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var best *models.OutreachOutcome
+	for i := range m.outcomes {
+		o := m.outcomes[i]
+		if o.OrganizationID != orgID {
+			continue
+		}
+		if strings.TrimSpace(o.SourceLeadID) != sourceLeadID {
+			continue
+		}
+		if best == nil || o.OccurredAt.After(best.OccurredAt) {
+			cp := o
+			best = &cp
+		}
+	}
+	return best, nil
+}
+
 func testSvc(repo repository.OutreachRepository) Service {
 	cfg := Config{
 		Enabled:              true,

--- a/internal/infrastructure/db/migrations/000101_outreach_commercial_intel.down.sql
+++ b/internal/infrastructure/db/migrations/000101_outreach_commercial_intel.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS outreach_intel_learning_candidates;
+DROP TABLE IF EXISTS outreach_intel_exceptions;
+DROP TABLE IF EXISTS outreach_intel_chains;

--- a/internal/infrastructure/db/migrations/000101_outreach_commercial_intel.up.sql
+++ b/internal/infrastructure/db/migrations/000101_outreach_commercial_intel.up.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS outreach_intel_exceptions (
         'stale_attribution',
         'out_of_order',
         'unconfirmed_won',
+        'unconfirmed_lost',
         'ledger_unavailable'
     ))
 );

--- a/internal/infrastructure/db/migrations/000101_outreach_commercial_intel.up.sql
+++ b/internal/infrastructure/db/migrations/000101_outreach_commercial_intel.up.sql
@@ -1,0 +1,73 @@
+-- Commercial intelligence (issue #47). Own tables, not a CRM and not a
+-- second execution ledger. Joins copy IDs from web-cfg / extra-cli / Warmbly.
+
+CREATE TABLE IF NOT EXISTS outreach_intel_chains (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    identity            text NOT NULL,
+    metric_key          text NOT NULL,
+    route_family        text NOT NULL DEFAULT 'UNKNOWN',
+    label               text NOT NULL DEFAULT 'REAL',
+    synthetic           boolean NOT NULL DEFAULT false,
+    payload             jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT outreach_intel_chains_family_check CHECK (route_family IN (
+        'inbound', 'outbound', 'partner', 'expansion', 'UNKNOWN')),
+    CONSTRAINT outreach_intel_chains_label_check CHECK (label IN ('REAL', 'SYNTHETIC'))
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_intel_chains_org_identity_uidx
+    ON outreach_intel_chains (organization_id, identity);
+
+CREATE INDEX IF NOT EXISTS outreach_intel_chains_org_month_idx
+    ON outreach_intel_chains (organization_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS outreach_intel_exceptions (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    code                text NOT NULL,
+    identity            text NOT NULL DEFAULT '',
+    metric_key          text NOT NULL DEFAULT '',
+    held                boolean NOT NULL DEFAULT false,
+    payload             jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT outreach_intel_exceptions_code_check CHECK (code IN (
+        'orphan',
+        'duplicate',
+        'conflicting_account',
+        'missing_version',
+        'stale_attribution',
+        'out_of_order',
+        'unconfirmed_won',
+        'ledger_unavailable'
+    ))
+);
+
+CREATE INDEX IF NOT EXISTS outreach_intel_exceptions_org_code_idx
+    ON outreach_intel_exceptions (organization_id, code, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS outreach_intel_learning_candidates (
+    id                  uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+    organization_id     uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    target              text NOT NULL DEFAULT 'UNKNOWN',
+    source              text NOT NULL DEFAULT 'UNKNOWN',
+    status              text NOT NULL DEFAULT 'PENDING',
+    identity            text NOT NULL DEFAULT '',
+    payload             jsonb NOT NULL DEFAULT '{}'::jsonb,
+    created_at          timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT outreach_intel_learning_target_check CHECK (target IN (
+        'demand', 'asset', 'offer', 'content', 'distribution', 'UNKNOWN')),
+    CONSTRAINT outreach_intel_learning_source_check CHECK (source IN (
+        'correction', 'outcome', 'UNKNOWN')),
+    CONSTRAINT outreach_intel_learning_status_check CHECK (status IN ('PENDING'))
+);
+
+CREATE INDEX IF NOT EXISTS outreach_intel_learning_org_idx
+    ON outreach_intel_learning_candidates (organization_id, created_at DESC);
+
+COMMENT ON TABLE outreach_intel_chains IS
+'Observed commercial join. Metric keys are ID hashes, never PII. Not causal proof.';
+COMMENT ON TABLE outreach_intel_exceptions IS
+'Orphan/duplicate/conflict/missing_version/stale/out_of_order/unconfirmed_won queue.';
+COMMENT ON TABLE outreach_intel_learning_candidates IS
+'Local LEARNING CANDIDATE rows. Never written to extra-cli, web-cfg, or SmartLic.';

--- a/internal/repository/pg_outreach_outcomes.go
+++ b/internal/repository/pg_outreach_outcomes.go
@@ -254,3 +254,33 @@ func (r *outreachRepository) GetLatestOutcomeForLead(ctx context.Context, orgID 
 	}
 	return &ev, nil
 }
+
+// GetOutcomeBySourceLeadID returns the newest outbox row whose
+// source_lead_id equals the inbound lead/receipt id. Empty IDs never match.
+func (r *outreachRepository) GetOutcomeBySourceLeadID(ctx context.Context, orgID uuid.UUID, sourceLeadID string) (*models.OutreachOutcome, error) {
+	sourceLeadID = strings.TrimSpace(sourceLeadID)
+	if sourceLeadID == "" {
+		return nil, nil
+	}
+	row := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, event_id, idempotency_key, COALESCE(source_lead_id,''), COALESCE(cnpj14,''),
+			COALESCE(contact_email,''), event_type, payload, occurred_at, attempts, next_attempt_at,
+			delivered_at, COALESCE(last_error,''), dead_letter, created_at, updated_at
+		FROM outreach_outcome_outbox
+		WHERE organization_id=$1 AND source_lead_id=$2
+		ORDER BY occurred_at DESC
+		LIMIT 1`, orgID, sourceLeadID)
+	var ev models.OutreachOutcome
+	err := row.Scan(
+		&ev.ID, &ev.OrganizationID, &ev.EventID, &ev.IdempotencyKey, &ev.SourceLeadID, &ev.CNPJ14,
+		&ev.ContactEmail, &ev.EventType, &ev.Payload, &ev.OccurredAt, &ev.Attempts, &ev.NextAttemptAt,
+		&ev.DeliveredAt, &ev.LastError, &ev.DeadLetter, &ev.CreatedAt, &ev.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &ev, nil
+}


### PR DESCRIPTION
Closes nothing yet. Addresses #47.

## What this is

A commercial-intelligence capability, not a CRM and not a second execution ledger.

`source/query/asset` → inbound `lead_id`/`receipt_id`/`correlation_id` → extra-cli account/event/person/version → Warmbly `action_id`/`outcome_id`/outbox IDs → observed association → local `LEARNING CANDIDATE`.

## Authority

- extra-cli: facts, entity, person, event, versions
- web-cfg: source/query/asset attribution
- Warmbly: human action and outcomes
- This module copies those IDs. It does not overwrite the sources.

## Shipped

- Typed join contract and idempotent `Reconcile` (`internal/app/confenge/intel`)
- Durable exception queue: `orphan`, `duplicate`, `conflicting_account`, `missing_version`, `stale_attribution`, plus `out_of_order` (held) and `unconfirmed_won` (stays `UNKNOWN`)
- Monthly executive query with families kept separate (`inbound` / `outbound` / `partner` / `expansion`): INBOUND QUALIFIED PIPELINE, QCO, conversations, meetings, proposals, pipeline, won/lost/UNKNOWN, breakdowns, denominators, latency, freshness
- `LEARNING CANDIDATE` from corrections/outcomes. `upstream_writes` is always empty (no extra-cli / web-cfg / SmartLic write)
- Labeled `SYNTHETIC` fixtures. Real rollups stay empty/`UNKNOWN` when `include_synthetic=0`
- Tables: `outreach_intel_chains`, `outreach_intel_exceptions`, `outreach_intel_learning_candidates` (000101)
- `GET /confenge/intel/executive`, `GET /confenge/intel/exceptions`, `POST /confenge/intel/learning`

## Honest bar

- No real inbound/action/outcome receipts were produced here. The ledger is still idle.
- “Code exists” is not production proof. This PR is not DoD for #47.
- Attribution is labeled `observed_association`. `causal_proof` is always false. No forecast, no score.
- Auto-send stays off.

## Tests

```
go test ./internal/app/confenge/intel/ ./internal/app/confenge/ ./internal/api/handler/ -count=1 -run 'TestReconcile|TestMetricKey|TestMissingVersion|TestNilStore|TestClassifyNamed|TestOutOfOrder|TestUnconfirmed|TestExecutiveView|TestLearning|TestRealEmpty|TestCommercial|TestObserveFromInbound|TestGetConfengeExecutiveIntel'
```