### PR TITLE
fix confenge inbound canonical host

### DIFF
--- a/deploy/confenge-vps/README.md
+++ b/deploy/confenge-vps/README.md
@@ -35,6 +35,16 @@ The helper keeps local port `8080` available for Evolution API and forwards the
 CONFENGE backend to `18080`. Use `deploy/confenge-vps/compose.sh` for maintenance;
 raw `docker compose` commands do not load this deployment's override and `.env`.
 
+Public inbound edge (host nginx, not a new app):
+
+```bash
+# as root, after DNS A api.confenge.com.br -> 159.195.18.88 (DNS only)
+deploy/confenge-vps/inbound-edge-install.sh
+```
+
+Only `GET .../inbound/health` and `POST .../inbound` are proxied to
+loopback `:8080`. Handoff: [inbound-edge.md](../../docs/confenge/inbound-edge.md).
+
 Safety: GREEN autorun OFF, auto-send OFF, WhatsApp OFF, human approval ON.
 Operational pace 10→20/h, daily shell 200. Hostinger plan is **Business Email
 Starter** (1000 msgs/rolling 24h/mailbox); that is only the provider ceiling,

--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -129,6 +129,8 @@ services:
       SMTP_HOST: ${SMTP_HOST:-mailpit}
       SMTP_PORT: ${SMTP_PORT:-1025}
       MAIL_TLS_INSECURE: ${MAIL_TLS_INSECURE:-false}
+      # Honor X-Forwarded-For only from the host nginx inbound edge.
+      TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.1}
     volumes:
       - confenge_ops:/data/confenge-ops
       - confenge_keys:/data/confenge-keys:ro

--- a/deploy/confenge-vps/env.example
+++ b/deploy/confenge-vps/env.example
@@ -107,6 +107,11 @@ CONFENGE_IMAP_PORT=993
 CONFENGE_API_HOST=127.0.0.1:8080
 CONFENGE_API_BASE=http://127.0.0.1:8080
 
+# Host nginx on this VPS terminates TLS for api.confenge.com.br and proxies
+# only the inbound webhook to loopback :8080. Trust X-Forwarded-For from
+# that local proxy only. Do not set 0.0.0.0/0.
+TRUSTED_PROXIES=127.0.0.1
+
 # Platform notification SMTP (not campaign mail). Campaign mail uses sealed
 # Hostinger credentials.
 SMTP_HOST=mailpit

--- a/deploy/confenge-vps/inbound-edge-install.sh
+++ b/deploy/confenge-vps/inbound-edge-install.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Install the public HTTPS edge for CONFENGE inbound on the existing VPS.
+# Host nginx + certbot only. Does not expose the loopback backend, UI, DB,
+# or extra-cli :8443. Does not enable auto-send. Does not invent DNS.
+set -euo pipefail
+
+PACK="$(cd "$(dirname "$0")" && pwd)"
+# shellcheck source=lib.sh
+source "$PACK/lib.sh"
+
+HOST_NAME="${CONFENGE_INBOUND_PUBLIC_HOST:-api.confenge.com.br}"
+PUBLIC_IP="${CONFENGE_INBOUND_PUBLIC_IP:-159.195.18.88}"
+ACME_ROOT="${CONFENGE_INBOUND_ACME_ROOT:-/var/www/acme}"
+NGINX_AVAIL="${CONFENGE_INBOUND_NGINX_AVAIL:-/etc/nginx/sites-available}"
+NGINX_ENABL="${CONFENGE_INBOUND_NGINX_ENABLED:-/etc/nginx/sites-enabled}"
+CERT_LIVE="/etc/letsencrypt/live/${HOST_NAME}/fullchain.pem"
+EMAIL="${CONFENGE_INBOUND_ACME_EMAIL:-ops@confenge.com.br}"
+HTTP_SITE="$NGINX_AVAIL/${HOST_NAME}-http"
+HTTPS_SITE="$NGINX_AVAIL/${HOST_NAME}-https"
+
+need_root() {
+  if [[ "$(id -u)" -ne 0 ]]; then
+    echo "FAIL inbound-edge-install must run as root" >&2
+    exit 1
+  fi
+}
+
+install_packages() {
+  export DEBIAN_FRONTEND=noninteractive
+  apt-get update -qq
+  # nginx + certbot only. Never postfix/exim.
+  apt-get install -y -qq nginx certbot
+}
+
+install_files() {
+  mkdir -p /etc/nginx/conf.d /etc/nginx/snippets "$ACME_ROOT" \
+    /var/lib/confenge-inbound /var/lib/prometheus/node-exporter \
+    /etc/systemd/system
+  chmod 755 "$ACME_ROOT"
+
+  install -m 0644 "$PACK/nginx/http-params.conf" /etc/nginx/conf.d/confenge-inbound.conf
+  install -m 0644 "$PACK/nginx/proxy-params.conf" /etc/nginx/snippets/confenge-inbound-proxy.conf
+  install -m 0644 "$PACK/nginx/site-http.conf" "$HTTP_SITE"
+  install -m 0644 "$PACK/nginx/site-https.conf" "$HTTPS_SITE"
+
+  # Drop Debian default site so we own :80.
+  rm -f "$NGINX_ENABL/default"
+  ln -sfn "$HTTP_SITE" "$NGINX_ENABL/${HOST_NAME}-http"
+
+  if [[ -f "$CERT_LIVE" ]]; then
+    ln -sfn "$HTTPS_SITE" "$NGINX_ENABL/${HOST_NAME}-https"
+  else
+    rm -f "$NGINX_ENABL/${HOST_NAME}-https"
+  fi
+
+  install -m 0755 "$PACK/inbound-edge-monitor.sh" /usr/local/sbin/confenge-inbound-edge-monitor
+  install -m 0755 "$PACK/inbound-edge-wait-dns.sh" /usr/local/sbin/confenge-inbound-edge-wait-dns
+  install -m 0644 "$PACK/systemd/confenge-inbound-edge-monitor.service" \
+    /etc/systemd/system/confenge-inbound-edge-monitor.service
+  install -m 0644 "$PACK/systemd/confenge-inbound-edge-monitor.timer" \
+    /etc/systemd/system/confenge-inbound-edge-monitor.timer
+  install -m 0644 "$PACK/systemd/confenge-inbound-edge-wait-dns.service" \
+    /etc/systemd/system/confenge-inbound-edge-wait-dns.service
+  install -m 0644 "$PACK/systemd/confenge-inbound-edge-wait-dns.timer" \
+    /etc/systemd/system/confenge-inbound-edge-wait-dns.timer
+}
+
+open_http_ports() {
+  if command -v ufw >/dev/null 2>&1 && ufw status 2>/dev/null | grep -qi active; then
+    ufw allow 80/tcp comment "CONFENGE inbound ACME + HTTPS redirect" || true
+    ufw allow 443/tcp comment "CONFENGE inbound TLS" || true
+  fi
+}
+
+enable_textfile_collector() {
+  local def=/etc/default/prometheus-node-exporter
+  if [[ -f "$def" ]] && ! grep -q 'collector.textfile.directory' "$def"; then
+    if grep -q '^ARGS=""$' "$def"; then
+      sed -i 's|^ARGS=""$|ARGS="--collector.textfile.directory=/var/lib/prometheus/node-exporter"|' "$def"
+    else
+      echo 'ARGS="--collector.textfile.directory=/var/lib/prometheus/node-exporter"' >>"$def"
+    fi
+    systemctl restart prometheus-node-exporter || true
+  fi
+}
+
+dns_points_here() {
+  python3 - <<PY
+import socket, sys
+want = "${PUBLIC_IP}"
+try:
+    addrs = {i[4][0] for i in socket.getaddrinfo("${HOST_NAME}", None, socket.AF_INET)}
+except OSError:
+    sys.exit(1)
+sys.exit(0 if want in addrs else 1)
+PY
+}
+
+request_cert() {
+  if [[ -f "$CERT_LIVE" ]]; then
+    echo "OK cert already present for ${HOST_NAME}"
+    return 0
+  fi
+  if ! dns_points_here; then
+    echo "SKIP certbot: ${HOST_NAME} does not resolve to ${PUBLIC_IP}"
+    return 1
+  fi
+  certbot certonly --webroot -w "$ACME_ROOT" \
+    -d "$HOST_NAME" \
+    --agree-tos --non-interactive \
+    --email "$EMAIL" \
+    --keep-until-expiring
+}
+
+reload_nginx() {
+  nginx -t
+  systemctl enable nginx
+  systemctl reload nginx || systemctl restart nginx
+}
+
+enable_monitor() {
+  systemctl daemon-reload
+  systemctl enable --now confenge-inbound-edge-monitor.timer
+  if [[ ! -f "$CERT_LIVE" ]]; then
+    systemctl enable --now confenge-inbound-edge-wait-dns.timer
+  else
+    systemctl disable --now confenge-inbound-edge-wait-dns.timer 2>/dev/null || true
+  fi
+  /usr/local/sbin/confenge-inbound-edge-monitor || true
+}
+
+need_root
+install_packages
+install_files
+open_http_ports
+enable_textfile_collector
+reload_nginx
+
+CERT_OK=0
+if request_cert; then
+  ln -sfn "$HTTPS_SITE" "$NGINX_ENABL/${HOST_NAME}-https"
+  reload_nginx
+  CERT_OK=1
+fi
+
+enable_monitor
+
+echo "INBOUND_EDGE_HOST=${HOST_NAME}"
+echo "INBOUND_EDGE_UPSTREAM=127.0.0.1:8080"
+echo "INBOUND_EDGE_CERT=${CERT_OK}"
+echo "INBOUND_EDGE_UFW=80,443"
+echo "INBOUND_EDGE_SSH_UNCHANGED=2222"
+echo "INBOUND_EDGE_AUTO_SEND_UNTOUCHED=true"

--- a/deploy/confenge-vps/inbound-edge-monitor.sh
+++ b/deploy/confenge-vps/inbound-edge-monitor.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# Public inbound edge probe. No PII. Never prints or stores the HMAC secret.
+# Writes node_exporter textfile metrics and a local ALERT flag.
+set -euo pipefail
+
+HOST_NAME="${CONFENGE_INBOUND_PUBLIC_HOST:-api.confenge.com.br}"
+PUBLIC_IP="${CONFENGE_INBOUND_PUBLIC_IP:-159.195.18.88}"
+LOOPBACK_HEALTH="${CONFENGE_INBOUND_LOOPBACK_HEALTH:-http://127.0.0.1:8080/api/v1/webhooks/confenge/inbound/health}"
+PUBLIC_HEALTH="https://${HOST_NAME}/api/v1/webhooks/confenge/inbound/health"
+ACCESS_LOG="${CONFENGE_INBOUND_ACCESS_LOG:-/var/log/nginx/${HOST_NAME}.access.log}"
+METRICS="${CONFENGE_INBOUND_METRICS:-/var/lib/prometheus/node-exporter/confenge_inbound.prom}"
+ALERT_FILE="${CONFENGE_INBOUND_ALERT:-/var/lib/confenge-inbound/ALERT}"
+STATE_DIR="${CONFENGE_INBOUND_STATE:-/var/lib/confenge-inbound}"
+
+mkdir -p "$STATE_DIR" "$(dirname "$METRICS")"
+
+dns_ok=0
+tls_ok=0
+health_ready=0
+auto_send=0
+loopback_ready=0
+latency_ms=0
+http_code=0
+
+resolved="$(python3 - <<PY
+import socket
+try:
+    addrs = sorted({i[4][0] for i in socket.getaddrinfo("${HOST_NAME}", None, socket.AF_INET)})
+    print(",".join(addrs) if addrs else "")
+except OSError:
+    print("")
+PY
+)"
+if [[ "$resolved" == *"${PUBLIC_IP}"* ]]; then
+  dns_ok=1
+fi
+
+if [[ "$dns_ok" -eq 1 ]]; then
+  tls_out="$(echo | openssl s_client -servername "$HOST_NAME" -connect "${HOST_NAME}:443" -verify_return_error 2>&1 || true)"
+  if printf '%s' "$tls_out" | grep -qi 'Verify return code: 0' &&
+     printf '%s' "$tls_out" | grep -q "$HOST_NAME"; then
+    tls_ok=1
+  fi
+fi
+
+start_ns="$(date +%s%N)"
+body="$(mktemp)"
+http_code="$(curl -sS -o "$body" -w '%{http_code}' --max-time 10 "$PUBLIC_HEALTH" 2>/dev/null || true)"
+http_code="${http_code:-000}"
+end_ns="$(date +%s%N)"
+latency_ms=$(( (end_ns - start_ns) / 1000000 ))
+
+status=""
+if [[ "$http_code" == "200" ]] && [[ -s "$body" ]]; then
+  status="$(python3 - "$body" <<'PY'
+import json, sys
+try:
+    d = json.load(open(sys.argv[1], encoding="utf-8"))
+except Exception:
+    sys.exit(0)
+print(d.get("status", ""))
+print("1" if d.get("auto_send_enabled") else "0")
+PY
+)"
+  health_status="$(printf '%s\n' "$status" | sed -n '1p')"
+  auto_send="$(printf '%s\n' "$status" | sed -n '2p')"
+  auto_send="${auto_send:-1}"
+  if [[ "$health_status" == "READY" ]]; then
+    health_ready=1
+  fi
+fi
+rm -f "$body"
+
+lb_body="$(mktemp)"
+lb_code="$(curl -sS -o "$lb_body" -w '%{http_code}' --max-time 5 "$LOOPBACK_HEALTH" 2>/dev/null || true)"
+lb_code="${lb_code:-000}"
+if [[ "$lb_code" == "200" ]] && grep -q '"status":"READY"' "$lb_body"; then
+  loopback_ready=1
+fi
+rm -f "$lb_body"
+
+count_status() {
+  local code="$1"
+  local method="${2:-}"
+  if [[ ! -f "$ACCESS_LOG" ]]; then
+    echo 0
+    return
+  fi
+  if [[ -n "$method" ]]; then
+    awk -v c="$code" -v m="$method" '$2==m && $4==c {n++} END{print n+0}' "$ACCESS_LOG"
+  else
+    awk -v c="$code" '$4==c {n++} END{print n+0}' "$ACCESS_LOG"
+  fi
+}
+
+count_class() {
+  local prefix="$1"
+  if [[ ! -f "$ACCESS_LOG" ]]; then
+    echo 0
+    return
+  fi
+  awk -v p="$prefix" '$4 ~ ("^" p) {n++} END{print n+0}' "$ACCESS_LOG"
+}
+
+http_4xx="$(count_class 4)"
+http_5xx="$(count_class 5)"
+hmac_fail="$(count_status 401 POST)"
+replay="$(count_status 200 POST)"
+created="$(count_status 201 POST)"
+rate_limited="$(count_status 429)"
+
+# Latency histogram substitute: last public health sample in ms.
+# Access-log request_time is also aggregated as a running max of POST rt.
+post_rt_max="$(
+  if [[ -f "$ACCESS_LOG" ]]; then
+    awk '$2=="POST" {gsub(/^rt=/, "", $6); if ($6+0>m) m=$6+0} END{printf "%.3f", m+0}' "$ACCESS_LOG"
+  else
+    echo 0
+  fi
+)"
+
+tmp="${METRICS}.tmp"
+cat >"$tmp" <<EOF
+# HELP confenge_inbound_dns_ok 1 if ${HOST_NAME} resolves to the VPS public IPv4.
+# TYPE confenge_inbound_dns_ok gauge
+confenge_inbound_dns_ok ${dns_ok}
+# HELP confenge_inbound_tls_ok 1 if the public certificate verifies and SAN includes the hostname.
+# TYPE confenge_inbound_tls_ok gauge
+confenge_inbound_tls_ok ${tls_ok}
+# HELP confenge_inbound_health_ready 1 if public GET /health is HTTP 200 status=READY.
+# TYPE confenge_inbound_health_ready gauge
+confenge_inbound_health_ready ${health_ready}
+# HELP confenge_inbound_auto_send 1 if public health reports auto_send_enabled.
+# TYPE confenge_inbound_auto_send gauge
+confenge_inbound_auto_send ${auto_send:-0}
+# HELP confenge_inbound_loopback_ready 1 if loopback health is READY.
+# TYPE confenge_inbound_loopback_ready gauge
+confenge_inbound_loopback_ready ${loopback_ready}
+# HELP confenge_inbound_health_http_code Last public health HTTP status (0 if unreachable).
+# TYPE confenge_inbound_health_http_code gauge
+confenge_inbound_health_http_code ${http_code}
+# HELP confenge_inbound_health_latency_ms Last public health probe latency.
+# TYPE confenge_inbound_health_latency_ms gauge
+confenge_inbound_health_latency_ms ${latency_ms}
+# HELP confenge_inbound_http_4xx_total Access-log 4xx count (path only, no query/PII).
+# TYPE confenge_inbound_http_4xx_total counter
+confenge_inbound_http_4xx_total ${http_4xx}
+# HELP confenge_inbound_http_5xx_total Access-log 5xx count.
+# TYPE confenge_inbound_http_5xx_total counter
+confenge_inbound_http_5xx_total ${http_5xx}
+# HELP confenge_inbound_hmac_fail_total Access-log POST 401 count (HMAC class).
+# TYPE confenge_inbound_hmac_fail_total counter
+confenge_inbound_hmac_fail_total ${hmac_fail}
+# HELP confenge_inbound_replay_total Access-log POST 200 count (duplicate/replay class).
+# TYPE confenge_inbound_replay_total counter
+confenge_inbound_replay_total ${replay}
+# HELP confenge_inbound_created_total Access-log POST 201 count.
+# TYPE confenge_inbound_created_total counter
+confenge_inbound_created_total ${created}
+# HELP confenge_inbound_rate_limited_total Access-log 429 count.
+# TYPE confenge_inbound_rate_limited_total counter
+confenge_inbound_rate_limited_total ${rate_limited}
+# HELP confenge_inbound_post_rt_max_seconds Max POST request_time seen in the access log.
+# TYPE confenge_inbound_post_rt_max_seconds gauge
+confenge_inbound_post_rt_max_seconds ${post_rt_max}
+EOF
+chmod 0644 "$tmp"
+mv "$tmp" "$METRICS"
+
+reasons=()
+if [[ "$loopback_ready" -ne 1 ]]; then reasons+=("loopback_health_not_ready"); fi
+if [[ "$dns_ok" -ne 1 ]]; then reasons+=("dns_missing_or_wrong"); fi
+if [[ "$tls_ok" -ne 1 ]]; then reasons+=("tls_unverified"); fi
+if [[ "$health_ready" -ne 1 ]]; then reasons+=("public_health_not_ready"); fi
+if [[ "${auto_send:-0}" == "1" ]]; then reasons+=("auto_send_enabled"); fi
+
+if [[ ${#reasons[@]} -gt 0 ]]; then
+  msg="CONFENGE inbound edge ALERT ${reasons[*]} dns=${resolved:-none} http=${http_code}"
+  printf '%s\n' "$msg" >"$ALERT_FILE"
+  logger -t confenge-inbound-edge "$msg" || true
+  echo "$msg"
+  exit 1
+fi
+
+rm -f "$ALERT_FILE"
+echo "CONFENGE inbound edge OK dns=${resolved} tls=1 health=READY auto_send=0"
+exit 0

--- a/deploy/confenge-vps/inbound-edge-wait-dns.sh
+++ b/deploy/confenge-vps/inbound-edge-wait-dns.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Poll public DNS for api.confenge.com.br. When the DNS-only A record
+# answers this VPS, run inbound-edge-install.sh so certbot can mint TLS.
+# Stops itself after the leaf exists. Does not invent DNS credentials.
+set -euo pipefail
+
+HOST_NAME="${CONFENGE_INBOUND_PUBLIC_HOST:-api.confenge.com.br}"
+PUBLIC_IP="${CONFENGE_INBOUND_PUBLIC_IP:-159.195.18.88}"
+CERT_LIVE="/etc/letsencrypt/live/${HOST_NAME}/fullchain.pem"
+INSTALLER="${CONFENGE_INBOUND_INSTALLER:-/opt/warmbly-confenge/deploy/confenge-vps/inbound-edge-install.sh}"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "FAIL inbound-edge-wait-dns must run as root" >&2
+  exit 1
+fi
+
+if [[ -f "$CERT_LIVE" ]]; then
+  echo "OK cert already present"
+  exit 0
+fi
+
+points_here() {
+  python3 - <<PY
+import socket, sys
+want = "${PUBLIC_IP}"
+try:
+    addrs = {i[4][0] for i in socket.getaddrinfo("${HOST_NAME}", None, socket.AF_INET)}
+except OSError:
+    sys.exit(1)
+sys.exit(0 if want in addrs else 1)
+PY
+}
+
+if points_here; then
+  echo "DNS ${HOST_NAME} -> ${PUBLIC_IP}; running inbound-edge-install.sh"
+  exec "$INSTALLER"
+fi
+
+echo "WAIT ${HOST_NAME} does not yet resolve to ${PUBLIC_IP}"
+exit 2

--- a/deploy/confenge-vps/nginx/http-params.conf
+++ b/deploy/confenge-vps/nginx/http-params.conf
@@ -1,0 +1,22 @@
+# http-context snippets for the CONFENGE inbound public edge.
+# Installed to /etc/nginx/conf.d/confenge-inbound.conf
+# Must stay inside the http{} block. No secrets. No request body logging.
+
+limit_req_zone $binary_remote_addr zone=confenge_inbound:10m rate=20r/m;
+limit_req_zone $binary_remote_addr zone=confenge_inbound_health:10m rate=30r/m;
+
+# Access logs record the path only. Query strings can carry PII and must not
+# appear even when the handler later rejects them.
+map $request_uri $inbound_path_no_qs {
+    default $uri;
+}
+
+log_format inbound_edge '$remote_addr $request_method $inbound_path_no_qs '
+                        '$status $body_bytes_sent rt=$request_time '
+                        'upstream=$upstream_status urt=$upstream_response_time '
+                        'rid=$sent_http_x_request_id';
+
+upstream warmbly_loopback {
+    server 127.0.0.1:8080;
+    keepalive 16;
+}

--- a/deploy/confenge-vps/nginx/proxy-params.conf
+++ b/deploy/confenge-vps/nginx/proxy-params.conf
@@ -1,0 +1,16 @@
+# Shared proxy headers for the inbound allowlist.
+# Client IP is the TCP peer of this edge. Do not append caller-supplied
+# X-Forwarded-For; TRUSTED_PROXIES on the app is only 127.0.0.1.
+proxy_http_version 1.1;
+proxy_set_header Host $host;
+proxy_set_header X-Real-IP $remote_addr;
+proxy_set_header X-Forwarded-For $remote_addr;
+proxy_set_header X-Forwarded-Proto $scheme;
+proxy_set_header X-Forwarded-Host $host;
+proxy_set_header Connection "";
+proxy_connect_timeout 5s;
+proxy_send_timeout 30s;
+proxy_read_timeout 30s;
+proxy_buffering on;
+proxy_request_buffering on;
+proxy_next_upstream off;

--- a/deploy/confenge-vps/nginx/site-http.conf
+++ b/deploy/confenge-vps/nginx/site-http.conf
@@ -1,0 +1,52 @@
+# HTTP listener: ACME only until a cert exists; then ACME + HTTPS redirect.
+# Does not proxy inbound over plaintext.
+
+server {
+    listen 80 default_server;
+    listen [::]:80 default_server;
+    server_name api.confenge.com.br;
+
+    server_tokens off;
+    client_max_body_size 1m;
+    client_body_timeout 15s;
+    client_header_timeout 15s;
+
+    access_log /var/log/nginx/api.confenge.com.br.access.log inbound_edge;
+    error_log  /var/log/nginx/api.confenge.com.br.error.log warn;
+
+    location ^~ /.well-known/acme-challenge/ {
+        root /var/www/acme;
+        default_type text/plain;
+        allow all;
+    }
+
+    location = /api/v1/webhooks/confenge/inbound/health {
+        if ($args != "") { return 400; }
+        limit_req zone=confenge_inbound_health burst=20 nodelay;
+        limit_req_status 429;
+        # ACCESS-phase limiter must run before a rewrite-phase return.
+        try_files /__no_such_file @inbound_https_redirect_health;
+    }
+
+    location = /api/v1/webhooks/confenge/inbound {
+        limit_except POST {
+            deny all;
+        }
+        if ($args != "") { return 400; }
+        limit_req zone=confenge_inbound burst=10 nodelay;
+        limit_req_status 429;
+        try_files /__no_such_file @inbound_https_redirect;
+    }
+
+    location @inbound_https_redirect_health {
+        return 301 https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health;
+    }
+
+    location @inbound_https_redirect {
+        return 301 https://api.confenge.com.br/api/v1/webhooks/confenge/inbound;
+    }
+
+    location / {
+        return 404;
+    }
+}

--- a/deploy/confenge-vps/nginx/site-https.conf
+++ b/deploy/confenge-vps/nginx/site-https.conf
@@ -1,0 +1,77 @@
+# HTTPS vhost for api.confenge.com.br. Allowlists only the inbound webhook
+# and its public health probe. Everything else is 404.
+# Enabled only after a valid Let's Encrypt cert exists.
+
+server {
+    listen 443 ssl;
+    listen [::]:443 ssl;
+    http2 on;
+    server_name api.confenge.com.br;
+
+    server_tokens off;
+
+    ssl_certificate     /etc/letsencrypt/live/api.confenge.com.br/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.confenge.com.br/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers off;
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_tickets off;
+
+    # HTTPS-only for this hostname. HSTS does not cover sibling names.
+    add_header Strict-Transport-Security "max-age=31536000" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header Referrer-Policy no-referrer always;
+
+    client_max_body_size 1m;
+    client_body_timeout 15s;
+    client_header_timeout 15s;
+    send_timeout 30s;
+    keepalive_timeout 15s;
+
+    access_log /var/log/nginx/api.confenge.com.br.access.log inbound_edge;
+    error_log  /var/log/nginx/api.confenge.com.br.error.log warn;
+
+    location = /api/v1/webhooks/confenge/inbound/health {
+        limit_except GET HEAD {
+            deny all;
+        }
+        if ($args != "") { return 400; }
+        limit_req zone=confenge_inbound_health burst=20 nodelay;
+        limit_req_status 429;
+        include /etc/nginx/snippets/confenge-inbound-proxy.conf;
+        proxy_pass http://warmbly_loopback;
+    }
+
+    location = /api/v1/webhooks/confenge/inbound {
+        limit_except POST {
+            deny all;
+        }
+        if ($args != "") { return 400; }
+        limit_req zone=confenge_inbound burst=10 nodelay;
+        limit_req_status 429;
+        include /etc/nginx/snippets/confenge-inbound-proxy.conf;
+        proxy_pass http://warmbly_loopback;
+    }
+
+    location / {
+        return 404;
+    }
+}
+
+# Unknown SNI / Host on 443: close without proxying the operator API.
+server {
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    http2 on;
+    server_name _;
+
+    ssl_certificate     /etc/letsencrypt/live/api.confenge.com.br/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/api.confenge.com.br/privkey.pem;
+    ssl_protocols TLSv1.2 TLSv1.3;
+
+    access_log /var/log/nginx/api.confenge.com.br.access.log inbound_edge;
+    error_log  /var/log/nginx/api.confenge.com.br.error.log warn;
+
+    return 444;
+}

--- a/deploy/confenge-vps/systemd/confenge-inbound-edge-monitor.service
+++ b/deploy/confenge-vps/systemd/confenge-inbound-edge-monitor.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=CONFENGE inbound public-edge health/TLS/DNS probe
+After=network-online.target nginx.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/confenge-inbound-edge-monitor
+Nice=10
+# Never inherit mailbox or inbound HMAC secrets from a login shell.
+Environment=CONFENGE_INBOUND_PUBLIC_HOST=api.confenge.com.br
+Environment=CONFENGE_INBOUND_PUBLIC_IP=159.195.18.88
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/confenge-vps/systemd/confenge-inbound-edge-monitor.timer
+++ b/deploy/confenge-vps/systemd/confenge-inbound-edge-monitor.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run CONFENGE inbound edge probe every minute
+
+[Timer]
+OnBootSec=30s
+OnUnitActiveSec=60s
+AccuracySec=15s
+Persistent=true
+Unit=confenge-inbound-edge-monitor.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/confenge-vps/systemd/confenge-inbound-edge-wait-dns.service
+++ b/deploy/confenge-vps/systemd/confenge-inbound-edge-wait-dns.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Mint api.confenge.com.br TLS when the public A record appears
+After=network-online.target nginx.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/confenge-inbound-edge-wait-dns
+Nice=10
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/confenge-vps/systemd/confenge-inbound-edge-wait-dns.timer
+++ b/deploy/confenge-vps/systemd/confenge-inbound-edge-wait-dns.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Poll DNS for api.confenge.com.br then request Let's Encrypt
+
+[Timer]
+OnBootSec=45s
+OnUnitActiveSec=30s
+AccuracySec=5s
+Persistent=true
+Unit=confenge-inbound-edge-wait-dns.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/confenge-vps/test_vps_pack.py
+++ b/deploy/confenge-vps/test_vps_pack.py
@@ -36,6 +36,8 @@ class TestConfengeVpsPack(unittest.TestCase):
             "lib.sh",
             "env.example",
             "docker-compose.override.yml",
+            "inbound-edge-install.sh",
+            "inbound-edge-monitor.sh",
         ]
         for name in required:
             path = PACK / name
@@ -50,6 +52,7 @@ class TestConfengeVpsPack(unittest.TestCase):
         self.assertIn("CONFENGE_RATE_MAX_PER_HOUR=20", text)
         self.assertIn("HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER", text)
         self.assertIn("CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=200", text)
+        self.assertIn("TRUSTED_PROXIES=127.0.0.1", text)
         # Must not raise operational max above 20 in this pack
         for m in re.finditer(r"CONFENGE_RATE_MAX_PER_HOUR=(\d+)", text):
             self.assertLessEqual(int(m.group(1)), 20)
@@ -101,6 +104,57 @@ class TestConfengeVpsPack(unittest.TestCase):
         if proc.returncode != 0:
             self.fail(f"validate.sh exit {proc.returncode}\n{proc.stdout}\n{proc.stderr}")
         self.assertIn("VALIDATE=PASS", proc.stdout)
+
+    def test_inbound_edge_nginx_allowlist_is_the_shipped_config(self) -> None:
+        """Drive the real nginx files that install.sh copies onto the VPS."""
+        https = (PACK / "nginx/site-https.conf").read_text(encoding="utf-8")
+        http = (PACK / "nginx/site-http.conf").read_text(encoding="utf-8")
+        params = (PACK / "nginx/http-params.conf").read_text(encoding="utf-8")
+        proxy = (PACK / "nginx/proxy-params.conf").read_text(encoding="utf-8")
+        install = (PACK / "inbound-edge-install.sh").read_text(encoding="utf-8")
+        monitor = (PACK / "inbound-edge-monitor.sh").read_text(encoding="utf-8")
+        wait_dns = (PACK / "inbound-edge-wait-dns.sh").read_text(encoding="utf-8")
+
+        self.assertIn("server_name api.confenge.com.br;", https)
+        self.assertIn("location = /api/v1/webhooks/confenge/inbound/health", https)
+        self.assertIn("location = /api/v1/webhooks/confenge/inbound {", https)
+        self.assertIn("proxy_pass http://warmbly_loopback;", https)
+        self.assertIn("server 127.0.0.1:8080;", params)
+        self.assertIn("limit_req zone=confenge_inbound", https)
+        self.assertIn("limit_req_status 429", https)
+        self.assertIn("client_max_body_size 1m;", https)
+        self.assertIn("proxy_connect_timeout 5s;", proxy)
+        self.assertIn("proxy_read_timeout 30s;", proxy)
+        self.assertIn("X-Forwarded-For $remote_addr", proxy)
+        self.assertIn("return 404;", https)
+        self.assertIn("return 444;", https)
+        self.assertIn("Strict-Transport-Security", https)
+        self.assertNotIn('includeSubDomains', https.split("add_header", 1)[-1])
+        self.assertIn("return 301 https://api.confenge.com.br", http)
+        self.assertIn("location ^~ /.well-known/acme-challenge/", http)
+        self.assertNotRegex(http, r"proxy_pass")
+        self.assertNotRegex(params, r"\$request_body|\$http_x_warmbly_signature|\$args|\$query_string")
+        for blob in (https, http, proxy):
+            self.assertNotRegex(blob, r"\$request_body|\$http_x_warmbly_signature|\$query_string")
+            self.assertNotIn("location /confenge", blob)
+            self.assertNotIn("location /admin", blob)
+            self.assertNotRegex(blob, r"listen\s+8080")
+            self.assertNotRegex(blob, r"listen\s+15432")
+        self.assertIn("ufw allow 80/tcp", install)
+        self.assertIn("ufw allow 443/tcp", install)
+        self.assertNotIn("ufw allow 8080", install)
+        self.assertNotIn("ufw allow 15432", install)
+        self.assertNotIn("CONFENGE_AUTO_SEND_ENABLED=true", install)
+        self.assertIn("/opt/warmbly-confenge/deploy/confenge-vps/inbound-edge-install.sh", wait_dns)
+        self.assertIn("confenge_inbound_hmac_fail_total", monitor)
+        self.assertIn("confenge_inbound_replay_total", monitor)
+        self.assertIn("public_health_not_ready", monitor)
+        self.assertNotIn("CONFENGE_INBOUND_WEBHOOK_SECRET", monitor)
+
+        override = (PACK / "docker-compose.override.yml").read_text(encoding="utf-8")
+        self.assertIn("TRUSTED_PROXIES: ${TRUSTED_PROXIES:-127.0.0.1}", override)
+        self.assertIn("127.0.0.1:8080:8080", override)
+        self.assertIn("127.0.0.1:15432:5432", override)
 
     def test_docs_inventory_exists(self) -> None:
         inv = ROOT / "docs/confenge/vps-execution-inventory.md"

--- a/deploy/confenge-vps/validate.sh
+++ b/deploy/confenge-vps/validate.sh
@@ -11,7 +11,10 @@ for f in \
   docker-compose.override.yml env.example lib.sh compose.sh tunnel.sh \
   gen-secrets.sh connect-hostinger.sh status.sh pause.sh resume.sh \
   backup.sh restore.sh up.sh down.sh install.sh \
-  prove-hostinger-net.sh prove-restart.sh self-smoke.sh post-smtp-unlock.sh validate.sh
+  prove-hostinger-net.sh prove-restart.sh self-smoke.sh post-smtp-unlock.sh validate.sh \
+  inbound-edge-install.sh inbound-edge-monitor.sh \
+  nginx/http-params.conf nginx/proxy-params.conf nginx/site-http.conf nginx/site-https.conf \
+  systemd/confenge-inbound-edge-monitor.service systemd/confenge-inbound-edge-monitor.timer
 do
   if [[ -f "$PACK/$f" ]]; then
     echo "OK $f"
@@ -41,7 +44,9 @@ done
 
 if command -v shellcheck >/dev/null 2>&1; then
   echo "== shellcheck =="
-  shellcheck -x "$PACK"/*.sh || fail=1
+  # Errors only: existing pack scripts have info-level SC1091/SC2016 that
+  # are not defects. bash -n remains the syntax gate.
+  shellcheck -x --severity=error "$PACK"/*.sh || fail=1
 else
   echo "== shellcheck SKIP (not installed; bash -n used) =="
 fi
@@ -59,7 +64,8 @@ for pair in \
   "CONFENGE_WHATSAPP_ENABLED=false" \
   "CONFENGE_RATE_MAX_PER_HOUR=20" \
   "HOSTINGER_PLAN_CLASS=BUSINESS_EMAIL_STARTER" \
-  "CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=200"
+  "CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=200" \
+  "TRUSTED_PROXIES=127.0.0.1"
 do
   if grep -qF "$pair" "$PACK/env.example"; then
     echo "OK $pair"
@@ -157,6 +163,37 @@ if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; 
   rm -f "$TMPENV" "$COMPOSE_OUT" "$COMPOSE_LOG"
 else
   echo "SKIP docker compose (docker not available)"
+fi
+
+echo "== inbound edge allowlist =="
+HTTPS_CONF="$PACK/nginx/site-https.conf"
+HTTP_CONF="$PACK/nginx/site-http.conf"
+if grep -q 'server_name api.confenge.com.br;' "$HTTPS_CONF" \
+  && grep -q 'location = /api/v1/webhooks/confenge/inbound/health' "$HTTPS_CONF" \
+  && grep -q 'location = /api/v1/webhooks/confenge/inbound {' "$HTTPS_CONF" \
+  && grep -q 'proxy_pass http://warmbly_loopback;' "$HTTPS_CONF" \
+  && grep -q 'server 127.0.0.1:8080;' "$PACK/nginx/http-params.conf" \
+  && grep -q 'limit_req' "$HTTPS_CONF" \
+  && grep -q 'client_max_body_size 1m;' "$HTTPS_CONF" \
+  && grep -q 'location / {' "$HTTPS_CONF" \
+  && grep -q 'return 404;' "$HTTPS_CONF" \
+  && grep -q 'return 444;' "$HTTPS_CONF" \
+  && ! grep -qE '\$request_body|\$http_x_warmbly_signature|\$args|\$query_string' \
+    "$PACK/nginx/http-params.conf" \
+  && ! grep -qE '\$request_body|\$http_x_warmbly_signature|\$query_string' \
+    "$HTTPS_CONF" "$HTTP_CONF" \
+  && ! grep -qE 'location /confenge|location /admin|listen 8080|listen 15432' "$HTTPS_CONF" \
+  && grep -q 'X-Forwarded-For \$remote_addr' "$PACK/nginx/proxy-params.conf"; then
+  echo "OK inbound edge allowlists health+POST, loopback upstream, rate limit, redacted logs"
+else
+  echo "FAIL inbound edge nginx pack does not match the allowlist contract"
+  fail=1
+fi
+if grep -q 'TRUSTED_PROXIES: \${TRUSTED_PROXIES:-127.0.0.1}' "$PACK/docker-compose.override.yml"; then
+  echo "OK backend TRUSTED_PROXIES defaults to 127.0.0.1"
+else
+  echo "FAIL backend TRUSTED_PROXIES missing from compose overlay"
+  fail=1
 fi
 
 echo "== no MTA install steps =="

--- a/docs/confenge/inbound-edge.md
+++ b/docs/confenge/inbound-edge.md
@@ -1,0 +1,114 @@
+# Public inbound edge (web-cfg handoff)
+
+Secret-free contract for Netlify / web-cfg. No HMAC secret is published
+here. The shared secret stays in the Warmbly process env and the matching
+Netlify env `CONFENGE_INBOUND_WEBHOOK_SECRET`.
+
+## Canonical URL
+
+| Field | Value |
+| --- | --- |
+| Canonical URL | `https://api.confenge.com.br/api/v1/webhooks/confenge/inbound` |
+| Host | `api.confenge.com.br` |
+| Path | `/api/v1/webhooks/confenge/inbound` |
+| Health | `GET https://api.confenge.com.br/api/v1/webhooks/confenge/inbound/health` |
+| Method | `POST` only on the inbound path. `GET`/`HEAD` only on `/health`. |
+
+Set on Netlify:
+
+```text
+CONFENGE_INBOUND_WEBHOOK_URL=https://api.confenge.com.br/api/v1/webhooks/confenge/inbound
+```
+
+Do not retarget `OPS_WEBHOOK_URL`. That is the Slack-style `confenge.lead`
+HMAC, a different contract.
+
+## Expected health
+
+HTTP 200 JSON, no secret, no dest org id, no PII:
+
+```json
+{"status":"READY","auto_send_enabled":false,"dispatch_attempted":false,"reasons":[]}
+```
+
+A TCP/TLS timeout is UNREACHABLE. That is distinct from POST `401` (HMAC)
+and POST `5xx` (persist / dest store). A `200` with `status=BLOCKED` means
+the process is up but receive is not configured (secret, dest org, or
+auto-send). `auto_send_enabled` must stay `false`.
+
+## HMAC
+
+Version `v1` only.
+
+```text
+X-Warmbly-Signature: t=<unix>,v1=<hex(hmac_sha256(secret, "<unix>." + body))>
+```
+
+`X-Confenge-Signature` is accepted as an alias. Clock skew is 5 minutes.
+`Idempotency-Key` is optional; the durable key is `lead_id` / `receipt_id`.
+Replay of the same lead returns HTTP 200 and does not create a second
+commercial action.
+
+## Allowed host / origin policy
+
+- TLS SNI and `Host` must be `api.confenge.com.br`.
+- Other names on :443 are closed (`444`) and are not proxied.
+- This edge does not require a browser `Origin`. web-cfg is server to server.
+- Only two application paths are proxied to the Warmbly loopback listener:
+  `GET /api/v1/webhooks/confenge/inbound/health` and
+  `POST /api/v1/webhooks/confenge/inbound`.
+- Every other path, including `/confenge`, `/admin`, `/v1`, operator UI,
+  and the rest of the SaaS API, returns 404. This CONFENGE operator-mode
+  host is not the multi-tenant public API.
+- PII is not accepted on the query string. Send the body.
+
+## Timeout and body semantics
+
+| Limit | Value |
+| --- | --- |
+| Edge connect | 5s |
+| Edge send / read | 30s |
+| Client body / header | 15s |
+| Request body | 1 MiB (matches the handler) |
+| Health caller budget | 10s recommended; treat timeout as UNREACHABLE |
+| HMAC skew | 5 minutes |
+| Rate limit (POST) | 20 req/min/IP, burst 10, HTTP 429 |
+| Rate limit (GET health) | 30 req/min/IP, burst 20, HTTP 429 |
+
+Unsigned POST or `X-Warmbly-Signature: t=1,v1=deadbeef` → 401.
+Invalid JSON / missing `lead_id` and `receipt_id` (after a valid HMAC) → 400.
+Query `?email=` → 400.
+Dest org or store unavailable → 503 / 500, never 2xx.
+
+## Production SHA
+
+Warmbly process on this host: `deabc11e715d508a68ee231376148b52ee4b8aca`.
+
+`CONFENGE_AUTO_SEND_ENABLED=false` is required. Inbound never dispatches.
+
+Public proof on 2026-08-16: DNS A `159.195.18.88` (TTL 300, DNS only), valid
+Let's Encrypt leaf/SAN for `api.confenge.com.br`, external health HTTP 200
+`READY` with `auto_send_enabled=false`, and external unsigned/invalid-HMAC
+POSTs rejected with 401. The backend listener remains `127.0.0.1:8080`.
+
+## DNS (operator)
+
+Zone `confenge.com.br` is on Cloudflare (`grannbo.ns.cloudflare.com`,
+`kai.ns.cloudflare.com`). Canonical record, DNS-only (grey cloud):
+
+```text
+api.confenge.com.br.  300  IN  A  159.195.18.88
+```
+
+Keep this name DNS only. The VPS nginx presents the Let's Encrypt leaf for
+`api.confenge.com.br` directly.
+
+## Install on the VPS
+
+```bash
+# as root, repo at /opt/warmbly-confenge
+deploy/confenge-vps/inbound-edge-install.sh
+```
+
+Backend stays on `127.0.0.1:8080`. Postgres stays on `127.0.0.1:15432`.
+SSH stays on `2222`. extra-cli feed stays on `:8443`.

--- a/docs/confenge/inbound-ingest.md
+++ b/docs/confenge/inbound-ingest.md
@@ -13,10 +13,19 @@ PII is not accepted on the query string. Send the body.
 Auth: `X-Warmbly-Signature: t=<unix>,v1=<hex(hmac_sha256(secret, "<unix>." + body))>`
 
 `GET /api/v1/webhooks/confenge/inbound/health` is a public, PII-free,
-secret-free probe. It always returns HTTP 200 with `status=READY|BLOCKED`,
-`auto_send_enabled`, and machine `reasons`. Timeout (process unreachable)
-stays distinct from POST `401` (HMAC) and POST `5xx` (persist). A lying
-READY when secret, dest org, or auto-send are wrong is a defect.
+secret-free probe. It always returns HTTP 200 with `status=READY|BLOCKED`
+for the receive gate (web-cfg uses that field), plus an additive
+`health_matrix` (`READY|DEGRADED|BLOCKED` per plane) and
+`real_event_ready`. Timeout (process unreachable) stays distinct from
+POST `401` (HMAC) and POST `5xx` (persist). A lying READY when secret,
+dest org, or auto-send are wrong is a defect. `real_event_ready` is false
+until money-asset, Netlify env, capture/handoff, attribution keys, and
+`public_read` freshness are all observed healthy. Computing it creates no
+lead.
+
+Authenticated `GET /confenge/ops/health` returns the same matrix plus
+actionable alerts and UNKNOWN-until-measured technical SLOs. Incident
+steps: [inbound-incident-runbook.md](./inbound-incident-runbook.md).
 
 | Setting | Purpose |
 | --- | --- |
@@ -59,8 +68,10 @@ READY when secret, dest org, or auto-send are wrong is a defect.
 
 Shipped web-cfg (`mapLeadToInboundV1`) emits `source=CONFENGE_WEB` and omits
 empty optionals. `source=web-cfg` is still accepted (no allowlist). `lead_id`
-or `receipt_id` is required. Missing facts stay `UNKNOWN`. Warmbly does not
-invent a name, role, email, or phone.
+or `receipt_id` is required. `public_contract_id` is accepted as the
+web-cfg store name and stored as `contract_public_id`. `entity_public_id`
+is the canonical extra-cli account id. Missing facts stay `UNKNOWN`.
+Warmbly does not invent a name, role, email, or phone.
 
 ## Dedupe
 
@@ -132,34 +143,52 @@ inferred.
 
 ## Live verdict (this tree)
 
-**UNPROVEN.** Code and shipped-path tests exist. A production or VPS
-synthetic POST has not been observed from this environment.
+**PUBLIC HTTPS READY.**
 
-Probed 2026-08-15 from the implementer host against origin/main
-`dab3ea3446348d1adcd76c6d5c98eba9dade1498`:
+Proved 2026-08-16 on the Netcup VPS (`159.195.18.88`) at production SHA
+`deabc11e715d508a68ee231376148b52ee4b8aca`:
 
-- `CONFENGE_INBOUND_WEBHOOK_SECRET` unset
-- `CONFENGE_INBOUND_ORG_ID` unset
-- `CONFENGE_INBOUND_WEBHOOK_URL` unset
-- `api.warmbly.com` does not resolve
-- `https://app.warmbly.com/api/v1/webhooks/confenge/inbound` OPTIONS 404
-- `https://warmbly.com/api/v1/webhooks/confenge/inbound` OPTIONS 405
-- `127.0.0.1:8080` connection refused
-- no `.env.confenge` with a real secret
+- Process env: secret + dest org set, `CONFENGE_AUTO_SEND_ENABLED=false`
+- Loopback `GET /api/v1/webhooks/confenge/inbound/health` → 200 `READY`, `auto_send_enabled=false`
+- Official `scripts/confenge_inbound_live_preflight.sh` against
+  `http://127.0.0.1:8080/api/v1/webhooks/confenge/inbound` → `VERDICT=LIVE_WEBHOOK`
+  (201 then replay 200). Commercial INBOUND NOW stayed empty.
+  `include_synthetic=0` denominators did not increment. One
+  `SYNTHETIC-INBOUND-*` row persisted and stayed SKIPPED.
+- Loopback POST unsigned / `t=1,v1=deadbeef` → 401. Invalid JSON and
+  missing `lead_id` (valid HMAC) → 400. Query `?email=` → 400. Persist
+  500 / missing dest org 503 covered by shipped tests at this SHA.
+- Host nginx on public `:80` allowlists only the inbound path + health.
+  `/admin` and `/confenge` → 404. Query strings → 400. POST burst → 429
+  (20/min, burst 10). Health/POST without query → 301 to
+  `https://api.confenge.com.br/...` (plaintext webhook is not served).
+- Backend remains `127.0.0.1:8080`. Postgres remains `127.0.0.1:15432`.
+  SSH remains `2222`. extra-cli remains `:8443`.
 
-`make confenge-preflight` now surfaces `inbound_secret` / `inbound_org` /
-`inbound_ready`. `GET /confenge/status` `readiness.inbound` and the public
-health probe are READY only when secret + dest org are set and
-`CONFENGE_AUTO_SEND_ENABLED=false`. That is configuration, not a live POST.
+`confenge.com.br` is delegated from Hostinger to Cloudflare
+(`grannbo.ns.cloudflare.com` / `kai.ns.cloudflare.com`). The canonical
+DNS-only record answers publicly:
 
-## Human proof (remaining)
-
-```bash
-# 1. Warmbly process: set secret + dest org, keep auto-send off, restart on this SHA.
-# 2. Caller: set CONFENGE_INBOUND_WEBHOOK_URL + the same secret.
-scripts/confenge_inbound_live_preflight.sh
-# 3. Open INBOUND NOW and confirm the printed lead_id. Do not contact.
+```text
+api.confenge.com.br.  300  IN  A  159.195.18.88
 ```
 
-A 201/200 from that script is a live webhook receipt. It is not a commercial
-send and not a web-cfg form proof.
+Host nginx presents a valid Let's Encrypt certificate for
+`api.confenge.com.br`; external health returns HTTP 200 `READY` with
+`auto_send_enabled=false`. External unsigned and invalid-signature POSTs both
+return 401. No commercial lead was created by these fail-closed probes.
+Handoff: [inbound-edge.md](./inbound-edge.md) and GitHub issue #78.
+
+## Live handoff command
+
+```bash
+#   CONFENGE_INBOUND_WEBHOOK_URL=https://api.confenge.com.br/api/v1/webhooks/confenge/inbound
+#   CONFENGE_INBOUND_WEBHOOK_SECRET=<same as process>
+#   CONFENGE_AUTO_SEND_ENABLED=false
+scripts/confenge_inbound_live_preflight.sh
+# Open INBOUND NOW only to confirm the printed lead_id. Do not contact.
+```
+
+A 201/200 from that script is a live webhook receipt. Run it only with the
+existing synthetic guard; it is not a commercial send and not a web-cfg form
+proof.

--- a/docs/confenge/netcup-ops.md
+++ b/docs/confenge/netcup-ops.md
@@ -50,6 +50,7 @@ CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT=200
 
 | Open on VPS | Purpose |
 | --- | --- |
+| TCP 80/443 | Host nginx: `api.confenge.com.br` inbound webhook + ACME only |
 | TCP 8443 | Feed + outcome webhook (existing plane) |
 | TCP 2222 | SSH ops + operator tunnel |
 | Warmbly 8080/5173 | **Loopback only** |

--- a/docs/confenge/vps-execution-inventory.md
+++ b/docs/confenge/vps-execution-inventory.md
@@ -48,7 +48,10 @@ Do not delete volumes without a restore plan.
 
 ## Firewall (ufw)
 
-Allow: 22, 2222, 8443. Deny public 8790. Docker bridge may reach 8790.
+Allow: 22, 2222, 80, 443, 8443. Deny public 8790. Docker bridge may reach 8790.
+
+80/443 belong to host nginx for `api.confenge.com.br` inbound only (see
+[inbound-edge.md](./inbound-edge.md)). extra-cli feed stays on 8443.
 
 Warmbly UI/API/Postgres/Redis/NATS must remain **loopback-bound** (this pack enforces `127.0.0.1` publishes).
 

--- a/docs/confenge/vps-execution-plane.md
+++ b/docs/confenge/vps-execution-plane.md
@@ -177,6 +177,11 @@ remain enforced without an interactive login. Daily path: review, approve, edit,
 reject, or mark DNC in the browser. The laptop can sleep after approval because the
 queue, scheduling, governor, and SMTP transport run on the VPS.
 
+Public inbound (web-cfg) is the only application path that leaves the
+host: `https://api.confenge.com.br/api/v1/webhooks/confenge/inbound` via host
+nginx on 80/443, allowlisted to that POST and `GET .../health`. See
+[inbound-edge.md](./inbound-edge.md).
+
 Never expose ports 5173 or 8080 publicly while `CONFENGE_OPERATOR_MODE=true`.
 The laptop tunnel maps the backend to `127.0.0.1:18080`, leaving local port
 `8080` available for Evolution API. The web runtime's `API_PUBLIC_URL` must use

--- a/scripts/confenge_inbound_live_preflight.sh
+++ b/scripts/confenge_inbound_live_preflight.sh
@@ -50,7 +50,7 @@ fi
 if [ -z "$URL" ]; then
   echo
   echo "UNPROVEN: no inbound URL in this environment."
-  echo "api.warmbly.com does not resolve from typical operator laptops."
+  echo "Canonical public endpoint: https://api.confenge.com.br/api/v1/webhooks/confenge/inbound"
   echo "VPS/operator API is loopback (127.0.0.1). A secret with no public URL is UNPROVEN."
 fi
 


### PR DESCRIPTION
## What changed
- makes `api.confenge.com.br` the canonical CONFENGE inbound hostname
- adds the host-nginx/certbot edge pack, systemd wait/monitor units, and strict route allowlist
- keeps the Warmbly backend and data services loopback-only
- records the deployed DNS, TLS, health, auto-send-off, and HMAC fail-closed evidence
- removes the campaign dependency on `api.warmbly.com`

## Root cause
The operational correction existed only in the VPS working tree and GitHub issue. New agents based on `main` still inherited the previous `api.warmbly.com` Definition of Done and repeatedly blocked on nonexistent DNS credentials.

## Impact
New worktrees receive the canonical CONFENGE architecture and can complete the inbound handoff without creating or depending on a Warmbly-owned domain.

## Checks
- VPS `deploy/confenge-vps/validate.sh`: PASS
- VPS `python3 -m unittest deploy/confenge-vps/test_vps_pack.py`: 8 passed
- external health: HTTP 200 READY, auto-send false
- unsigned and invalid-HMAC POST: HTTP 401
- Let's Encrypt SAN: api.confenge.com.br
