### PR TITLE
feat: fail-close CONFENGE auto-send, green-autorun, and worker kill switch so isolated env cannot birth send jobs without individual approval

### DIFF
--- a/.env.confenge.example
+++ b/.env.confenge.example
@@ -5,7 +5,8 @@
 # Then: make confenge-local
 # Preflight: make confenge-preflight
 #
-# Fail-closed defaults are intentional. Do not flip AUTO_SEND on.
+# Fail-closed defaults are invariants. AUTO_SEND / GREEN_AUTORUN / human-approval-off
+# cannot be reactivated: startup and the worker refuse them.
 
 # ─── Master switches (local demo path) ───────────────────────────────────
 CONFENGE_OUTREACH_ENABLED=true
@@ -14,7 +15,9 @@ CONFENGE_OPERATOR_USER_ID=11111111-0000-0000-0000-000000000001
 CONFENGE_OPERATOR_ORG_ID=22222222-0000-0000-0000-000000000001
 CONFENGE_REQUIRE_HUMAN_APPROVAL=true
 # Global auto-send is PROHIBITED for CONFENGE commercial outreach.
+# Setting this true fails startup and worker transport.
 CONFENGE_AUTO_SEND_ENABLED=false
+CONFENGE_GREEN_AUTORUN_ENABLED=false
 # Operational kill switch (also toggled by make confenge-stop-sending).
 CONFENGE_SENDING_PAUSED=false
 CONFENGE_KILL_SWITCH_PATH=data/confenge-kill-switch

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1101,7 +1101,7 @@ func main() {
 			// Global dispatch governor: ~10 outbound/hour shared email+WhatsApp.
 			confengeServiceForHandler.WireDispatch(primaryDB.Pool)
 			confengeServiceForHandler.WireIntel(primaryDB.Pool)
-			// CAMPAIGN_POLICY_AUTHORIZATION store for GREEN autorun (no fake approved_by).
+			// CAMPAIGN_POLICY_AUTHORIZATION store is persist-only. It cannot transport.
 			confengeServiceForHandler.WirePolicyAuth(repository.NewConfengePolicyRepository(primaryDB.Pool))
 		}
 		if confengeServiceForHandler != nil && aiProvider != nil {

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -15,7 +15,7 @@ Set on the backend:
 CONFENGE_OUTREACH_ENABLED=true
 ```
 
-Leave `CONFENGE_AUTO_SEND_ENABLED=false` unless you have an explicit operational policy. Human approval remains the default (`CONFENGE_REQUIRE_HUMAN_APPROVAL=true`).
+`CONFENGE_AUTO_SEND_ENABLED`, `CONFENGE_GREEN_AUTORUN_ENABLED`, and `CONFENGE_REQUIRE_HUMAN_APPROVAL=false` cannot be activated. Startup, enroll, queue, and the worker transport boundary fail closed. Bulk green-autorun endpoints create zero send jobs. Human approval of the exact recipient, copy, and evidence versions remains required (`CONFENGE_REQUIRE_HUMAN_APPROVAL=true`).
 
 Optional feed source:
 

--- a/internal/app/confenge/campaign.go
+++ b/internal/app/confenge/campaign.go
@@ -124,8 +124,8 @@ func (s *service) EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.U
 	if xerr := s.requireEnabled(); xerr != nil {
 		return nil, xerr
 	}
-	if s.cfg.AutoSendEnabled && !s.cfg.RequireHumanApproval {
-		return nil, errx.New(errx.BadRequest, "refusing enroll: auto-send without human approval is not allowed")
+	if s.cfg.AutoSendEnabled || s.cfg.GreenAutorunEnabled {
+		return nil, errx.New(errx.BadRequest, "refusing enroll: auto-send and green autorun cannot create send jobs")
 	}
 	if !s.cfg.SendingAllowed() {
 		return nil, errx.New(errx.BadRequest, "sending paused (kill switch); run make confenge-resume-sending when safe")

--- a/internal/app/confenge/config.go
+++ b/internal/app/confenge/config.go
@@ -224,14 +224,34 @@ func envDuration(key string, def time.Duration) time.Duration {
 	return d
 }
 
-// ValidateStartup fails closed on insecure production combinations.
-// Called when the feature is enabled.
+// ForbiddenAutomation reports env/config that must never birth a CONFENGE send
+// job. Isolated env cannot reactivate auto-send, bulk/green autorun, or
+// human-approval-off. Used at startup, enroll/queue, and the worker boundary.
+func (c Config) ForbiddenAutomation() error {
+	if c.AutoSendEnabled {
+		return fmt.Errorf("%s=true is not supported; CONFENGE requires an explicit dispatch action", EnvAutoSend)
+	}
+	if !c.RequireHumanApproval {
+		return fmt.Errorf("%s must remain true; individual human approval is required", EnvRequireHuman)
+	}
+	if c.GreenAutorunEnabled {
+		return fmt.Errorf("%s=true is not supported; individual human approval is required", EnvGreenAutorun)
+	}
+	return nil
+}
+
+// ValidateStartup fails closed on insecure or policy-violating combinations.
+// Called when the feature is enabled. Auto-send, green autorun, and
+// human-approval-off are rejected in every environment, not only operator mode.
 func (c Config) ValidateStartup(appEnv string) error {
 	if !c.Enabled {
 		if c.OperatorMode {
 			return fmt.Errorf("%s requires %s=true", EnvOperatorMode, EnvEnabled)
 		}
 		return nil
+	}
+	if err := c.ForbiddenAutomation(); err != nil {
+		return err
 	}
 	if c.OperatorMode {
 		if c.OperatorUserID == uuid.Nil {
@@ -245,15 +265,6 @@ func (c Config) ValidateStartup(appEnv string) error {
 		}
 	}
 	prod := strings.EqualFold(appEnv, "prod") || strings.EqualFold(appEnv, "production")
-	if c.AutoSendEnabled {
-		return fmt.Errorf("%s=true is not supported; CONFENGE requires an explicit dispatch action", EnvAutoSend)
-	}
-	if c.OperatorMode && !c.RequireHumanApproval {
-		return fmt.Errorf("%s=true requires %s=true", EnvOperatorMode, EnvRequireHuman)
-	}
-	if c.OperatorMode && c.GreenAutorunEnabled {
-		return fmt.Errorf("%s=true is not supported in operator mode", EnvGreenAutorun)
-	}
 	if prod {
 		if (c.FeedURL != "" || c.ManifestURL != "") && len(c.AllowedHosts) == 0 {
 			return fmt.Errorf("%s is required when a feed URL is set in production", EnvAllowedHosts)

--- a/internal/app/confenge/execution_pipeline_test.go
+++ b/internal/app/confenge/execution_pipeline_test.go
@@ -201,6 +201,12 @@ func TestResolveRecipientMissingDateStaleDNCBounce(t *testing.T) {
 	if got := ResolveRecipient(acc, []models.OutreachContactCandidate{sup}, now); got.State != RecipientBlocked {
 		t.Fatalf("suppressed want BLOCKED got %s", got.State)
 	}
+
+	unknown := validatedCand("Ana Silva", "Diretora", "ana@encopav.com.br")
+	unknown.RecipientCommercialSuitability = "UNKNOWN"
+	if got := ResolveRecipient(acc, []models.OutreachContactCandidate{unknown}, now); got.State == RecipientValidated {
+		t.Fatal("UNKNOWN suitability must not VALIDATE")
+	}
 }
 
 func TestResolveRecipientDoesNotInventIdentity(t *testing.T) {

--- a/internal/app/confenge/green_autorun.go
+++ b/internal/app/confenge/green_autorun.go
@@ -114,192 +114,51 @@ func (s *service) RevokeCampaignPolicy(ctx context.Context, orgID, campaignID, a
 	return ok, nil
 }
 
-// TryGreenAutorun evaluates GREEN predicates and, when all pass, marks the
-// touchpoint APPROVED with authorization_mode=CAMPAIGN_POLICY (no approved_by)
-// and queues it for transport. YELLOW/RED never enter this path.
+// TryGreenAutorun never approves or queues. AUTO_SEND and bulk/green autorun
+// are forbidden on the CONFENGE profile even if isolated env flips the flag.
+// The predicate engine remains for audit/explain only.
 func (s *service) TryGreenAutorun(ctx context.Context, orgID, actorID, touchpointID uuid.UUID) (*models.OutreachTouchpoint, GreenAutorunDecision, *errx.Error) {
-	dec := GreenAutorunDecision{Allow: false, Reasons: []string{"not_evaluated"}}
+	_ = actorID
+	dec := GreenAutorunDecision{Allow: false, Reasons: []string{"individual_approval_required"}}
 	if xerr := s.requireEnabled(); xerr != nil {
 		return nil, dec, xerr
-	}
-	if !s.cfg.GreenAutorunEnabled {
-		dec = GreenAutorunDecision{Allow: false, Reasons: []string{"green_autorun_disabled"}}
-		return nil, dec, nil
 	}
 	tp, err := s.repo.GetTouchpoint(ctx, orgID, touchpointID)
 	if err != nil || tp == nil {
 		return nil, dec, errx.New(errx.NotFound, "touchpoint not found")
 	}
-	if tp.State != models.TouchpointNeedsReview && tp.State != models.TouchpointDrafted && tp.State != models.TouchpointApproved {
-		dec = GreenAutorunDecision{Allow: false, Reasons: []string{"state_" + tp.State}}
-		return tp, dec, nil
-	}
-
-	campaignID := uuid.Nil
-	if settings, _ := s.repo.GetOrgSettings(ctx, orgID); settings != nil && settings.CampaignID != nil {
-		campaignID = *settings.CampaignID
-	}
-	if campaignID == uuid.Nil {
-		dec = GreenAutorunDecision{Allow: false, Reasons: []string{"no_campaign_id"}}
-		return tp, dec, nil
-	}
-
-	var auth *models.CampaignPolicyAuthorization
-	if s.policyStore != nil {
-		auth, err = s.policyStore.GetActiveCampaignPolicy(ctx, orgID, campaignID, time.Now().UTC())
-		if err != nil {
-			return tp, dec, errx.New(errx.Internal, "load policy: "+err.Error())
-		}
-	}
-	in := s.buildGreenAutorunInput(ctx, orgID, tp, auth)
-	now := time.Now().UTC()
-	dec = EvaluateGreenAutorun(s.cfg.GreenAutorunEnabled, auth, in, now)
-	if !dec.Allow {
-		return tp, dec, nil
-	}
-
-	if err := ApplyCampaignPolicyAuthorization(tp, auth, now); err != nil {
-		return tp, dec, errx.New(errx.BadRequest, err.Error())
-	}
-	if err := s.repo.UpdateTouchpoint(ctx, tp); err != nil {
-		return tp, dec, errx.New(errx.Internal, "persist policy approval: "+err.Error())
-	}
-	// Queue without requiring human approved_by. actorID is used for enrollment audit only.
-	queued, xerr := s.QueueTouchpoint(ctx, orgID, actorID, tp.ID)
-	if xerr != nil {
-		return tp, dec, xerr
-	}
-	return queued, dec, nil
+	return tp, dec, nil
 }
 
-// RunGreenAutorunBatch generates (if needed) then tries policy autoqueue for up
-// to limit EMAIL touchpoints that are due for review. Ready-to-generate accounts
-// without open touchpoints are planned+generated first so GREEN stock can form.
+// RunGreenAutorunBatch never queues. Isolated env that flips
+// CONFENGE_GREEN_AUTORUN_ENABLED cannot birth send jobs.
 func (s *service) RunGreenAutorunBatch(ctx context.Context, orgID, actorID uuid.UUID, limit int) (queued, skipped int, details []map[string]any, xerr *errx.Error) {
 	if xerr = s.requireEnabled(); xerr != nil {
 		return 0, 0, nil, xerr
 	}
-	if !s.cfg.GreenAutorunEnabled {
-		return 0, 0, nil, nil
-	}
+	_ = actorID
 	if limit <= 0 || limit > 100 {
 		limit = 25
 	}
-	// Seed GREEN-eligible drafts: plan READY accounts and promote due/planned
-	// ordinal-1 touches into NEEDS_REVIEW with policy-approved templates.
-	seeded := 0
-	if ready, err := s.repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{
-		QueueState: models.OutreachQueueReadyToGenerate, Limit: limit * 2,
-	}); err == nil {
-		for i := range ready {
-			if seeded >= limit {
-				break
-			}
-			acc := ready[i]
-			if acc.DoNotContact || acc.Blocked {
-				continue
-			}
-			// Activation is not send tier. Still only seed actionable accounts.
-			if acc.ActivationState != "" && acc.ActivationState != "ACTIONABLE_NOW" {
-				continue
-			}
-			// Legacy / missing send-fit: may generate for human review, not seed autorun stock.
-			if !ImportedSendTierEligible(acc.TargetFitSendTier) {
-				continue
-			}
-			existing, _ := s.repo.ListTouchpoints(ctx, orgID, acc.ID, "", 20, 0)
-			var due *models.OutreachTouchpoint
-			for j := range existing {
-				t := existing[j]
-				if t.Ordinal == 1 && (t.State == models.TouchpointDue || t.State == models.TouchpointPlanned ||
-					t.State == models.TouchpointNeedsReview || t.State == models.TouchpointDrafted) {
-					due = &existing[j]
-					break
-				}
-			}
-			if due == nil {
-				var contactID *uuid.UUID
-				if cands, _ := s.repo.ListCandidates(ctx, orgID, acc.ID); len(cands) > 0 {
-					for j := range cands {
-						// Autorun stock only from candidates with imported email_send_ready.
-						if !cands[j].EmailSendReady {
-							continue
-						}
-						if cands[j].CanEnroll() && strings.Contains(cands[j].Email, "@") && MailboxPurposeAllowed(cands[j].Email) {
-							if cands[j].MailboxPurposeSendBlocked {
-								continue
-							}
-							id := cands[j].ID
-							contactID = &id
-							break
-						}
-					}
-				}
-				if contactID == nil {
-					continue
-				}
-				tps, px := s.PlanAccountCadence(ctx, orgID, actorID, acc.ID, contactID, models.OutreachChannelEmail)
-				if px != nil || len(tps) == 0 {
-					continue
-				}
-				due = &tps[0]
-			}
-			if due.State == models.TouchpointPlanned {
-				due.State = models.TouchpointDue
-				_ = s.repo.UpdateTouchpoint(ctx, due)
-			}
-			if gen, gx := s.GenerateTouchpointDraft(ctx, orgID, actorID, due.ID); gx == nil && gen != nil {
-				seeded++
-			}
-		}
-	}
-
 	list, err := s.repo.ListReviewTouchpoints(ctx, orgID, limit, 0)
 	if err != nil {
 		return 0, 0, nil, errx.New(errx.Internal, "list review: "+err.Error())
 	}
 	details = make([]map[string]any, 0, len(list))
 	for i := range list {
-		tp := list[i]
-		if strings.ToUpper(tp.Channel) != "EMAIL" {
-			skipped++
-			details = append(details, map[string]any{"id": tp.ID.String(), "allow": false, "reasons": []string{"channel_not_email"}})
-			continue
-		}
-		// Re-generate stale YELLOW jit drafts under active policy so they can become policy GREEN.
-		if tp.DraftID != nil {
-			if d, _ := s.repo.GetDraft(ctx, orgID, *tp.DraftID); d != nil && d.RiskClass != "GREEN" {
-				_, _ = s.GenerateTouchpointDraft(ctx, orgID, actorID, tp.ID)
-			}
-		} else if tp.State == models.TouchpointDue || tp.State == models.TouchpointNeedsReview {
-			_, _ = s.GenerateTouchpointDraft(ctx, orgID, actorID, tp.ID)
-		}
-		out, dec, x := s.TryGreenAutorun(ctx, orgID, actorID, tp.ID)
+		_, dec, x := s.TryGreenAutorun(ctx, orgID, actorID, list[i].ID)
 		row := map[string]any{
-			"id":                 tp.ID.String(),
-			"allow":              dec.Allow,
-			"reasons":            dec.Reasons,
-			"authorization_mode": dec.AuthorizationMode,
-		}
-		if out != nil {
-			row["state"] = out.State
-			row["authorization_mode_stored"] = out.AuthorizationMode
-			row["approved_by"] = out.ApprovedBy
-			if out.CampaignPolicyAuthorizationID != nil {
-				row["campaign_policy_authorization_id"] = out.CampaignPolicyAuthorizationID.String()
-			}
+			"id":      list[i].ID.String(),
+			"allow":   false,
+			"reasons": dec.Reasons,
 		}
 		if x != nil {
 			row["error"] = x.Message
 		}
 		details = append(details, row)
-		if x != nil || !dec.Allow {
-			skipped++
-			continue
-		}
-		queued++
+		skipped++
 	}
-	return queued, skipped, details, nil
+	return 0, skipped, details, nil
 }
 
 // ImportedSendTierEligible reports whether an imported target_fit_send_tier may

--- a/internal/app/confenge/green_autorun_test.go
+++ b/internal/app/confenge/green_autorun_test.go
@@ -127,13 +127,19 @@ func TestCampaignPolicyGreenAutoqueueNoFakeApprovedBy(t *testing.T) {
 	store := newMemPolicyStore()
 	svc.WirePolicyAuth(store)
 
-	// No policy yet → refuse
-	_, dec, xerr := svc.TryGreenAutorun(ctx, org, user, tp.ID)
+	// Isolated env cannot reactivate green autorun: TryGreenAutorun never queues.
+	out, dec, xerr := svc.TryGreenAutorun(ctx, org, user, tp.ID)
 	if xerr != nil {
 		t.Fatal(xerr)
 	}
 	if dec.Allow {
-		t.Fatal("must not allow without campaign policy")
+		t.Fatal("green autorun must not allow")
+	}
+	if !containsString(dec.Reasons, "individual_approval_required") {
+		t.Fatalf("want individual_approval_required, got %v", dec.Reasons)
+	}
+	if out != nil && (out.State == models.TouchpointQueued || out.ApprovedBy != nil) {
+		t.Fatalf("autorun must not mint a sendable touchpoint: %+v", out)
 	}
 
 	auth, xerr := svc.AuthorizeCampaignPolicy(ctx, org, user, &models.CampaignPolicyAuthorization{
@@ -196,23 +202,26 @@ func TestCampaignPolicyGreenAutoqueueNoFakeApprovedBy(t *testing.T) {
 	if tp.AuthorizationMode != AuthorizationModeCampaignPolicy {
 		t.Fatalf("auth mode=%s", tp.AuthorizationMode)
 	}
-	if err := CanTransport(tp); err != nil {
-		t.Fatalf("CanTransport: %v", err)
+	if err := CanTransport(tp); err == nil {
+		t.Fatal("campaign_policy must not satisfy CanTransport")
 	}
 	_ = repo.UpdateTouchpoint(ctx, tp)
-	queued, err := repo.CASQueueTouchpoint(ctx, org, tp.ID, tp.ContentHash)
-	if err != nil || queued == nil {
-		t.Fatalf("CASQueue policy path failed: %v %v", err, queued)
+	if _, xerr := svc.QueueTouchpoint(ctx, org, user, tp.ID); xerr == nil {
+		t.Fatal("QueueTouchpoint must refuse policy-only authorization")
 	}
-	if queued.State != models.TouchpointQueued {
-		t.Fatalf("state=%s", queued.State)
+	stored, _ := repo.GetTouchpoint(ctx, org, tp.ID)
+	if stored != nil && stored.State == models.TouchpointQueued {
+		t.Fatal("policy-only path must not birth a queued send job")
 	}
-	if queued.ApprovedBy != nil {
-		t.Fatal("queued touchpoint still has approved_by")
+}
+
+func containsString(vals []string, want string) bool {
+	for _, v := range vals {
+		if v == want {
+			return true
+		}
 	}
-	if queued.AuthorizationMode != AuthorizationModeCampaignPolicy {
-		t.Fatalf("queued mode=%s", queued.AuthorizationMode)
-	}
+	return false
 }
 
 func TestYellowAndRedStayOutOfAutorun(t *testing.T) {

--- a/internal/app/confenge/inbound_e2e_test.go
+++ b/internal/app/confenge/inbound_e2e_test.go
@@ -190,6 +190,15 @@ func TestInboundShippedPathIngestToOutcome(t *testing.T) {
 	if svc.cfg.AutoSendEnabled {
 		t.Fatal("CONFENGE_AUTO_SEND_ENABLED must remain false")
 	}
+	if n := len(repo.touchpoints); n != 0 {
+		t.Fatalf("inbound persist/reprocess must not enroll or queue touchpoints: %d", n)
+	}
+	if n := len(repo.drafts); n != 0 {
+		t.Fatalf("inbound persist/reprocess must not mint drafts: %d", n)
+	}
+	if replay.DispatchAttempted {
+		t.Fatal("reprocess must not attempt dispatch")
+	}
 
 	if err := RejectInboundQueryPII(url.Values{"phone": []string{"4199"}}); err == nil {
 		t.Fatal("query PII must still be rejected after path")

--- a/internal/app/confenge/killswitch_e2e_test.go
+++ b/internal/app/confenge/killswitch_e2e_test.go
@@ -1,0 +1,109 @@
+package confenge
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// TestKillSwitchE2EBlocksEnrollQueueAndFinalGate drives the shipped pause path
+// twice. Both runs must refuse new send jobs with a paused/deferred reason.
+func TestKillSwitchE2EBlocksEnrollQueueAndFinalGate(t *testing.T) {
+	for i := 1; i <= 2; i++ {
+		if err := runKillSwitchE2E(t, i); err != nil {
+			t.Fatalf("kill-switch e2e run %d: %v", i, err)
+		}
+	}
+}
+
+func runKillSwitchE2E(t *testing.T, run int) error {
+	t.Helper()
+	t.Setenv(EnvKillSwitchPath, filepath.Join(t.TempDir(), "kill-e2e"))
+	if err := EngageKillSwitch(); err != nil {
+		return err
+	}
+	if !FileKillSwitchActive() {
+		t.Fatal("kill switch file must be engaged")
+	}
+
+	ctx := context.Background()
+	repo := newMemRepoWithSettings()
+	org, user, accID := uuid.New(), uuid.New(), uuid.New()
+	svc := NewService(Config{
+		Enabled: true, RequireHumanApproval: true, DefaultDailyLimit: 10,
+		MaxInitialEmailWords: 120, AutoSendEnabled: false, GreenAutorunEnabled: false,
+	}, repo, nil).(*service)
+	contacts := &mockContacts{}
+	svc.WireExecution(&mockCampaigns{}, contacts)
+	clock := &dispatch.FixedClock{T: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)}
+	cfg := dispatch.DefaultConfig()
+	cfg.WindowStart, cfg.WindowEnd, cfg.Timezone, cfg.MinGap = "00:00", "23:59", "UTC", 0
+	cfg.BusinessDaysOnly = false
+	svc.WireDispatchGovernor(dispatch.NewGovernor(cfg, dispatch.NewMemoryStore(), clock))
+
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", NomeFantasia: "ACME", QueueState: models.OutreachQueueApproved,
+		FactToMention: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
+	}
+	_, _ = repo.UpsertAccount(ctx, acc)
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, Name: "Ana Silva",
+		Email: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Recommended: true,
+	}
+	_, _ = repo.UpsertCandidate(ctx, cand)
+	d := &models.OutreachDraft{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, ContactCandidateID: &cand.ID,
+		Subject: "Sobre ACME", BodyText: "Ola Ana,\n\nNotei a prorrogacao do contrato. Faz sentido conversarmos?\n\nPosso enviar checklist?",
+		FactUsed: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
+		Status: models.OutreachDraftApproved, RiskClass: "GREEN", RecipientEmail: cand.Email,
+	}
+	ok := true
+	d.ValidationOK = &ok
+	_ = repo.UpsertDraft(ctx, d)
+	tp := &models.OutreachTouchpoint{
+		OrganizationID: org, AccountID: accID, ContactCandidateID: &cand.ID,
+		Ordinal: 1, Channel: models.OutreachChannelEmail, Purpose: models.TouchpointPurposeInitial,
+		State: models.TouchpointNeedsReview, Recipient: cand.Email,
+		Subject: d.Subject, BodyText: d.BodyText, DraftID: &d.ID,
+		IdempotencyKey: "kill-e2e-" + uuid.NewString(),
+	}
+	if err := ApplyHumanApproval(tp, user, time.Now().UTC()); err != nil {
+		return err
+	}
+	if err := repo.InsertTouchpoint(ctx, tp); err != nil {
+		return err
+	}
+
+	if _, xerr := svc.QueueTouchpoint(ctx, org, user, tp.ID); xerr == nil {
+		t.Fatalf("run %d: queue must refuse while paused", run)
+	} else if !containsFold(xerr.Message, "paused") {
+		t.Fatalf("run %d: queue reason %q want paused", run, xerr.Message)
+	}
+	stored, _ := repo.GetTouchpoint(ctx, org, tp.ID)
+	if stored.State != models.TouchpointApproved {
+		t.Fatalf("run %d: pause must preserve approval state=%s", run, stored.State)
+	}
+
+	if _, xerr := svc.EnrollDraft(ctx, org, user, d.ID); xerr == nil {
+		t.Fatalf("run %d: enroll must refuse while paused", run)
+	} else if !containsFold(xerr.Message, "paused") && !containsFold(xerr.Message, "kill") {
+		t.Fatalf("run %d: enroll reason %q", run, xerr.Message)
+	}
+	if len(contacts.added) != 0 {
+		t.Fatalf("run %d: enroll created send job: %+v", run, contacts.added)
+	}
+
+	gate := svc.GateCampaignEmail(ctx, org, DefaultCampaignName, cand.Email, uuid.New(), uuid.New(), uuid.New())
+	if gate.Kind != GateDeferred || gate.Reason != ReasonSendingOff {
+		t.Fatalf("run %d: final gate %+v", run, gate)
+	}
+	_ = run
+	return nil
+}

--- a/internal/app/confenge/outbound_gate_test.go
+++ b/internal/app/confenge/outbound_gate_test.go
@@ -234,10 +234,12 @@ func bindTransportableEnrollment(t *testing.T, repo *memRepo, orgID, accountID, 
 		OrganizationID: orgID, AccountID: accountID, ContactCandidateID: &candidateID,
 		DraftID: &draft.ID, Ordinal: 1, Channel: models.OutreachChannelEmail,
 		State: models.TouchpointQueued, Recipient: email, Subject: "Approved subject",
-		BodyText: "Approved body with enough detail", ContentHash: "hash", ApprovedContentHash: "hash",
+		BodyText:   "Approved body with enough detail",
 		ApprovedBy: &approver, AuthorizationMode: AuthorizationModeHumanTouchpoint,
 		GeneratedContextHash: account.MessageContextHash,
 	}
+	RecomputeContentHash(touchpoint)
+	touchpoint.ApprovedContentHash = touchpoint.ContentHash
 	if err := repo.InsertTouchpoint(ctx, touchpoint); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/app/confenge/revoke_final_send_test.go
+++ b/internal/app/confenge/revoke_final_send_test.go
@@ -277,9 +277,8 @@ func TestAssertTransportableAfterRevokeFails(t *testing.T) {
 	if err := ApplyCampaignPolicyAuthorization(tp, auth, time.Now().UTC()); err != nil {
 		t.Fatal(err)
 	}
-	// Structural CanTransport still passes (binding fields present).
-	if err := CanTransport(tp); err != nil {
-		t.Fatalf("structural CanTransport: %v", err)
+	if err := CanTransport(tp); err == nil {
+		t.Fatal("policy-only CanTransport must fail; individual approval is required")
 	}
 	// Revoke live grant.
 	if ok, _ := svc.RevokeCampaignPolicy(ctx, org, camp, user); !ok {
@@ -346,11 +345,11 @@ func TestRequireTouchTransportAfterRevokeBlocks(t *testing.T) {
 	}
 	_ = repo.InsertTouchpoint(ctx, tp)
 
-	if err := CanTransport(tp); err != nil {
-		t.Fatalf("structural CanTransport: %v", err)
+	if err := CanTransport(tp); err == nil {
+		t.Fatal("policy-only CanTransport must fail before enroll")
 	}
-	if xerr := AssertTransportAllowed(tp); xerr != nil {
-		t.Fatalf("structural AssertTransportAllowed: %v", xerr)
+	if xerr := AssertTransportAllowed(tp); xerr == nil {
+		t.Fatal("policy-only AssertTransportAllowed must fail")
 	}
 
 	if ok, _ := svc.RevokeCampaignPolicy(ctx, org, camp, user); !ok {

--- a/internal/app/confenge/safety_invariants_test.go
+++ b/internal/app/confenge/safety_invariants_test.go
@@ -1,0 +1,392 @@
+package confenge
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestEnvDriftCannotReactivateForbiddenAutomation(t *testing.T) {
+	t.Setenv(EnvEnabled, "true")
+	t.Setenv(EnvRequireHuman, "true")
+	t.Setenv(EnvAutoSend, "true")
+	t.Setenv(EnvGreenAutorun, "false")
+	cfg := LoadConfig()
+	if err := cfg.ValidateStartup("test"); err == nil {
+		t.Fatal("CONFENGE_AUTO_SEND_ENABLED=true must fail startup")
+	}
+	if err := cfg.ForbiddenAutomation(); err == nil || !strings.Contains(err.Error(), EnvAutoSend) {
+		t.Fatalf("ForbiddenAutomation auto-send: %v", err)
+	}
+
+	t.Setenv(EnvAutoSend, "false")
+	t.Setenv(EnvGreenAutorun, "true")
+	cfg = LoadConfig()
+	if err := cfg.ValidateStartup("dev"); err == nil {
+		t.Fatal("CONFENGE_GREEN_AUTORUN_ENABLED=true must fail startup")
+	}
+
+	t.Setenv(EnvGreenAutorun, "false")
+	t.Setenv(EnvRequireHuman, "false")
+	cfg = LoadConfig()
+	if err := cfg.ValidateStartup("production"); err == nil {
+		t.Fatal("CONFENGE_REQUIRE_HUMAN_APPROVAL=false must fail startup")
+	}
+
+	t.Setenv(EnvRequireHuman, "true")
+	cfg = LoadConfig()
+	if err := cfg.ValidateStartup("test"); err != nil {
+		t.Fatalf("safe env must start: %v", err)
+	}
+}
+
+func TestGreenAutorunAndBatchCreateZeroSendJobsWhenEnvFlipped(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepo()
+	org, user, accID := uuid.New(), uuid.New(), uuid.New()
+	camp := uuid.New()
+	_ = repo.UpsertOrgSettings(ctx, &models.OutreachOrgSettings{OrganizationID: org, CampaignID: &camp})
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "12345678000199",
+		RazaoSocial: "Engenharia Alpha LTDA", ServiceCode: "REAJUSTE",
+		FactToMention:   "prorrogação do contrato 001/2025 no PNCP",
+		ActivationState: "ACTIONABLE_NOW", TargetFitSendTier: "A_AUTOMATIC",
+		EmailSendReady: true, MessageContextHash: "ctx-hash-1",
+		QueueState: models.OutreachQueueNeedsReview,
+	}
+	_, _ = repo.UpsertAccount(ctx, acc)
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID,
+		Name: "Ana Silva", Email: "ana.silva@alphaeng.com.br",
+		VerificationStatus: models.OutreachVerifyOfficialSource, Confidence: "HIGH",
+		Recommended: true, EmailSendReady: true, OwnershipStatus: "COMPANY_OWNED",
+	}
+	_, _ = repo.UpsertCandidate(ctx, cand)
+	tp := &models.OutreachTouchpoint{
+		OrganizationID: org, AccountID: accID, ContactCandidateID: &cand.ID,
+		Ordinal: 1, Channel: models.OutreachChannelEmail, Purpose: models.TouchpointPurposeInitial,
+		State: models.TouchpointNeedsReview, Recipient: cand.Email,
+		Subject: "Sobre Alpha Eng", BodyText: "Olá Ana,\n\nNotei a prorrogação.\n\nFaz sentido?\n\n" + SignaturePlain(),
+		ServiceCode: "REAJUSTE", FactUsed: acc.FactToMention, GeneratedContextHash: "ctx-hash-1",
+		IdempotencyKey: "drift-autorun-1",
+	}
+	RecomputeContentHash(tp)
+	_ = repo.InsertTouchpoint(ctx, tp)
+	ok := true
+	draft := &models.OutreachDraft{
+		OrganizationID: org, AccountID: accID, ContactCandidateID: &cand.ID,
+		Channel: models.OutreachChannelEmail, Subject: tp.Subject, BodyText: tp.BodyText,
+		RecipientEmail: cand.Email, ServiceCode: "REAJUSTE", FactUsed: acc.FactToMention,
+		Provider: "template", Model: TemplatePolicyVersionV1, Status: models.OutreachDraftNeedsReview,
+		RiskClass: "GREEN", ValidationOK: &ok,
+	}
+	_ = repo.UpsertDraft(ctx, draft)
+	tp.DraftID = &draft.ID
+	_ = repo.UpdateTouchpoint(ctx, tp)
+
+	svc := NewService(Config{
+		Enabled: true, RequireHumanApproval: true, GreenAutorunEnabled: true,
+		MaxInitialEmailWords: 120, AppEnv: "test",
+	}, repo, nil).(*service)
+	store := newMemPolicyStore()
+	svc.WirePolicyAuth(store)
+	if _, xerr := svc.AuthorizeCampaignPolicy(ctx, org, user, &models.CampaignPolicyAuthorization{
+		CampaignID: camp, Channel: "EMAIL", AllowedRiskClass: "GREEN",
+		SenderMailbox: "tiago.sasaki@confenge.com.br", AllowPolicyTemplateGREEN: true,
+		EffectiveAt: time.Now().UTC().Add(-time.Minute),
+	}); xerr != nil {
+		t.Fatal(xerr)
+	}
+
+	out, dec, xerr := svc.TryGreenAutorun(ctx, org, user, tp.ID)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if dec.Allow || !containsString(dec.Reasons, "individual_approval_required") {
+		t.Fatalf("autorun must refuse: %+v", dec)
+	}
+	if out != nil && out.State == models.TouchpointQueued {
+		t.Fatal("TryGreenAutorun must not queue")
+	}
+
+	queued, skipped, details, xerr := svc.RunGreenAutorunBatch(ctx, org, user, 10)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if queued != 0 {
+		t.Fatalf("batch queued=%d details=%v", queued, details)
+	}
+	if skipped == 0 && len(details) == 0 {
+		t.Fatal("batch must visit review items and skip them")
+	}
+	stored, _ := repo.GetTouchpoint(ctx, org, tp.ID)
+	if stored.State == models.TouchpointQueued || stored.ApprovedBy != nil {
+		t.Fatalf("batch must not mint approval/queue: %+v", stored)
+	}
+}
+
+func TestStaleApprovalAndEvidenceVersionsRefuseTransport(t *testing.T) {
+	tp := sampleTouch(models.OutreachChannelEmail, "ana@empresa.com.br", "Sobre ACME", "Corpo aprovado com fato.")
+	tp.EvidenceIDs = []string{"ev-1"}
+	tp.GeneratedContextHash = "ctx-v1"
+	human := uuid.New()
+	if err := ApplyHumanApproval(tp, human, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	if err := CanTransport(tp); err != nil {
+		t.Fatalf("fresh individual approval must transport: %v", err)
+	}
+
+	tp.EvidenceIDs = []string{"ev-2"}
+	if err := CanTransport(tp); err == nil {
+		t.Fatal("evidence version drift must refuse transport")
+	}
+	tp.EvidenceIDs = []string{"ev-1"}
+	tp.GeneratedContextHash = "ctx-v2"
+	if err := CanTransport(tp); err == nil {
+		t.Fatal("context/evidence version drift must refuse transport")
+	}
+	tp.GeneratedContextHash = "ctx-v1"
+	tp.Recipient = "outro@empresa.com.br"
+	if err := CanTransport(tp); err == nil {
+		t.Fatal("recipient drift must refuse transport")
+	}
+	tp.Recipient = "ana@empresa.com.br"
+	tp.BodyText = "corpo editado depois da aprovação"
+	if err := CanTransport(tp); err == nil {
+		t.Fatal("content drift must refuse transport")
+	}
+}
+
+func TestPolicyOnlyAndMissingApprovalCannotBirthSendJob(t *testing.T) {
+	allowConfengeSendingForTest(t)
+	ctx := context.Background()
+	repo := newMemRepoWithSettings()
+	org, user, accID := uuid.New(), uuid.New(), uuid.New()
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120}, repo, nil).(*service)
+	contacts := &mockContacts{}
+	svc.WireExecution(&mockCampaigns{}, contacts)
+
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", NomeFantasia: "ACME", QueueState: models.OutreachQueueApproved,
+		FactToMention: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
+	}
+	_, _ = repo.UpsertAccount(ctx, acc)
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, Name: "Ana Silva",
+		Email: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Recommended: true,
+	}
+	_, _ = repo.UpsertCandidate(ctx, cand)
+	d := &models.OutreachDraft{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, ContactCandidateID: &cand.ID,
+		Subject: "Sobre ACME", BodyText: "Ola Ana,\n\nNotei a prorrogacao do contrato. Faz sentido conversarmos?\n\nPosso enviar checklist?",
+		FactUsed: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
+		Status: models.OutreachDraftApproved, RiskClass: "GREEN", RecipientEmail: cand.Email,
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	ok := true
+	d.ValidationOK = &ok
+	_ = repo.UpsertDraft(ctx, d)
+
+	missing := &models.OutreachTouchpoint{
+		OrganizationID: org, AccountID: accID, ContactCandidateID: &cand.ID,
+		Ordinal: 1, Channel: models.OutreachChannelEmail, Purpose: models.TouchpointPurposeInitial,
+		State: models.TouchpointNeedsReview, Recipient: cand.Email,
+		Subject: d.Subject, BodyText: d.BodyText, DraftID: &d.ID, IdempotencyKey: "bypass-missing",
+	}
+	RecomputeContentHash(missing)
+	_ = repo.InsertTouchpoint(ctx, missing)
+	if _, xerr := svc.QueueTouchpoint(ctx, org, user, missing.ID); xerr == nil {
+		t.Fatal("missing approval must not queue")
+	}
+	if _, xerr := svc.EnrollDraft(ctx, org, user, d.ID); xerr == nil {
+		t.Fatal("missing approval must not enroll")
+	}
+	if len(contacts.added) != 0 {
+		t.Fatalf("no contact/send job on missing approval: %+v", contacts.added)
+	}
+
+	store := newMemPolicyStore()
+	svc.WirePolicyAuth(store)
+	auth, xerr := svc.AuthorizeCampaignPolicy(ctx, org, user, &models.CampaignPolicyAuthorization{
+		CampaignID: uuid.New(), Channel: "EMAIL", AllowedRiskClass: "GREEN",
+		EffectiveAt: time.Now().UTC().Add(-time.Minute), SenderMailbox: "tiago.sasaki@confenge.com.br",
+	})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if err := ApplyCampaignPolicyAuthorization(missing, auth, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	_ = repo.UpdateTouchpoint(ctx, missing)
+	if CanTransport(missing) == nil {
+		t.Fatal("policy-only must not transport")
+	}
+	if _, xerr := svc.QueueTouchpoint(ctx, org, user, missing.ID); xerr == nil {
+		t.Fatal("policy-only must not queue")
+	}
+	if _, xerr := svc.EnrollDraft(ctx, org, user, d.ID); xerr == nil {
+		t.Fatal("policy-only must not enroll")
+	}
+	if len(contacts.added) != 0 {
+		t.Fatal("policy-only must create zero send jobs")
+	}
+}
+
+func TestAutoSendAndGreenAutorunConfigRefuseQueueAndEnroll(t *testing.T) {
+	allowConfengeSendingForTest(t)
+	ctx := context.Background()
+	repo := newMemRepoWithSettings()
+	org, user, accID := uuid.New(), uuid.New(), uuid.New()
+	svc := NewService(Config{
+		Enabled: true, RequireHumanApproval: true, AutoSendEnabled: true,
+		DefaultDailyLimit: 10, MaxInitialEmailWords: 120,
+	}, repo, nil).(*service)
+	contacts := &mockContacts{}
+	svc.WireExecution(&mockCampaigns{}, contacts)
+	acc := &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "11222333000181",
+		RazaoSocial: "ACME", NomeFantasia: "ACME", QueueState: models.OutreachQueueApproved,
+		FactToMention: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
+	}
+	_, _ = repo.UpsertAccount(ctx, acc)
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, Name: "Ana Silva",
+		Email: "ana@example.com", VerificationStatus: models.OutreachVerifyOfficialSource, Recommended: true,
+	}
+	_, _ = repo.UpsertCandidate(ctx, cand)
+	d := &models.OutreachDraft{
+		ID: uuid.New(), OrganizationID: org, AccountID: accID, ContactCandidateID: &cand.ID,
+		Subject: "Sobre ACME", BodyText: "Ola Ana,\n\nNotei a prorrogacao do contrato. Faz sentido conversarmos?\n\nPosso enviar checklist?",
+		FactUsed: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
+		Status: models.OutreachDraftApproved, RiskClass: "GREEN", RecipientEmail: cand.Email,
+	}
+	ok := true
+	d.ValidationOK = &ok
+	_ = repo.UpsertDraft(ctx, d)
+	tp := &models.OutreachTouchpoint{
+		OrganizationID: org, AccountID: accID, ContactCandidateID: &cand.ID,
+		Ordinal: 1, Channel: models.OutreachChannelEmail, Purpose: models.TouchpointPurposeInitial,
+		State: models.TouchpointNeedsReview, Recipient: cand.Email,
+		Subject: d.Subject, BodyText: d.BodyText, DraftID: &d.ID, IdempotencyKey: "autosend-refuse",
+	}
+	if err := ApplyHumanApproval(tp, user, time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	_ = repo.InsertTouchpoint(ctx, tp)
+	if _, xerr := svc.QueueTouchpoint(ctx, org, user, tp.ID); xerr == nil {
+		t.Fatal("auto-send config must not queue")
+	}
+	if _, xerr := svc.EnrollDraft(ctx, org, user, d.ID); xerr == nil {
+		t.Fatal("auto-send config must not enroll")
+	}
+	if len(contacts.added) != 0 {
+		t.Fatal("auto-send config must create zero send jobs")
+	}
+
+	svc.cfg.AutoSendEnabled = false
+	svc.cfg.GreenAutorunEnabled = true
+	if _, xerr := svc.QueueTouchpoint(ctx, org, user, tp.ID); xerr == nil {
+		t.Fatal("green-autorun config must not queue")
+	}
+	if _, xerr := svc.EnrollDraft(ctx, org, user, d.ID); xerr == nil {
+		t.Fatal("green-autorun config must not enroll")
+	}
+}
+
+func TestDuplicateGateDoesNotMintSecondSend(t *testing.T) {
+	allowConfengeSendingForTest(t)
+	repo := newMemRepoWithSettings()
+	org, accID := uuid.New(), uuid.New()
+	_, _ = repo.UpsertAccount(context.Background(), &models.OutreachAccount{
+		ID: accID, OrganizationID: org, CNPJ14: "12345678000166",
+	})
+	candidateID := uuid.New()
+	_, _ = repo.UpsertCandidate(context.Background(), &models.OutreachContactCandidate{
+		ID: candidateID, OrganizationID: org, AccountID: accID, Email: "lead@example.com",
+	})
+	campaignID, contactID := bindTransportableEnrollment(t, repo.memRepo, org, accID, candidateID, "lead@example.com")
+	clock := &dispatch.FixedClock{T: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)}
+	cfg := dispatch.DefaultConfig()
+	cfg.WindowStart, cfg.WindowEnd, cfg.Timezone, cfg.MinGap = "00:00", "23:59", "UTC", 0
+	cfg.BusinessDaysOnly = false
+	cfg.SendsPerHour = 10
+	svc := &service{
+		cfg:  Config{Enabled: true, RequireHumanApproval: true},
+		repo: repo, governor: dispatch.NewGovernor(cfg, dispatch.NewMemoryStore(), clock),
+	}
+	seq := uuid.New()
+	first := svc.GateCampaignEmail(context.Background(), org, DefaultCampaignName, "lead@example.com", campaignID, contactID, seq)
+	if first.Kind != GateProceed {
+		t.Fatalf("first gate: %+v", first)
+	}
+	if err := svc.governor.Commit(context.Background(), first.ReservationID); err != nil {
+		t.Fatal(err)
+	}
+	replay := svc.GateCampaignEmail(context.Background(), org, DefaultCampaignName, "lead@example.com", campaignID, contactID, seq)
+	if replay.Kind != GateAlready {
+		t.Fatalf("replay must be GateAlready, got %+v", replay)
+	}
+}
+
+func TestPauseDispatchAuditsKillSwitch(t *testing.T) {
+	allowConfengeSendingForTest(t)
+	t.Setenv(EnvKillSwitchPath, filepath.Join(t.TempDir(), "kill"))
+	repo := newMemRepo()
+	audit := &recordingAudit{}
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true, DefaultDailyLimit: 10, MaxInitialEmailWords: 120}, repo, audit).(*service)
+	clock := &dispatch.FixedClock{T: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)}
+	cfg := dispatch.DefaultConfig()
+	cfg.WindowStart, cfg.WindowEnd, cfg.Timezone = "00:00", "23:59", "UTC"
+	svc.WireDispatchGovernor(dispatch.NewGovernor(cfg, dispatch.NewMemoryStore(), clock))
+	org, user := uuid.New(), uuid.New()
+	if xerr := svc.PauseDispatch(context.Background(), org, user, "safety-invariant"); xerr != nil {
+		t.Fatal(xerr)
+	}
+	if svc.cfg.SendingAllowed() {
+		t.Fatal("pause must engage kill switch")
+	}
+	if !audit.saw("dispatch_pause") {
+		t.Fatalf("pause must be audited: %+v", audit.actions)
+	}
+	if xerr := svc.ResumeDispatch(context.Background(), org, user); xerr != nil {
+		t.Fatal(xerr)
+	}
+	if !audit.saw("dispatch_resume") {
+		t.Fatal("resume must be audited")
+	}
+}
+
+type recordingAudit struct {
+	actions []string
+}
+
+func (r *recordingAudit) LogAction(_ context.Context, _, _ uuid.UUID, _ models.AuditAction, _ models.AuditEntityType, _ *uuid.UUID, _, _ string, changes, metadata map[string]string) {
+	if changes != nil {
+		if a := changes["action"]; a != "" {
+			r.actions = append(r.actions, a)
+		}
+	}
+	if metadata != nil {
+		if a := metadata["action"]; a != "" {
+			r.actions = append(r.actions, a)
+		}
+	}
+}
+
+func (r *recordingAudit) saw(action string) bool {
+	for _, a := range r.actions {
+		if a == action {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/confenge/schema_test.go
+++ b/internal/app/confenge/schema_test.go
@@ -237,9 +237,12 @@ func TestConfigDefaultsOff(t *testing.T) {
 
 func TestConfigValidateProdHTTPS(t *testing.T) {
 	cfg := Config{
-		Enabled:      true,
-		FeedURL:      "http://insecure.example.com/feed",
-		AllowedHosts: []string{"insecure.example.com"},
+		Enabled:              true,
+		RequireHumanApproval: true,
+		DefaultDailyLimit:    200,
+		MaxInitialEmailWords: 120,
+		FeedURL:              "http://insecure.example.com/feed",
+		AllowedHosts:         []string{"insecure.example.com"},
 	}
 	if err := cfg.ValidateStartup("prod"); err == nil {
 		t.Fatal("prod must require https feed")
@@ -281,6 +284,28 @@ func TestConfigValidateStartupRejectsUnsafeOperatorAutomation(t *testing.T) {
 	green.GreenAutorunEnabled = true
 	if err := green.ValidateStartup("production"); err == nil {
 		t.Fatal("operator startup must reject green autorun")
+	}
+}
+
+func TestConfigValidateStartupRejectsUnsafeAutomationWithoutOperatorMode(t *testing.T) {
+	base := Config{Enabled: true, RequireHumanApproval: true, DefaultDailyLimit: 200, MaxInitialEmailWords: 120}
+	auto := base
+	auto.AutoSendEnabled = true
+	if err := auto.ValidateStartup("test"); err == nil {
+		t.Fatal("isolated env must not reactivate auto-send")
+	}
+	noHuman := base
+	noHuman.RequireHumanApproval = false
+	if err := noHuman.ValidateStartup("test"); err == nil {
+		t.Fatal("isolated env must not turn off human approval")
+	}
+	green := base
+	green.GreenAutorunEnabled = true
+	if err := green.ValidateStartup("dev"); err == nil {
+		t.Fatal("isolated env must not reactivate green autorun")
+	}
+	if err := base.ValidateStartup("test"); err != nil {
+		t.Fatalf("safe defaults must start: %v", err)
 	}
 }
 

--- a/internal/app/confenge/touchpoint_sm.go
+++ b/internal/app/confenge/touchpoint_sm.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -29,6 +30,13 @@ func CadencePolicyV1() []CadenceStepSpec {
 }
 
 func ContentHash(channel, recipient, subject, body, purpose string) string {
+	return ContentBindingHash(channel, recipient, subject, body, purpose, nil, "")
+}
+
+// ContentBindingHash binds recipient, content, and evidence/context versions.
+// A later evidence or context drift produces a different hash and cannot ride
+// an earlier individual approval.
+func ContentBindingHash(channel, recipient, subject, body, purpose string, evidenceIDs []string, contextHash string) string {
 	var b strings.Builder
 	b.WriteString(strings.ToUpper(strings.TrimSpace(channel)))
 	b.WriteByte(0)
@@ -39,15 +47,29 @@ func ContentHash(channel, recipient, subject, body, purpose string) string {
 	b.WriteString(strings.TrimSpace(body))
 	b.WriteByte(0)
 	b.WriteString(strings.ToUpper(strings.TrimSpace(purpose)))
+	b.WriteByte(0)
+	ev := append([]string(nil), evidenceIDs...)
+	sort.Strings(ev)
+	b.WriteString(strings.Join(ev, ","))
+	b.WriteByte(0)
+	b.WriteString(strings.TrimSpace(contextHash))
 	sum := sha256.Sum256([]byte(b.String()))
 	return hex.EncodeToString(sum[:])
+}
+
+// TouchpointBindingHash is the live recipient/content/evidence version stamp.
+func TouchpointBindingHash(tp *models.OutreachTouchpoint) string {
+	if tp == nil {
+		return ""
+	}
+	return ContentBindingHash(tp.Channel, tp.Recipient, tp.Subject, tp.BodyText, tp.Purpose, tp.EvidenceIDs, tp.GeneratedContextHash)
 }
 
 func RecomputeContentHash(tp *models.OutreachTouchpoint) {
 	if tp == nil {
 		return
 	}
-	tp.ContentHash = ContentHash(tp.Channel, tp.Recipient, tp.Subject, tp.BodyText, tp.Purpose)
+	tp.ContentHash = TouchpointBindingHash(tp)
 }
 
 // ClearApproval is the single canonical invalidation of any authorization
@@ -75,9 +97,7 @@ func ApplyHumanApproval(tp *models.OutreachTouchpoint, humanUserID uuid.UUID, no
 	if humanUserID == uuid.Nil {
 		return fmt.Errorf("approved_by requires a human user id")
 	}
-	if tp.ContentHash == "" {
-		RecomputeContentHash(tp)
-	}
+	RecomputeContentHash(tp)
 	if tp.ContentHash == "" || tp.BodyText == "" {
 		return fmt.Errorf("cannot approve empty content")
 	}
@@ -153,24 +173,18 @@ func CanTransport(tp *models.OutreachTouchpoint) error {
 	if tp.ContentHash == "" || tp.ApprovedContentHash == "" {
 		return fmt.Errorf("missing content hash")
 	}
-	if tp.ApprovedContentHash != tp.ContentHash {
-		return fmt.Errorf("approved_content_hash does not match content_hash")
+	// Recompute from the live recipient, copy, evidence ids, and context
+	// version so a stale approval cannot ride mutated fields.
+	want := TouchpointBindingHash(tp)
+	if want == "" || tp.ContentHash != want || tp.ApprovedContentHash != want {
+		return fmt.Errorf("approved_content_hash does not match live recipient/content/evidence versions")
 	}
 	mode := strings.TrimSpace(tp.AuthorizationMode)
 	if mode == AuthorizationModeCampaignPolicy {
-		// Policy path: must not invent a human reviewer; must bind grant.
-		if tp.ApprovedBy != nil && *tp.ApprovedBy != uuid.Nil {
-			return fmt.Errorf("campaign_policy must not set approved_by")
-		}
-		if tp.CampaignPolicyAuthorizationID == nil || *tp.CampaignPolicyAuthorizationID == uuid.Nil {
-			return fmt.Errorf("campaign_policy missing authorization binding")
-		}
-		if strings.TrimSpace(tp.AuthorizationPolicyHash) == "" {
-			return fmt.Errorf("campaign_policy missing authorization_policy_hash")
-		}
-		return nil
+		// CAMPAIGN_POLICY is not an individual approval record. Isolated env
+		// cannot reactivate bulk/green autorun as a transport authority.
+		return fmt.Errorf("campaign_policy cannot transport; individual approval required")
 	}
-	// Human (or legacy empty mode) requires a real human approver.
 	if tp.ApprovedBy == nil || *tp.ApprovedBy == uuid.Nil {
 		return fmt.Errorf("missing human approved_by")
 	}

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -602,7 +602,7 @@ func (s *service) EditTouchpoint(ctx context.Context, orgID, userID, id uuid.UUI
 			return nil, errx.New(errx.Internal, "load draft failed")
 		} else if d != nil {
 			// Keep draft transport fields in lockstep with the touchpoint so
-			// requireTouchTransport ContentHash(draft) matches approved hash.
+			// requireTouchTransport binding hash matches approved hash.
 			d.Subject, d.BodyText = tp.Subject, tp.BodyText
 			d.Channel = tp.Channel
 			if tp.Channel == models.OutreachChannelWhatsApp || tp.Channel == "WHATSAPP" {
@@ -875,6 +875,9 @@ func (s *service) QueueTouchpoint(ctx context.Context, orgID, userID, id uuid.UU
 	if xerr := s.requireEnabled(); xerr != nil {
 		return nil, xerr
 	}
+	if s.cfg.AutoSendEnabled || s.cfg.GreenAutorunEnabled {
+		return nil, errx.New(errx.BadRequest, "refusing queue: auto-send and green autorun cannot create send jobs")
+	}
 	if !s.cfg.SendingAllowed() {
 		return nil, errx.New(errx.Conflict, "sending paused; approval was preserved and nothing was queued")
 	}
@@ -1088,7 +1091,7 @@ func (s *service) requireTouchTransport(ctx context.Context, orgID, draftID uuid
 				recipient = tp.Recipient
 			}
 		}
-		live := ContentHash(ch, recipient, d.Subject, d.BodyText, tp.Purpose)
+		live := ContentBindingHash(ch, recipient, d.Subject, d.BodyText, tp.Purpose, tp.EvidenceIDs, tp.GeneratedContextHash)
 		if live != tp.ContentHash || live != tp.ApprovedContentHash {
 			return nil, errx.New(errx.BadRequest, "draft content diverged from approved touchpoint; re-approve the exact send payload")
 		}

--- a/internal/app/whatsapp/config.go
+++ b/internal/app/whatsapp/config.go
@@ -97,6 +97,9 @@ func (c Config) ValidateStartup() error {
 	if !c.Enabled {
 		return nil
 	}
+	if c.AutoSendEnabled {
+		return fmt.Errorf("%s=true is not supported; CONFENGE WhatsApp requires an explicit human send", EnvAutoSend)
+	}
 	// Baileys must never enable under production.
 	if c.IsProduction() && c.AllowBaileys {
 		return fmt.Errorf("%s cannot be true when APP_ENV is production (Cloud API only)", EnvEvolutionAllowBaileys)

--- a/internal/app/worker/event_send_email.go
+++ b/internal/app/worker/event_send_email.go
@@ -27,12 +27,14 @@ func (w *WorkerService) HandleSendEmail(ctx context.Context, sendEmail models.Se
 	// the backend. Re-check it at the worker boundary so a stale or directly
 	// published queue item cannot reach SMTP while dispatch is paused.
 	confengeCfg := confenge.LoadConfig()
-	if confengeCfg.Enabled && confengeCfg.OperatorMode &&
-		(!confengeCfg.RequireHumanApproval || confengeCfg.AutoSendEnabled || confengeCfg.GreenAutorunEnabled) {
-		return fmt.Errorf("CONFENGE unsafe authorization configuration at worker transport boundary")
-	}
-	if confengeCfg.Enabled && confengeCfg.OperatorMode && !confengeCfg.SendingAllowed() {
-		return fmt.Errorf("CONFENGE sending paused at worker transport boundary")
+	// Isolated env that omits operator mode must not become fail-open at SMTP.
+	if confengeCfg.Enabled {
+		if err := confengeCfg.ForbiddenAutomation(); err != nil {
+			return fmt.Errorf("CONFENGE unsafe authorization configuration at worker transport boundary: %w", err)
+		}
+		if !confengeCfg.SendingAllowed() {
+			return fmt.Errorf("CONFENGE sending paused at worker transport boundary")
+		}
 	}
 
 	// Get the email account from MailManager

--- a/internal/app/worker/event_send_email_confenge_test.go
+++ b/internal/app/worker/event_send_email_confenge_test.go
@@ -23,6 +23,22 @@ func TestHandleSendEmailConfengeKillSwitchBlocksBeforeMailboxTransport(t *testin
 	}
 }
 
+func TestHandleSendEmailConfengeKillSwitchBlocksWithoutOperatorMode(t *testing.T) {
+	t.Setenv(confenge.EnvEnabled, "true")
+	t.Setenv(confenge.EnvOperatorMode, "false")
+	t.Setenv(confenge.EnvRequireHuman, "true")
+	t.Setenv(confenge.EnvAutoSend, "false")
+	t.Setenv(confenge.EnvGreenAutorun, "false")
+	t.Setenv(confenge.EnvKillSwitchPath, filepath.Join(t.TempDir(), "engaged"))
+	if err := confenge.EngageKillSwitch(); err != nil {
+		t.Fatal(err)
+	}
+	err := (&WorkerService{}).HandleSendEmail(context.Background(), models.SendEmail{})
+	if err == nil || !strings.Contains(err.Error(), "sending paused") {
+		t.Fatalf("worker without operator mode must still honor kill switch: %v", err)
+	}
+}
+
 func TestHandleSendEmailConfengeUnsafeAutomationBlocksBeforeMailboxTransport(t *testing.T) {
 	t.Setenv(confenge.EnvEnabled, "true")
 	t.Setenv(confenge.EnvOperatorMode, "true")
@@ -32,5 +48,36 @@ func TestHandleSendEmailConfengeUnsafeAutomationBlocksBeforeMailboxTransport(t *
 	err := (&WorkerService{}).HandleSendEmail(context.Background(), models.SendEmail{})
 	if err == nil || !strings.Contains(err.Error(), "unsafe authorization") {
 		t.Fatalf("worker transport must reject unsafe operator automation: %v", err)
+	}
+}
+
+func TestHandleSendEmailConfengeKillSwitchE2ETwice(t *testing.T) {
+	t.Setenv(confenge.EnvEnabled, "true")
+	t.Setenv(confenge.EnvOperatorMode, "false")
+	t.Setenv(confenge.EnvRequireHuman, "true")
+	t.Setenv(confenge.EnvAutoSend, "false")
+	t.Setenv(confenge.EnvGreenAutorun, "false")
+	t.Setenv(confenge.EnvKillSwitchPath, filepath.Join(t.TempDir(), "e2e"))
+	if err := confenge.EngageKillSwitch(); err != nil {
+		t.Fatal(err)
+	}
+	for i := 1; i <= 2; i++ {
+		err := (&WorkerService{}).HandleSendEmail(context.Background(), models.SendEmail{})
+		if err == nil || !strings.Contains(err.Error(), "sending paused") {
+			t.Fatalf("run %d: worker must stay paused: %v", i, err)
+		}
+	}
+}
+
+func TestHandleSendEmailConfengeUnsafeAutomationBlocksWithoutOperatorMode(t *testing.T) {
+	t.Setenv(confenge.EnvEnabled, "true")
+	t.Setenv(confenge.EnvOperatorMode, "")
+	t.Setenv(confenge.EnvRequireHuman, "true")
+	t.Setenv(confenge.EnvAutoSend, "false")
+	t.Setenv(confenge.EnvGreenAutorun, "true")
+	t.Setenv(confenge.EnvKillSwitchPath, filepath.Join(t.TempDir(), "not-engaged"))
+	err := (&WorkerService{}).HandleSendEmail(context.Background(), models.SendEmail{})
+	if err == nil || !strings.Contains(err.Error(), "unsafe authorization") {
+		t.Fatalf("isolated env must not reactivate green autorun at worker: %v", err)
 	}
 }


### PR DESCRIPTION
## Outcome

On the CONFENGE profile, isolated env/config cannot reactivate auto-send, green-autorun/batch, or human-approval-off. No send job is created without a persisted individual approval that binds the exact recipient, content, and evidence/context versions. The central kill switch blocks enroll, queue, `GateCampaignEmail`, and worker SMTP even when operator mode is omitted.

**Decision: `READY_BEHIND_HUMAN_GATE`**

In-repo shipped-function regressions and the kill-switch E2E (run twice, both PASS) prove the gates. Live SMTP/Mailpit and human APPROVE of 1-3 messages (#41) were not exercised here. That does not weaken the drift/invariant proof; it is the remaining live-send gate.

## Scope

- Startup `ValidateStartup` rejects `CONFENGE_AUTO_SEND_ENABLED=true`, `CONFENGE_GREEN_AUTORUN_ENABLED=true`, and `CONFENGE_REQUIRE_HUMAN_APPROVAL=false` in every environment, not only operator mode.
- `CanTransport` requires individual `approved_by`. `CAMPAIGN_POLICY` is not transportable. Live binding hash covers recipient, copy, evidence IDs, and generated context hash.
- `TryGreenAutorun` and `POST .../green-autorun/batch` never approve or queue (`individual_approval_required`, `queued=0`) even if the env flag is flipped at runtime.
- Enroll/queue refuse auto-send and green-autorun config. Worker kill switch and forbidden-automation checks run whenever `CONFENGE_OUTREACH_ENABLED=true`.
- WhatsApp startup rejects `CONFENGE_WHATSAPP_AUTO_SEND_ENABLED=true`.
- Kill switch remains the shared file + governor pause, with existing audit (`dispatch_pause` / `dispatch_resume`).
- Docs: auto-send / green-autorun cannot be activated.

## Out of scope

- Issue close or comments on #39 #41 #42 #43.
- PR #80 intel/reconciliation, CRM, forecast, identity/consent inference, WON/LOST without evidence.
- Live canary send, human APPROVE of 1-3 messages, GO/NO-GO for #43.
- Merge, deploy, DNS, spend, mass approval.
- Non-CONFENGE warmup/contact-import bulk except where those paths could birth a CONFENGE send job (they still hit `GateCampaignEmail`).

## Risks

- Existing GREEN autorun tests that treated `CAMPAIGN_POLICY` as transportable were inverted to fail-closed. The predicate engine `EvaluateGreenAutorun` still exists for audit/explain; it cannot birth a send job.
- Campaign-policy grants can still be persisted. They cannot satisfy `CanTransport`.
- Worker now pauses all SMTP on that process when CONFENGE is enabled and the kill switch is engaged. Isolated CONFENGE workers are the intended plane.

## Rollback

Revert this commit. Prior behavior allowed policy-only transport and operator-mode-gated worker checks.

## Refs

#39 #41 #43 #42

## Commands executed

```
git fetch origin main
git rev-parse origin/main
# 2444058ef3a64774b84eea57425b731700946b84
git worktree add -b feat/confenge-no-autosend-drift ... origin/main
# commit a957ad08aa44361be8e2b2e7e47cafa27d8121dc

gofmt -w <touched Go>
make fmt
make lint
# gofmt -l empty; golangci-lint via make lint: pass

go test ./internal/app/confenge/ ./internal/app/worker/ ./internal/app/whatsapp/ -count=1 \
  -skip TestProductAcceptanceMultichannelSum
# ok

go test ... -run 'TestKillSwitchE2EBlocksEnrollQueueAndFinalGate|TestHandleSendEmailConfengeKillSwitchE2ETwice'
# run 1 PASS; run 2 PASS (same result)
```

Mailpit was not reachable on 11025/18025 or 1025/8025. Product-acceptance live SMTP was not claimed. Kill-switch E2E drives shipped `EngageKillSwitch` + `QueueTouchpoint` + `EnrollDraft` + `GateCampaignEmail` + `HandleSendEmail`.

## Residual (still open)

- #39 recipient email-safe reprocess; #41 human APPROVE of 1-3 messages; #43 GO/NO-GO canary. Not this PR.
- Live Mailpit/SMTP on a CONFENGE host. Next command if a stronger live claim is required:
  `make infra && CONFENGE_MAILPIT_SMTP=127.0.0.1:11025 CONFENGE_MAILPIT_API=http://127.0.0.1:18025 go test ./internal/app/confenge/ -count=1 -run TestProductAcceptanceMultichannelSum`
- Human decision to APPROVE real copy remains #41. This PR does not authorize transport of a live canary.

## Final decision

`READY_BEHIND_HUMAN_GATE`