### PR TITLE
feat: add /live /ready /health/deps, opsprobe, and platform incident runbook so process-up HTTP 200 is not treated as healthy

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -66,6 +66,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/organization"
 	"github.com/warmbly/warmbly/internal/app/passkey"
 	"github.com/warmbly/warmbly/internal/app/placement"
+	"github.com/warmbly/warmbly/internal/app/plathealth"
 	"github.com/warmbly/warmbly/internal/app/provisioning"
 	"github.com/warmbly/warmbly/internal/app/ratelimit"
 	"github.com/warmbly/warmbly/internal/app/referral"
@@ -138,6 +139,7 @@ func main() {
 	var websocketURI string
 	var allowedOrigins []string
 	var systemChecker *sysstatus.Checker
+	var platformHealth *plathealth.Collector
 
 	var tzService tz.TzService
 
@@ -1578,6 +1580,44 @@ func main() {
 		if v := os.Getenv("TRACKING_SERVICE_URL"); v != "" {
 			systemChecker.Add("tracking", sysstatus.HTTPCheck(strings.TrimRight(v, "/")+"/health"))
 		}
+
+		// Dependency matrix for /ready and /health/deps. /health stays process-up.
+		platformHealth = plathealth.NewCollector(plathealth.Options{
+			Timeout: plathealth.DefaultTimeout,
+			DB: func(ctx context.Context) error {
+				var n int
+				return primaryDB.QueryRow(ctx, "SELECT 1").Scan(&n)
+			},
+			Cache: func(ctx context.Context) error {
+				const key = "ops.health.probe"
+				if err := cache.Set(ctx, key, "1", 30*time.Second).Err(); err != nil {
+					return err
+				}
+				v, err := cache.Get(ctx, key).Result()
+				if err != nil {
+					return err
+				}
+				if v != "1" {
+					return errors.New("cache mismatch")
+				}
+				return nil
+			},
+			Bus: bus,
+			Heartbeat: func(ctx context.Context) (plathealth.HeartbeatSnapshot, error) {
+				var fresh, stale int
+				err := primaryDB.QueryRow(ctx, plathealth.HeartbeatSQL, plathealth.HeartbeatWindow).Scan(&fresh, &stale)
+				if err != nil {
+					return plathealth.HeartbeatSnapshot{}, err
+				}
+				return plathealth.HeartbeatSnapshot{Observed: true, Fresh: fresh, Stale: stale}, nil
+			},
+			Provider: func(ctx context.Context) error {
+				if mailTransport == nil {
+					return plathealth.ErrUnobserved
+				}
+				return mailTransport.Preflight(ctx)
+			},
+		})
 	}
 
 	h := &handler.Handler{
@@ -1731,6 +1771,9 @@ func main() {
 
 		// Admin System Status probes
 		SystemChecker: systemChecker,
+
+		// Platform /live /ready /health/deps evaluator
+		PlatformHealth: platformHealth,
 
 		// Organization-wide audit trail, backed by Postgres. The no-op
 		// fallback (audit.NewNoOpService) remains for entrypoints without

--- a/cmd/opsprobe/main.go
+++ b/cmd/opsprobe/main.go
@@ -1,0 +1,64 @@
+// Command opsprobe is the external platform health probe. It names TLS, DNS,
+// API, event ingest, read-after-write, and worker heartbeat. Partial failure
+// is not green. GET /health HTTP 200 is never enough.
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/plathealth"
+)
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("opsprobe", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	base := fs.String("base-url", "", "API base URL (for example http://127.0.0.1:8080)")
+	natsURL := fs.String("nats-url", "", "optional NATS URL for a live bus round-trip")
+	fixture := fs.String("fixture", "", "JSON ProbeInput fixture (offline path)")
+	timeout := fs.Duration("timeout", plathealth.DefaultTimeout, "per-check timeout")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if *fixture == "" && *base == "" && *natsURL == "" {
+		fmt.Fprintf(stderr, "usage: opsprobe --fixture PATH | --base-url URL [--nats-url URL]\n")
+		return 2
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 6*(*timeout)+time.Second)
+	defer cancel()
+	report, err := plathealth.RunProbe(ctx, plathealth.ProbeConfig{
+		BaseURL:     *base,
+		NATSURL:     *natsURL,
+		FixturePath: *fixture,
+		Timeout:     *timeout,
+	})
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	raw, err := plathealth.MarshalProbe(report)
+	if err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	if hits := plathealth.PIIFindings(raw); len(hits) > 0 {
+		fmt.Fprintf(stderr, "refusing to print payload with pii: %v\n", hits)
+		return 1
+	}
+	if _, err := stdout.Write(append(raw, '\n')); err != nil {
+		fmt.Fprintln(stderr, err)
+		return 2
+	}
+	if report.Green {
+		return 0
+	}
+	return 1
+}

--- a/cmd/opsprobe/main_test.go
+++ b/cmd/opsprobe/main_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/app/plathealth"
+)
+
+func TestRunFixtureAllOK(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := run([]string{"--fixture", testdata(t, "all-ok.json")}, &out, &errBuf)
+	if code != 0 {
+		t.Fatalf("exit=%d stderr=%s stdout=%s", code, errBuf.String(), out.String())
+	}
+	var report plathealth.ProbeReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if !report.Green {
+		t.Fatalf("expected green: %s", out.Bytes())
+	}
+	assertNamedChecks(t, report)
+}
+
+func TestRunFixtureStaleHeartbeat(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := run([]string{"--fixture", testdata(t, "api-200-stale-heartbeat.json")}, &out, &errBuf)
+	if code != 1 {
+		t.Fatalf("exit=%d want 1 stderr=%s stdout=%s", code, errBuf.String(), out.String())
+	}
+	var report plathealth.ProbeReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Green {
+		t.Fatal("API 200 plus stale heartbeat must not be green")
+	}
+	assertNamedChecks(t, report)
+	found := false
+	for _, c := range report.Checks {
+		if c.Name == plathealth.CheckWorkerHeartbeat && c.Status == plathealth.StatusStale {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected stale worker_heartbeat: %s", out.Bytes())
+	}
+	if hits := plathealth.PIIFindings(out.Bytes()); len(hits) > 0 {
+		t.Fatalf("pii: %v %s", hits, out.Bytes())
+	}
+}
+
+func TestRunFixturePartialFail(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	code := run([]string{"--fixture", testdata(t, "partial-fail.json")}, &out, &errBuf)
+	if code != 1 {
+		t.Fatalf("exit=%d want 1 stderr=%s stdout=%s", code, errBuf.String(), out.String())
+	}
+	var report plathealth.ProbeReport
+	if err := json.Unmarshal(out.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Green || report.Status == plathealth.OverallOK {
+		t.Fatalf("partial fail collapsed to ok: %s", out.Bytes())
+	}
+	assertNamedChecks(t, report)
+}
+
+func TestRunUsage(t *testing.T) {
+	var out, errBuf bytes.Buffer
+	if code := run(nil, &out, &errBuf); code != 2 {
+		t.Fatalf("exit=%d want 2", code)
+	}
+}
+
+func testdata(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join("..", "..", "internal", "app", "plathealth", "testdata", name)
+}
+
+func assertNamedChecks(t *testing.T, r plathealth.ProbeReport) {
+	t.Helper()
+	got := map[string]bool{}
+	for _, c := range r.Checks {
+		got[c.Name] = true
+	}
+	for _, name := range plathealth.RequiredProbeChecks {
+		if !got[name] {
+			t.Fatalf("missing check %s", name)
+		}
+	}
+}

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -328,7 +328,10 @@ External MCP servers whose tools the assistant can use (see [Connect MCP tools](
 
 ## Public
 
-- `GET /health`
+- `GET /health` (process-up only; HTTP 200 does not mean the platform is ready)
+- `GET /live` (process-up liveness)
+- `GET /ready` (dependency readiness; 503 when any required plane is down, stale, timed out, or unobserved)
+- `GET /health/deps` (same matrix as `/ready`, for operators)
 - `POST /auth/confenge-operator/session` (dedicated loopback CONFENGE deployment only; returns `404` when operator mode is disabled)
 - `POST /webhooks/github/releases` (HMAC-SHA256 signature)
 - `POST /webhooks/confenge/inbound` (HMAC `X-Warmbly-Signature`; web-cfg inbound lead; PII is not accepted on the query string)

--- a/docs/content/docs/development/deployment-guide.mdx
+++ b/docs/content/docs/development/deployment-guide.mdx
@@ -168,13 +168,19 @@ make status
 Each entry point answers on its own port:
 
 ```bash
-curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/health   # backend
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/health   # backend process-up (compose)
+curl -s -o /dev/null -w '%{http_code}\n' http://localhost:8080/live     # backend liveness
+curl -sS http://localhost:8080/ready                                   # backend readiness (503 if a plane is down)
+curl -sS http://localhost:8080/health/deps                             # per-plane matrix
+go run ./cmd/opsprobe --base-url http://localhost:8080                 # external probe
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:3000/health   # tracking
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:4000/health   # realtime
 curl -s -o /dev/null -w '%{http_code}\n' http://localhost:5173          # dashboard
 ```
 
-If one does not print `200`, `make logs backend` (or the service in question) will say why, and [troubleshooting](#troubleshooting) covers the usual causes.
+`GET /health` on the backend is process-up only so compose does not restart the API when Postgres, Redis, or NATS blips. A 200 there is not a healthy platform. Use `/live` for orchestrator restarts, `/ready` and `/health/deps` for traffic, and `cmd/opsprobe` from outside the box. See [Incident runbook](/development/incident-runbook/).
+
+If `/live` does not print `200`, `make logs backend` (or the service in question) will say why, and [troubleshooting](#troubleshooting) covers the usual causes.
 
 The admin panel's **System Status** page shows the same probes plus the platform mail transport, with a live connection check and a send-test button.
 
@@ -183,7 +189,7 @@ The admin panel's **System Status** page shows the same probes plus the platform
 | Service | Port | Purpose |
 |---------|------|---------|
 | web / admin | 5173 / 5174 | Dashboard and admin panel (static nginx builds, URLs injected at container start) |
-| backend | 8080 | REST API; applies migrations on every boot; `GET /health` |
+| backend | 8080 | REST API; applies migrations on every boot; `GET /health` (process-up), `GET /live`, `GET /ready`, `GET /health/deps` |
 | tracking | 3000 | Open pixels and click redirects; `GET /health` |
 | realtime | 4000 | WebSocket fanout; `GET /health` |
 | consumer / worker | none | Event processor; send and sync executor |

--- a/docs/content/docs/development/events.mdx
+++ b/docs/content/docs/development/events.mdx
@@ -30,6 +30,7 @@ These are the real topic names. On NATS each is prefixed with the subject prefix
 | `tracking-events` | Tracking service | Consumer service | Email opens and link clicks |
 | `email-events` | Backend | None (write-only analytics stream) | Campaign send records |
 | `warmup-events` | Backend | None (write-only analytics stream) | Warmup send records |
+| `ops.health.probe` | Backend `/ready` and `cmd/opsprobe` | The same process (short-lived consume) | Labeled non-commercial health payload. Not a campaign, warmup, or inbound lead. |
 
 Each worker subscribes only to its own `w.<worker-uuid>` topic; the UUID is the worker's identity (derived from its public IP at install time). The consumer service reads `jobs.worker-events` with the consumer group `consumer-group` and `tracking-events` with the group `tracking-consumer`.
 

--- a/docs/content/docs/development/incident-runbook.mdx
+++ b/docs/content/docs/development/incident-runbook.mdx
@@ -1,0 +1,319 @@
+---
+title: Incident runbook
+description: Diagnose and recover platform incidents by plane, with copy-paste commands and named owners.
+---
+
+This page is the platform incident runbook. It classifies an outage as control plane, DB, cache, NATS, email provider, or contract drift, then gives diagnose, mitigation, rollback, evidence capture, commands, and owners. You do not need tribal knowledge of who last touched a box.
+
+It is not the CONFENGE inbound last-mile runbook. Inbound receive stays on `GET /api/v1/webhooks/confenge/inbound/health` and its own docs.
+
+Do not send campaign or warmup mail to "test" a plane. Do not put recipient addresses, message bodies, webhook secrets, or tokens into tickets or chat. Capture `/health/deps` and `opsprobe` JSON instead. Those payloads are allowlisted.
+
+## How to use this page
+
+1. Confirm the process is up: `GET /live` must return `{"status":"live"}`. Compose still uses `GET /health` as process-up. A 200 there is not a healthy platform.
+2. Read dependency truth: `GET /ready` and `GET /health/deps`. HTTP 503 plus `ready: false` is the expected not-ready signal. Look at `planes[].status` and `incident_classes`.
+3. From outside the box, run `go run ./cmd/opsprobe --base-url https://<api-host>`. The probe names TLS, DNS, API, event ingest, read-after-write, and worker heartbeat. Partial failure is not green.
+4. Open the class section that matches `incident_classes` (or the failed plane) and run the commands there.
+5. Capture evidence before you mutate state. Roll back with the command in that section.
+
+Default per-check timeout is 3 seconds. Timeouts fail closed: `status=timeout` is a failure, not a skip.
+
+## Surfaces
+
+| Surface | Path | Meaning |
+|---------|------|---------|
+| Process-up (compose) | `GET /health` | Process answers. Always 200 if the binary is up. Not readiness. |
+| Liveness | `GET /live` | Process answers. Safe for orchestrator restarts. |
+| Readiness | `GET /ready` | 200 only when every required plane is observed and ok. 503 otherwise. |
+| Dependency matrix | `GET /health/deps` | Same body as `/ready`. Planes: `control_plane`, `db`, `cache`, `queue`, `event_processing`, `worker_heartbeat`, `provider_edge`. |
+| External probe | `go run ./cmd/opsprobe` | TLS, DNS, API, event ingest, read-after-write, worker heartbeat. |
+
+Required planes fail closed when unobserved. Admin `GET /admin/system/status` is a separate 3s ping page. Do not treat it as this matrix.
+
+## Classification
+
+| Class | Failed plane or check | Owner |
+|-------|----------------------|-------|
+| `control_plane` | `control_plane`, API/DNS/TLS, stale worker heartbeat | Backend on-call (`cmd/backend`) |
+| `db` | `db` | Backend on-call (Postgres) |
+| `cache` | `cache` | Backend on-call (Redis) |
+| `nats` | `queue`, `event_processing`, event ingest, read-after-write | Backend on-call (event bus) |
+| `email_provider` | `provider_edge` | Deliverability on-call |
+| `contract_drift` | missing expected plane or probe check | API owner (`docs/content/docs/api/`) and Backend on-call |
+
+## Control plane
+
+Process, HTTP API, DNS/TLS at the edge, or worker heartbeat into the control plane.
+
+### Diagnose
+
+- `curl -sS http://127.0.0.1:8080/live`
+- `curl -sS -D- http://127.0.0.1:8080/ready`
+- `curl -sS http://127.0.0.1:8080/health/deps`
+- `go run ./cmd/opsprobe --base-url http://127.0.0.1:8080`
+- `make status` or `docker compose ps`
+- `make logs backend`
+
+Expect `/live` 200 even when `/ready` is 503. If `/live` fails, the binary or listener is down. If `/live` works and `worker_heartbeat` is `stale` or `no_fresh_heartbeat`, workers are not posting `POST /api/v1/internal/worker/heartbeat` inside 10 minutes.
+
+### Mitigation
+
+- Restart only the backend process if `/live` is down: `docker compose up -d backend` or the native `make backend` unit.
+- Do not restart Postgres, Redis, or NATS to "fix" a control-plane listener failure.
+- If heartbeat is stale, restart the worker unit (`make worker` / compose `worker`). Placement already ignores heartbeats older than 10 minutes.
+- If DNS or TLS fails on the external probe, fix the edge (certificate, listener, published hostname). Do not change application secrets.
+
+### Rollback
+
+- Redeploy the previous backend image or `git revert` the control-plane commit and restart backend.
+- Leave data stores alone.
+
+### Evidence capture
+
+- `curl -sS http://127.0.0.1:8080/health/deps > health-deps.json`
+- `go run ./cmd/opsprobe --base-url http://127.0.0.1:8080 > opsprobe.json`
+- `docker compose logs --tail=200 backend > backend.log`
+- Confirm the JSON has no recipient or message fields (`planes` and `checks` only).
+
+### Commands
+
+```bash
+curl -sS http://127.0.0.1:8080/live
+curl -sS -o /tmp/ready.json -w '%{http_code}\n' http://127.0.0.1:8080/ready
+curl -sS http://127.0.0.1:8080/health/deps
+go run ./cmd/opsprobe --base-url http://127.0.0.1:8080
+make logs backend
+```
+
+### Owners
+
+Backend on-call owns `cmd/backend`, `internal/api`, and worker heartbeat ingest (`POST /api/v1/internal/worker/heartbeat`). Escalate TLS/DNS at a published hostname to whoever operates the reverse proxy for that host.
+
+## DB
+
+Postgres is the control-plane store. A failed `SELECT 1` or an unobserved `db` plane is this class.
+
+### Diagnose
+
+- Read `planes` where `plane=db` on `/health/deps`.
+- `docker compose ps postgres` (or the managed primary).
+- From a shell that already has `PRIMARY_DB`: `psql "$PRIMARY_DB" -c 'SELECT 1'`
+- `make logs postgres` or the host Postgres log.
+
+Do not dump `emails`, `contacts`, or message tables into the ticket.
+
+### Mitigation
+
+- If the process is down, start it: `docker compose up -d postgres`.
+- If connections are exhausted, restart the backend (it holds the pool), not a failover, unless the primary is actually down.
+- If migrations failed on boot, the backend log names the migration. Do not `--force` a dirty version.
+
+### Rollback
+
+- Restore the last known-good backup onto a new instance and point `PRIMARY_DB` at it.
+- Roll back the backend to the image from before the failing migration. Do not run a newer `*.down.sql` against production unless that migration was just applied and the owner of `internal/infrastructure/db/migrations` approves.
+
+### Evidence capture
+
+- `/health/deps` JSON (`db.status`, `db.latency_ms`, `db.reason`).
+- Backend boot lines around `Running database migrations`.
+- `SELECT 1` success or failure only. No table dumps.
+
+### Commands
+
+```bash
+curl -sS http://127.0.0.1:8080/health/deps | jq '.planes[] | select(.plane=="db")'
+docker compose ps postgres
+psql "$PRIMARY_DB" -c 'SELECT 1'
+make logs postgres
+```
+
+### Owners
+
+Backend on-call (Postgres). The person who applied the last migration in `internal/infrastructure/db/migrations` is the reviewer for a down-migration.
+
+## Cache
+
+Redis is the cache and the local realtime bridge. Readiness writes `ops.health.probe` and reads it back. `PING` alone is not the plane.
+
+### Diagnose
+
+- `/health/deps` `plane=cache`.
+- `docker compose ps redis`
+- `redis-cli -u "$REDIS_URL" PING`
+- `redis-cli -u "$REDIS_URL" GET ops.health.probe`
+
+### Mitigation
+
+- Restart Redis only if the process is down: `docker compose up -d redis`.
+- If Redis is up and the plane is `cache_mismatch`, restart backend so it reconnects.
+- Do not `FLUSHALL` to "fix" health. That drops sessions and rate-limit keys.
+
+### Rollback
+
+- Point the backend at the previous Redis URL if you just changed `PRIMARY_REDIS` / `REDIS`.
+- Restore Redis only from a snapshot that the cache owner approves. Cache loss is recoverable; a flush during an incident is usually worse.
+
+### Evidence capture
+
+- `/health/deps` `cache` object.
+- `redis-cli INFO persistence` (no key values).
+- Backend logs mentioning redis.
+
+### Commands
+
+```bash
+curl -sS http://127.0.0.1:8080/health/deps | jq '.planes[] | select(.plane=="cache")'
+docker compose ps redis
+redis-cli -u "$REDIS_URL" PING
+make logs redis
+```
+
+### Owners
+
+Backend on-call (Redis). Realtime on-call only if `/health/deps` is fine and the Elixir socket is the broken surface (out of this runbook).
+
+## NATS
+
+The event bus (NATS JetStream by default). `queue` is publish of a labeled `ops.health.probe` payload. `event_processing` is the consume half (read-after-write). A TCP ping to `:4222` is not enough.
+
+### Diagnose
+
+- `/health/deps` `queue` and `event_processing`.
+- `go run ./cmd/opsprobe --base-url http://127.0.0.1:8080 --nats-url nats://127.0.0.1:4222`
+- `docker compose ps nats`
+- NATS monitor: `curl -sS http://127.0.0.1:8222/healthz`
+- `nats stream ls` / `nats stream info warmbly` if the NATS CLI is installed.
+
+`event_ingest` or `read_after_write` failed on the external probe is this class, even when `GET /health` is 200.
+
+### Mitigation
+
+- Restart NATS if the process is down: `docker compose up -d nats`.
+- Restart consumer and workers after the stream is up so they resubscribe.
+- Do not delete the `warmbly` stream to "clear" a probe. That drops worker commands and results.
+
+### Rollback
+
+- Revert an `EVENTBUS_*` config change and restart backend, consumer, and workers.
+- Restore JetStream storage only from the backup the bus owner names. A fresh empty stream is a data loss event for in-flight work.
+
+### Evidence capture
+
+- `/health/deps` `queue` and `event_processing`.
+- `opsprobe` JSON `event_ingest` and `read_after_write`.
+- NATS monitor healthz. No message payloads from `jobs.worker-events` or `tracking-events`.
+
+### Commands
+
+```bash
+curl -sS http://127.0.0.1:8080/health/deps | jq '.planes[] | select(.plane=="queue" or .plane=="event_processing")'
+curl -sS http://127.0.0.1:8222/healthz
+go run ./cmd/opsprobe --base-url http://127.0.0.1:8080 --nats-url "${NATS_URL:-nats://127.0.0.1:4222}"
+docker compose ps nats
+make logs nats
+```
+
+### Owners
+
+Backend on-call (event bus: `internal/infrastructure/eventbus`). Consumer on-call if publish succeeds and the consumer process is the one that is not reading `jobs.worker-events`.
+
+## Email provider
+
+Platform mail transport (login codes, resets) and the provider edge. This plane dials SMTP preflight when `MAIL_TRANSPORT=smtp`. It does not send campaign or warmup mail.
+
+### Diagnose
+
+- `/health/deps` `plane=provider_edge`.
+- Backend boot line `Platform mail transport:` or `platform mail preflight FAILED`.
+- `MAIL_TRANSPORT` in the running environment (`log`, `smtp`, `ses`).
+- For SMTP: reachability of the configured relay host (TCP only). Do not authenticate with a personal mailbox.
+
+Worker send path uses each mailbox's own provider. A healthy `provider_edge` does not mean Gmail or Microsoft accepted campaign mail. A failed `provider_edge` does mean the platform cannot prove its configured transport.
+
+### Mitigation
+
+- Set `MAIL_TRANSPORT=log` to fail open for login codes in an emergency (codes appear in backend logs). That is a product degradation, not a send-test.
+- Fix SMTP host, port, or credentials if preflight failed. Rotate the relay password out of band. Do not paste it into chat.
+- Pause campaign sending from the dashboard if customers are also reporting provider rejects. That is a separate action from this plane.
+
+### Rollback
+
+- Restore the previous `MAIL_TRANSPORT` / SMTP settings and restart backend.
+- Revert a relay change at the provider console.
+
+### Evidence capture
+
+- `/health/deps` `provider_edge` (`status`, `reason`, `latency_ms` only).
+- Backend preflight log line. Redact hostnames if they embed credentials.
+- No `To:`, no raw MIME, no campaign IDs in the ticket unless an existing admin page already shows them to the operator.
+
+### Commands
+
+```bash
+curl -sS http://127.0.0.1:8080/health/deps | jq '.planes[] | select(.plane=="provider_edge")'
+make logs backend | sed -n '/[Mm]ail/p'
+# do not: send a campaign, warmup, or personal test message
+```
+
+### Owners
+
+Deliverability on-call. Backend on-call owns the `notify.Transport` preflight. Mailbox-provider outages (Google, Microsoft) stay with deliverability; do not "fix" them by raising send volume.
+
+## Contract drift
+
+The running API no longer matches the documented health contract: a required plane or probe check is missing, `/ready` lost the `ready` field, or `/health/deps` stopped listing `control_plane`, `db`, `cache`, `queue`, `event_processing`, `worker_heartbeat`, `provider_edge`.
+
+### Diagnose
+
+- Compare `planes[].plane` on `/health/deps` to the list in [Surfaces](#surfaces).
+- Compare `opsprobe` `checks[].name` to `dns`, `tls`, `api`, `event_ingest`, `read_after_write`, `worker_heartbeat`.
+- Diff the running image against `docs/content/docs/api/endpoints.mdx` and this page.
+- `incident_classes` containing `contract_drift` is the signal. Do not invent a class.
+
+This is not inbound contract drift and not commercial-event schema drift. Those stay with their own PRs.
+
+### Mitigation
+
+- Stop deploying further API changes until the contract matches.
+- Pin orchestrators to `/live` for restarts and `/ready` for traffic. Do not point a load balancer at `/health` and call it ready.
+
+### Rollback
+
+- Revert the PR that changed `/live`, `/ready`, `/health/deps`, or `cmd/opsprobe`.
+- Restore the previous backend image.
+
+### Evidence capture
+
+- Full `/health/deps` JSON and `opsprobe` JSON (already allowlisted).
+- `git log -1 --oneline` on the running tag.
+- The endpoints page section that disagrees.
+
+### Commands
+
+```bash
+curl -sS http://127.0.0.1:8080/health/deps | jq '{status,ready,planes:[.planes[].plane],classes:.incident_classes}'
+go run ./cmd/opsprobe --fixture internal/app/plathealth/testdata/all-ok.json
+git -C "$(git rev-parse --show-toplevel)" log -1 --oneline
+```
+
+### Owners
+
+API owner (`docs/content/docs/api/`) and Backend on-call. Docs stay in the same change as the route.
+
+## External probe
+
+```bash
+# fixture (offline, what CI drives)
+go run ./cmd/opsprobe --fixture internal/app/plathealth/testdata/all-ok.json
+go run ./cmd/opsprobe --fixture internal/app/plathealth/testdata/api-200-stale-heartbeat.json
+
+# live edge (needs a reachable API)
+go run ./cmd/opsprobe --base-url https://api.example.com
+go run ./cmd/opsprobe --base-url http://127.0.0.1:8080 --nats-url nats://127.0.0.1:4222
+```
+
+Exit `0` only when every required check is `ok`. Exit `1` on partial failure. `/health` returning 200 never forces a green probe.
+
+See also [Deployment](/development/deployment-guide/) and [Event system](/development/events/).

--- a/docs/content/docs/development/meta.json
+++ b/docs/content/docs/development/meta.json
@@ -7,6 +7,7 @@
     "local-development",
     "sandbox",
     "deployment-guide",
+    "incident-runbook",
     "events"
   ]
 }

--- a/internal/api/handler/handler.go
+++ b/internal/api/handler/handler.go
@@ -34,6 +34,7 @@ import (
 	"github.com/warmbly/warmbly/internal/app/organization"
 	"github.com/warmbly/warmbly/internal/app/passkey"
 	"github.com/warmbly/warmbly/internal/app/placement"
+	"github.com/warmbly/warmbly/internal/app/plathealth"
 	"github.com/warmbly/warmbly/internal/app/ratelimit"
 	"github.com/warmbly/warmbly/internal/app/referral"
 	"github.com/warmbly/warmbly/internal/app/releases"
@@ -292,4 +293,8 @@ type Handler struct {
 	// Infrastructure liveness probes for the admin System Status page.
 	// Wired in cmd/backend/main.go where the concrete clients live.
 	SystemChecker *sysstatus.Checker
+
+	// Platform liveness/readiness/dependency evaluator. Distinct from
+	// GET /health (process-up) and from inbound receive health.
+	PlatformHealth *plathealth.Collector
 }

--- a/internal/api/handler/plathealth.go
+++ b/internal/api/handler/plathealth.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/warmbly/warmbly/internal/app/plathealth"
+)
+
+// Live is process-up. Orchestrators may restart on failure. A 200 here is
+// not readiness and is not all-planes healthy.
+func (h *Handler) Live(c *gin.Context) {
+	c.JSON(http.StatusOK, gin.H{"status": "live", "live": true})
+}
+
+// Ready is dependency truth. 200 only when every required plane is observed
+// and ok. 503 otherwise. Timeouts and unobserved planes fail closed.
+func (h *Handler) Ready(c *gin.Context) {
+	report := h.platformReport(c.Request.Context())
+	code := http.StatusOK
+	if !report.Ready {
+		code = http.StatusServiceUnavailable
+	}
+	c.JSON(code, report)
+}
+
+// HealthDeps is the same matrix as Ready, for operators who want the
+// dependency document at a stable path.
+func (h *Handler) HealthDeps(c *gin.Context) {
+	h.Ready(c)
+}
+
+func (h *Handler) platformReport(ctx context.Context) plathealth.Report {
+	if h.PlatformHealth == nil {
+		return plathealth.Evaluate(true, nil, time.Now().UTC(), plathealth.DefaultTimeout)
+	}
+	return h.PlatformHealth.Report(ctx)
+}

--- a/internal/api/handler/plathealth_test.go
+++ b/internal/api/handler/plathealth_test.go
@@ -1,0 +1,109 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/warmbly/warmbly/internal/app/plathealth"
+)
+
+func TestLiveStaysUpWhenReadyIsNot(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handler{PlatformHealth: failingDBCollector()}
+
+	live := httptest.NewRecorder()
+	cLive, _ := gin.CreateTestContext(live)
+	cLive.Request = httptest.NewRequest(http.MethodGet, "/live", nil)
+	h.Live(cLive)
+	if live.Code != http.StatusOK {
+		t.Fatalf("/live status=%d", live.Code)
+	}
+	var liveBody map[string]any
+	if err := json.Unmarshal(live.Body.Bytes(), &liveBody); err != nil {
+		t.Fatal(err)
+	}
+	if liveBody["status"] != "live" {
+		t.Fatalf("/live body=%s", live.Body.Bytes())
+	}
+
+	ready := httptest.NewRecorder()
+	cReady, _ := gin.CreateTestContext(ready)
+	cReady.Request = httptest.NewRequest(http.MethodGet, "/ready", nil)
+	h.Ready(cReady)
+	if ready.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready status=%d body=%s", ready.Code, ready.Body.Bytes())
+	}
+	var report plathealth.Report
+	if err := json.Unmarshal(ready.Body.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Ready {
+		t.Fatal("/ready reported ready with db down")
+	}
+	if !report.Live {
+		t.Fatal("/ready should still say live")
+	}
+}
+
+func TestHealthDepsNotGreenOnProcessUp(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handler{} // nil collector: every required plane unobserved
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/health/deps", nil)
+	h.HealthDeps(c)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("nil collector must not return 200 on /health/deps, got %d %s", w.Code, w.Body.Bytes())
+	}
+	if hits := plathealth.PIIFindings(w.Body.Bytes()); len(hits) > 0 {
+		t.Fatalf("pii in deps: %v %s", hits, w.Body.Bytes())
+	}
+}
+
+func TestReadyAllPlanesOK(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &Handler{PlatformHealth: healthyCollector()}
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/ready", nil)
+	h.Ready(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("/ready status=%d body=%s", w.Code, w.Body.Bytes())
+	}
+	var report plathealth.Report
+	if err := json.Unmarshal(w.Body.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if !report.Ready {
+		t.Fatalf("want ready: %+v", report)
+	}
+}
+
+func failingDBCollector() *plathealth.Collector {
+	return plathealth.NewCollector(plathealth.Options{
+		DB:    func(context.Context) error { return plathealth.ErrUnobserved },
+		Cache: func(context.Context) error { return nil },
+		Heartbeat: func(context.Context) (plathealth.HeartbeatSnapshot, error) {
+			return plathealth.HeartbeatSnapshot{Observed: true, Fresh: 1}, nil
+		},
+		Provider: func(context.Context) error { return nil },
+		Bus:      nil,
+	})
+}
+
+func healthyCollector() *plathealth.Collector {
+	return plathealth.NewCollector(plathealth.Options{
+		DB:    func(context.Context) error { return nil },
+		Cache: func(context.Context) error { return nil },
+		Heartbeat: func(context.Context) (plathealth.HeartbeatSnapshot, error) {
+			return plathealth.HeartbeatSnapshot{Observed: true, Fresh: 1}, nil
+		},
+		Provider: func(context.Context) error { return nil },
+		Bus:      plathealth.NewMemoryBus(),
+	})
+}

--- a/internal/api/health_routes_test.go
+++ b/internal/api/health_routes_test.go
@@ -1,0 +1,58 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/warmbly/warmbly/internal/api/handler"
+	"github.com/warmbly/warmbly/internal/app/plathealth"
+)
+
+func TestProcessUpHealthIsNotReadiness(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	h := &handler.Handler{} // nil collector: fail closed
+	r := gin.New()
+	registerPlatformHealth(r, h)
+
+	health := httptest.NewRecorder()
+	r.ServeHTTP(health, httptest.NewRequest(http.MethodGet, "/health", nil))
+	if health.Code != http.StatusOK {
+		t.Fatalf("/health status=%d", health.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(health.Body.Bytes(), &body); err != nil {
+		t.Fatal(err)
+	}
+	if body["status"] != "ok" {
+		t.Fatalf("/health body=%s", health.Body.Bytes())
+	}
+
+	live := httptest.NewRecorder()
+	r.ServeHTTP(live, httptest.NewRequest(http.MethodGet, "/live", nil))
+	if live.Code != http.StatusOK {
+		t.Fatalf("/live status=%d", live.Code)
+	}
+
+	ready := httptest.NewRecorder()
+	r.ServeHTTP(ready, httptest.NewRequest(http.MethodGet, "/ready", nil))
+	if ready.Code != http.StatusServiceUnavailable {
+		t.Fatalf("/ready status=%d body=%s (HTTP 200 on /health must not make ready)", ready.Code, ready.Body.Bytes())
+	}
+	var report plathealth.Report
+	if err := json.Unmarshal(ready.Body.Bytes(), &report); err != nil {
+		t.Fatal(err)
+	}
+	if report.Ready {
+		t.Fatal("ready true after process-up only")
+	}
+	if !report.Live {
+		t.Fatal("live should be true")
+	}
+	if hits := plathealth.PIIFindings(ready.Body.Bytes()); len(hits) > 0 {
+		t.Fatalf("pii: %v", hits)
+	}
+}

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -15,6 +15,18 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
+// registerPlatformHealth mounts process-up, liveness, readiness, and
+// dependency health. /health stays process-up so compose does not flap
+// when a dependency is down.
+func registerPlatformHealth(r *gin.Engine, h *handler.Handler) {
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(200, gin.H{"status": "ok"})
+	})
+	r.GET("/live", h.Live)
+	r.GET("/ready", h.Ready)
+	r.GET("/health/deps", h.HealthDeps)
+}
+
 // splitCSV parses a comma-separated env list, dropping empty entries.
 func splitCSV(value string) []string {
 	out := make([]string, 0, 4)
@@ -53,9 +65,7 @@ func Run(
 	r.Use(middleware.RequestIDMiddleware())
 	r.Use(middleware.APIVersionMiddleware(middleware.APIVersion))
 
-	r.GET("/health", func(c *gin.Context) {
-		c.JSON(200, gin.H{"status": "ok"})
-	})
+	registerPlatformHealth(r, h)
 
 	// Public inbound webhooks for third-party integrations. Auth is the
 	// per-org secret embedded in the URL path, minted at connect time and

--- a/internal/app/plathealth/collect.go
+++ b/internal/app/plathealth/collect.go
@@ -1,0 +1,274 @@
+package plathealth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/infrastructure/eventbus"
+)
+
+// ErrUnobserved is returned by an adapter that could not even attempt a check.
+var ErrUnobserved = errors.New("unobserved")
+
+// Options wires I/O adapters. Nil funcs are unobserved (fail closed).
+type Options struct {
+	Timeout   time.Duration
+	Now       func() time.Time
+	DB        func(context.Context) error
+	Cache     func(context.Context) error
+	Bus       eventbus.EventBus
+	Heartbeat func(context.Context) (HeartbeatSnapshot, error)
+	Provider  func(context.Context) error
+}
+
+// Collector runs adapters with a per-check timeout and evaluates the report.
+type Collector struct {
+	opts Options
+}
+
+// NewCollector returns a collector. Timeout defaults to DefaultTimeout.
+func NewCollector(opts Options) *Collector {
+	if opts.Timeout <= 0 {
+		opts.Timeout = DefaultTimeout
+	}
+	if opts.Now == nil {
+		opts.Now = func() time.Time { return time.Now().UTC() }
+	}
+	return &Collector{opts: opts}
+}
+
+// Report runs every plane and evaluates readiness. The process is live
+// because this method is executing.
+func (c *Collector) Report(ctx context.Context) Report {
+	return Evaluate(true, c.Observe(ctx), c.opts.Now(), c.opts.Timeout)
+}
+
+// Observe runs adapters in parallel. One hung plane cannot stall the rest.
+func (c *Collector) Observe(ctx context.Context) []Observation {
+	obs := make([]Observation, len(RequiredPlanes))
+	var wg sync.WaitGroup
+	for i, plane := range RequiredPlanes {
+		wg.Add(1)
+		go func(i int, plane string) {
+			defer wg.Done()
+			obs[i] = c.observeOne(ctx, plane)
+		}(i, plane)
+	}
+	wg.Wait()
+	return obs
+}
+
+func (c *Collector) observeOne(ctx context.Context, plane string) Observation {
+	cctx, cancel := context.WithTimeout(ctx, c.opts.Timeout)
+	defer cancel()
+	start := time.Now()
+	ch := make(chan Observation, 1)
+	go func() {
+		ch <- c.runPlane(cctx, plane)
+	}()
+	select {
+	case o := <-ch:
+		if o.LatencyMS == 0 {
+			o.LatencyMS = time.Since(start).Milliseconds()
+		}
+		if errors.Is(cctx.Err(), context.DeadlineExceeded) && !o.OK {
+			o.Timeout = true
+			if o.Reason == "" {
+				o.Reason = ReasonTimeout
+			}
+		}
+		o.Plane = plane
+		o.Required = true
+		return o
+	case <-cctx.Done():
+		return Observation{
+			Plane:     plane,
+			Required:  true,
+			Observed:  true,
+			Timeout:   true,
+			OK:        false,
+			LatencyMS: c.opts.Timeout.Milliseconds(),
+			Reason:    ReasonTimeout,
+		}
+	}
+}
+
+func (c *Collector) runPlane(ctx context.Context, plane string) Observation {
+	switch plane {
+	case PlaneControlPlane:
+		return Observation{Plane: plane, Required: true, Observed: true, OK: true}
+	case PlaneDB:
+		return fromErr(plane, c.opts.DB, ctx, ReasonSelectFailed)
+	case PlaneCache:
+		return fromErr(plane, c.opts.Cache, ctx, ReasonCacheMismatch)
+	case PlaneQueue:
+		return c.observeQueue(ctx)
+	case PlaneEventProcessing:
+		return c.observeEventProcessing(ctx)
+	case PlaneWorkerHeartbeat:
+		return c.observeHeartbeat(ctx)
+	case PlaneProviderEdge:
+		return fromErr(plane, c.opts.Provider, ctx, ReasonSMTPPreflightFailed)
+	default:
+		return Observation{Plane: plane, Required: true, Observed: false, Reason: ReasonUnobserved}
+	}
+}
+
+func fromErr(plane string, fn func(context.Context) error, ctx context.Context, failReason string) Observation {
+	if fn == nil {
+		return Observation{Plane: plane, Required: true, Observed: false, Reason: ReasonUnobserved}
+	}
+	err := fn(ctx)
+	if err == nil {
+		return Observation{Plane: plane, Required: true, Observed: true, OK: true}
+	}
+	if errors.Is(err, ErrUnobserved) {
+		return Observation{Plane: plane, Required: true, Observed: false, Reason: ReasonUnobserved}
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return Observation{Plane: plane, Required: true, Observed: true, Timeout: true, Reason: ReasonTimeout}
+	}
+	return Observation{Plane: plane, Required: true, Observed: true, OK: false, Reason: failReason}
+}
+
+func (c *Collector) observeQueue(ctx context.Context) Observation {
+	if c.opts.Bus == nil {
+		return Observation{Plane: PlaneQueue, Required: true, Observed: false, Reason: ReasonUnobserved}
+	}
+	id := uuid.NewString()
+	payload, _ := json.Marshal(probePayload{Kind: "ops_health_probe", ProbeID: id})
+	if err := c.opts.Bus.Publish(ctx, ProbeTopic, id, payload); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			return Observation{Plane: PlaneQueue, Required: true, Observed: true, Timeout: true, Reason: ReasonTimeout}
+		}
+		return Observation{Plane: PlaneQueue, Required: true, Observed: true, OK: false, Reason: ReasonPublishFailed}
+	}
+	return Observation{Plane: PlaneQueue, Required: true, Observed: true, OK: true}
+}
+
+func (c *Collector) observeEventProcessing(ctx context.Context) Observation {
+	ingest, raw := ProbeBusRoundTrip(ctx, c.opts.Bus)
+	// Event processing requires the consume half (read-after-write). Publish
+	// alone is the queue plane.
+	if raw.Timeout || ingest.Timeout {
+		return Observation{Plane: PlaneEventProcessing, Required: true, Observed: true, Timeout: true, Reason: ReasonRoundTripTimeout}
+	}
+	if !raw.Observed {
+		return Observation{Plane: PlaneEventProcessing, Required: true, Observed: false, Reason: raw.Reason}
+	}
+	if !raw.OK {
+		return Observation{Plane: PlaneEventProcessing, Required: true, Observed: true, OK: false, Reason: raw.Reason}
+	}
+	return Observation{Plane: PlaneEventProcessing, Required: true, Observed: true, OK: true, LatencyMS: raw.LatencyMS}
+}
+
+func (c *Collector) observeHeartbeat(ctx context.Context) Observation {
+	if c.opts.Heartbeat == nil {
+		return Observation{Plane: PlaneWorkerHeartbeat, Required: true, Observed: false, Reason: ReasonUnobserved}
+	}
+	snap, err := c.opts.Heartbeat(ctx)
+	if err != nil {
+		if errors.Is(err, ErrUnobserved) {
+			return Observation{Plane: PlaneWorkerHeartbeat, Required: true, Observed: false, Reason: ReasonUnobserved}
+		}
+		if errors.Is(err, context.DeadlineExceeded) {
+			return Observation{Plane: PlaneWorkerHeartbeat, Required: true, Observed: true, Timeout: true, Reason: ReasonTimeout}
+		}
+		return Observation{Plane: PlaneWorkerHeartbeat, Required: true, Observed: true, OK: false, Reason: ReasonFailed}
+	}
+	if !snap.Observed {
+		return Observation{Plane: PlaneWorkerHeartbeat, Required: true, Observed: false, Reason: ReasonUnobserved}
+	}
+	if snap.Fresh == 0 && snap.Stale > 0 {
+		return Observation{Plane: PlaneWorkerHeartbeat, Required: true, Observed: true, Stale: true, Reason: ReasonNewestHeartbeatStale}
+	}
+	if snap.Fresh == 0 {
+		return Observation{Plane: PlaneWorkerHeartbeat, Required: true, Observed: true, OK: false, Reason: ReasonNoFreshHeartbeat}
+	}
+	return Observation{Plane: PlaneWorkerHeartbeat, Required: true, Observed: true, OK: true}
+}
+
+type probePayload struct {
+	Kind    string `json:"kind"`
+	ProbeID string `json:"probe_id"`
+}
+
+// ProbeBusRoundTrip publishes a labeled probe payload on the shipped EventBus
+// and waits to consume the same probe_id. ingest is the publish half;
+// raw (read-after-write) is the consume half.
+func ProbeBusRoundTrip(ctx context.Context, bus eventbus.EventBus) (ingest, raw Observation) {
+	ingest = Observation{Plane: PlaneQueue, Required: true}
+	raw = Observation{Plane: PlaneEventProcessing, Required: true}
+	if bus == nil {
+		ingest.Reason = ReasonUnobserved
+		raw.Reason = ReasonUnobserved
+		return ingest, raw
+	}
+	id := uuid.NewString()
+	payload, _ := json.Marshal(probePayload{Kind: "ops_health_probe", ProbeID: id})
+	start := time.Now()
+
+	got := make(chan struct{})
+	subCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	subErr := make(chan error, 1)
+	go func() {
+		subErr <- bus.Subscribe(subCtx, []string{ProbeTopic}, ProbeConsumerGroup, func(_ context.Context, msg eventbus.Message) error {
+			if !bytes.Contains(msg.Payload, []byte(id)) {
+				return nil
+			}
+			select {
+			case <-got:
+			default:
+				close(got)
+			}
+			cancel()
+			return nil
+		})
+	}()
+
+	if err := bus.Publish(ctx, ProbeTopic, id, payload); err != nil {
+		ingest.Observed = true
+		ingest.OK = false
+		if errors.Is(err, context.DeadlineExceeded) {
+			ingest.Timeout = true
+			ingest.Reason = ReasonTimeout
+		} else {
+			ingest.Reason = ReasonPublishFailed
+		}
+		raw.Observed = true
+		raw.OK = false
+		raw.Reason = ReasonPublishFailed
+		return ingest, raw
+	}
+	ingest.Observed = true
+	ingest.OK = true
+	ingest.LatencyMS = time.Since(start).Milliseconds()
+
+	select {
+	case <-got:
+		raw.Observed = true
+		raw.OK = true
+		raw.LatencyMS = time.Since(start).Milliseconds()
+		return ingest, raw
+	case err := <-subErr:
+		raw.Observed = true
+		raw.OK = false
+		if err != nil && !errors.Is(err, context.Canceled) {
+			raw.Reason = ReasonSubscribeFailed
+		} else {
+			raw.Reason = ReasonRoundTripMismatch
+		}
+		return ingest, raw
+	case <-ctx.Done():
+		raw.Observed = true
+		raw.Timeout = true
+		raw.Reason = ReasonRoundTripTimeout
+		return ingest, raw
+	}
+}

--- a/internal/app/plathealth/collect.go
+++ b/internal/app/plathealth/collect.go
@@ -198,6 +198,10 @@ type probePayload struct {
 	ProbeID string `json:"probe_id"`
 }
 
+// errForeignProbe is returned from the shared durable handler so a payload
+// for another probe_id is NAK'd, not ACKed. Returning nil would steal it.
+var errForeignProbe = errors.New("foreign ops health probe")
+
 // ProbeBusRoundTrip publishes a labeled probe payload on the shipped EventBus
 // and waits to consume the same probe_id. ingest is the publish half;
 // raw (read-after-write) is the consume half.
@@ -220,14 +224,13 @@ func ProbeBusRoundTrip(ctx context.Context, bus eventbus.EventBus) (ingest, raw 
 	go func() {
 		subErr <- bus.Subscribe(subCtx, []string{ProbeTopic}, ProbeConsumerGroup, func(_ context.Context, msg eventbus.Message) error {
 			if !bytes.Contains(msg.Payload, []byte(id)) {
-				return nil
+				return errForeignProbe
 			}
 			select {
 			case <-got:
 			default:
 				close(got)
 			}
-			cancel()
 			return nil
 		})
 	}()
@@ -250,22 +253,44 @@ func ProbeBusRoundTrip(ctx context.Context, bus eventbus.EventBus) (ingest, raw 
 	ingest.OK = true
 	ingest.LatencyMS = time.Since(start).Milliseconds()
 
-	select {
-	case <-got:
+	success := func() (Observation, Observation) {
 		raw.Observed = true
 		raw.OK = true
+		raw.Reason = ""
+		raw.Timeout = false
 		raw.LatencyMS = time.Since(start).Milliseconds()
 		return ingest, raw
+	}
+	matched := func() bool {
+		select {
+		case <-got:
+			return true
+		default:
+			return false
+		}
+	}
+
+	select {
+	case <-got:
+		return success()
 	case err := <-subErr:
+		// Subscribe often returns Canceled (or exits) after a match. A
+		// received probe_id is success even if that error wins the select.
+		if matched() {
+			return success()
+		}
 		raw.Observed = true
 		raw.OK = false
-		if err != nil && !errors.Is(err, context.Canceled) {
+		if err != nil && !errors.Is(err, context.Canceled) && !errors.Is(err, errForeignProbe) {
 			raw.Reason = ReasonSubscribeFailed
 		} else {
 			raw.Reason = ReasonRoundTripMismatch
 		}
 		return ingest, raw
 	case <-ctx.Done():
+		if matched() {
+			return success()
+		}
 		raw.Observed = true
 		raw.Timeout = true
 		raw.Reason = ReasonRoundTripTimeout

--- a/internal/app/plathealth/evaluate.go
+++ b/internal/app/plathealth/evaluate.go
@@ -1,0 +1,150 @@
+package plathealth
+
+import "time"
+
+// Evaluate turns injected plane observations into a readiness report.
+// live is process-up (the server can answer). A live process with a down,
+// stale, timed-out, or unobserved required plane is not ready. HTTP 200
+// on a process-up path is not treated as all-planes healthy.
+func Evaluate(live bool, obs []Observation, now time.Time, timeout time.Duration) Report {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if timeout <= 0 {
+		timeout = DefaultTimeout
+	}
+	byPlane := make(map[string]Observation, len(obs))
+	for _, o := range obs {
+		if o.Plane == "" {
+			continue
+		}
+		byPlane[o.Plane] = o
+	}
+
+	planes := make([]PlaneResult, 0, len(RequiredPlanes))
+	ready := live
+	for _, name := range RequiredPlanes {
+		o, ok := byPlane[name]
+		if !ok {
+			o = Observation{Plane: name, Required: true}
+		}
+		o.Required = true
+		pr := observationToPlane(o)
+		planes = append(planes, pr)
+		if pr.Status != StatusOK {
+			ready = false
+		}
+	}
+
+	status := OverallNotReady
+	if live && ready {
+		status = OverallOK
+	} else if live && !ready {
+		status = OverallNotReady
+	}
+
+	r := Report{
+		Live:      live,
+		Ready:     ready,
+		Status:    status,
+		CheckedAt: now.UTC(),
+		TimeoutMS: timeout.Milliseconds(),
+		Planes:    planes,
+	}
+	r.IncidentClasses = ClassifyReport(r)
+	return r
+}
+
+func observationToPlane(o Observation) PlaneResult {
+	reason := AllowReason(o.Reason)
+	status := StatusUnobserved
+	switch {
+	case o.Timeout:
+		status = StatusTimeout
+		if reason == "" {
+			reason = ReasonTimeout
+		}
+	case o.Stale:
+		status = StatusStale
+		if reason == "" {
+			reason = ReasonStale
+		}
+	case reason == ReasonHTTPProcessUpOnly && o.Plane != PlaneControlPlane:
+		// Process-up HTTP 200 is not evidence that this plane works.
+		status = StatusProcessUpOnly
+	case !o.Observed:
+		status = StatusUnobserved
+		if reason == "" {
+			reason = ReasonUnobserved
+		}
+	case o.OK && reason != ReasonHTTPProcessUpOnly:
+		status = StatusOK
+		reason = ""
+	case o.OK && o.Plane == PlaneControlPlane && reason == ReasonHTTPProcessUpOnly:
+		status = StatusOK
+		reason = ""
+	default:
+		status = StatusFailed
+		if reason == "" {
+			reason = ReasonFailed
+		}
+	}
+	if status == StatusOK {
+		reason = ""
+	}
+	return PlaneResult{
+		Plane:     o.Plane,
+		Status:    status,
+		Required:  o.Required,
+		LatencyMS: o.LatencyMS,
+		Reason:    reason,
+	}
+}
+
+// ClassifyReport maps failed/unobserved/stale/timeout planes onto the six
+// incident classes. contract_drift is added when the report itself is missing
+// a required plane slot (should not happen for Evaluate output).
+func ClassifyReport(r Report) []string {
+	seen := make(map[string]bool, 6)
+	var out []string
+	add := func(c string) {
+		if c == "" || seen[c] {
+			return
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	have := make(map[string]bool, len(r.Planes))
+	for _, p := range r.Planes {
+		have[p.Plane] = true
+		if p.Status == StatusOK || p.Status == StatusSkipped {
+			continue
+		}
+		switch p.Plane {
+		case PlaneControlPlane:
+			add(ClassControlPlane)
+		case PlaneDB:
+			add(ClassDB)
+		case PlaneCache:
+			add(ClassCache)
+		case PlaneQueue, PlaneEventProcessing:
+			add(ClassNATS)
+		case PlaneProviderEdge:
+			add(ClassEmailProvider)
+		case PlaneWorkerHeartbeat:
+			// Heartbeat is a worker-plane failure; it is not a provider or
+			// control-plane outage by itself. Surface it under control plane
+			// only when the API also failed. Otherwise NATS/execution.
+			add(ClassControlPlane)
+		}
+		if p.Reason == ReasonContractMissingPlane {
+			add(ClassContractDrift)
+		}
+	}
+	for _, name := range RequiredPlanes {
+		if !have[name] {
+			add(ClassContractDrift)
+		}
+	}
+	return out
+}

--- a/internal/app/plathealth/evaluate_test.go
+++ b/internal/app/plathealth/evaluate_test.go
@@ -1,0 +1,271 @@
+package plathealth
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func allOKObs() []Observation {
+	out := make([]Observation, 0, len(RequiredPlanes))
+	for _, p := range RequiredPlanes {
+		out = append(out, Observation{Plane: p, Required: true, Observed: true, OK: true})
+	}
+	return out
+}
+
+func replacePlane(obs []Observation, plane string, next Observation) []Observation {
+	next.Plane = plane
+	next.Required = true
+	out := make([]Observation, len(obs))
+	copy(out, obs)
+	for i := range out {
+		if out[i].Plane == plane {
+			out[i] = next
+			return out
+		}
+	}
+	return append(out, next)
+}
+
+func TestEvaluateLiveWhileNotReady(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+	obs := replacePlane(allOKObs(), PlaneDB, Observation{Observed: true, OK: false, Reason: ReasonSelectFailed})
+	r := Evaluate(true, obs, now, DefaultTimeout)
+	if !r.Live {
+		t.Fatalf("live: got false, want true (process is up)")
+	}
+	if r.Ready {
+		t.Fatalf("ready: got true, want false when db failed")
+	}
+	if r.Status != OverallNotReady {
+		t.Fatalf("status: got %q, want %q", r.Status, OverallNotReady)
+	}
+}
+
+func TestEvaluateAllOKIsReady(t *testing.T) {
+	t.Parallel()
+	r := Evaluate(true, allOKObs(), time.Unix(0, 0).UTC(), DefaultTimeout)
+	if !r.Live || !r.Ready || r.Status != OverallOK {
+		t.Fatalf("got live=%v ready=%v status=%q", r.Live, r.Ready, r.Status)
+	}
+	if len(r.Planes) != len(RequiredPlanes) {
+		t.Fatalf("planes: got %d, want %d", len(r.Planes), len(RequiredPlanes))
+	}
+}
+
+func TestEvaluateMissingRequiredPlaneFailsClosed(t *testing.T) {
+	t.Parallel()
+	// Only control plane observed. HTTP-style process-up is not all-planes healthy.
+	r := Evaluate(true, []Observation{{
+		Plane:    PlaneControlPlane,
+		Required: true,
+		Observed: true,
+		OK:       true,
+	}}, time.Now().UTC(), DefaultTimeout)
+	if r.Ready {
+		t.Fatal("ready must be false when required planes are unobserved")
+	}
+	by := indexPlanes(r)
+	for _, name := range []string{PlaneDB, PlaneCache, PlaneQueue, PlaneEventProcessing, PlaneWorkerHeartbeat, PlaneProviderEdge} {
+		if by[name].Status != StatusUnobserved {
+			t.Fatalf("%s status=%q, want unobserved", name, by[name].Status)
+		}
+	}
+	if by[PlaneControlPlane].Status != StatusOK {
+		t.Fatalf("control_plane status=%q, want ok", by[PlaneControlPlane].Status)
+	}
+}
+
+func TestEvaluateEachRequiredPlaneFailureMakesNotReady(t *testing.T) {
+	t.Parallel()
+	now := time.Now().UTC()
+	for _, plane := range RequiredPlanes {
+		obs := replacePlane(allOKObs(), plane, Observation{Observed: true, OK: false, Reason: ReasonFailed})
+		r := Evaluate(true, obs, now, DefaultTimeout)
+		if r.Ready {
+			t.Fatalf("ready stayed true when %s failed", plane)
+		}
+		if indexPlanes(r)[plane].Status != StatusFailed {
+			t.Fatalf("%s status=%q, want failed", plane, indexPlanes(r)[plane].Status)
+		}
+	}
+}
+
+func TestEvaluateUnobservedRequiredPlaneMakesNotReady(t *testing.T) {
+	t.Parallel()
+	obs := replacePlane(allOKObs(), PlaneCache, Observation{Observed: false, Reason: ReasonUnobserved})
+	r := Evaluate(true, obs, time.Now().UTC(), DefaultTimeout)
+	if r.Ready {
+		t.Fatal("ready stayed true when cache was unobserved")
+	}
+	if indexPlanes(r)[PlaneCache].Status != StatusUnobserved {
+		t.Fatalf("cache status=%q", indexPlanes(r)[PlaneCache].Status)
+	}
+}
+
+func TestEvaluateHTTPProcessUpOnlyIsNotHealthyForNonControlPlane(t *testing.T) {
+	t.Parallel()
+	obs := replacePlane(allOKObs(), PlaneQueue, Observation{
+		Observed: true,
+		OK:       true,
+		Reason:   ReasonHTTPProcessUpOnly,
+	})
+	r := Evaluate(true, obs, time.Now().UTC(), DefaultTimeout)
+	if r.Ready {
+		t.Fatal("ready stayed true when queue only had process-up HTTP 200")
+	}
+	got := indexPlanes(r)[PlaneQueue]
+	if got.Status != StatusProcessUpOnly {
+		t.Fatalf("queue status=%q, want process_up_only", got.Status)
+	}
+}
+
+func TestEvaluateTimeoutIsFailure(t *testing.T) {
+	t.Parallel()
+	obs := replacePlane(allOKObs(), PlaneNATSAlias(), Observation{Observed: true, Timeout: true, Reason: ReasonTimeout})
+	r := Evaluate(true, obs, time.Now().UTC(), 50*time.Millisecond)
+	if r.Ready {
+		t.Fatal("ready stayed true after timeout")
+	}
+	if indexPlanes(r)[PlaneQueue].Status != StatusTimeout {
+		t.Fatalf("queue status=%q, want timeout", indexPlanes(r)[PlaneQueue].Status)
+	}
+}
+
+// PlaneNATSAlias keeps the timeout test pointed at the queue plane.
+func PlaneNATSAlias() string { return PlaneQueue }
+
+func TestEvaluateStaleHeartbeatMakesNotReady(t *testing.T) {
+	t.Parallel()
+	obs := replacePlane(allOKObs(), PlaneWorkerHeartbeat, Observation{
+		Observed: true,
+		Stale:    true,
+		Reason:   ReasonNewestHeartbeatStale,
+	})
+	r := Evaluate(true, obs, time.Now().UTC(), DefaultTimeout)
+	if r.Ready {
+		t.Fatal("ready stayed true with stale heartbeat")
+	}
+	if indexPlanes(r)[PlaneWorkerHeartbeat].Status != StatusStale {
+		t.Fatalf("heartbeat status=%q", indexPlanes(r)[PlaneWorkerHeartbeat].Status)
+	}
+}
+
+func TestEvaluateClassifiesIncidentPlanes(t *testing.T) {
+	t.Parallel()
+	obs := allOKObs()
+	obs = replacePlane(obs, PlaneDB, Observation{Observed: true, OK: false})
+	obs = replacePlane(obs, PlaneCache, Observation{Observed: true, OK: false})
+	obs = replacePlane(obs, PlaneQueue, Observation{Observed: true, OK: false})
+	obs = replacePlane(obs, PlaneProviderEdge, Observation{Observed: true, OK: false})
+	r := Evaluate(true, obs, time.Now().UTC(), DefaultTimeout)
+	want := map[string]bool{ClassDB: true, ClassCache: true, ClassNATS: true, ClassEmailProvider: true}
+	got := map[string]bool{}
+	for _, c := range r.IncidentClasses {
+		got[c] = true
+	}
+	for name := range want {
+		if !got[name] {
+			t.Fatalf("missing incident class %s in %v", name, r.IncidentClasses)
+		}
+	}
+}
+
+func TestCollectorTimeoutFailsClosed(t *testing.T) {
+	t.Parallel()
+	c := NewCollector(Options{
+		Timeout: 40 * time.Millisecond,
+		Now:     func() time.Time { return time.Unix(1, 0).UTC() },
+		DB: func(ctx context.Context) error {
+			<-ctx.Done()
+			return ctx.Err()
+		},
+		Cache: func(context.Context) error { return nil },
+		Heartbeat: func(context.Context) (HeartbeatSnapshot, error) {
+			return HeartbeatSnapshot{Observed: true, Fresh: 1}, nil
+		},
+		Provider: func(context.Context) error { return nil },
+		Bus:      NewMemoryBus(),
+	})
+	r := c.Report(context.Background())
+	if r.Ready {
+		t.Fatal("ready stayed true when db exceeded timeout")
+	}
+	if indexPlanes(r)[PlaneDB].Status != StatusTimeout {
+		t.Fatalf("db status=%q, want timeout", indexPlanes(r)[PlaneDB].Status)
+	}
+	if !r.Live {
+		t.Fatal("live should stay true during a dependency timeout")
+	}
+}
+
+func TestCollectorNilAdaptersUnobserved(t *testing.T) {
+	t.Parallel()
+	r := NewCollector(Options{Timeout: 50 * time.Millisecond}).Report(context.Background())
+	if r.Ready {
+		t.Fatal("nil adapters must fail closed")
+	}
+	if !r.Live {
+		t.Fatal("live should be true")
+	}
+	by := indexPlanes(r)
+	if by[PlaneControlPlane].Status != StatusOK {
+		t.Fatalf("control_plane=%q", by[PlaneControlPlane].Status)
+	}
+	if by[PlaneDB].Status != StatusUnobserved {
+		t.Fatalf("db=%q", by[PlaneDB].Status)
+	}
+}
+
+func TestCollectorBusRoundTripReady(t *testing.T) {
+	t.Parallel()
+	c := NewCollector(Options{
+		Timeout: time.Second,
+		DB:      func(context.Context) error { return nil },
+		Cache:   func(context.Context) error { return nil },
+		Heartbeat: func(context.Context) (HeartbeatSnapshot, error) {
+			return HeartbeatSnapshot{Observed: true, Fresh: 2}, nil
+		},
+		Provider: func(context.Context) error { return nil },
+		Bus:      NewMemoryBus(),
+	})
+	r := c.Report(context.Background())
+	if !r.Ready {
+		t.Fatalf("want ready, got %+v", r)
+	}
+}
+
+func TestCollectorDroppedConsumeFailsEventProcessing(t *testing.T) {
+	t.Parallel()
+	c := NewCollector(Options{
+		Timeout: 80 * time.Millisecond,
+		DB:      func(context.Context) error { return nil },
+		Cache:   func(context.Context) error { return nil },
+		Heartbeat: func(context.Context) (HeartbeatSnapshot, error) {
+			return HeartbeatSnapshot{Observed: true, Fresh: 1}, nil
+		},
+		Provider: func(context.Context) error { return nil },
+		Bus:      &MemoryBus{Drop: true},
+	})
+	r := c.Report(context.Background())
+	if r.Ready {
+		t.Fatal("ready stayed true when consume was dropped")
+	}
+	if indexPlanes(r)[PlaneQueue].Status != StatusOK {
+		t.Fatalf("queue should still be ok on publish-only, got %q", indexPlanes(r)[PlaneQueue].Status)
+	}
+	got := indexPlanes(r)[PlaneEventProcessing].Status
+	if got != StatusTimeout && got != StatusFailed {
+		t.Fatalf("event_processing status=%q, want timeout or failed", got)
+	}
+}
+
+func indexPlanes(r Report) map[string]PlaneResult {
+	m := make(map[string]PlaneResult, len(r.Planes))
+	for _, p := range r.Planes {
+		m[p.Plane] = p
+	}
+	return m
+}

--- a/internal/app/plathealth/membus.go
+++ b/internal/app/plathealth/membus.go
@@ -55,9 +55,9 @@ func (m *MemoryBus) Subscribe(ctx context.Context, _ []string, _ string, handler
 		case <-ctx.Done():
 			return ctx.Err()
 		case p := <-ch:
-			if err := handler(ctx, eventbus.Message{Topic: ProbeTopic, Payload: p}); err != nil {
-				return err
-			}
+			// Handler errors are NAK, not fatal. Subscribe stays up until ctx ends,
+			// matching JetStream: a foreign probe_id must not kill the consumer.
+			_ = handler(ctx, eventbus.Message{Topic: ProbeTopic, Payload: p})
 		}
 	}
 }

--- a/internal/app/plathealth/membus.go
+++ b/internal/app/plathealth/membus.go
@@ -1,0 +1,66 @@
+package plathealth
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/eventbus"
+)
+
+// MemoryBus is an in-process EventBus with DeliverAll semantics. Tests and
+// fixture-only probe runs use it so they do not need NATS.
+type MemoryBus struct {
+	mu      sync.Mutex
+	buf     [][]byte
+	waiters []chan []byte
+	FailPub bool
+	Drop    bool
+}
+
+// NewMemoryBus returns an empty in-process bus.
+func NewMemoryBus() *MemoryBus { return &MemoryBus{} }
+
+func (m *MemoryBus) Publish(_ context.Context, _, _ string, payload []byte) error {
+	if m.FailPub {
+		return errors.New("publish failed")
+	}
+	if m.Drop {
+		return nil
+	}
+	cp := append([]byte(nil), payload...)
+	m.mu.Lock()
+	m.buf = append(m.buf, cp)
+	waiters := append([]chan []byte(nil), m.waiters...)
+	m.mu.Unlock()
+	for _, w := range waiters {
+		select {
+		case w <- cp:
+		default:
+		}
+	}
+	return nil
+}
+
+func (m *MemoryBus) Subscribe(ctx context.Context, _ []string, _ string, handler eventbus.Handler) error {
+	ch := make(chan []byte, 16)
+	m.mu.Lock()
+	for _, p := range m.buf {
+		ch <- append([]byte(nil), p...)
+	}
+	m.waiters = append(m.waiters, ch)
+	m.mu.Unlock()
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case p := <-ch:
+			if err := handler(ctx, eventbus.Message{Topic: ProbeTopic, Payload: p}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (m *MemoryBus) Close() error { return nil }
+func (m *MemoryBus) Name() string { return "memory" }

--- a/internal/app/plathealth/probe.go
+++ b/internal/app/plathealth/probe.go
@@ -1,0 +1,182 @@
+package plathealth
+
+import (
+	"encoding/json"
+	"io"
+	"time"
+)
+
+// EvaluateProbe turns injected TLS/DNS/API/ingest/read-after-write/heartbeat
+// observations into a per-check report. API HTTP 200 on the process-up
+// path is never enough for green when another required check failed, is
+// stale, timed out, or is unobserved.
+func EvaluateProbe(in ProbeInput) ProbeReport {
+	now := in.CheckedAt
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	checks := []CheckResult{
+		checkFromInput(CheckDNS, in.DNS, true),
+		tlsCheck(in.TLS),
+		apiCheck(in.API),
+		checkFromInput(CheckEventIngest, in.EventIngest, true),
+		checkFromInput(CheckReadAfterWrite, in.ReadAfterWrite, true),
+		heartbeatCheck(in.WorkerHeartbeat),
+	}
+
+	green := true
+	for _, c := range checks {
+		if !c.Required {
+			continue
+		}
+		if c.Status != StatusOK {
+			green = false
+		}
+	}
+
+	status := OverallOK
+	if !green {
+		status = OverallNotOK
+	}
+	r := ProbeReport{
+		Green:     green,
+		Status:    status,
+		CheckedAt: now.UTC(),
+		Checks:    checks,
+	}
+	r.IncidentClasses = ClassifyProbe(r)
+	return r
+}
+
+func tlsCheck(in CheckInput) CheckResult {
+	if AllowReason(in.Reason) == ReasonHTTPScheme {
+		return CheckResult{
+			Name:      CheckTLS,
+			Status:    StatusSkipped,
+			Required:  false,
+			LatencyMS: in.LatencyMS,
+			Reason:    ReasonHTTPScheme,
+		}
+	}
+	return checkFromInput(CheckTLS, in, true)
+}
+
+func heartbeatCheck(in CheckInput) CheckResult {
+	c := checkFromInput(CheckWorkerHeartbeat, in, true)
+	if in.Stale && c.Status != StatusTimeout {
+		c.Status = StatusStale
+		if c.Reason == "" {
+			c.Reason = ReasonNewestHeartbeatStale
+		}
+	}
+	return c
+}
+
+func apiCheck(in APIInput) CheckResult {
+	c := CheckResult{Name: CheckAPI, Required: true, LatencyMS: in.LatencyMS}
+	if !in.Observed {
+		c.Status = StatusUnobserved
+		c.Reason = ReasonUnobserved
+		return c
+	}
+	// /live 200 means the control-plane process is up. /health 200 is the
+	// same process-up signal and is not treated as all-planes healthy:
+	// process_up_only is a non-green API status when /live was not seen.
+	liveUp := in.LiveStatus == 200
+	healthUp := in.HealthStatus == 200
+	if !liveUp && !healthUp {
+		c.Status = StatusFailed
+		c.Reason = ReasonFailed
+		return c
+	}
+	if in.ProcessUpOnly || (healthUp && !liveUp && in.Ready == nil && in.DepsReady == nil) {
+		c.Status = StatusProcessUpOnly
+		c.Reason = ReasonHTTPProcessUpOnly
+		return c
+	}
+	c.Status = StatusOK
+	return c
+}
+
+func checkFromInput(name string, in CheckInput, required bool) CheckResult {
+	c := CheckResult{Name: name, Required: required, LatencyMS: in.LatencyMS}
+	reason := AllowReason(in.Reason)
+	switch {
+	case in.Timeout:
+		c.Status = StatusTimeout
+		if reason == "" {
+			reason = ReasonTimeout
+		}
+		c.Reason = reason
+	case in.Stale:
+		c.Status = StatusStale
+		if reason == "" {
+			reason = ReasonStale
+		}
+		c.Reason = reason
+	case !in.Observed:
+		c.Status = StatusUnobserved
+		if reason == "" {
+			reason = ReasonUnobserved
+		}
+		c.Reason = reason
+	case in.OK:
+		c.Status = StatusOK
+	default:
+		c.Status = StatusFailed
+		if reason == "" {
+			reason = ReasonFailed
+		}
+		c.Reason = reason
+	}
+	return c
+}
+
+// ClassifyProbe maps failed probe checks onto the six incident classes.
+func ClassifyProbe(r ProbeReport) []string {
+	seen := make(map[string]bool, 6)
+	var out []string
+	add := func(c string) {
+		if c == "" || seen[c] {
+			return
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	have := make(map[string]bool, len(r.Checks))
+	for _, c := range r.Checks {
+		have[c.Name] = true
+		if c.Status == StatusOK || c.Status == StatusSkipped {
+			continue
+		}
+		switch c.Name {
+		case CheckDNS, CheckTLS, CheckAPI:
+			add(ClassControlPlane)
+		case CheckEventIngest, CheckReadAfterWrite:
+			add(ClassNATS)
+		case CheckWorkerHeartbeat:
+			add(ClassControlPlane)
+		}
+		if c.Reason == ReasonContractMissingPlane {
+			add(ClassContractDrift)
+		}
+	}
+	for _, name := range RequiredProbeChecks {
+		if !have[name] {
+			add(ClassContractDrift)
+		}
+	}
+	return out
+}
+
+// DecodeProbeInput reads a fixture JSON document into ProbeInput.
+func DecodeProbeInput(r io.Reader) (ProbeInput, error) {
+	var in ProbeInput
+	dec := json.NewDecoder(r)
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(&in); err != nil {
+		return ProbeInput{}, err
+	}
+	return in, nil
+}

--- a/internal/app/plathealth/probe_run.go
+++ b/internal/app/plathealth/probe_run.go
@@ -1,0 +1,299 @@
+package plathealth
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/eventbus"
+)
+
+// ProbeConfig is the shipped external-probe entry. Fixture mode is the
+// testable path. Live mode talks to a base URL (and optional NATS URL).
+type ProbeConfig struct {
+	BaseURL     string
+	NATSURL     string
+	FixturePath string
+	Timeout     time.Duration
+	// Optional injections. Nil uses net/http and net.DefaultResolver.
+	LookupHost func(ctx context.Context, host string) ([]string, error)
+	TLSDial    func(ctx context.Context, network, addr string, cfg *tls.Config) error
+	HTTPClient *http.Client
+	Bus        eventbus.EventBus
+	Now        func() time.Time
+}
+
+// RunProbe is the shipped probe entry point. Tests drive this function.
+func RunProbe(ctx context.Context, cfg ProbeConfig) (ProbeReport, error) {
+	if cfg.Timeout <= 0 {
+		cfg.Timeout = DefaultTimeout
+	}
+	if cfg.Now == nil {
+		cfg.Now = func() time.Time { return time.Now().UTC() }
+	}
+	if cfg.FixturePath != "" {
+		f, err := os.Open(cfg.FixturePath)
+		if err != nil {
+			return ProbeReport{}, err
+		}
+		defer f.Close()
+		in, err := DecodeProbeInput(f)
+		if err != nil {
+			return ProbeReport{}, err
+		}
+		if in.CheckedAt.IsZero() {
+			in.CheckedAt = cfg.Now()
+		}
+		return EvaluateProbe(in), nil
+	}
+	in, err := collectLive(ctx, cfg)
+	if err != nil {
+		return ProbeReport{}, err
+	}
+	in.CheckedAt = cfg.Now()
+	return EvaluateProbe(in), nil
+}
+
+func collectLive(ctx context.Context, cfg ProbeConfig) (ProbeInput, error) {
+	var in ProbeInput
+	if strings.TrimSpace(cfg.BaseURL) == "" && cfg.Bus == nil && cfg.NATSURL == "" {
+		return in, fmt.Errorf("base-url, nats-url, or fixture is required")
+	}
+
+	if cfg.BaseURL != "" {
+		u, err := url.Parse(cfg.BaseURL)
+		if err != nil || u.Host == "" {
+			return in, fmt.Errorf("invalid base-url")
+		}
+		host := u.Hostname()
+		in.DNS = liveDNS(ctx, cfg, host)
+		if u.Scheme == "https" {
+			port := u.Port()
+			if port == "" {
+				port = "443"
+			}
+			in.TLS = liveTLS(ctx, cfg, net.JoinHostPort(host, port), host)
+		} else {
+			in.TLS = CheckInput{Observed: false, Reason: ReasonHTTPScheme}
+		}
+		in.API = liveAPI(ctx, cfg, strings.TrimRight(cfg.BaseURL, "/"))
+		// Prefer explicit bus when provided; otherwise lift ingest/raw/heartbeat
+		// from /health/deps so a remote probe does not need broker credentials.
+		if cfg.Bus == nil && cfg.NATSURL == "" {
+			liftDeps(&in, cfg)
+		}
+	} else {
+		in.DNS = CheckInput{Observed: false, Reason: ReasonUnobserved}
+		in.TLS = CheckInput{Observed: false, Reason: ReasonUnobserved}
+		in.API = APIInput{Observed: false}
+	}
+
+	if cfg.Bus != nil || cfg.NATSURL != "" {
+		bus := cfg.Bus
+		var closer io.Closer
+		if bus == nil {
+			b, err := eventbus.NewNATS(eventbus.NATSConfig{URL: cfg.NATSURL})
+			if err != nil {
+				in.EventIngest = CheckInput{Observed: true, OK: false, Reason: ReasonPublishFailed}
+				in.ReadAfterWrite = CheckInput{Observed: true, OK: false, Reason: ReasonSubscribeFailed}
+				return in, nil
+			}
+			bus = b
+			closer = b
+		}
+		if closer != nil {
+			defer closer.Close()
+		}
+		cctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+		ingest, raw := ProbeBusRoundTrip(cctx, bus)
+		cancel()
+		in.EventIngest = CheckInput{Observed: ingest.Observed, OK: ingest.OK, Timeout: ingest.Timeout, Reason: ingest.Reason, LatencyMS: ingest.LatencyMS}
+		in.ReadAfterWrite = CheckInput{Observed: raw.Observed, OK: raw.OK, Timeout: raw.Timeout, Reason: raw.Reason, LatencyMS: raw.LatencyMS}
+	}
+	return in, nil
+}
+
+func liveDNS(ctx context.Context, cfg ProbeConfig, host string) CheckInput {
+	lookup := cfg.LookupHost
+	if lookup == nil {
+		var r net.Resolver
+		lookup = r.LookupHost
+	}
+	start := time.Now()
+	cctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+	addrs, err := lookup(cctx, host)
+	out := CheckInput{Observed: true, LatencyMS: time.Since(start).Milliseconds()}
+	if err != nil || len(addrs) == 0 {
+		out.OK = false
+		out.Reason = ReasonDNSFailed
+		if cctx.Err() != nil {
+			out.Timeout = true
+			out.Reason = ReasonTimeout
+		}
+		return out
+	}
+	out.OK = true
+	return out
+}
+
+func liveTLS(ctx context.Context, cfg ProbeConfig, addr, serverName string) CheckInput {
+	start := time.Now()
+	cctx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+	out := CheckInput{Observed: true, LatencyMS: time.Since(start).Milliseconds()}
+	tlsCfg := &tls.Config{ServerName: serverName, MinVersion: tls.VersionTLS12}
+	dial := cfg.TLSDial
+	if dial == nil {
+		dial = func(ctx context.Context, network, address string, cfg *tls.Config) error {
+			d := &tls.Dialer{Config: cfg}
+			conn, err := d.DialContext(ctx, network, address)
+			if err != nil {
+				return err
+			}
+			return conn.Close()
+		}
+	}
+	if err := dial(cctx, "tcp", addr, tlsCfg); err != nil {
+		out.OK = false
+		out.Reason = ReasonTLSFailed
+		if cctx.Err() != nil {
+			out.Timeout = true
+			out.Reason = ReasonTimeout
+		}
+		return out
+	}
+	out.OK = true
+	out.LatencyMS = time.Since(start).Milliseconds()
+	return out
+}
+
+type depsBody struct {
+	Ready  bool `json:"ready"`
+	Live   bool `json:"live"`
+	Planes []struct {
+		Plane  string `json:"plane"`
+		Status string `json:"status"`
+		Reason string `json:"reason"`
+	} `json:"planes"`
+}
+
+func liveAPI(ctx context.Context, cfg ProbeConfig, base string) APIInput {
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: cfg.Timeout}
+	}
+	start := time.Now()
+	out := APIInput{Observed: true, LatencyMS: time.Since(start).Milliseconds()}
+	out.HealthStatus = getStatus(ctx, client, base+"/health")
+	out.LiveStatus = getStatus(ctx, client, base+"/live")
+	readyStatus, readyBody := getJSON(ctx, client, base+"/ready")
+	out.ReadyStatus = readyStatus
+	if readyBody != nil {
+		out.Ready = &readyBody.Ready
+	}
+	depsStatus, depsBody := getJSON(ctx, client, base+"/health/deps")
+	if depsStatus > 0 && depsBody != nil {
+		out.DepsReady = &depsBody.Ready
+	}
+	if out.HealthStatus == 200 && out.LiveStatus == 0 && out.Ready == nil && out.DepsReady == nil {
+		out.ProcessUpOnly = true
+	}
+	out.LatencyMS = time.Since(start).Milliseconds()
+	return out
+}
+
+func getStatus(ctx context.Context, client *http.Client, rawURL string) int {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, io.LimitReader(resp.Body, 1<<16))
+	return resp.StatusCode
+}
+
+func getJSON(ctx context.Context, client *http.Client, rawURL string) (int, *depsBody) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return 0, nil
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, nil
+	}
+	defer resp.Body.Close()
+	var body depsBody
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&body); err != nil {
+		return resp.StatusCode, nil
+	}
+	return resp.StatusCode, &body
+}
+
+func liftDeps(in *ProbeInput, cfg ProbeConfig) {
+	client := cfg.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: cfg.Timeout}
+	}
+	_, body := getJSON(context.Background(), client, strings.TrimRight(cfg.BaseURL, "/")+"/health/deps")
+	if body == nil {
+		if !in.EventIngest.Observed {
+			in.EventIngest = CheckInput{Observed: false, Reason: ReasonUnobserved}
+		}
+		if !in.ReadAfterWrite.Observed {
+			in.ReadAfterWrite = CheckInput{Observed: false, Reason: ReasonUnobserved}
+		}
+		if !in.WorkerHeartbeat.Observed {
+			in.WorkerHeartbeat = CheckInput{Observed: false, Reason: ReasonUnobserved}
+		}
+		return
+	}
+	for _, p := range body.Planes {
+		ci := planeToCheck(p.Status, p.Reason)
+		switch p.Plane {
+		case PlaneQueue:
+			if !in.EventIngest.Observed {
+				in.EventIngest = ci
+			}
+		case PlaneEventProcessing:
+			in.EventIngest = ci
+			in.ReadAfterWrite = ci
+		case PlaneWorkerHeartbeat:
+			in.WorkerHeartbeat = ci
+		}
+	}
+	if !in.EventIngest.Observed && !in.ReadAfterWrite.Observed {
+		in.EventIngest.Reason = ReasonContractMissingPlane
+		in.ReadAfterWrite.Reason = ReasonContractMissingPlane
+	}
+}
+
+func planeToCheck(status, reason string) CheckInput {
+	ci := CheckInput{Observed: status != StatusUnobserved, Reason: AllowReason(reason)}
+	switch status {
+	case StatusOK:
+		ci.Observed = true
+		ci.OK = true
+	case StatusTimeout:
+		ci.Timeout = true
+	case StatusStale:
+		ci.Stale = true
+	case StatusUnobserved:
+		ci.Observed = false
+	default:
+		ci.OK = false
+	}
+	return ci
+}

--- a/internal/app/plathealth/probe_run.go
+++ b/internal/app/plathealth/probe_run.go
@@ -85,11 +85,9 @@ func collectLive(ctx context.Context, cfg ProbeConfig) (ProbeInput, error) {
 			in.TLS = CheckInput{Observed: false, Reason: ReasonHTTPScheme}
 		}
 		in.API = liveAPI(ctx, cfg, strings.TrimRight(cfg.BaseURL, "/"))
-		// Prefer explicit bus when provided; otherwise lift ingest/raw/heartbeat
-		// from /health/deps so a remote probe does not need broker credentials.
-		if cfg.Bus == nil && cfg.NATSURL == "" {
-			liftDeps(&in, cfg)
-		}
+		// Always lift heartbeat from /health/deps. A live --nats-url only
+		// replaces ingest/raw; it must not leave worker_heartbeat zero-value.
+		liftDeps(ctx, &in, cfg)
 	} else {
 		in.DNS = CheckInput{Observed: false, Reason: ReasonUnobserved}
 		in.TLS = CheckInput{Observed: false, Reason: ReasonUnobserved}
@@ -242,12 +240,12 @@ func getJSON(ctx context.Context, client *http.Client, rawURL string) (int, *dep
 	return resp.StatusCode, &body
 }
 
-func liftDeps(in *ProbeInput, cfg ProbeConfig) {
+func liftDeps(ctx context.Context, in *ProbeInput, cfg ProbeConfig) {
 	client := cfg.HTTPClient
 	if client == nil {
 		client = &http.Client{Timeout: cfg.Timeout}
 	}
-	_, body := getJSON(context.Background(), client, strings.TrimRight(cfg.BaseURL, "/")+"/health/deps")
+	_, body := getJSON(ctx, client, strings.TrimRight(cfg.BaseURL, "/")+"/health/deps")
 	if body == nil {
 		if !in.EventIngest.Observed {
 			in.EventIngest = CheckInput{Observed: false, Reason: ReasonUnobserved}

--- a/internal/app/plathealth/probe_test.go
+++ b/internal/app/plathealth/probe_test.go
@@ -3,12 +3,17 @@ package plathealth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
+
+	"github.com/warmbly/warmbly/internal/infrastructure/eventbus"
 )
 
 func TestEvaluateProbeNamesEveryCheck(t *testing.T) {
@@ -186,6 +191,67 @@ func TestProbeBusRoundTrip(t *testing.T) {
 	}
 }
 
+func TestProbeBusRoundTripSubscribeCanceledAfterMatch(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ingest, raw := ProbeBusRoundTrip(ctx, newDeliverThenCancelBus())
+	if !ingest.OK {
+		t.Fatalf("publish half failed: %+v", ingest)
+	}
+	if !raw.OK {
+		t.Fatalf("matched probe_id must stay success when Subscribe returns Canceled, got %+v", raw)
+	}
+}
+
+func TestProbeBusRoundTripDoesNotAckForeign(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bus := newRecordHandlerBus()
+	ingest, raw := ProbeBusRoundTrip(ctx, bus)
+	if !ingest.OK || !raw.OK {
+		t.Fatalf("own probe must still succeed: ingest=%+v raw=%+v", ingest, raw)
+	}
+	got := bus.handlerErrors()
+	if len(got) < 2 {
+		t.Fatalf("handler should see foreign then own, got %d results", len(got))
+	}
+	if got[0] == nil {
+		t.Fatal("foreign probe_id was ACKed on the shared durable")
+	}
+	if !errors.Is(got[0], errForeignProbe) {
+		t.Fatalf("foreign handler err=%v, want errForeignProbe", got[0])
+	}
+	if got[1] != nil {
+		t.Fatalf("own probe_id should be ACKed, handler err=%v", got[1])
+	}
+}
+
+func TestRunProbeLiveBusKeepsHeartbeatFromDeps(t *testing.T) {
+	t.Parallel()
+	srv := newDepsServer(t, true, "ok")
+	defer srv.Close()
+	r, err := RunProbe(context.Background(), ProbeConfig{
+		BaseURL: srv.URL,
+		Bus:     NewMemoryBus(),
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	by := indexChecks(r)
+	if by[CheckWorkerHeartbeat].Status != StatusOK {
+		t.Fatalf("documented --base-url --nats-url path left heartbeat %q (want ok from /health/deps)", by[CheckWorkerHeartbeat].Status)
+	}
+	if by[CheckEventIngest].Status != StatusOK || by[CheckReadAfterWrite].Status != StatusOK {
+		t.Fatalf("bus should replace ingest/raw, got ingest=%q raw=%q", by[CheckEventIngest].Status, by[CheckReadAfterWrite].Status)
+	}
+	if !r.Green {
+		t.Fatalf("live command with fresh deps + working bus must be able to go green: %+v", r)
+	}
+}
+
 func TestProbeBusRoundTripPublishFail(t *testing.T) {
 	t.Parallel()
 	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
@@ -226,19 +292,21 @@ func mustFixture(t *testing.T, name string) ProbeInput {
 func newDepsServer(t *testing.T, ready bool, heartbeatStatus string) *httptest.Server {
 	t.Helper()
 	mux := http.NewServeMux()
+	hb := Observation{Plane: PlaneWorkerHeartbeat, Observed: true, Required: true, OK: true}
+	if heartbeatStatus == "stale" || !ready {
+		hb.OK = false
+		hb.Stale = true
+		hb.Reason = ReasonNewestHeartbeatStale
+	}
 	report := Evaluate(true, []Observation{
 		{Plane: PlaneControlPlane, Observed: true, OK: true, Required: true},
 		{Plane: PlaneDB, Observed: true, OK: true, Required: true},
 		{Plane: PlaneCache, Observed: true, OK: true, Required: true},
 		{Plane: PlaneQueue, Observed: true, OK: true, Required: true},
 		{Plane: PlaneEventProcessing, Observed: true, OK: ready, Required: true},
-		{Plane: PlaneWorkerHeartbeat, Observed: true, Stale: !ready, Required: true, Reason: ReasonNewestHeartbeatStale},
+		hb,
 		{Plane: PlaneProviderEdge, Observed: true, OK: true, Required: true},
 	}, time.Now().UTC(), DefaultTimeout)
-	if heartbeatStatus != "stale" {
-		// keep Evaluate output
-		_ = heartbeatStatus
-	}
 	body, err := MarshalReport(report)
 	if err != nil {
 		t.Fatal(err)
@@ -275,3 +343,97 @@ func indexChecks(r ProbeReport) map[string]CheckResult {
 	}
 	return m
 }
+
+// deliverThenCancelBus delivers the published payload then returns Canceled
+// from Subscribe, which is the race that used to flip a successful consume
+// into round_trip_mismatch.
+type deliverThenCancelBus struct {
+	mu      sync.Mutex
+	payload []byte
+	ready   chan struct{}
+	once    sync.Once
+}
+
+func newDeliverThenCancelBus() *deliverThenCancelBus {
+	return &deliverThenCancelBus{ready: make(chan struct{})}
+}
+
+func (b *deliverThenCancelBus) Publish(_ context.Context, _, _ string, payload []byte) error {
+	b.mu.Lock()
+	b.payload = append([]byte(nil), payload...)
+	b.mu.Unlock()
+	b.once.Do(func() { close(b.ready) })
+	return nil
+}
+
+func (b *deliverThenCancelBus) Subscribe(ctx context.Context, _ []string, _ string, handler eventbus.Handler) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-b.ready:
+	}
+	b.mu.Lock()
+	p := append([]byte(nil), b.payload...)
+	b.mu.Unlock()
+	_ = handler(ctx, eventbus.Message{Topic: ProbeTopic, Payload: p})
+	return context.Canceled
+}
+
+func (b *deliverThenCancelBus) Close() error { return nil }
+func (b *deliverThenCancelBus) Name() string { return "deliver-then-cancel" }
+
+// recordHandlerBus delivers a foreign probe_id first, then the published one,
+// and records each handler error so the test can see ACK vs NAK.
+type recordHandlerBus struct {
+	mu        sync.Mutex
+	published []byte
+	ready     chan struct{}
+	once      sync.Once
+	results   []error
+}
+
+func newRecordHandlerBus() *recordHandlerBus {
+	return &recordHandlerBus{ready: make(chan struct{})}
+}
+
+func (b *recordHandlerBus) Publish(_ context.Context, _, _ string, payload []byte) error {
+	b.mu.Lock()
+	b.published = append([]byte(nil), payload...)
+	b.mu.Unlock()
+	b.once.Do(func() { close(b.ready) })
+	return nil
+}
+
+func (b *recordHandlerBus) Subscribe(ctx context.Context, _ []string, _ string, handler eventbus.Handler) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-b.ready:
+	}
+	foreign, err := json.Marshal(probePayload{Kind: "ops_health_probe", ProbeID: "00000000-0000-0000-0000-000000000000"})
+	if err != nil {
+		return err
+	}
+	errF := handler(ctx, eventbus.Message{Topic: ProbeTopic, Payload: foreign})
+	b.mu.Lock()
+	b.results = append(b.results, errF)
+	own := append([]byte(nil), b.published...)
+	b.mu.Unlock()
+	errOwn := handler(ctx, eventbus.Message{Topic: ProbeTopic, Payload: own})
+	b.mu.Lock()
+	b.results = append(b.results, errOwn)
+	b.mu.Unlock()
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (b *recordHandlerBus) handlerErrors() []error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	out := make([]error, len(b.results))
+	copy(out, b.results)
+	return out
+}
+
+func (b *recordHandlerBus) Close() error { return nil }
+func (b *recordHandlerBus) Name() string { return "record-handler" }

--- a/internal/app/plathealth/probe_test.go
+++ b/internal/app/plathealth/probe_test.go
@@ -1,0 +1,277 @@
+package plathealth
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestEvaluateProbeNamesEveryCheck(t *testing.T) {
+	t.Parallel()
+	r := EvaluateProbe(mustFixture(t, "all-ok.json"))
+	got := map[string]CheckResult{}
+	for _, c := range r.Checks {
+		got[c.Name] = c
+	}
+	for _, name := range RequiredProbeChecks {
+		if _, ok := got[name]; !ok {
+			t.Fatalf("missing check %s in %+v", name, r.Checks)
+		}
+	}
+	if !r.Green || r.Status != OverallOK {
+		t.Fatalf("all-ok fixture should be green, got %+v", r)
+	}
+}
+
+func TestEvaluateProbeAPI200StaleHeartbeatIsNotGreen(t *testing.T) {
+	t.Parallel()
+	r := EvaluateProbe(mustFixture(t, "api-200-stale-heartbeat.json"))
+	if r.Green {
+		t.Fatal("API 200 plus stale heartbeat must not be green")
+	}
+	by := indexChecks(r)
+	if by[CheckAPI].Status != StatusOK {
+		t.Fatalf("api status=%q, want ok (process answers); overall must still be not green", by[CheckAPI].Status)
+	}
+	if by[CheckWorkerHeartbeat].Status != StatusStale {
+		t.Fatalf("heartbeat status=%q, want stale", by[CheckWorkerHeartbeat].Status)
+	}
+	if len(r.Checks) < 6 {
+		t.Fatalf("partial fail collapsed to %d checks", len(r.Checks))
+	}
+}
+
+func TestEvaluateProbeFailedIngestIsNotGreen(t *testing.T) {
+	t.Parallel()
+	in := mustFixture(t, "all-ok.json")
+	in.EventIngest = CheckInput{Observed: true, OK: false, Reason: ReasonPublishFailed}
+	r := EvaluateProbe(in)
+	if r.Green {
+		t.Fatal("failed ingest must not be green")
+	}
+	if indexChecks(r)[CheckEventIngest].Status != StatusFailed {
+		t.Fatalf("event_ingest=%q", indexChecks(r)[CheckEventIngest].Status)
+	}
+	if indexChecks(r)[CheckDNS].Status != StatusOK {
+		t.Fatal("dns should stay named and ok; must not collapse to a single status")
+	}
+}
+
+func TestEvaluateProbeFailedReadAfterWriteIsNotGreen(t *testing.T) {
+	t.Parallel()
+	in := mustFixture(t, "all-ok.json")
+	in.ReadAfterWrite = CheckInput{Observed: true, OK: false, Reason: ReasonRoundTripMismatch}
+	r := EvaluateProbe(in)
+	if r.Green {
+		t.Fatal("failed read-after-write must not be green")
+	}
+	if indexChecks(r)[CheckReadAfterWrite].Status != StatusFailed {
+		t.Fatalf("read_after_write=%q", indexChecks(r)[CheckReadAfterWrite].Status)
+	}
+}
+
+func TestEvaluateProbeProcessUpOnlyIsNotGreen(t *testing.T) {
+	t.Parallel()
+	r := EvaluateProbe(mustFixture(t, "process-up-only.json"))
+	if r.Green {
+		t.Fatal("process-up HTTP 200 must not make the probe green")
+	}
+	if indexChecks(r)[CheckAPI].Status != StatusProcessUpOnly {
+		t.Fatalf("api status=%q, want process_up_only", indexChecks(r)[CheckAPI].Status)
+	}
+	if indexChecks(r)[CheckTLS].Status != StatusSkipped {
+		t.Fatalf("tls status=%q, want skipped on http_scheme", indexChecks(r)[CheckTLS].Status)
+	}
+}
+
+func TestEvaluateProbePartialFailDoesNotCollapse(t *testing.T) {
+	t.Parallel()
+	r := EvaluateProbe(mustFixture(t, "partial-fail.json"))
+	if r.Green {
+		t.Fatal("partial fail must not be green")
+	}
+	if r.Status != OverallNotOK {
+		t.Fatalf("status=%q", r.Status)
+	}
+	by := indexChecks(r)
+	if by[CheckDNS].Status != StatusOK || by[CheckTLS].Status != StatusOK {
+		t.Fatalf("dns/tls should remain individually ok, got dns=%q tls=%q", by[CheckDNS].Status, by[CheckTLS].Status)
+	}
+	if by[CheckEventIngest].Status != StatusFailed {
+		t.Fatalf("event_ingest=%q", by[CheckEventIngest].Status)
+	}
+	if by[CheckReadAfterWrite].Status != StatusFailed {
+		t.Fatalf("read_after_write=%q", by[CheckReadAfterWrite].Status)
+	}
+	if by[CheckWorkerHeartbeat].Status != StatusUnobserved {
+		t.Fatalf("worker_heartbeat=%q", by[CheckWorkerHeartbeat].Status)
+	}
+	foundNATS := false
+	for _, c := range r.IncidentClasses {
+		if c == ClassNATS {
+			foundNATS = true
+		}
+	}
+	if !foundNATS {
+		t.Fatalf("expected nats class, got %v", r.IncidentClasses)
+	}
+}
+
+func TestRunProbeFixtureEntryPoint(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	r, err := RunProbe(ctx, ProbeConfig{FixturePath: testdata(t, "api-200-stale-heartbeat.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Green {
+		t.Fatal("fixture with stale heartbeat must not be green")
+	}
+	if indexChecks(r)[CheckWorkerHeartbeat].Status != StatusStale {
+		t.Fatalf("heartbeat=%q", indexChecks(r)[CheckWorkerHeartbeat].Status)
+	}
+}
+
+func TestRunProbeLiveHTTPPartialFail(t *testing.T) {
+	t.Parallel()
+	srv := newDepsServer(t, false, "stale")
+	defer srv.Close()
+	r, err := RunProbe(context.Background(), ProbeConfig{
+		BaseURL: srv.URL,
+		Timeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.Green {
+		t.Fatalf("live probe must not be green on stale heartbeat: %+v", r)
+	}
+	by := indexChecks(r)
+	for _, name := range RequiredProbeChecks {
+		if _, ok := by[name]; !ok {
+			t.Fatalf("missing check %s", name)
+		}
+	}
+	if by[CheckWorkerHeartbeat].Status != StatusStale {
+		t.Fatalf("heartbeat=%q", by[CheckWorkerHeartbeat].Status)
+	}
+	if by[CheckAPI].Status != StatusOK {
+		t.Fatalf("api=%q (process answers; overall still not green)", by[CheckAPI].Status)
+	}
+}
+
+func TestRunProbeAllOKFixture(t *testing.T) {
+	t.Parallel()
+	r, err := RunProbe(context.Background(), ProbeConfig{FixturePath: testdata(t, "all-ok.json")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !r.Green {
+		t.Fatalf("all-ok fixture should be green, got %+v", r)
+	}
+}
+
+func TestProbeBusRoundTrip(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	ingest, raw := ProbeBusRoundTrip(ctx, NewMemoryBus())
+	if !ingest.OK || !raw.OK {
+		t.Fatalf("round trip failed ingest=%+v raw=%+v", ingest, raw)
+	}
+}
+
+func TestProbeBusRoundTripPublishFail(t *testing.T) {
+	t.Parallel()
+	ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer cancel()
+	ingest, raw := ProbeBusRoundTrip(ctx, &MemoryBus{FailPub: true})
+	if ingest.OK {
+		t.Fatal("publish failure must fail ingest")
+	}
+	if raw.OK {
+		t.Fatal("publish failure must fail read-after-write")
+	}
+	if ingest.Reason != ReasonPublishFailed {
+		t.Fatalf("ingest reason=%q", ingest.Reason)
+	}
+}
+
+func TestDecodeProbeInputRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+	_, err := DecodeProbeInput(bytes.NewReader([]byte(`{"dns":{},"extra":true}`)))
+	if err == nil {
+		t.Fatal("expected unknown field error")
+	}
+}
+
+func mustFixture(t *testing.T, name string) ProbeInput {
+	t.Helper()
+	b, err := os.ReadFile(testdata(t, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+	in, err := DecodeProbeInput(bytes.NewReader(b))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return in
+}
+
+func newDepsServer(t *testing.T, ready bool, heartbeatStatus string) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	report := Evaluate(true, []Observation{
+		{Plane: PlaneControlPlane, Observed: true, OK: true, Required: true},
+		{Plane: PlaneDB, Observed: true, OK: true, Required: true},
+		{Plane: PlaneCache, Observed: true, OK: true, Required: true},
+		{Plane: PlaneQueue, Observed: true, OK: true, Required: true},
+		{Plane: PlaneEventProcessing, Observed: true, OK: ready, Required: true},
+		{Plane: PlaneWorkerHeartbeat, Observed: true, Stale: !ready, Required: true, Reason: ReasonNewestHeartbeatStale},
+		{Plane: PlaneProviderEdge, Observed: true, OK: true, Required: true},
+	}, time.Now().UTC(), DefaultTimeout)
+	if heartbeatStatus != "stale" {
+		// keep Evaluate output
+		_ = heartbeatStatus
+	}
+	body, err := MarshalReport(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+	mux.HandleFunc("/live", func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"live","live":true}`))
+	})
+	writeMatrix := func(w http.ResponseWriter) {
+		w.Header().Set("Content-Type", "application/json")
+		if !report.Ready {
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}
+		_, _ = w.Write(body)
+	}
+	mux.HandleFunc("/ready", func(w http.ResponseWriter, _ *http.Request) { writeMatrix(w) })
+	mux.HandleFunc("/health/deps", func(w http.ResponseWriter, _ *http.Request) { writeMatrix(w) })
+	return httptest.NewServer(mux)
+}
+
+func testdata(t *testing.T, name string) string {
+	t.Helper()
+	return filepath.Join("testdata", name)
+}
+
+func indexChecks(r ProbeReport) map[string]CheckResult {
+	m := make(map[string]CheckResult, len(r.Checks))
+	for _, c := range r.Checks {
+		m[c.Name] = c
+	}
+	return m
+}

--- a/internal/app/plathealth/runbook_test.go
+++ b/internal/app/plathealth/runbook_test.go
@@ -1,0 +1,102 @@
+package plathealth
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunbookCoversSixClassesAndSections(t *testing.T) {
+	raw, err := os.ReadFile(findRunbook(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := string(raw)
+	classes := []string{
+		"## Control plane",
+		"## DB",
+		"## Cache",
+		"## NATS",
+		"## Email provider",
+		"## Contract drift",
+	}
+	for _, h := range classes {
+		if !strings.Contains(doc, h) {
+			t.Fatalf("runbook missing class heading %q", h)
+		}
+	}
+	// Each class section must carry the operator blocks before the next class.
+	for i, h := range classes {
+		start := strings.Index(doc, h)
+		end := len(doc)
+		if i+1 < len(classes) {
+			end = strings.Index(doc, classes[i+1])
+		}
+		if start < 0 || end <= start {
+			t.Fatalf("cannot slice section %s", h)
+		}
+		section := doc[start:end]
+		for _, need := range []string{
+			"### Diagnose",
+			"### Mitigation",
+			"### Rollback",
+			"### Evidence capture",
+			"### Commands",
+			"### Owners",
+		} {
+			if !strings.Contains(section, need) {
+				t.Fatalf("%s missing %s", h, need)
+			}
+		}
+		if !strings.Contains(section, "```") {
+			t.Fatalf("%s has no fenced command block", h)
+		}
+	}
+	for _, needle := range []string{
+		ClassControlPlane,
+		ClassDB,
+		ClassCache,
+		ClassNATS,
+		ClassEmailProvider,
+		ClassContractDrift,
+		"/live",
+		"/ready",
+		"/health/deps",
+		"opsprobe",
+	} {
+		if !strings.Contains(doc, needle) {
+			t.Fatalf("runbook missing %q", needle)
+		}
+	}
+}
+
+func TestRunbookRegisteredInMeta(t *testing.T) {
+	meta, err := os.ReadFile(filepath.Join(findDocsDev(t), "meta.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(meta), "incident-runbook") {
+		t.Fatal("docs/content/docs/development/meta.json must list incident-runbook")
+	}
+}
+
+func findRunbook(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(findDocsDev(t), "incident-runbook.mdx")
+}
+
+func findDocsDev(t *testing.T) string {
+	t.Helper()
+	candidates := []string{
+		filepath.Join("docs", "content", "docs", "development"),
+		filepath.Join("..", "..", "..", "docs", "content", "docs", "development"),
+	}
+	for _, c := range candidates {
+		if st, err := os.Stat(c); err == nil && st.IsDir() {
+			return c
+		}
+	}
+	t.Fatal("could not find docs/content/docs/development")
+	return ""
+}

--- a/internal/app/plathealth/sanitize.go
+++ b/internal/app/plathealth/sanitize.go
@@ -1,0 +1,81 @@
+package plathealth
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+var allowedReasons = map[string]struct{}{
+	ReasonTimeout:              {},
+	ReasonUnobserved:           {},
+	ReasonFailed:               {},
+	ReasonStale:                {},
+	ReasonHTTPProcessUpOnly:    {},
+	ReasonNoFreshHeartbeat:     {},
+	ReasonNewestHeartbeatStale: {},
+	ReasonRoundTripMismatch:    {},
+	ReasonRoundTripTimeout:     {},
+	ReasonPublishFailed:        {},
+	ReasonSubscribeFailed:      {},
+	ReasonContractMissingPlane: {},
+	ReasonMailTransportMissing: {},
+	ReasonTransportConfigured:  {},
+	ReasonSMTPPreflightFailed:  {},
+	ReasonHTTPScheme:           {},
+	ReasonDNSFailed:            {},
+	ReasonTLSFailed:            {},
+	ReasonReadyNotReady:        {},
+	ReasonDepsNotReady:         {},
+	ReasonSelectFailed:         {},
+	ReasonCacheMismatch:        {},
+}
+
+// AllowReason returns reason if it is on the allowlist, otherwise "failed".
+// Empty stays empty.
+func AllowReason(reason string) string {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return ""
+	}
+	if _, ok := allowedReasons[reason]; ok {
+		return reason
+	}
+	return ReasonFailed
+}
+
+var (
+	emailLike   = regexp.MustCompile(`[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}`)
+	secretLike  = regexp.MustCompile(`(?i)(password|passwd|secret|token|bearer |authorization:|api[_-]?key|BEGIN [A-Z ]+PRIVATE KEY)`)
+	messageLike = regexp.MustCompile(`(?i)("body"|"message"|"subject"|"html"|"text"|"recipient"|"to_addr"|"from_addr")\s*:`)
+)
+
+// PIIFindings reports forbidden substrings in a health/probe JSON payload.
+// Used by tests and by the probe CLI self-check. Empty means clean.
+func PIIFindings(raw []byte) []string {
+	if len(raw) == 0 {
+		return nil
+	}
+	s := string(raw)
+	var hits []string
+	if emailLike.MatchString(s) {
+		hits = append(hits, "recipient_or_email")
+	}
+	if secretLike.MatchString(s) {
+		hits = append(hits, "secret_or_token")
+	}
+	if messageLike.MatchString(s) {
+		hits = append(hits, "message_body_field")
+	}
+	return hits
+}
+
+// MarshalReport encodes a Report using the allowlisted struct tags only.
+func MarshalReport(r Report) ([]byte, error) {
+	return json.Marshal(r)
+}
+
+// MarshalProbe encodes a ProbeReport using the allowlisted struct tags only.
+func MarshalProbe(r ProbeReport) ([]byte, error) {
+	return json.Marshal(r)
+}

--- a/internal/app/plathealth/sanitize_test.go
+++ b/internal/app/plathealth/sanitize_test.go
@@ -1,0 +1,82 @@
+package plathealth
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAllowReasonDropsSecrets(t *testing.T) {
+	t.Parallel()
+	if got := AllowReason("password=hunter2"); got != ReasonFailed {
+		t.Fatalf("got %q", got)
+	}
+	if got := AllowReason("smtp auth failed for user=ops@example.com token=abc"); got != ReasonFailed {
+		t.Fatalf("got %q", got)
+	}
+	if got := AllowReason(ReasonTimeout); got != ReasonTimeout {
+		t.Fatalf("got %q", got)
+	}
+}
+
+func TestReportJSONHasNoPII(t *testing.T) {
+	t.Parallel()
+	obs := replacePlane(allOKObs(), PlaneProviderEdge, Observation{
+		Observed: true,
+		OK:       false,
+		Reason:   "relay auth failed for alice@example.com password=sekrit token=abcd",
+	})
+	r := Evaluate(true, obs, time.Date(2026, 8, 16, 0, 0, 0, 0, time.UTC), DefaultTimeout)
+	raw, err := MarshalReport(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits := PIIFindings(raw); len(hits) > 0 {
+		t.Fatalf("pii in report %v: %s", hits, raw)
+	}
+	if strings.Contains(string(raw), "alice@") || strings.Contains(string(raw), "sekrit") {
+		t.Fatalf("secret leaked: %s", raw)
+	}
+	if !strings.Contains(string(raw), ReasonFailed) && !strings.Contains(string(raw), ReasonSMTPPreflightFailed) {
+		// rewritten reason must be allowlisted, never the raw error
+		if strings.Contains(string(raw), "password=") {
+			t.Fatalf("raw error leaked: %s", raw)
+		}
+	}
+}
+
+func TestProbeJSONHasNoPII(t *testing.T) {
+	t.Parallel()
+	in := mustFixture(t, "partial-fail.json")
+	in.EventIngest.Reason = "webhook secret=whsec_live body=hi recipient=bob@x.com"
+	r := EvaluateProbe(in)
+	raw, err := MarshalProbe(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hits := PIIFindings(raw); len(hits) > 0 {
+		t.Fatalf("pii in probe %v: %s", hits, raw)
+	}
+	if strings.Contains(string(raw), "whsec_") || strings.Contains(string(raw), "bob@") {
+		t.Fatalf("secret leaked: %s", raw)
+	}
+}
+
+func TestPIIFindingsCatchesBannedShapes(t *testing.T) {
+	t.Parallel()
+	samples := []string{
+		`{"to":"lead@example.com"}`,
+		`{"token":"abc"}`,
+		`{"body":"hello"}`,
+		`Authorization: Bearer abc`,
+	}
+	for _, s := range samples {
+		if hits := PIIFindings([]byte(s)); len(hits) == 0 {
+			t.Fatalf("expected a finding for %s", s)
+		}
+	}
+	clean := `{"status":"ok","planes":[{"plane":"db","status":"failed","reason":"select_failed"}]}`
+	if hits := PIIFindings([]byte(clean)); len(hits) > 0 {
+		t.Fatalf("false positive on clean payload: %v", hits)
+	}
+}

--- a/internal/app/plathealth/testdata/all-ok.json
+++ b/internal/app/plathealth/testdata/all-ok.json
@@ -1,0 +1,8 @@
+{
+  "dns": {"observed": true, "ok": true},
+  "tls": {"observed": true, "ok": true},
+  "api": {"observed": true, "health_status": 200, "live_status": 200, "ready_status": 200, "ready": true, "deps_ready": true},
+  "event_ingest": {"observed": true, "ok": true},
+  "read_after_write": {"observed": true, "ok": true},
+  "worker_heartbeat": {"observed": true, "ok": true}
+}

--- a/internal/app/plathealth/testdata/api-200-stale-heartbeat.json
+++ b/internal/app/plathealth/testdata/api-200-stale-heartbeat.json
@@ -1,0 +1,8 @@
+{
+  "dns": {"observed": true, "ok": true},
+  "tls": {"observed": true, "ok": true},
+  "api": {"observed": true, "health_status": 200, "live_status": 200, "ready_status": 503, "ready": false, "process_up_only": false},
+  "event_ingest": {"observed": true, "ok": true},
+  "read_after_write": {"observed": true, "ok": true},
+  "worker_heartbeat": {"observed": true, "ok": false, "stale": true, "reason": "newest_heartbeat_stale"}
+}

--- a/internal/app/plathealth/testdata/partial-fail.json
+++ b/internal/app/plathealth/testdata/partial-fail.json
@@ -1,0 +1,8 @@
+{
+  "dns": {"observed": true, "ok": true},
+  "tls": {"observed": true, "ok": true},
+  "api": {"observed": true, "health_status": 200, "live_status": 200, "ready_status": 503, "ready": false},
+  "event_ingest": {"observed": true, "ok": false, "reason": "publish_failed"},
+  "read_after_write": {"observed": true, "ok": false, "reason": "round_trip_mismatch"},
+  "worker_heartbeat": {"observed": false, "ok": false, "reason": "unobserved"}
+}

--- a/internal/app/plathealth/testdata/process-up-only.json
+++ b/internal/app/plathealth/testdata/process-up-only.json
@@ -1,0 +1,8 @@
+{
+  "dns": {"observed": true, "ok": true},
+  "tls": {"observed": false, "reason": "http_scheme"},
+  "api": {"observed": true, "health_status": 200, "process_up_only": true},
+  "event_ingest": {"observed": false},
+  "read_after_write": {"observed": false},
+  "worker_heartbeat": {"observed": false}
+}

--- a/internal/app/plathealth/types.go
+++ b/internal/app/plathealth/types.go
@@ -1,0 +1,222 @@
+// Package plathealth evaluates platform liveness, readiness, and dependency
+// health as pure functions over injected plane observations. I/O lives in
+// adapters so tests can flip one plane at a time without booting Postgres,
+// Redis, NATS, or TLS.
+package plathealth
+
+import "time"
+
+// Plane is a named operational surface. These are the readiness planes.
+const (
+	PlaneControlPlane    = "control_plane"
+	PlaneDB              = "db"
+	PlaneCache           = "cache"
+	PlaneQueue           = "queue"
+	PlaneEventProcessing = "event_processing"
+	PlaneWorkerHeartbeat = "worker_heartbeat"
+	PlaneProviderEdge    = "provider_edge"
+)
+
+// ProbeCheck names an external-probe check. Distinct from readiness planes.
+const (
+	CheckDNS             = "dns"
+	CheckTLS             = "tls"
+	CheckAPI             = "api"
+	CheckEventIngest     = "event_ingest"
+	CheckReadAfterWrite  = "read_after_write"
+	CheckWorkerHeartbeat = "worker_heartbeat"
+)
+
+// Incident class names used by the runbook and by Classify.
+const (
+	ClassControlPlane  = "control_plane"
+	ClassDB            = "db"
+	ClassCache         = "cache"
+	ClassNATS          = "nats"
+	ClassEmailProvider = "email_provider"
+	ClassContractDrift = "contract_drift"
+)
+
+// Check status values written into JSON. Allowlisted.
+const (
+	StatusOK            = "ok"
+	StatusFailed        = "failed"
+	StatusTimeout       = "timeout"
+	StatusUnobserved    = "unobserved"
+	StatusStale         = "stale"
+	StatusProcessUpOnly = "process_up_only"
+	StatusSkipped       = "skipped"
+)
+
+// Overall report status.
+const (
+	OverallOK       = "ok"
+	OverallNotReady = "not_ready"
+	OverallLive     = "live"
+	OverallNotOK    = "not_ok"
+)
+
+// Allowlisted reason codes. Unknown reasons are rewritten to "failed"
+// so free-text errors (and any secret or address they might contain)
+// never leave this package.
+const (
+	ReasonTimeout              = "timeout"
+	ReasonUnobserved           = "unobserved"
+	ReasonFailed               = "failed"
+	ReasonStale                = "stale"
+	ReasonHTTPProcessUpOnly    = "http_process_up_only"
+	ReasonNoFreshHeartbeat     = "no_fresh_heartbeat"
+	ReasonNewestHeartbeatStale = "newest_heartbeat_stale"
+	ReasonRoundTripMismatch    = "round_trip_mismatch"
+	ReasonRoundTripTimeout     = "round_trip_timeout"
+	ReasonPublishFailed        = "publish_failed"
+	ReasonSubscribeFailed      = "subscribe_failed"
+	ReasonContractMissingPlane = "contract_missing_plane"
+	ReasonMailTransportMissing = "mail_transport_not_configured"
+	ReasonTransportConfigured  = "transport_configured"
+	ReasonSMTPPreflightFailed  = "smtp_preflight_failed"
+	ReasonHTTPScheme           = "http_scheme"
+	ReasonDNSFailed            = "dns_failed"
+	ReasonTLSFailed            = "tls_failed"
+	ReasonReadyNotReady        = "ready_not_ready"
+	ReasonDepsNotReady         = "deps_not_ready"
+	ReasonSelectFailed         = "select_failed"
+	ReasonCacheMismatch        = "cache_mismatch"
+)
+
+// RequiredPlanes is the readiness set. Missing any one fails closed.
+var RequiredPlanes = []string{
+	PlaneControlPlane,
+	PlaneDB,
+	PlaneCache,
+	PlaneQueue,
+	PlaneEventProcessing,
+	PlaneWorkerHeartbeat,
+	PlaneProviderEdge,
+}
+
+// RequiredProbeChecks is the external-probe set. Partial failure is not green.
+var RequiredProbeChecks = []string{
+	CheckDNS,
+	CheckTLS,
+	CheckAPI,
+	CheckEventIngest,
+	CheckReadAfterWrite,
+	CheckWorkerHeartbeat,
+}
+
+// Observation is one plane sample. Adapters fill this; Evaluate decides status.
+type Observation struct {
+	Plane     string
+	Required  bool
+	Observed  bool
+	OK        bool
+	Timeout   bool
+	Stale     bool
+	LatencyMS int64
+	Reason    string
+}
+
+// HeartbeatSnapshot is a PII-free view of worker liveness. No worker IDs,
+// IPs, hostnames, or mailbox fields.
+type HeartbeatSnapshot struct {
+	Observed bool
+	Fresh    int
+	Stale    int
+}
+
+// PlaneResult is the allowlisted JSON shape for one plane.
+type PlaneResult struct {
+	Plane     string `json:"plane"`
+	Status    string `json:"status"`
+	Required  bool   `json:"required"`
+	LatencyMS int64  `json:"latency_ms"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// Report is the allowlisted JSON shape for /ready and /health/deps.
+type Report struct {
+	Live            bool          `json:"live"`
+	Ready           bool          `json:"ready"`
+	Status          string        `json:"status"`
+	CheckedAt       time.Time     `json:"checked_at"`
+	TimeoutMS       int64         `json:"timeout_ms"`
+	Planes          []PlaneResult `json:"planes"`
+	IncidentClasses []string      `json:"incident_classes,omitempty"`
+}
+
+// CheckResult is the allowlisted JSON shape for one external-probe check.
+type CheckResult struct {
+	Name      string `json:"name"`
+	Status    string `json:"status"`
+	Required  bool   `json:"required"`
+	LatencyMS int64  `json:"latency_ms"`
+	Reason    string `json:"reason,omitempty"`
+}
+
+// ProbeReport is the allowlisted JSON shape for cmd/opsprobe.
+type ProbeReport struct {
+	Green           bool          `json:"green"`
+	Status          string        `json:"status"`
+	CheckedAt       time.Time     `json:"checked_at"`
+	Checks          []CheckResult `json:"checks"`
+	IncidentClasses []string      `json:"incident_classes,omitempty"`
+}
+
+// CheckInput is one fixture/injected probe observation.
+type CheckInput struct {
+	Observed  bool   `json:"observed"`
+	OK        bool   `json:"ok"`
+	Timeout   bool   `json:"timeout"`
+	Stale     bool   `json:"stale"`
+	Reason    string `json:"reason,omitempty"`
+	LatencyMS int64  `json:"latency_ms,omitempty"`
+}
+
+// APIInput is the API check. HealthStatus 200 alone is not overall green.
+type APIInput struct {
+	Observed      bool  `json:"observed"`
+	HealthStatus  int   `json:"health_status"`
+	LiveStatus    int   `json:"live_status"`
+	ReadyStatus   int   `json:"ready_status"`
+	Ready         *bool `json:"ready"`
+	ProcessUpOnly bool  `json:"process_up_only"`
+	DepsReady     *bool `json:"deps_ready"`
+	LatencyMS     int64 `json:"latency_ms,omitempty"`
+}
+
+// ProbeInput is the injected/fixture form of the external probe.
+type ProbeInput struct {
+	DNS             CheckInput `json:"dns"`
+	TLS             CheckInput `json:"tls"`
+	API             APIInput   `json:"api"`
+	EventIngest     CheckInput `json:"event_ingest"`
+	ReadAfterWrite  CheckInput `json:"read_after_write"`
+	WorkerHeartbeat CheckInput `json:"worker_heartbeat"`
+	CheckedAt       time.Time  `json:"checked_at,omitempty"`
+}
+
+// DefaultTimeout bounds each plane or probe check. Fail closed on expiry.
+const DefaultTimeout = 3 * time.Second
+
+// HeartbeatWindow matches repository.WorkerLivenessWindow so placement and
+// health agree on what "fresh" means. The SQL interval is a string.
+const HeartbeatWindow = "10 minutes"
+
+// HeartbeatSQL counts active workers inside/outside the liveness window.
+// It returns only integers. No worker ids, IPs, or mailbox fields.
+const HeartbeatSQL = `
+SELECT
+  COUNT(*) FILTER (WHERE last_seen_at > now() - $1::interval)::int AS fresh,
+  COUNT(*) FILTER (WHERE last_seen_at IS NULL OR last_seen_at <= now() - $1::interval)::int AS stale
+FROM workers
+WHERE active = true
+`
+
+// ProbeTopic is the labeled non-commercial bus subject used by ingest and
+// read-after-write. It is not a campaign, warmup, or inbound lead topic.
+const ProbeTopic = "ops.health.probe"
+
+// ProbeConsumerGroup is a fixed JetStream durable so health checks do not
+// accumulate consumers.
+const ProbeConsumerGroup = "ops-health-probe"


### PR DESCRIPTION
## Outcome

Warmbly can now tell process-up from ready. `GET /health` stays the compose process-up 200. `GET /live` is liveness. `GET /ready` and `GET /health/deps` fail closed (503) when a required plane is down, stale, timed out, or unobserved. `cmd/opsprobe` names TLS, DNS, API, event ingest, read-after-write, and worker heartbeat and is not green on partial failure. The development incident runbook classifies control plane, DB, cache, NATS, email provider, and contract drift with diagnose, mitigation, rollback, evidence capture, commands, and owners.

Decision: **READY_BEHIND_HUMAN_GATE**

## Scope

- `internal/app/plathealth`: timeout-bounded evaluator and probe over injected observations. HTTP 200 process-up is not all-planes healthy. Timeouts and unobserved required planes fail closed. JSON is allowlisted; reasons are rewritten off a fixed set so secrets and recipient/message PII cannot leak.
- HTTP: `GET /live`, `GET /ready`, `GET /health/deps`. `GET /health` unchanged (`{"status":"ok"}`) so compose does not flap.
- Backend collector: `SELECT 1` (db), Redis SET/GET (cache), labeled `ops.health.probe` publish (queue) plus consume (event processing), worker `last_seen_at` counts only (no IDs/IPs), mail transport preflight (provider edge).
- `cmd/opsprobe --fixture PATH` (CI/offline) and `--base-url URL [--nats-url URL]` (live edge).
- Runbook: `docs/content/docs/development/incident-runbook.mdx`. Endpoint map and deployment/events pages updated.

## Out of scope

- PR #80 inbound-pipeline reconciliation and inbound `EvaluateInboundReceive`.
- `GET /api/v1/webhooks/confenge/inbound/health` (stays a separate inbound surface).
- Warmup mailbox health scoring, worker placement scoring, admin System Status UI rewrite.
- Public marketing status page.
- Sending campaign or warmup mail as a probe.
- Merge, deploy, DNS, spend, or issue close.

## Risks

- Operators who keep using only `GET /health` will still see 200 during a dependency outage. `/ready` and `opsprobe` are the truth.
- A first `/ready` against a cold JetStream can time out (3s, fail closed). That is honest, not a flap of `/health`.
- SES/log transports are "configured" without a dial. SMTP is the transport that is actually preflighted.

## Rollback

Revert this PR and restart backend. Compose keeps working on `GET /health`. No migration.

## Refs

- Base: `origin/main` `2444058ef3a64774b84eea57425b731700946b84`
- Branch: `feat/warmbly-006-ops-health` (worktree, not the dirty last-mile branch)
- PR #80 is inbound commercial-event reconciliation. Not this campaign.
- WARMBLY-006

## Evidence (executed)

```
go test ./internal/app/plathealth/ ./internal/api/ ./internal/api/handler/ ./cmd/opsprobe/ -count=1
# twice: PASS / PASS

go run ./cmd/opsprobe --fixture internal/app/plathealth/testdata/api-200-stale-heartbeat.json
# green=false, worker_heartbeat=stale, api=ok, exit 1

go run ./cmd/opsprobe --fixture internal/app/plathealth/testdata/partial-fail.json
# green=false, event_ingest=failed, read_after_write=failed, exit 1

go run ./cmd/opsprobe --fixture internal/app/plathealth/testdata/all-ok.json
# green=true, exit 0

gofmt -l (touched Go): empty
golangci-lint v1.64.8 (go1.25.0) on touched packages: pass
docs pnpm types:check: pass
docs pnpm lint: pass (2 pre-existing warnings, not in this change)
```

PII scan of shipped health/probe JSON: no recipient emails, message bodies, webhook secrets, tokens, or credentials.

## Residual (explicit)

- No process listened on `127.0.0.1:8080`. No production API host, TLS cert, NATS URL, or worker heartbeat credential was provided. Live TLS/DNS/provider/heartbeat against a real edge was **not** run. That is not a green live close.
- Next command when a host exists: `go run ./cmd/opsprobe --base-url https://<api-host> --nats-url nats://<nats-host>:4222`
- Merge, deploy, and pointing orchestrators at `/live` + `/ready` remain a human gate.
- Inbound last-mile ops health on `feat/confenge-inbound-last-mile` is a different lane and was not mixed in.

## Final decision

`READY_BEHIND_HUMAN_GATE`