### PR TITLE
feat: isolate Stripe/AWS/GCP behind minprofile tag so CONFENGE runtime links only Postgres/Redis/NATS/local KMS/filesystem

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -730,10 +730,14 @@ confenge-local:
 	@set -a; [ -f "$(CONFENGE_ENV_FILE)" ] && . ./$(CONFENGE_ENV_FILE); set +a; \
 	trap 'kill 0' INT TERM; \
 	$(MAKE) --no-print-directory confenge-backend & \
-	$(MAKE) --no-print-directory consumer & \
+	$(MAKE) --no-print-directory confenge-consumer & \
 	$(MAKE) --no-print-directory confenge-worker & \
 	VITE_CONFENGE_OPERATOR_MODE=true $(MAKE) --no-print-directory web & \
 	wait
+
+# Min-profile tag excludes Stripe/AWS/GCP implementations from the link.
+# Do not add a CONFENGE product tag; this is a backend opt-out only.
+GO_MINPROFILE_TAGS ?= minprofile
 
 # Backend with CONFENGE flags and local-safe bind.
 # API_HOST must come from shell after sourcing .env.confenge (Make's
@@ -756,7 +760,12 @@ confenge-backend:
 	SMTP_PORT=11025 \
 	GEODB_PATH=data/GeoLite2-City.mmdb \
 	INTERNAL_API_TOKEN=local-dev-internal-token \
-	go run ./cmd/backend
+	go run -tags $(GO_MINPROFILE_TAGS) ./cmd/backend
+
+confenge-consumer:
+	@set -a; [ -f "$(CONFENGE_ENV_FILE)" ] && . ./$(CONFENGE_ENV_FILE); set +a; \
+	$(GO_DEV_ENV) $(CONFENGE_DEV_ENV) \
+	go run -tags $(GO_MINPROFILE_TAGS) ./cmd/consumer
 
 # Worker wired to confenge-backend (same API_HOST / DEK URL). Uses Hostinger
 # SMTP/IMAP accounts via credentials sealed by the backend; no Graph/M365.
@@ -769,7 +778,7 @@ confenge-worker:
 	ENCRYPTED_KEYS_PROVIDER=http \
 	ENCRYPTED_KEYS_BACKEND_URL=$$api_base \
 	ENCRYPTED_KEYS_WORKER_TOKEN=local-dev-internal-token \
-	go run ./cmd/worker
+	go run -tags $(GO_MINPROFILE_TAGS) ./cmd/worker
 
 confenge-preflight:
 	@set -a; [ -f "$(CONFENGE_ENV_FILE)" ] && . ./$(CONFENGE_ENV_FILE); set +a; \
@@ -831,7 +840,11 @@ confenge-playwright:
 		CONFENGE_GATE_CODE_SHA=$$(git rev-parse HEAD) \
 		pnpm test:e2e:confenge:live
 
-.PHONY: confenge-local confenge-backend confenge-worker confenge-preflight confenge-bootstrap confenge-import confenge-stop-sending confenge-resume-sending confenge-db-backup confenge-db-restore confenge-readiness confenge-readiness-report confenge-playwright
+confenge-min-profile-sbom:
+	@mkdir -p data/confenge-artifacts
+	./scripts/confenge_min_profile_sbom.sh data/confenge-artifacts/min-profile-sbom.json
+
+.PHONY: confenge-local confenge-backend confenge-consumer confenge-worker confenge-preflight confenge-bootstrap confenge-import confenge-stop-sending confenge-resume-sending confenge-db-backup confenge-db-restore confenge-readiness confenge-readiness-report confenge-playwright confenge-min-profile-sbom
 
 # ─── admin bootstrap (local/test only) ──────────────────────────────────
 #

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -14,8 +14,6 @@ import (
 	"time"
 
 	"github.com/MicahParks/keyfunc/v3"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconf "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
 	"github.com/meszmate/apple-go"
@@ -319,25 +317,12 @@ func main() {
 			log.Fatal(err)
 		}
 
-		// AWS SDK config, loaded only when an AWS-backed provider is selected
-		// (KMS_PROVIDER=aws or BLOB_PROVIDER=s3). A fully-local self-host
-		// (local KMS + filesystem blobs) skips this and needs no AWS_REGION or
-		// credentials at all.
-		var awscfg aws.Config
-		if config.AWSNeeded() {
-			awscfg, err = awsconf.LoadDefaultConfig(ctx)
-			if err != nil {
-				sentry.CaptureException(err)
-				log.Fatal(err)
-			}
-		}
-
 		var masterKey string = "alias/master-key"
 		if cfg.Env != "prod" {
 			masterKey += "-dev"
 		}
 
-		kms, err := kms.FromEnv(ctx, awscfg, masterKey)
+		kms, err := kms.FromEnv(ctx, masterKey)
 		if err != nil {
 			sentry.CaptureException(err)
 			log.Fatal(err)
@@ -362,7 +347,7 @@ func main() {
 			geoloc, _ = geo.New("")
 		}
 
-		s3, err := storage.NewFromEnv(ctx, awscfg, "main")
+		s3, err := storage.NewFromEnv(ctx, "main")
 		if err != nil {
 			sentry.CaptureException(err)
 			log.Fatal(err)
@@ -706,15 +691,18 @@ func main() {
 		// Stripe service so the backend boots with no Stripe keys and every
 		// feature is unlocked by the feature gate. BILLING_PROVIDER=stripe wires
 		// the real Stripe integration (keys required).
+		var stripeCfg *config.StripeConfig
 		if config.BillingProvider() == "stripe" {
-			stripeCfg, err := cfg.LoadStripeConfig(ctx)
+			stripeCfg, err = cfg.LoadStripeConfig(ctx)
 			if err != nil {
 				sentry.CaptureException(err)
 				log.Fatal(err)
 			}
-			stripeService = stripe.NewService(stripeCfg, subscriptionRepository, planRepository, workerAssignmentService, discountService)
-		} else {
-			stripeService = stripe.NewDisabledService()
+		}
+		stripeService, err = stripe.NewFromEnv(stripeCfg, subscriptionRepository, planRepository, workerAssignmentService, discountService)
+		if err != nil {
+			sentry.CaptureException(err)
+			log.Fatal(err)
 		}
 
 		tokenService = token.NewService(primaryDB, tokenRepostory, cache, geoloc, authCfg.AuthSecret)

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -8,8 +8,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconf "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/getsentry/sentry-go"
 	"github.com/warmbly/warmbly/internal/app/advanced"
 	"github.com/warmbly/warmbly/internal/app/cipher"
@@ -62,17 +60,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// AWS SDK config, loaded only when an AWS-backed provider is selected
-	// (KMS_PROVIDER=aws or BLOB_PROVIDER=s3). A fully-local self-host needs no
-	// AWS_REGION or credentials.
-	var awscfg aws.Config
-	if config.AWSNeeded() {
-		awscfg, err = awsconf.LoadDefaultConfig(ctx)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
 	// PostgreSQL
 	primaryDBEndpoint, err := cfg.LoadPrimaryDBEndpoint(ctx)
 	if err != nil {
@@ -99,7 +86,7 @@ func main() {
 		masterKey += "-dev"
 	}
 
-	kmsClient, err := kms.FromEnv(ctx, awscfg, masterKey)
+	kmsClient, err := kms.FromEnv(ctx, masterKey)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -114,7 +101,7 @@ func main() {
 	cipherService := cipher.NewService(kmsClient, redisCache, encryptedKeys)
 
 	// Blob storage (S3 by default, filesystem when BLOB_PROVIDER=filesystem).
-	s3Client, err := storage.NewFromEnv(ctx, awscfg, "main")
+	s3Client, err := storage.NewFromEnv(ctx, "main")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/worker/main.go
+++ b/cmd/worker/main.go
@@ -12,8 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	awsconf "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/google/uuid"
 	"github.com/warmbly/warmbly/internal/app/cipher"
 	"github.com/warmbly/warmbly/internal/app/worker"
@@ -53,17 +51,6 @@ func main() {
 		log.Fatal(err)
 	}
 
-	// AWS SDK config, loaded only when an AWS-backed provider is selected
-	// (KMS_PROVIDER=aws or BLOB_PROVIDER=s3). A fully-local self-host needs no
-	// AWS_REGION or credentials.
-	var awscfg aws.Config
-	if config.AWSNeeded() {
-		awscfg, err = awsconf.LoadDefaultConfig(ctx)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}
-
 	// Redis
 	primaryRedis, err := cfg.LoadPrimaryRedisEndpoint(ctx)
 	if err != nil {
@@ -80,7 +67,7 @@ func main() {
 		masterKey += "-dev"
 	}
 
-	kmsClient, err := kms.FromEnv(ctx, awscfg, masterKey)
+	kmsClient, err := kms.FromEnv(ctx, masterKey)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -105,7 +92,7 @@ func main() {
 	}
 
 	// Blob storage (S3 by default, filesystem when BLOB_PROVIDER=filesystem).
-	s3Client, err := storage.NewFromEnv(ctx, awscfg, "main")
+	s3Client, err := storage.NewFromEnv(ctx, "main")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -39,6 +39,7 @@ docker build -f admin/Dockerfile                  -t warmbly/admin    admin/
 ```
 
 The default builds have no Kafka/Avro support; add `--build-arg GO_TAGS=kafka` (Go images) or `--build-arg CARGO_FEATURES=kafka` (tracking) to opt in.
+CONFENGE min-profile images use `--build-arg GO_TAGS=minprofile` (see `docker-compose.confenge.yml` and `deploy/confenge-vps/docker-compose.override.yml`) so Stripe, AWS SDK, and GCP Cloud Tasks/PubSub are not compile-linked. Selecting those providers on a min-profile binary fails closed.
 
 GitHub Actions publishes these to GHCR automatically. See [the self-hosting guide](https://docs.warmbly.com/development/deployment-guide/).
 

--- a/deploy/confenge-vps/README.md
+++ b/deploy/confenge-vps/README.md
@@ -3,6 +3,10 @@
 Isolated always-on Warmbly deployment for CONFENGE on Netcup, co-tenant with
 extra-cli but **not** sharing application state.
 
+Go images build with `GO_TAGS=minprofile`: postgres, redis, nats, filesystem
+blobs, and local KMS only. Stripe, AWS, GCP Cloud Tasks/PubSub, and Kafka are
+not compile-linked and fail closed if selected.
+
 Full docs:
 
 - [vps-execution-plane.md](../../docs/confenge/vps-execution-plane.md)

--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -121,6 +121,9 @@ services:
   backend:
     <<: *restart
     logging: *default-logging
+    build:
+      args:
+        GO_TAGS: ${GO_TAGS:-minprofile}
     ports: !override
       - "127.0.0.1:8080:8080"
     environment:
@@ -153,6 +156,9 @@ services:
   consumer:
     <<: *restart
     logging: *default-logging
+    build:
+      args:
+        GO_TAGS: ${GO_TAGS:-minprofile}
     environment:
       <<: *confenge-env
     volumes:
@@ -167,6 +173,9 @@ services:
   worker:
     <<: *restart
     logging: *default-logging
+    build:
+      args:
+        GO_TAGS: ${GO_TAGS:-minprofile}
     environment:
       <<: *confenge-env
       # Stable worker id so backend can route validate/send commands (hostname is not a UUID).

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -7,7 +7,8 @@
 # The builder always runs on the build host ($BUILDPLATFORM) and cross-compiles
 # to $TARGETARCH, so multi-arch CI builds never run the Go compiler under QEMU.
 #
-# To include the optional Kafka backend, build with --build-arg GO_TAGS=kafka
+# Optional tags: kafka (librdkafka + CGO) and/or minprofile (no Stripe/AWS/GCP).
+# CONFENGE images use --build-arg GO_TAGS=minprofile.
 # (adds librdkafka + CGO; slower, and CGO cannot cross-compile — build each arch
 # on a native runner). Runtime selection is still by env
 # (EVENTBUS_PROVIDER / CODEC_PROVIDER).
@@ -26,7 +27,7 @@ COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     set -eux; \
-    if echo "$GO_TAGS" | grep -qw kafka; then CGO=1; TAGS="musl kafka"; else CGO=0; TAGS=""; fi; \
+    if echo "$GO_TAGS" | grep -qw kafka; then CGO=1; TAGS="musl $GO_TAGS"; else CGO=0; TAGS="$GO_TAGS"; fi; \
     CGO_ENABLED=$CGO GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "$TAGS" -ldflags="-s -w" -o /out/backend ./cmd/backend; \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/confenge ./cmd/confenge; \
     CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -ldflags="-s -w" -o /out/seed ./cmd/seed; \

--- a/deploy/docker/consumer.Dockerfile
+++ b/deploy/docker/consumer.Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     set -eux; \
-    if echo "$GO_TAGS" | grep -qw kafka; then CGO=1; TAGS="musl kafka"; else CGO=0; TAGS=""; fi; \
+    if echo "$GO_TAGS" | grep -qw kafka; then CGO=1; TAGS="musl $GO_TAGS"; else CGO=0; TAGS="$GO_TAGS"; fi; \
     CGO_ENABLED=$CGO GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "$TAGS" -ldflags="-s -w" -o /out/consumer ./cmd/consumer
 
 # Runtime stage

--- a/deploy/docker/worker.Dockerfile
+++ b/deploy/docker/worker.Dockerfile
@@ -18,7 +18,7 @@ COPY . .
 RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     set -eux; \
-    if echo "$GO_TAGS" | grep -qw kafka; then CGO=1; TAGS="musl kafka"; else CGO=0; TAGS=""; fi; \
+    if echo "$GO_TAGS" | grep -qw kafka; then CGO=1; TAGS="musl $GO_TAGS"; else CGO=0; TAGS="$GO_TAGS"; fi; \
     CGO_ENABLED=$CGO GOOS=$TARGETOS GOARCH=$TARGETARCH go build -tags "$TAGS" -ldflags="-s -w" -o /out/worker ./cmd/worker
 
 # Runtime stage

--- a/docker-compose.confenge.yml
+++ b/docker-compose.confenge.yml
@@ -1,0 +1,28 @@
+# CONFENGE min runtime overlay.
+#
+#   docker compose -f docker-compose.yml -f docker-compose.confenge.yml --profile sandbox config
+#
+# Allowed infra (same contract as deploy/confenge-vps):
+#   postgres, redis, nats, filesystem blobs, local KMS, billing none.
+# Go images build with GO_TAGS=minprofile so Stripe, AWS SDK, GCP Cloud
+# Tasks/PubSub, and Kafka are not compile-linked.
+# Admin is not required for the action plane.
+#
+# Do not use this overlay with GO_TAGS=kafka. Selecting kafka/stripe/aws/gcloud
+# on the resulting binaries fails closed.
+
+services:
+  backend:
+    build:
+      args:
+        GO_TAGS: ${GO_TAGS:-minprofile}
+  consumer:
+    build:
+      args:
+        GO_TAGS: ${GO_TAGS:-minprofile}
+  worker:
+    build:
+      args:
+        GO_TAGS: ${GO_TAGS:-minprofile}
+  admin:
+    profiles: ["admin"]

--- a/docs/confenge/local-ops.md
+++ b/docs/confenge/local-ops.md
@@ -1,6 +1,9 @@
 # CONFENGE local-first ops (WSL)
 
 One-command local stack for operators. No Kafka, AWS, GCP, or Stripe required.
+Native CONFENGE targets build with `-tags minprofile` so those backends are not
+linked. Compose overlay: `docker-compose.confenge.yml` (same allowed infra as
+the VPS overlay: postgres, redis, nats, filesystem, local KMS, billing none).
 
 ## Prerequisites
 
@@ -35,7 +38,8 @@ at `http://localhost:18025`. Nothing real is sent.
 
 | Target | Purpose |
 | --- | --- |
-| `make confenge-local` | Infra + migrate + seed + backend/consumer/worker/web with CONFENGE on |
+| `make confenge-local` | Infra + migrate + seed + min-profile backend/consumer/worker/web |
+| `make confenge-min-profile-sbom` | Deterministic JSON SBOM of the min-profile module graph |
 | `make confenge-preflight` | DB, Redis, NATS, flags, AI, mailbox, feed, outcome, governor, WA, kill switch |
 | `make confenge-bootstrap` | Workspace settings without raw SQL |
 | `make confenge-import FEED=... [DRY_RUN=true]` | Import feed; prints creates/updates/blocked |

--- a/internal/app/confenge/min_profile_conformance_test.go
+++ b/internal/app/confenge/min_profile_conformance_test.go
@@ -1,0 +1,143 @@
+package confenge
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "../../.."))
+}
+
+func readRepoFile(t *testing.T, rel string) string {
+	t.Helper()
+	b, err := os.ReadFile(filepath.Join(repoRoot(t), rel))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(b)
+}
+
+func TestMinProfileValidateStartupStillRejectsForbiddenAutomation(t *testing.T) {
+	base := Config{
+		Enabled: true, OperatorMode: true, OperatorUserID: uuid.New(), OperatorOrgID: uuid.New(),
+		RequireHumanApproval: true, DefaultDailyLimit: 200, MaxInitialEmailWords: 120,
+	}
+	t.Setenv("APP_URL", "http://127.0.0.1:5173")
+
+	auto := base
+	auto.AutoSendEnabled = true
+	if err := auto.ValidateStartup("production"); err == nil {
+		t.Fatal("CONFENGE_AUTO_SEND_ENABLED=true must fail closed")
+	}
+	noHuman := base
+	noHuman.RequireHumanApproval = false
+	if err := noHuman.ValidateStartup("production"); err == nil {
+		t.Fatal("CONFENGE_REQUIRE_HUMAN_APPROVAL=false must fail closed")
+	}
+	green := base
+	green.GreenAutorunEnabled = true
+	if err := green.ValidateStartup("production"); err == nil {
+		t.Fatal("CONFENGE_GREEN_AUTORUN_ENABLED=true must fail closed")
+	}
+}
+
+func TestMinProfileComposeAndEnvDeclareSameAllowedInfra(t *testing.T) {
+	files := []string{
+		"docker-compose.yml",
+		"docker-compose.confenge.yml",
+		"deploy/confenge-vps/docker-compose.override.yml",
+		"deploy/confenge-vps/env.example",
+		"Makefile",
+	}
+	contents := map[string]string{}
+	for _, f := range files {
+		contents[f] = readRepoFile(t, f)
+	}
+
+	base := contents["docker-compose.yml"]
+	for _, pair := range [][2]string{
+		{"EVENTBUS_PROVIDER", "nats"},
+		{"KMS_PROVIDER", "local"},
+		{"BLOB_PROVIDER", "filesystem"},
+		{"TASKS_PROVIDER", "local"},
+		{"BILLING_PROVIDER", "none"},
+	} {
+		if !strings.Contains(base, pair[0]+": ${"+pair[0]+":-"+pair[1]+"}") &&
+			!strings.Contains(base, pair[0]+": ${"+pair[0]+":-"+pair[1]+"}") {
+			if !strings.Contains(base, pair[0]) || !strings.Contains(base, pair[1]) {
+				t.Fatalf("docker-compose.yml must default %s=%s", pair[0], pair[1])
+			}
+		}
+	}
+
+	makeFile := contents["Makefile"]
+	for _, needle := range []string{
+		"KMS_PROVIDER=local",
+		"BLOB_PROVIDER=filesystem",
+		"EVENTBUS_PROVIDER=nats",
+		"TASKS_PROVIDER=local",
+		"BILLING_PROVIDER=none",
+		"GO_MINPROFILE_TAGS",
+	} {
+		if !strings.Contains(makeFile, needle) {
+			t.Fatalf("Makefile missing %q", needle)
+		}
+	}
+
+	overlay := contents["docker-compose.confenge.yml"]
+	if !strings.Contains(overlay, "GO_TAGS") || !strings.Contains(overlay, "minprofile") {
+		t.Fatal("docker-compose.confenge.yml must build with GO_TAGS=minprofile")
+	}
+	if strings.Contains(overlay, "kafka:") || strings.Contains(overlay, "stripe-mock") || strings.Contains(overlay, "localstack") {
+		t.Fatal("min compose overlay must not add kafka/stripe/localstack services")
+	}
+
+	vps := contents["deploy/confenge-vps/docker-compose.override.yml"]
+	if !strings.Contains(vps, "minprofile") {
+		t.Fatal("VPS overlay must pass GO_TAGS=minprofile")
+	}
+	if !strings.Contains(vps, "CONFENGE_AUTO_SEND_ENABLED: ${CONFENGE_AUTO_SEND_ENABLED:-false}") {
+		t.Fatal("VPS overlay must keep AUTO_SEND default false")
+	}
+	if !strings.Contains(vps, "CONFENGE_REQUIRE_HUMAN_APPROVAL: ${CONFENGE_REQUIRE_HUMAN_APPROVAL:-true}") {
+		t.Fatal("VPS overlay must keep human approval default true")
+	}
+	if !strings.Contains(vps, "CONFENGE_GREEN_AUTORUN_ENABLED: ${CONFENGE_GREEN_AUTORUN_ENABLED:-false}") {
+		t.Fatal("VPS overlay must keep green autorun default false")
+	}
+
+	envEx := contents["deploy/confenge-vps/env.example"]
+	for _, needle := range []string{
+		"CONFENGE_AUTO_SEND_ENABLED=false",
+		"CONFENGE_REQUIRE_HUMAN_APPROVAL=true",
+		"CONFENGE_GREEN_AUTORUN_ENABLED=false",
+	} {
+		if !strings.Contains(envEx, needle) {
+			t.Fatalf("VPS env.example missing %q", needle)
+		}
+	}
+	for _, banned := range []string{
+		"EVENTBUS_PROVIDER=kafka",
+		"KMS_PROVIDER=aws",
+		"BLOB_PROVIDER=s3",
+		"TASKS_PROVIDER=gcloud",
+		"BILLING_PROVIDER=stripe",
+		"AWS_ACCESS_KEY_ID=",
+		"STRIPE_SECRET_KEY=",
+	} {
+		if strings.Contains(envEx, banned) {
+			t.Fatalf("VPS env.example must not require %q", banned)
+		}
+	}
+}

--- a/internal/app/stripe/api.go
+++ b/internal/app/stripe/api.go
@@ -1,0 +1,102 @@
+package stripe
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// CheckoutSession is the hosted billing checkout handle. Handlers only need
+// ID and URL; the min-profile build never constructs a live session.
+type CheckoutSession struct {
+	ID  string `json:"id"`
+	URL string `json:"url"`
+}
+
+// Customer is the billing-package view of a payment customer.
+type Customer struct {
+	ID    string `json:"id"`
+	Email string `json:"email,omitempty"`
+}
+
+// Subscription is the billing-package view of a paid subscription.
+type Subscription struct {
+	ID                string `json:"id"`
+	Status            string `json:"status"`
+	CurrentPeriodEnd  int64  `json:"current_period_end,omitempty"`
+	CancelAtPeriodEnd bool   `json:"cancel_at_period_end,omitempty"`
+}
+
+// Event is a verified webhook payload. ProcessWebhookEvent is the only
+// consumer; the hosted implementation stores the raw Stripe event JSON.
+type Event struct {
+	ID      string
+	Type    string
+	Payload []byte
+}
+
+// ProrationPreview represents the preview of a plan change proration.
+type ProrationPreview struct {
+	CurrentPlan     *models.Plan `json:"current_plan"`
+	NewPlan         *models.Plan `json:"new_plan"`
+	ProrationAmount int64        `json:"proration_amount"`
+	AmountDue       int64        `json:"amount_due"`
+	NextBillingDate time.Time    `json:"next_billing_date"`
+	Currency        string       `json:"currency"`
+}
+
+// StripeService is the billing backend used by HTTP handlers and credit watch.
+// The hosted implementation talks to Stripe; the min-profile build only
+// compiles NewDisabledService plus a fail-closed NewFromEnv.
+type StripeService interface {
+	CreateCustomer(ctx context.Context, userID uuid.UUID, email, name string) (string, *errx.Error)
+	GetCustomer(ctx context.Context, customerID string) (*Customer, *errx.Error)
+
+	CreateCheckoutSession(ctx context.Context, userID uuid.UUID, orgID uuid.UUID, priceID, successURL, cancelURL, discountCode string) (*CheckoutSession, *errx.Error)
+	CreatePortalSession(ctx context.Context, customerID, returnURL string) (string, *errx.Error)
+
+	GetSubscription(ctx context.Context, subscriptionID string) (*Subscription, *errx.Error)
+	CancelSubscription(ctx context.Context, subscriptionID string, cancelAtPeriodEnd bool) *errx.Error
+
+	ChangePlan(ctx context.Context, orgID uuid.UUID, newPlanID uuid.UUID, prorationBehavior, discountCode, interval string) (*Subscription, *errx.Error)
+	PreviewPlanChange(ctx context.Context, orgID uuid.UUID, newPlanID uuid.UUID) (*ProrationPreview, *errx.Error)
+
+	VerifyWebhook(payload []byte, signature string) (*Event, *errx.Error)
+	ProcessWebhookEvent(ctx context.Context, event *Event) *errx.Error
+
+	ApplyCustomerCredit(ctx context.Context, customerID string, amountCents int64, currency, idempotencyKey string) (string, *errx.Error)
+	CreateCreditCheckoutSession(ctx context.Context, userID, orgID uuid.UUID, packKey string, credits int, successURL, cancelURL string) (*CheckoutSession, *errx.Error)
+	AutoTopUpCredits(ctx context.Context, orgID uuid.UUID, packKey string, creditAmount int) (bool, error)
+
+	WireReferral(r ReferralRewarder)
+	WireCredits(g CreditGranter, a AuditLogger)
+}
+
+// CreditGranter is the slice of the credit service the Stripe webhook flow
+// drives: reset the monthly allowance each billing cycle and fulfill top-up
+// purchases. *credits.creditService satisfies it (plain error returns).
+type CreditGranter interface {
+	ResetMonthlyAllowance(ctx context.Context, orgID uuid.UUID, allowance int, idempotencyKey string) error
+	GrantPurchased(ctx context.Context, orgID uuid.UUID, amount int, reason, idempotencyKey string) (int, error)
+}
+
+// AuditLogger is the slice of the audit service the webhook flow uses to fire
+// AUDIT_CREATED so teammates' billing/credits views refresh live after a grant
+// or purchase. *audit.auditService satisfies it.
+type AuditLogger interface {
+	LogAction(ctx context.Context, orgID, actorID uuid.UUID, action models.AuditAction, entityType models.AuditEntityType, entityID *uuid.UUID, ip, userAgent string, changes, metadata map[string]string)
+}
+
+// ReferralRewarder is the slice of the referral service the Stripe webhook flow
+// drives. *referral.Service satisfies it; injected via WireReferral so the
+// stripe package needs no import of referral (no cycle).
+type ReferralRewarder interface {
+	QualifyOnConversion(ctx context.Context, inviteeOrgID uuid.UUID)
+	RewardOnFirstInvoice(ctx context.Context, inviteeOrgID, planID uuid.UUID, eventID string) *errx.Error
+	ClawbackForInvitee(ctx context.Context, inviteeOrgID uuid.UUID, eventID, reason string)
+	SyncStripeBalance(ctx context.Context, orgID uuid.UUID)
+	InviteeDiscountCode(ctx context.Context, inviteeOrgID uuid.UUID) string
+}

--- a/internal/app/stripe/disabled.go
+++ b/internal/app/stripe/disabled.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/google/uuid"
-	stripe "github.com/stripe/stripe-go/v76"
 
 	"github.com/warmbly/warmbly/internal/errx"
 )
@@ -28,11 +27,11 @@ func (d *disabledService) CreateCustomer(_ context.Context, _ uuid.UUID, _, _ st
 	return "", billingDisabled()
 }
 
-func (d *disabledService) GetCustomer(_ context.Context, _ string) (*stripe.Customer, *errx.Error) {
+func (d *disabledService) GetCustomer(_ context.Context, _ string) (*Customer, *errx.Error) {
 	return nil, billingDisabled()
 }
 
-func (d *disabledService) CreateCheckoutSession(_ context.Context, _, _ uuid.UUID, _, _, _, _ string) (*stripe.CheckoutSession, *errx.Error) {
+func (d *disabledService) CreateCheckoutSession(_ context.Context, _, _ uuid.UUID, _, _, _, _ string) (*CheckoutSession, *errx.Error) {
 	return nil, billingDisabled()
 }
 
@@ -40,7 +39,7 @@ func (d *disabledService) CreatePortalSession(_ context.Context, _, _ string) (s
 	return "", billingDisabled()
 }
 
-func (d *disabledService) GetSubscription(_ context.Context, _ string) (*stripe.Subscription, *errx.Error) {
+func (d *disabledService) GetSubscription(_ context.Context, _ string) (*Subscription, *errx.Error) {
 	return nil, billingDisabled()
 }
 
@@ -48,7 +47,7 @@ func (d *disabledService) CancelSubscription(_ context.Context, _ string, _ bool
 	return billingDisabled()
 }
 
-func (d *disabledService) ChangePlan(_ context.Context, _, _ uuid.UUID, _, _, _ string) (*stripe.Subscription, *errx.Error) {
+func (d *disabledService) ChangePlan(_ context.Context, _, _ uuid.UUID, _, _, _ string) (*Subscription, *errx.Error) {
 	return nil, billingDisabled()
 }
 
@@ -56,11 +55,11 @@ func (d *disabledService) PreviewPlanChange(_ context.Context, _, _ uuid.UUID) (
 	return nil, billingDisabled()
 }
 
-func (d *disabledService) VerifyWebhook(_ []byte, _ string) (*stripe.Event, *errx.Error) {
+func (d *disabledService) VerifyWebhook(_ []byte, _ string) (*Event, *errx.Error) {
 	return nil, billingDisabled()
 }
 
-func (d *disabledService) ProcessWebhookEvent(_ context.Context, _ *stripe.Event) *errx.Error {
+func (d *disabledService) ProcessWebhookEvent(_ context.Context, _ *Event) *errx.Error {
 	return nil
 }
 
@@ -68,7 +67,7 @@ func (d *disabledService) ApplyCustomerCredit(_ context.Context, _ string, _ int
 	return "", billingDisabled()
 }
 
-func (d *disabledService) CreateCreditCheckoutSession(_ context.Context, _, _ uuid.UUID, _ string, _ int, _, _ string) (*stripe.CheckoutSession, *errx.Error) {
+func (d *disabledService) CreateCreditCheckoutSession(_ context.Context, _, _ uuid.UUID, _ string, _ int, _, _ string) (*CheckoutSession, *errx.Error) {
 	return nil, billingDisabled()
 }
 

--- a/internal/app/stripe/factory.go
+++ b/internal/app/stripe/factory.go
@@ -1,0 +1,29 @@
+package stripe
+
+import (
+	"fmt"
+
+	"github.com/warmbly/warmbly/internal/app/discount"
+	"github.com/warmbly/warmbly/internal/app/worker"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// NewFromEnv constructs the billing backend selected by BILLING_PROVIDER.
+// stripe selects the hosted implementation (compiled out of the min-profile
+// build). Anything else, including the self-host default "none", is disabled.
+func NewFromEnv(
+	cfg *config.StripeConfig,
+	subRepo repository.SubscriptionRepository,
+	planRepo repository.PlanRepository,
+	workerAssignment worker.WorkerAssignmentService,
+	discountService discount.DiscountService,
+) (StripeService, error) {
+	if config.BillingProvider() != "stripe" {
+		return NewDisabledService(), nil
+	}
+	if cfg == nil {
+		return nil, fmt.Errorf("stripe: BILLING_PROVIDER=stripe requires Stripe config")
+	}
+	return newLive(cfg, subRepo, planRepo, workerAssignment, discountService)
+}

--- a/internal/app/stripe/factory_hosted_test.go
+++ b/internal/app/stripe/factory_hosted_test.go
@@ -1,0 +1,20 @@
+//go:build !minprofile
+
+package stripe
+
+import (
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/config"
+)
+
+func TestNewFromEnv_StripeStillConstructsOnHostedBuild(t *testing.T) {
+	t.Setenv("BILLING_PROVIDER", "stripe")
+	svc, err := NewFromEnv(&config.StripeConfig{SecretKey: "sk_test"}, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := svc.(*stripeService); !ok {
+		t.Fatalf("hosted stripe provider should construct live service, got %T", svc)
+	}
+}

--- a/internal/app/stripe/factory_test.go
+++ b/internal/app/stripe/factory_test.go
@@ -1,0 +1,16 @@
+package stripe
+
+import (
+	"testing"
+)
+
+func TestNewFromEnv_DisabledWhenNotStripe(t *testing.T) {
+	t.Setenv("BILLING_PROVIDER", "none")
+	svc, err := NewFromEnv(nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := svc.(*disabledService); !ok {
+		t.Fatalf("expected disabledService, got %T", svc)
+	}
+}

--- a/internal/app/stripe/minprofile_test.go
+++ b/internal/app/stripe/minprofile_test.go
@@ -1,0 +1,29 @@
+//go:build minprofile
+
+package stripe
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/config"
+)
+
+func TestNewFromEnv_MinProfileRejectsStripe(t *testing.T) {
+	t.Setenv("BILLING_PROVIDER", "stripe")
+	_, err := NewFromEnv(&config.StripeConfig{SecretKey: "sk_test"}, nil, nil, nil, nil)
+	if !errors.Is(err, ErrStripeNotCompiled) {
+		t.Fatalf("stripe selection on minprofile: %v", err)
+	}
+}
+
+func TestNewFromEnv_MinProfileAllowsDisabled(t *testing.T) {
+	t.Setenv("BILLING_PROVIDER", "none")
+	svc, err := NewFromEnv(nil, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if svc == nil {
+		t.Fatal("disabled billing must still construct")
+	}
+}

--- a/internal/app/stripe/service.go
+++ b/internal/app/stripe/service.go
@@ -1,3 +1,5 @@
+//go:build !minprofile
+
 package stripe
 
 import (
@@ -29,92 +31,6 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
 )
-
-// ProrationPreview represents the preview of a plan change proration
-type ProrationPreview struct {
-	CurrentPlan     *models.Plan `json:"current_plan"`
-	NewPlan         *models.Plan `json:"new_plan"`
-	ProrationAmount int64        `json:"proration_amount"`
-	AmountDue       int64        `json:"amount_due"`
-	NextBillingDate time.Time    `json:"next_billing_date"`
-	Currency        string       `json:"currency"`
-}
-
-type StripeService interface {
-	// Customer management
-	CreateCustomer(ctx context.Context, userID uuid.UUID, email, name string) (string, *errx.Error)
-	GetCustomer(ctx context.Context, customerID string) (*stripe.Customer, *errx.Error)
-
-	// Checkout. discountCode is optional ("" for none); when set, a one-off
-	// Stripe coupon (money discounts) or trial extension is applied.
-	CreateCheckoutSession(ctx context.Context, userID uuid.UUID, orgID uuid.UUID, priceID, successURL, cancelURL, discountCode string) (*stripe.CheckoutSession, *errx.Error)
-	CreatePortalSession(ctx context.Context, customerID, returnURL string) (string, *errx.Error)
-
-	// Subscriptions
-	GetSubscription(ctx context.Context, subscriptionID string) (*stripe.Subscription, *errx.Error)
-	CancelSubscription(ctx context.Context, subscriptionID string, cancelAtPeriodEnd bool) *errx.Error
-
-	// Plan changes with proration. discountCode is optional ("" for none).
-	ChangePlan(ctx context.Context, orgID uuid.UUID, newPlanID uuid.UUID, prorationBehavior, discountCode, interval string) (*stripe.Subscription, *errx.Error)
-	PreviewPlanChange(ctx context.Context, orgID uuid.UUID, newPlanID uuid.UUID) (*ProrationPreview, *errx.Error)
-
-	// Webhooks
-	VerifyWebhook(payload []byte, signature string) (*stripe.Event, *errx.Error)
-	ProcessWebhookEvent(ctx context.Context, event *stripe.Event) *errx.Error
-
-	// ApplyCustomerCredit adds a signed cents delta to a customer's Stripe
-	// balance (negative = credit the customer). Satisfies referral.StripeBalancer.
-	ApplyCustomerCredit(ctx context.Context, customerID string, amountCents int64, currency, idempotencyKey string) (string, *errx.Error)
-
-	// CreateCreditCheckoutSession creates a one-time (mode=payment) Stripe
-	// Checkout session to buy a top-up credit pack, reusing the org's existing
-	// Stripe customer. Fulfillment happens only in the webhook. packKey is a
-	// credits.CreditPack.Key; credits is the pack's credit count (recorded in
-	// session metadata so the webhook grants the right amount). The pack's
-	// Stripe price is resolved from config; an unconfigured pack returns 503.
-	CreateCreditCheckoutSession(ctx context.Context, userID, orgID uuid.UUID, packKey string, credits int, successURL, cancelURL string) (*stripe.CheckoutSession, *errx.Error)
-
-	// AutoTopUpCredits charges the org's saved payment method OFF-SESSION for
-	// one credit pack and fulfills it immediately on success (idempotent on
-	// the PaymentIntent id). Used by the credit-watch auto top-up; returns
-	// true when credits were granted. Fails cleanly (false, err) when the org
-	// has no saved payment method or the charge is declined.
-	AutoTopUpCredits(ctx context.Context, orgID uuid.UUID, packKey string, creditAmount int) (bool, error)
-
-	// WireReferral attaches the referral program (post-construction; nil = the
-	// referral hooks in the webhook flow are skipped).
-	WireReferral(r ReferralRewarder)
-
-	// WireCredits attaches the AI-credit granter and an audit logger
-	// (post-construction; nil = the credit grant/reset hooks are skipped).
-	WireCredits(g CreditGranter, a AuditLogger)
-}
-
-// CreditGranter is the slice of the credit service the Stripe webhook flow
-// drives: reset the monthly allowance each billing cycle and fulfill top-up
-// purchases. *credits.creditService satisfies it (plain error returns).
-type CreditGranter interface {
-	ResetMonthlyAllowance(ctx context.Context, orgID uuid.UUID, allowance int, idempotencyKey string) error
-	GrantPurchased(ctx context.Context, orgID uuid.UUID, amount int, reason, idempotencyKey string) (int, error)
-}
-
-// AuditLogger is the slice of the audit service the webhook flow uses to fire
-// AUDIT_CREATED so teammates' billing/credits views refresh live after a grant
-// or purchase. *audit.auditService satisfies it.
-type AuditLogger interface {
-	LogAction(ctx context.Context, orgID, actorID uuid.UUID, action models.AuditAction, entityType models.AuditEntityType, entityID *uuid.UUID, ip, userAgent string, changes, metadata map[string]string)
-}
-
-// ReferralRewarder is the slice of the referral service the Stripe webhook flow
-// drives. *referral.Service satisfies it; injected via WireReferral so the
-// stripe package needs no import of referral (no cycle).
-type ReferralRewarder interface {
-	QualifyOnConversion(ctx context.Context, inviteeOrgID uuid.UUID)
-	RewardOnFirstInvoice(ctx context.Context, inviteeOrgID, planID uuid.UUID, eventID string) *errx.Error
-	ClawbackForInvitee(ctx context.Context, inviteeOrgID uuid.UUID, eventID, reason string)
-	SyncStripeBalance(ctx context.Context, orgID uuid.UUID)
-	InviteeDiscountCode(ctx context.Context, inviteeOrgID uuid.UUID) string
-}
 
 type stripeService struct {
 	cfg              *config.StripeConfig
@@ -148,6 +64,43 @@ func NewService(
 	}
 }
 
+func newLive(
+	cfg *config.StripeConfig,
+	subRepo repository.SubscriptionRepository,
+	planRepo repository.PlanRepository,
+	workerAssignment worker.WorkerAssignmentService,
+	discountService discount.DiscountService,
+) (StripeService, error) {
+	return NewService(cfg, subRepo, planRepo, workerAssignment, discountService), nil
+}
+
+func checkoutFrom(s *stripe.CheckoutSession) *CheckoutSession {
+	if s == nil {
+		return nil
+	}
+	return &CheckoutSession{ID: s.ID, URL: s.URL}
+}
+
+func subscriptionFrom(s *stripe.Subscription) *Subscription {
+	if s == nil {
+		return nil
+	}
+	return &Subscription{
+		ID:                s.ID,
+		Status:            string(s.Status),
+		CurrentPeriodEnd:  s.CurrentPeriodEnd,
+		CancelAtPeriodEnd: s.CancelAtPeriodEnd,
+	}
+}
+
+func (s *stripeService) fetchStripeSubscription(subscriptionID string) (*stripe.Subscription, *errx.Error) {
+	sub, err := subscription.Get(subscriptionID, nil)
+	if err != nil {
+		return nil, errx.New(errx.NotFound, "subscription not found")
+	}
+	return sub, nil
+}
+
 func (s *stripeService) CreateCustomer(ctx context.Context, userID uuid.UUID, email, name string) (string, *errx.Error) {
 	params := &stripe.CustomerParams{
 		Email: stripe.String(email),
@@ -166,12 +119,12 @@ func (s *stripeService) CreateCustomer(ctx context.Context, userID uuid.UUID, em
 	return cust.ID, nil
 }
 
-func (s *stripeService) GetCustomer(ctx context.Context, customerID string) (*stripe.Customer, *errx.Error) {
+func (s *stripeService) GetCustomer(ctx context.Context, customerID string) (*Customer, *errx.Error) {
 	cust, err := customer.Get(customerID, nil)
 	if err != nil {
 		return nil, errx.New(errx.NotFound, "customer not found")
 	}
-	return cust, nil
+	return &Customer{ID: cust.ID, Email: cust.Email}, nil
 }
 
 // ApplyCustomerCredit posts a customer balance transaction. amountCents is the
@@ -199,7 +152,7 @@ func (s *stripeService) ApplyCustomerCredit(ctx context.Context, customerID stri
 	return txn.ID, nil
 }
 
-func (s *stripeService) CreateCheckoutSession(ctx context.Context, userID uuid.UUID, orgID uuid.UUID, priceID, successURL, cancelURL, discountCode string) (*stripe.CheckoutSession, *errx.Error) {
+func (s *stripeService) CreateCheckoutSession(ctx context.Context, userID uuid.UUID, orgID uuid.UUID, priceID, successURL, cancelURL, discountCode string) (*CheckoutSession, *errx.Error) {
 	// Get or create customer
 	sub, err := s.subRepo.GetByOrganizationID(ctx, orgID)
 	if err != nil {
@@ -312,7 +265,7 @@ func (s *stripeService) CreateCheckoutSession(ctx context.Context, userID uuid.U
 		}
 	}
 
-	return sess, nil
+	return checkoutFrom(sess), nil
 }
 
 // mintCoupon creates a one-off Stripe coupon for a money discount code.
@@ -360,7 +313,7 @@ func (s *stripeService) mintCoupon(dc *models.DiscountCode) (string, *errx.Error
 // checkout.session.completed webhook, keyed by the Stripe event id so a retry
 // can't double-grant. The org must already have a Stripe customer (paid-org
 // gating is enforced in the handler).
-func (s *stripeService) CreateCreditCheckoutSession(ctx context.Context, userID, orgID uuid.UUID, packKey string, credits int, successURL, cancelURL string) (*stripe.CheckoutSession, *errx.Error) {
+func (s *stripeService) CreateCreditCheckoutSession(ctx context.Context, userID, orgID uuid.UUID, packKey string, credits int, successURL, cancelURL string) (*CheckoutSession, *errx.Error) {
 	priceID := ""
 	if s.cfg != nil && s.cfg.CreditPackPriceIDs != nil {
 		priceID = s.cfg.CreditPackPriceIDs[packKey]
@@ -402,7 +355,7 @@ func (s *stripeService) CreateCreditCheckoutSession(ctx context.Context, userID,
 		sentry.CaptureException(fmt.Errorf("stripe credit checkout session failed: %w", serr))
 		return nil, errx.New(errx.Internal, "failed to create checkout session")
 	}
-	return sess, nil
+	return checkoutFrom(sess), nil
 }
 
 func (s *stripeService) AutoTopUpCredits(ctx context.Context, orgID uuid.UUID, packKey string, creditAmount int) (bool, error) {
@@ -495,12 +448,12 @@ func (s *stripeService) CreatePortalSession(ctx context.Context, customerID, ret
 	return sess.URL, nil
 }
 
-func (s *stripeService) GetSubscription(ctx context.Context, subscriptionID string) (*stripe.Subscription, *errx.Error) {
-	sub, err := subscription.Get(subscriptionID, nil)
-	if err != nil {
-		return nil, errx.New(errx.NotFound, "subscription not found")
+func (s *stripeService) GetSubscription(ctx context.Context, subscriptionID string) (*Subscription, *errx.Error) {
+	sub, xerr := s.fetchStripeSubscription(subscriptionID)
+	if xerr != nil {
+		return nil, xerr
 	}
-	return sub, nil
+	return subscriptionFrom(sub), nil
 }
 
 func (s *stripeService) CancelSubscription(ctx context.Context, subscriptionID string, cancelAtPeriodEnd bool) *errx.Error {
@@ -518,7 +471,7 @@ func (s *stripeService) CancelSubscription(ctx context.Context, subscriptionID s
 }
 
 // ChangePlan changes the organization's subscription to a new plan with proration
-func (s *stripeService) ChangePlan(ctx context.Context, orgID uuid.UUID, newPlanID uuid.UUID, prorationBehavior, discountCode, interval string) (*stripe.Subscription, *errx.Error) {
+func (s *stripeService) ChangePlan(ctx context.Context, orgID uuid.UUID, newPlanID uuid.UUID, prorationBehavior, discountCode, interval string) (*Subscription, *errx.Error) {
 	sub, err := s.subRepo.GetByOrganizationID(ctx, orgID)
 	if err != nil {
 		return nil, errx.New(errx.Internal, "failed to get subscription")
@@ -556,7 +509,7 @@ func (s *stripeService) ChangePlan(ctx context.Context, orgID uuid.UUID, newPlan
 	}
 
 	// Get current subscription from Stripe
-	stripeSub, xerr := s.GetSubscription(ctx, *sub.StripeSubscriptionID)
+	stripeSub, xerr := s.fetchStripeSubscription(*sub.StripeSubscriptionID)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -623,7 +576,7 @@ func (s *stripeService) ChangePlan(ctx context.Context, orgID uuid.UUID, newPlan
 		}
 	}
 
-	return updated, nil
+	return subscriptionFrom(updated), nil
 }
 
 // PreviewPlanChange previews the proration for changing to a new plan
@@ -647,7 +600,7 @@ func (s *stripeService) PreviewPlanChange(ctx context.Context, orgID uuid.UUID, 
 	}
 
 	// Get current subscription from Stripe
-	stripeSub, xerr := s.GetSubscription(ctx, *sub.StripeSubscriptionID)
+	stripeSub, xerr := s.fetchStripeSubscription(*sub.StripeSubscriptionID)
 	if xerr != nil {
 		return nil, xerr
 	}
@@ -694,15 +647,27 @@ func (s *stripeService) PreviewPlanChange(ctx context.Context, orgID uuid.UUID, 
 	}, nil
 }
 
-func (s *stripeService) VerifyWebhook(payload []byte, signature string) (*stripe.Event, *errx.Error) {
+func (s *stripeService) VerifyWebhook(payload []byte, signature string) (*Event, *errx.Error) {
 	event, err := webhook.ConstructEvent(payload, signature, s.cfg.WebhookSecret)
 	if err != nil {
 		return nil, errx.New(errx.BadRequest, "invalid webhook signature")
 	}
-	return &event, nil
+	raw, err := json.Marshal(event)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to encode webhook event")
+	}
+	return &Event{ID: event.ID, Type: string(event.Type), Payload: raw}, nil
 }
 
-func (s *stripeService) ProcessWebhookEvent(ctx context.Context, event *stripe.Event) *errx.Error {
+func (s *stripeService) ProcessWebhookEvent(ctx context.Context, wrapped *Event) *errx.Error {
+	if wrapped == nil || len(wrapped.Payload) == 0 {
+		return errx.New(errx.BadRequest, "invalid webhook event")
+	}
+	var decoded stripe.Event
+	if err := json.Unmarshal(wrapped.Payload, &decoded); err != nil {
+		return errx.New(errx.BadRequest, "invalid webhook event")
+	}
+	event := &decoded
 	// Check idempotency
 	exists, err := s.subRepo.WebhookEventExists(ctx, event.ID)
 	if err != nil {

--- a/internal/app/stripe/service_stub.go
+++ b/internal/app/stripe/service_stub.go
@@ -1,0 +1,26 @@
+//go:build minprofile
+
+package stripe
+
+import (
+	"errors"
+
+	"github.com/warmbly/warmbly/internal/app/discount"
+	"github.com/warmbly/warmbly/internal/app/worker"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// ErrStripeNotCompiled is returned when BILLING_PROVIDER=stripe on a
+// min-profile build that did not compile the Stripe backend.
+var ErrStripeNotCompiled = errors.New("stripe: billing backend not compiled in; rebuild without -tags minprofile (or use BILLING_PROVIDER=none)")
+
+func newLive(
+	_ *config.StripeConfig,
+	_ repository.SubscriptionRepository,
+	_ repository.PlanRepository,
+	_ worker.WorkerAssignmentService,
+	_ discount.DiscountService,
+) (StripeService, error) {
+	return nil, ErrStripeNotCompiled
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,17 +6,20 @@ import (
 	"os"
 	"strconv"
 	"strings"
-
-	awsconfig "github.com/aws/aws-sdk-go-v2/config"
-	"github.com/warmbly/warmbly/internal/infrastructure/secrets"
-	"github.com/warmbly/warmbly/internal/infrastructure/ssm"
 )
+
+// remoteKV is the env-fallback store used when AWS_CONFIG_ENABLED=true.
+// Hosted builds wire SSM / Secrets Manager; the min-profile build rejects
+// AWS_CONFIG_ENABLED so this stays nil.
+type remoteKV interface {
+	Get(ctx context.Context, key string) (string, error)
+}
 
 type Config struct {
 	Env              string // "dev" or "prod"
 	AWSConfigEnabled bool
-	params           *ssm.SSMParameterStore
-	secrets          *secrets.SecretsManagerClient
+	params           remoteKV
+	secrets          remoteKV
 }
 
 // NewConfig creates a new config instance with env-first loading and optional AWS fallback.
@@ -31,38 +34,12 @@ func NewConfig(ctx context.Context) (*Config, error) {
 	}
 
 	if awsEnabled {
-		awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to load AWS config: %w", err)
+		if err := cfg.initAWS(ctx); err != nil {
+			return nil, err
 		}
-
-		params, err := ssm.NewSSMParameterStore(ctx, awsCfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create SSM client: %w", err)
-		}
-		cfg.params = params
-
-		secretsClient, err := secrets.NewSecretsManagerClient(ctx, awsCfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create Secrets Manager client: %w", err)
-		}
-		cfg.secrets = secretsClient
 	}
 
 	return cfg, nil
-}
-
-// Load creates a Config with pre-initialized AWS clients (legacy compatibility).
-// Deprecated: Use NewConfig for new code.
-func Load(params *ssm.SSMParameterStore, secrets *secrets.SecretsManagerClient) *Config {
-	env := getEnvOrDefault("APP_ENV", "dev")
-
-	return &Config{
-		Env:              env,
-		AWSConfigEnabled: true, // Legacy mode always has AWS enabled
-		params:           params,
-		secrets:          secrets,
-	}
 }
 
 // GetKeyID returns the full AWS parameter/secret path with environment prefix.

--- a/internal/config/config_aws.go
+++ b/internal/config/config_aws.go
@@ -1,0 +1,45 @@
+//go:build !minprofile
+
+package config
+
+import (
+	"context"
+	"fmt"
+
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/warmbly/warmbly/internal/infrastructure/secrets"
+	"github.com/warmbly/warmbly/internal/infrastructure/ssm"
+)
+
+func (c *Config) initAWS(ctx context.Context) error {
+	awsCfg, err := awsconfig.LoadDefaultConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load AWS config: %w", err)
+	}
+
+	params, err := ssm.NewSSMParameterStore(ctx, awsCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create SSM client: %w", err)
+	}
+	c.params = params
+
+	secretsClient, err := secrets.NewSecretsManagerClient(ctx, awsCfg)
+	if err != nil {
+		return fmt.Errorf("failed to create Secrets Manager client: %w", err)
+	}
+	c.secrets = secretsClient
+	return nil
+}
+
+// Load creates a Config with pre-initialized AWS clients (legacy compatibility).
+// Deprecated: Use NewConfig for new code.
+func Load(params *ssm.SSMParameterStore, secretsClient *secrets.SecretsManagerClient) *Config {
+	env := getEnvOrDefault("APP_ENV", "dev")
+
+	return &Config{
+		Env:              env,
+		AWSConfigEnabled: true, // Legacy mode always has AWS enabled
+		params:           params,
+		secrets:          secretsClient,
+	}
+}

--- a/internal/config/config_aws_stub.go
+++ b/internal/config/config_aws_stub.go
@@ -1,0 +1,15 @@
+//go:build minprofile
+
+package config
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrAWSNotCompiled is returned when AWS_CONFIG_ENABLED=true on a min-profile build.
+var ErrAWSNotCompiled = errors.New("config: AWS config backend not compiled in; rebuild without -tags minprofile (or set AWS_CONFIG_ENABLED=false)")
+
+func (c *Config) initAWS(_ context.Context) error {
+	return ErrAWSNotCompiled
+}

--- a/internal/config/minprofile_test.go
+++ b/internal/config/minprofile_test.go
@@ -1,0 +1,28 @@
+//go:build minprofile
+
+package config
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNewConfig_MinProfileRejectsAWSConfig(t *testing.T) {
+	t.Setenv("AWS_CONFIG_ENABLED", "true")
+	_, err := NewConfig(context.Background())
+	if !errors.Is(err, ErrAWSNotCompiled) {
+		t.Fatalf("AWS_CONFIG_ENABLED on minprofile: %v", err)
+	}
+}
+
+func TestNewConfig_MinProfileAllowsEnvOnly(t *testing.T) {
+	t.Setenv("AWS_CONFIG_ENABLED", "false")
+	cfg, err := NewConfig(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.AWSConfigEnabled {
+		t.Fatal("env-only config must not enable AWS")
+	}
+}

--- a/internal/infrastructure/eventbus/minprofile_test.go
+++ b/internal/infrastructure/eventbus/minprofile_test.go
@@ -1,0 +1,16 @@
+//go:build minprofile
+
+package eventbus
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestFromEnv_MinProfileRejectsKafka(t *testing.T) {
+	t.Setenv("EVENTBUS_PROVIDER", "kafka")
+	_, err := FromEnv("localhost:9092", nil)
+	if !errors.Is(err, ErrKafkaNotCompiled) {
+		t.Fatalf("kafka selection on minprofile: %v", err)
+	}
+}

--- a/internal/infrastructure/gtasks/gtasks.go
+++ b/internal/infrastructure/gtasks/gtasks.go
@@ -1,3 +1,5 @@
+//go:build !minprofile
+
 package gtasks
 
 import (

--- a/internal/infrastructure/gtasks/gtasks_stub.go
+++ b/internal/infrastructure/gtasks/gtasks_stub.go
@@ -1,0 +1,29 @@
+//go:build minprofile
+
+package gtasks
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/tasks/proto"
+)
+
+// ErrGCPNotCompiled is returned when TASKS_PROVIDER=gcloud on a min-profile build.
+var ErrGCPNotCompiled = errors.New("gtasks: gcloud backend not compiled in; rebuild without -tags minprofile (or use TASKS_PROVIDER=local)")
+
+// Client is a placeholder so cmd/backend type-checks the gcloud branch.
+type Client struct{}
+
+func NewClient(_ context.Context, _, _, _, _ string) (*Client, error) {
+	return nil, ErrGCPNotCompiled
+}
+
+func (c *Client) CreateTask(_ context.Context, _ *proto.ProcessTask, _ time.Time) (string, error) {
+	return "", ErrGCPNotCompiled
+}
+
+func (c *Client) DeleteTask(_ context.Context, _ string) error {
+	return ErrGCPNotCompiled
+}

--- a/internal/infrastructure/gtasks/minprofile_test.go
+++ b/internal/infrastructure/gtasks/minprofile_test.go
@@ -1,0 +1,16 @@
+//go:build minprofile
+
+package gtasks
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNewClient_MinProfileRejectsGCloud(t *testing.T) {
+	_, err := NewClient(context.Background(), "q", "http://example", "sa@example", "")
+	if !errors.Is(err, ErrGCPNotCompiled) {
+		t.Fatalf("gcloud client on minprofile: %v", err)
+	}
+}

--- a/internal/infrastructure/kms/aws.go
+++ b/internal/infrastructure/kms/aws.go
@@ -1,0 +1,17 @@
+//go:build !minprofile
+
+package kms
+
+import (
+	"context"
+
+	awsconf "github.com/aws/aws-sdk-go-v2/config"
+)
+
+func newAWS(ctx context.Context, keyID string) (Provider, error) {
+	awscfg, err := awsconf.LoadDefaultConfig(ctx, awsconf.WithDefaultRegion("us-east-1"))
+	if err != nil {
+		return nil, err
+	}
+	return New(ctx, awscfg, keyID)
+}

--- a/internal/infrastructure/kms/aws_stub.go
+++ b/internal/infrastructure/kms/aws_stub.go
@@ -1,0 +1,15 @@
+//go:build minprofile
+
+package kms
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrAWSNotCompiled is returned when KMS_PROVIDER=aws on a min-profile build.
+var ErrAWSNotCompiled = errors.New("kms: aws backend not compiled in; rebuild without -tags minprofile (or use KMS_PROVIDER=local)")
+
+func newAWS(_ context.Context, _ string) (Provider, error) {
+	return nil, ErrAWSNotCompiled
+}

--- a/internal/infrastructure/kms/decryption.go
+++ b/internal/infrastructure/kms/decryption.go
@@ -1,3 +1,5 @@
+//go:build !minprofile
+
 package kms
 
 import (

--- a/internal/infrastructure/kms/encryption.go
+++ b/internal/infrastructure/kms/encryption.go
@@ -1,3 +1,5 @@
+//go:build !minprofile
+
 package kms
 
 import (

--- a/internal/infrastructure/kms/factory.go
+++ b/internal/infrastructure/kms/factory.go
@@ -4,20 +4,19 @@ import (
 	"context"
 	"fmt"
 	"os"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 // FromEnv constructs the active KMS provider from environment variables.
 //
-//	KMS_PROVIDER=aws    -> NewAWS (uses awscfg, KMS_AWS_KEY_ID or fallbackAWSKeyID)
+//	KMS_PROVIDER=aws    -> newAWS (KMS_AWS_KEY_ID or fallbackAWSKeyID)
 //	KMS_PROVIDER=local  -> NewLocalFromEnv
 //	(unset)             -> defaults to "aws" for backwards compatibility
 //
-// Callers pass an AWS config that's only consulted when the AWS provider is
-// selected. The fallbackAWSKeyID is used when KMS_AWS_KEY_ID is empty — this
+// The fallbackAWSKeyID is used when KMS_AWS_KEY_ID is empty — this
 // preserves the historical "alias/master-key[-dev]" default used at boot.
-func FromEnv(ctx context.Context, awscfg aws.Config, fallbackAWSKeyID string) (Provider, error) {
+// AWS config is loaded inside the hosted AWS implementation so the
+// min-profile build never imports the AWS SDK.
+func FromEnv(ctx context.Context, fallbackAWSKeyID string) (Provider, error) {
 	provider := os.Getenv("KMS_PROVIDER")
 	if provider == "" {
 		provider = "aws"
@@ -31,7 +30,7 @@ func FromEnv(ctx context.Context, awscfg aws.Config, fallbackAWSKeyID string) (P
 		if keyID == "" {
 			return nil, fmt.Errorf("kms: aws provider requires KMS_AWS_KEY_ID or fallback key id")
 		}
-		return New(ctx, awscfg, keyID)
+		return newAWS(ctx, keyID)
 	case "local":
 		return NewLocalFromEnv()
 	default:

--- a/internal/infrastructure/kms/factory_aws_test.go
+++ b/internal/infrastructure/kms/factory_aws_test.go
@@ -1,0 +1,31 @@
+//go:build !minprofile
+
+package kms
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFromEnv_AWSFallsBackToProvidedKeyID(t *testing.T) {
+	t.Setenv("KMS_PROVIDER", "aws")
+	t.Setenv("KMS_AWS_KEY_ID", "")
+	p, err := FromEnv(context.Background(), "alias/fallback")
+	if err != nil {
+		t.Fatalf("aws provider with fallback key should construct: %v", err)
+	}
+	if p.Name() != "aws-kms" {
+		t.Fatalf("expected aws-kms, got %q", p.Name())
+	}
+}
+
+func TestFromEnv_DefaultsToAWS(t *testing.T) {
+	t.Setenv("KMS_PROVIDER", "")
+	p, err := FromEnv(context.Background(), "alias/x")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if p.Name() != "aws-kms" {
+		t.Fatalf("unset KMS_PROVIDER should default to aws-kms, got %q", p.Name())
+	}
+}

--- a/internal/infrastructure/kms/factory_minprofile_test.go
+++ b/internal/infrastructure/kms/factory_minprofile_test.go
@@ -1,0 +1,25 @@
+//go:build minprofile
+
+package kms
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestFromEnv_MinProfileRejectsAWS(t *testing.T) {
+	t.Setenv("KMS_PROVIDER", "aws")
+	_, err := FromEnv(context.Background(), "alias/fallback")
+	if !errors.Is(err, ErrAWSNotCompiled) {
+		t.Fatalf("aws selection on minprofile: %v", err)
+	}
+}
+
+func TestFromEnv_MinProfileRejectsAWSKMSAlias(t *testing.T) {
+	t.Setenv("KMS_PROVIDER", "aws-kms")
+	_, err := FromEnv(context.Background(), "alias/fallback")
+	if !errors.Is(err, ErrAWSNotCompiled) {
+		t.Fatalf("aws-kms selection on minprofile: %v", err)
+	}
+}

--- a/internal/infrastructure/kms/factory_test.go
+++ b/internal/infrastructure/kms/factory_test.go
@@ -6,13 +6,11 @@ import (
 	"encoding/base64"
 	"io"
 	"testing"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 func TestFromEnv_UnknownProvider(t *testing.T) {
 	t.Setenv("KMS_PROVIDER", "no-such-provider")
-	_, err := FromEnv(context.Background(), aws.Config{}, "fallback")
+	_, err := FromEnv(context.Background(), "fallback")
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
 	}
@@ -26,7 +24,7 @@ func TestFromEnv_LocalRoundTrip(t *testing.T) {
 	t.Setenv("KMS_PROVIDER", "local")
 	t.Setenv("KMS_LOCAL_MASTER_KEY", base64.StdEncoding.EncodeToString(key))
 
-	p, err := FromEnv(context.Background(), aws.Config{}, "")
+	p, err := FromEnv(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -52,40 +50,15 @@ func TestFromEnv_LocalMissingKeyErrors(t *testing.T) {
 	t.Setenv("KMS_LOCAL_MASTER_KEY", "")
 	t.Setenv("KMS_LOCAL_MASTER_KEY_FILE", "")
 
-	if _, err := FromEnv(context.Background(), aws.Config{}, ""); err == nil {
+	if _, err := FromEnv(context.Background(), ""); err == nil {
 		t.Fatal("expected error when local key unset")
-	}
-}
-
-func TestFromEnv_AWSFallsBackToProvidedKeyID(t *testing.T) {
-	// AWS provider construction is allowed even without real AWS — it just
-	// builds the client. Failure would only occur on real KMS calls.
-	t.Setenv("KMS_PROVIDER", "aws")
-	t.Setenv("KMS_AWS_KEY_ID", "")
-	p, err := FromEnv(context.Background(), aws.Config{}, "alias/fallback")
-	if err != nil {
-		t.Fatalf("aws provider with fallback key should construct: %v", err)
-	}
-	if p.Name() != "aws-kms" {
-		t.Fatalf("expected aws-kms, got %q", p.Name())
 	}
 }
 
 func TestFromEnv_AWSWithoutAnyKeyIDErrors(t *testing.T) {
 	t.Setenv("KMS_PROVIDER", "aws")
 	t.Setenv("KMS_AWS_KEY_ID", "")
-	if _, err := FromEnv(context.Background(), aws.Config{}, ""); err == nil {
+	if _, err := FromEnv(context.Background(), ""); err == nil {
 		t.Fatal("aws provider without key id should error")
-	}
-}
-
-func TestFromEnv_DefaultsToAWS(t *testing.T) {
-	t.Setenv("KMS_PROVIDER", "")
-	p, err := FromEnv(context.Background(), aws.Config{}, "alias/x")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if p.Name() != "aws-kms" {
-		t.Fatalf("unset KMS_PROVIDER should default to aws-kms, got %q", p.Name())
 	}
 }

--- a/internal/infrastructure/kms/kms.go
+++ b/internal/infrastructure/kms/kms.go
@@ -1,3 +1,5 @@
+//go:build !minprofile
+
 package kms
 
 import (
@@ -18,3 +20,7 @@ func New(ctx context.Context, cfg aws.Config, keyID string) (*KMS, error) {
 		MasterKey: keyID,
 	}, nil
 }
+
+func (k *KMS) Name() string { return "aws-kms" }
+
+var _ Provider = (*KMS)(nil)

--- a/internal/infrastructure/kms/provider.go
+++ b/internal/infrastructure/kms/provider.go
@@ -27,9 +27,5 @@ type Provider interface {
 
 // Compile-time interface checks.
 var (
-	_ Provider = (*KMS)(nil)
 	_ Provider = (*LocalProvider)(nil)
 )
-
-// Name satisfies Provider for the AWS implementation.
-func (k *KMS) Name() string { return "aws-kms" }

--- a/internal/infrastructure/pubsub/client.go
+++ b/internal/infrastructure/pubsub/client.go
@@ -2,125 +2,12 @@ package pubsub
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
-	"cloud.google.com/go/pubsub"
 	"github.com/getsentry/sentry-go"
 	"github.com/google/uuid"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 )
-
-// Client wraps Google Pub/Sub for real-time streaming
-type Client struct {
-	client    *pubsub.Client
-	projectID string
-}
-
-// NewClient creates a new Pub/Sub client
-func NewClient(ctx context.Context, projectID string) (*Client, error) {
-	client, err := pubsub.NewClient(ctx, projectID)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create pubsub client: %w", err)
-	}
-
-	return &Client{
-		client:    client,
-		projectID: projectID,
-	}, nil
-}
-
-// Close closes the Pub/Sub client
-func (c *Client) Close() error {
-	return c.client.Close()
-}
-
-// getTopic gets or creates a topic
-func (c *Client) getTopic(ctx context.Context, topicID string) (*pubsub.Topic, error) {
-	topic := c.client.Topic(topicID)
-	exists, err := topic.Exists(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	if !exists {
-		topic, err = c.client.CreateTopic(ctx, topicID)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	return topic, nil
-}
-
-// realtimeTopology is the full topic -> pull-subscription set the Elixir
-// realtime service consumes. It is the single source of truth for provisioning:
-// every topic the StreamingPublisher writes to gets exactly one subscription
-// named "<topic>-sub", matching :realtime, :pubsub_subscriptions in the Elixir
-// config (realtime/config/{config,runtime}.exs). Keep the two lists in lockstep.
-var realtimeTopology = map[string]string{
-	TopicTaskStatus:     TopicTaskStatus + "-sub",
-	TopicCampaignUpdate: TopicCampaignUpdate + "-sub",
-	TopicWarmupUpdate:   TopicWarmupUpdate + "-sub",
-	TopicEmailError:     TopicEmailError + "-sub",
-	TopicEmailWarning:   TopicEmailWarning + "-sub",
-	TopicUserEvents:     TopicUserEvents + "-sub",
-	TopicEmailInbox:     TopicEmailInbox + "-sub",
-	TopicBulkOps:        TopicBulkOps + "-sub",
-	TopicContactsSync:   TopicContactsSync + "-sub",
-}
-
-// EnsureRealtimeTopology idempotently creates every realtime topic and its pull
-// subscription. Safe to call on every boot and from multiple services
-// concurrently: AlreadyExists is treated as success. Provisioning here (the
-// control plane) means the Elixir Broadway producers always find their
-// subscriptions, instead of silently consuming from a subscription that was
-// never created. Called only when PUBSUB_ENABLED=true.
-func (c *Client) EnsureRealtimeTopology(ctx context.Context) error {
-	for topicID, subID := range realtimeTopology {
-		topic, err := c.client.CreateTopic(ctx, topicID)
-		if err != nil {
-			if status.Code(err) != codes.AlreadyExists {
-				return fmt.Errorf("create topic %s: %w", topicID, err)
-			}
-			topic = c.client.Topic(topicID)
-		}
-		if _, err := c.client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
-			Topic:       topic,
-			AckDeadline: 30 * time.Second,
-		}); err != nil && status.Code(err) != codes.AlreadyExists {
-			return fmt.Errorf("create subscription %s: %w", subID, err)
-		}
-	}
-	return nil
-}
-
-// Publish publishes a message to a topic
-func (c *Client) Publish(ctx context.Context, topicID string, data interface{}, attributes map[string]string) error {
-	topic, err := c.getTopic(ctx, topicID)
-	if err != nil {
-		return fmt.Errorf("failed to get topic: %w", err)
-	}
-
-	jsonData, err := json.Marshal(data)
-	if err != nil {
-		return fmt.Errorf("failed to marshal data: %w", err)
-	}
-
-	result := topic.Publish(ctx, &pubsub.Message{
-		Data:       jsonData,
-		Attributes: attributes,
-	})
-
-	_, err = result.Get(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to publish message: %w", err)
-	}
-
-	return nil
-}
 
 // eventBus is the transport the StreamingPublisher writes to. Both the Google
 // Pub/Sub Client and the Redis bridge implement it, so the publish helpers stay

--- a/internal/infrastructure/pubsub/gcp.go
+++ b/internal/infrastructure/pubsub/gcp.go
@@ -1,0 +1,123 @@
+//go:build !minprofile
+
+package pubsub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"cloud.google.com/go/pubsub"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// Client wraps Google Pub/Sub for real-time streaming
+type Client struct {
+	client    *pubsub.Client
+	projectID string
+}
+
+// NewClient creates a new Pub/Sub client
+func NewClient(ctx context.Context, projectID string) (*Client, error) {
+	client, err := pubsub.NewClient(ctx, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pubsub client: %w", err)
+	}
+
+	return &Client{
+		client:    client,
+		projectID: projectID,
+	}, nil
+}
+
+// Close closes the Pub/Sub client
+func (c *Client) Close() error {
+	return c.client.Close()
+}
+
+// getTopic gets or creates a topic
+func (c *Client) getTopic(ctx context.Context, topicID string) (*pubsub.Topic, error) {
+	topic := c.client.Topic(topicID)
+	exists, err := topic.Exists(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if !exists {
+		topic, err = c.client.CreateTopic(ctx, topicID)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return topic, nil
+}
+
+// realtimeTopology is the full topic -> pull-subscription set the Elixir
+// realtime service consumes. It is the single source of truth for provisioning:
+// every topic the StreamingPublisher writes to gets exactly one subscription
+// named "<topic>-sub", matching :realtime, :pubsub_subscriptions in the Elixir
+// config (realtime/config/{config,runtime}.exs). Keep the two lists in lockstep.
+var realtimeTopology = map[string]string{
+	TopicTaskStatus:     TopicTaskStatus + "-sub",
+	TopicCampaignUpdate: TopicCampaignUpdate + "-sub",
+	TopicWarmupUpdate:   TopicWarmupUpdate + "-sub",
+	TopicEmailError:     TopicEmailError + "-sub",
+	TopicEmailWarning:   TopicEmailWarning + "-sub",
+	TopicUserEvents:     TopicUserEvents + "-sub",
+	TopicEmailInbox:     TopicEmailInbox + "-sub",
+	TopicBulkOps:        TopicBulkOps + "-sub",
+	TopicContactsSync:   TopicContactsSync + "-sub",
+}
+
+// EnsureRealtimeTopology idempotently creates every realtime topic and its pull
+// subscription. Safe to call on every boot and from multiple services
+// concurrently: AlreadyExists is treated as success. Provisioning here (the
+// control plane) means the Elixir Broadway producers always find their
+// subscriptions, instead of silently consuming from a subscription that was
+// never created. Called only when PUBSUB_ENABLED=true.
+func (c *Client) EnsureRealtimeTopology(ctx context.Context) error {
+	for topicID, subID := range realtimeTopology {
+		topic, err := c.client.CreateTopic(ctx, topicID)
+		if err != nil {
+			if status.Code(err) != codes.AlreadyExists {
+				return fmt.Errorf("create topic %s: %w", topicID, err)
+			}
+			topic = c.client.Topic(topicID)
+		}
+		if _, err := c.client.CreateSubscription(ctx, subID, pubsub.SubscriptionConfig{
+			Topic:       topic,
+			AckDeadline: 30 * time.Second,
+		}); err != nil && status.Code(err) != codes.AlreadyExists {
+			return fmt.Errorf("create subscription %s: %w", subID, err)
+		}
+	}
+	return nil
+}
+
+// Publish publishes a message to a topic
+func (c *Client) Publish(ctx context.Context, topicID string, data interface{}, attributes map[string]string) error {
+	topic, err := c.getTopic(ctx, topicID)
+	if err != nil {
+		return fmt.Errorf("failed to get topic: %w", err)
+	}
+
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return fmt.Errorf("failed to marshal data: %w", err)
+	}
+
+	result := topic.Publish(ctx, &pubsub.Message{
+		Data:       jsonData,
+		Attributes: attributes,
+	})
+
+	_, err = result.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to publish message: %w", err)
+	}
+
+	return nil
+}

--- a/internal/infrastructure/pubsub/gcp_stub.go
+++ b/internal/infrastructure/pubsub/gcp_stub.go
@@ -1,0 +1,26 @@
+//go:build minprofile
+
+package pubsub
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrGCPNotCompiled is returned when PUBSUB_ENABLED=true on a min-profile build.
+var ErrGCPNotCompiled = errors.New("pubsub: google pub/sub backend not compiled in; rebuild without -tags minprofile (or set PUBSUB_ENABLED=false)")
+
+// Client is a placeholder so cmd mains type-check the GCP branch.
+type Client struct{}
+
+func NewClient(_ context.Context, _ string) (*Client, error) {
+	return nil, ErrGCPNotCompiled
+}
+
+func (c *Client) Close() error { return ErrGCPNotCompiled }
+
+func (c *Client) EnsureRealtimeTopology(_ context.Context) error { return ErrGCPNotCompiled }
+
+func (c *Client) Publish(_ context.Context, _ string, _ interface{}, _ map[string]string) error {
+	return ErrGCPNotCompiled
+}

--- a/internal/infrastructure/pubsub/minprofile_test.go
+++ b/internal/infrastructure/pubsub/minprofile_test.go
@@ -1,0 +1,16 @@
+//go:build minprofile
+
+package pubsub
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNewClient_MinProfileRejectsGCP(t *testing.T) {
+	_, err := NewClient(context.Background(), "proj")
+	if !errors.Is(err, ErrGCPNotCompiled) {
+		t.Fatalf("gcp pubsub on minprofile: %v", err)
+	}
+}

--- a/internal/infrastructure/storage/exists.go
+++ b/internal/infrastructure/storage/exists.go
@@ -1,3 +1,5 @@
+//go:build !minprofile
+
 package storage
 
 import (

--- a/internal/infrastructure/storage/factory.go
+++ b/internal/infrastructure/storage/factory.go
@@ -4,18 +4,15 @@ import (
 	"context"
 	"fmt"
 	"os"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 // NewFromEnv constructs the active blob store from environment variables.
 //
-//	BLOB_PROVIDER=s3          -> existing S3 client (works for AWS / MinIO /
-//	                             R2 / B2 / Hetzner Object Storage)
+//	BLOB_PROVIDER=s3          -> newS3 (works for AWS / MinIO / R2 / B2)
 //	BLOB_PROVIDER=filesystem  -> NewFilesystem at BLOB_FS_ROOT
 //	(unset)                   -> defaults to "s3" for backwards compatibility
 //
-// awscfg + defaultBucket are only consulted when the S3 provider is selected.
+// defaultBucket is only consulted when the S3 provider is selected.
 // For non-AWS S3-compatible endpoints, the operator sets standard AWS env vars:
 //
 //	AWS_ENDPOINT_URL_S3       -> override endpoint (MinIO, R2, etc.)
@@ -24,7 +21,7 @@ import (
 //	AWS_SECRET_ACCESS_KEY     -> S3 credential
 //
 // BLOB_BUCKET overrides defaultBucket when set.
-func NewFromEnv(ctx context.Context, awscfg aws.Config, defaultBucket string) (Store, error) {
+func NewFromEnv(ctx context.Context, defaultBucket string) (Store, error) {
 	provider := os.Getenv("BLOB_PROVIDER")
 	if provider == "" {
 		provider = "s3"
@@ -39,12 +36,7 @@ func NewFromEnv(ctx context.Context, awscfg aws.Config, defaultBucket string) (S
 		if bucket == "" {
 			return nil, fmt.Errorf("storage: s3 provider requires BLOB_BUCKET or default bucket")
 		}
-		client, err := NewClient(ctx, awscfg, bucket)
-		if err != nil {
-			return nil, err
-		}
-		client.PublicBaseURL = publicBaseURL
-		return client, nil
+		return newS3(ctx, bucket, publicBaseURL)
 	case "filesystem", "fs":
 		root := os.Getenv("BLOB_FS_ROOT")
 		if root == "" {
@@ -58,6 +50,5 @@ func NewFromEnv(ctx context.Context, awscfg aws.Config, defaultBucket string) (S
 
 // Compile-time interface checks.
 var (
-	_ Store = (*Client)(nil)
 	_ Store = (*FilesystemStore)(nil)
 )

--- a/internal/infrastructure/storage/factory_minprofile_test.go
+++ b/internal/infrastructure/storage/factory_minprofile_test.go
@@ -1,0 +1,17 @@
+//go:build minprofile
+
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func TestNewFromEnv_MinProfileRejectsS3(t *testing.T) {
+	t.Setenv("BLOB_PROVIDER", "s3")
+	_, err := NewFromEnv(context.Background(), "fallback-bucket")
+	if !errors.Is(err, ErrS3NotCompiled) {
+		t.Fatalf("s3 selection on minprofile: %v", err)
+	}
+}

--- a/internal/infrastructure/storage/factory_s3_test.go
+++ b/internal/infrastructure/storage/factory_s3_test.go
@@ -1,0 +1,20 @@
+//go:build !minprofile
+
+package storage
+
+import (
+	"context"
+	"testing"
+)
+
+func TestNewFromEnv_S3WithFallbackBucket(t *testing.T) {
+	t.Setenv("BLOB_PROVIDER", "s3")
+	t.Setenv("BLOB_BUCKET", "")
+	s, err := NewFromEnv(context.Background(), "fallback-bucket")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Name() != "s3" {
+		t.Fatalf("expected s3, got %q", s.Name())
+	}
+}

--- a/internal/infrastructure/storage/factory_test.go
+++ b/internal/infrastructure/storage/factory_test.go
@@ -3,13 +3,11 @@ package storage
 import (
 	"context"
 	"testing"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
 )
 
 func TestNewFromEnv_UnknownProvider(t *testing.T) {
 	t.Setenv("BLOB_PROVIDER", "garage-but-not-really")
-	_, err := NewFromEnv(context.Background(), aws.Config{}, "")
+	_, err := NewFromEnv(context.Background(), "")
 	if err == nil {
 		t.Fatal("expected error for unknown provider")
 	}
@@ -18,7 +16,7 @@ func TestNewFromEnv_UnknownProvider(t *testing.T) {
 func TestNewFromEnv_FilesystemNeedsRoot(t *testing.T) {
 	t.Setenv("BLOB_PROVIDER", "filesystem")
 	t.Setenv("BLOB_FS_ROOT", "")
-	if _, err := NewFromEnv(context.Background(), aws.Config{}, ""); err == nil {
+	if _, err := NewFromEnv(context.Background(), ""); err == nil {
 		t.Fatal("filesystem provider should require BLOB_FS_ROOT")
 	}
 }
@@ -26,7 +24,7 @@ func TestNewFromEnv_FilesystemNeedsRoot(t *testing.T) {
 func TestNewFromEnv_FilesystemHappy(t *testing.T) {
 	t.Setenv("BLOB_PROVIDER", "filesystem")
 	t.Setenv("BLOB_FS_ROOT", t.TempDir())
-	s, err := NewFromEnv(context.Background(), aws.Config{}, "")
+	s, err := NewFromEnv(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,27 +36,15 @@ func TestNewFromEnv_FilesystemHappy(t *testing.T) {
 func TestNewFromEnv_S3NeedsBucket(t *testing.T) {
 	t.Setenv("BLOB_PROVIDER", "s3")
 	t.Setenv("BLOB_BUCKET", "")
-	if _, err := NewFromEnv(context.Background(), aws.Config{}, ""); err == nil {
+	if _, err := NewFromEnv(context.Background(), ""); err == nil {
 		t.Fatal("s3 provider should require BLOB_BUCKET or fallback bucket")
-	}
-}
-
-func TestNewFromEnv_S3WithFallbackBucket(t *testing.T) {
-	t.Setenv("BLOB_PROVIDER", "s3")
-	t.Setenv("BLOB_BUCKET", "")
-	s, err := NewFromEnv(context.Background(), aws.Config{}, "fallback-bucket")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if s.Name() != "s3" {
-		t.Fatalf("expected s3, got %q", s.Name())
 	}
 }
 
 func TestNewFromEnv_FSAlias(t *testing.T) {
 	t.Setenv("BLOB_PROVIDER", "fs")
 	t.Setenv("BLOB_FS_ROOT", t.TempDir())
-	s, err := NewFromEnv(context.Background(), aws.Config{}, "")
+	s, err := NewFromEnv(context.Background(), "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/infrastructure/storage/s3.go
+++ b/internal/infrastructure/storage/s3.go
@@ -1,3 +1,5 @@
+//go:build !minprofile
+
 package storage
 
 import (
@@ -31,3 +33,5 @@ func NewClient(ctx context.Context, cfg aws.Config, bucket string) (*Client, err
 		}),
 	}, nil
 }
+
+var _ Store = (*Client)(nil)

--- a/internal/infrastructure/storage/s3_construct.go
+++ b/internal/infrastructure/storage/s3_construct.go
@@ -1,0 +1,22 @@
+//go:build !minprofile
+
+package storage
+
+import (
+	"context"
+
+	awsconf "github.com/aws/aws-sdk-go-v2/config"
+)
+
+func newS3(ctx context.Context, bucket, publicBaseURL string) (Store, error) {
+	awscfg, err := awsconf.LoadDefaultConfig(ctx, awsconf.WithDefaultRegion("us-east-1"))
+	if err != nil {
+		return nil, err
+	}
+	client, err := NewClient(ctx, awscfg, bucket)
+	if err != nil {
+		return nil, err
+	}
+	client.PublicBaseURL = publicBaseURL
+	return client, nil
+}

--- a/internal/infrastructure/storage/s3_store.go
+++ b/internal/infrastructure/storage/s3_store.go
@@ -1,3 +1,5 @@
+//go:build !minprofile
+
 package storage
 
 import (

--- a/internal/infrastructure/storage/s3_stub.go
+++ b/internal/infrastructure/storage/s3_stub.go
@@ -1,0 +1,15 @@
+//go:build minprofile
+
+package storage
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrS3NotCompiled is returned when BLOB_PROVIDER=s3 on a min-profile build.
+var ErrS3NotCompiled = errors.New("storage: s3 backend not compiled in; rebuild without -tags minprofile (or use BLOB_PROVIDER=filesystem)")
+
+func newS3(_ context.Context, _, _ string) (Store, error) {
+	return nil, ErrS3NotCompiled
+}

--- a/internal/notify/email.go
+++ b/internal/notify/email.go
@@ -1,3 +1,5 @@
+//go:build !minprofile
+
 package notify
 
 import (
@@ -9,15 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sesv2/types"
 	"github.com/getsentry/sentry-go"
 )
-
-type EmailNotificationService interface {
-	Send(ctx context.Context, to, cc, bcc []string, subject, message string) error
-	// SendOutreach is the same as Send but lets the caller override
-	// the Reply-To header. Used by the admin outreach composer so a
-	// noreply From: address can still funnel replies into a real
-	// support inbox. Empty replyTo falls back to the From address.
-	SendOutreach(ctx context.Context, to []string, replyTo, subject, message string) error
-}
 
 type emailNotificationService struct {
 	Name    string

--- a/internal/notify/factory.go
+++ b/internal/notify/factory.go
@@ -9,6 +9,16 @@ import (
 	"github.com/warmbly/warmbly/internal/config"
 )
 
+// EmailNotificationService sends platform mail (login codes, resets, invites).
+type EmailNotificationService interface {
+	Send(ctx context.Context, to, cc, bcc []string, subject, message string) error
+	// SendOutreach is the same as Send but lets the caller override
+	// the Reply-To header. Used by the admin outreach composer so a
+	// noreply From: address can still funnel replies into a real
+	// support inbox. Empty replyTo falls back to the From address.
+	SendOutreach(ctx context.Context, to []string, replyTo, subject, message string) error
+}
+
 // Transport is a constructed platform-mail sender plus enough metadata for the
 // boot preflight, the admin diagnostics endpoint, and the login screen to tell
 // the operator what is actually happening to their mail.

--- a/internal/notify/minprofile_test.go
+++ b/internal/notify/minprofile_test.go
@@ -1,0 +1,19 @@
+//go:build minprofile
+
+package notify
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/config"
+)
+
+func TestNewTransport_MinProfileRejectsSES(t *testing.T) {
+	t.Setenv("MAIL_TRANSPORT", "ses")
+	_, err := NewTransport(context.Background(), &config.Config{}, "Warmbly", "dev@localhost")
+	if !errors.Is(err, ErrSESNotCompiled) {
+		t.Fatalf("ses transport on minprofile: %v", err)
+	}
+}

--- a/internal/notify/ses_stub.go
+++ b/internal/notify/ses_stub.go
@@ -1,0 +1,16 @@
+//go:build minprofile
+
+package notify
+
+import (
+	"context"
+	"errors"
+)
+
+// ErrSESNotCompiled is returned when MAIL_TRANSPORT=ses on a min-profile build.
+var ErrSESNotCompiled = errors.New("notify: ses backend not compiled in; rebuild without -tags minprofile (or use MAIL_TRANSPORT=smtp or log)")
+
+// NewEmailNotficiationService is the stub used when SES is not compiled in.
+func NewEmailNotficiationService(_ context.Context, _, _ string) (EmailNotificationService, error) {
+	return nil, ErrSESNotCompiled
+}

--- a/scripts/confenge_min_profile_sbom.sh
+++ b/scripts/confenge_min_profile_sbom.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Deterministic CONFENGE min-profile SBOM.
+# Usage: scripts/confenge_min_profile_sbom.sh [out.json]
+# Re-running the same command on the same tree must yield the same SHA-256.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+OUT="${1:-/dev/stdout}"
+TAGS="${GO_MINPROFILE_TAGS:-minprofile}"
+BINS="${CONFENGE_MIN_BINS:-./cmd/backend ./cmd/consumer ./cmd/worker ./cmd/confenge}"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+{
+  echo "{"
+  echo "  \"profile\": \"minprofile\","
+  echo "  \"go_tags\": \"${TAGS}\","
+  echo "  \"go_version\": \"$(go version | tr -d '"')\","
+  echo "  \"modules\": ["
+  first=1
+  # Module list of packages that actually link into the min-profile binaries.
+  # Sorted + unique so two runs hash identically.
+  for pkg in $BINS; do
+    go list -deps -f '{{if .Module}}{{.Module.Path}} {{.Module.Version}}{{end}}' -tags "$TAGS" "$pkg"
+  done | awk 'NF && $1 != "github.com/warmbly/warmbly" {print}' | sort -u > "$tmp/mods.txt"
+  while read -r path ver; do
+    [ -n "$path" ] || continue
+    if [ "$first" -eq 1 ]; then first=0; else echo ","; fi
+    printf '    {"path": "%s", "version": "%s"}' "$path" "$ver"
+  done < "$tmp/mods.txt"
+  echo
+  echo "  ]"
+  echo "}"
+} > "$tmp/sbom.json"
+
+# Normalize trailing whitespace; keep stable JSON.
+python3 - "$tmp/sbom.json" "$OUT" <<'PY'
+import json, sys
+src, dest = sys.argv[1], sys.argv[2]
+with open(src) as f:
+    data = json.load(f)
+data["modules"] = sorted(data["modules"], key=lambda m: (m["path"], m["version"]))
+text = json.dumps(data, indent=2, sort_keys=True) + "\n"
+if dest == "/dev/stdout":
+    sys.stdout.write(text)
+else:
+    with open(dest, "w") as f:
+        f.write(text)
+PY


### PR DESCRIPTION
## Outcome

`READY_BEHIND_HUMAN_GATE`

CONFENGE min-profile (`-tags minprofile`) no longer compile-links Stripe, AWS SDK, GCP Cloud Tasks/PubSub, or Kafka. Local and VPS compose/env keep the same allowed infra: Postgres, Redis, NATS, filesystem blobs, local KMS, billing none. Selecting kafka/stripe/aws/s3/gcloud/ses on that binary fails closed. AUTO_SEND, green-autorun, and human-approval-off still fail closed. Default/hosted `go test` / `go build` still compile those backends.

Live compose-up, `/health`, and product-acceptance E2E were not run here (no Docker, no backend on :8080). That is the human gate, not a code gap in the isolation.

## Scope

- Opt-out tag `minprofile` (not a CONFENGE product tag). Kafka polarity unchanged (`-tags kafka`).
- Stripe interface uses local types; live Stripe-go stays behind `!minprofile`.
- KMS/S3/SES/SSM/Secrets/Cloud Tasks/PubSub implementations tagged out; factories stay untagged and fail closed.
- `docker-compose.confenge.yml` + VPS overlay pass `GO_TAGS=minprofile`. Dockerfiles forward extra tags.
- `scripts/confenge_min_profile_sbom.sh` writes a deterministic JSON SBOM.
- Conformance tests next to the factories they exercise.

## Out of scope

- PR #80 residual (real inbound event / action / outcome).
- Deleting Stripe/AWS/GCP from `go.mod` (hosted path still needs them).
- Gmail/Google OAuth mailbox connect (still pulls `cloud.google.com/go/auth`).
- WhatsApp/Evolution or `POST /confenge/crm/bootstrap`.
- AUTO_SEND, bulk approval, identity/consent inference, CRM/forecast.
- Merge, deploy, DNS, spend, sending mail, issue close.

## Risks

- Hosted ChangePlan JSON is now a local `Subscription` (`id`, `status`, period/cancel fields), not the raw Stripe object.
- A min-profile image built without the overlay/`GO_TAGS=minprofile` still links hosted backends.
- `go.mod` still names Stripe/AWS/GCP; audit the min binary/SBOM, not the module file.

## Rollback

Revert the commit. Hosted default build is unchanged in provider polarity (still compiles Stripe/AWS/GCP). CONFENGE local/VPS can drop `-tags minprofile` / `GO_TAGS=minprofile`.

## Refs

- Base: `2444058ef3a64774b84eea57425b731700946b84`
- Commit: `3f5b8dc0ffda22b24955f12521065cbee17c1b1a`
- WARMBLY-014 / attack-surface
- WARMBLY-013 PR #84 (audit-only, unmerged; no `//go:build confenge`)
- PR #80: context only

## Commands actually run

```
git rev-parse origin/main
# 2444058ef3a64774b84eea57425b731700946b84
go version
# go1.25.0 linux/amd64
golangci-lint version
# v1.64.8

# baseline (no tags): backend 80486692 B, 1010 pkgs, stripe-go 12, aws-sdk 75, cloud.google.com/go 35
# minprofile backend: 61899044 B (-23.09%), 834 pkgs, stripe-go 0, aws-sdk 0
# Cloud Tasks + PubSub gone; leftover cloud.google.com/go is auth/metadata (Gmail OAuth)
# four-binary total: 230687888 -> 183923856 B (-20.27%)

gofmt -l on touched Go: empty
golangci-lint run [default + --build-tags minprofile] on touched packages: PASS

go test [factories] -count=1                         # PASS (run 1 and 2)
go test -tags minprofile [factories] -count=1        # PASS (run 1 and 2)
go test ./internal/app/confenge/ -count=1 -run 'TestMinProfile|TestConfigValidate...'
# PASS both profiles, both runs
# full ./internal/app/confenge/ hits pre-existing Mailpit gate (TestProductAcceptanceMultichannelSum)

./scripts/confenge_min_profile_sbom.sh
# sbom-1.json sha256 = sbom-2.json sha256
# f0bf78676a8bd00db8fffc775783f681f16f95c8fdfc100f1f760c617e34f781
# banned Stripe/AWS/Cloud Tasks/PubSub/Kafka modules: none

govulncheck: not installed (not a green CVE claim)
docker compose: not installed
GET /health: BLOCKED (no backend on 127.0.0.1:8080)
```

## Residual (still open)

1. Human must `docker compose -f docker-compose.yml -f docker-compose.confenge.yml` (or VPS `up.sh`) and prove `/health` + preflight on a machine with infra. Not done here.
2. `confenge-product-acceptance` / Mailpit E2E not run. Leave as residual.
3. `cloud.google.com/go/auth` remains via Gmail OAuth. Out of scope to strip mailbox OAuth.
4. govulncheck/Trivy not run here.
5. PR #80 still needs a real inbound event crossing action/outcome.
6. WARMBLY-013 (PR #84) is still unmerged. WhatsApp/CRM bootstrap stay ISOLATE.

## Final token

`READY_BEHIND_HUMAN_GATE`