### PR TITLE
feat: add operator list/detail/filter/resolve queue for intel orphans conflicts and impossible transitions

### DIFF
--- a/cmd/confenge/intel_exceptions.go
+++ b/cmd/confenge/intel_exceptions.go
@@ -1,0 +1,283 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+)
+
+func cmdIntelExceptions(args []string) int {
+	return runIntelExceptions(args, os.Stdout, os.Stderr)
+}
+
+func runIntelExceptions(args []string, stdout, stderr io.Writer) int {
+	if len(args) < 1 || args[0] == "-h" || args[0] == "--help" {
+		fmt.Fprintf(stderr, `confenge intel-exceptions — operator queue without a UI
+
+Usage:
+  confenge intel-exceptions list [--type CODE] [--lane LANE] [--source SRC] [--severity SEV] [--status ST] [--age-min SEC] [--age-max SEC] [--format json|md] [--fixture] [--org-id UUID]
+  confenge intel-exceptions show <id> [--format json|md] [--fixture] [--org-id UUID]
+  confenge intel-exceptions resolve <id> --action link|defer|reject|mark_external_evidence_required --actor WHO --reason WHY [--link-identity ID] [--link-lead-id ID] [--link-action-id ID] [--link-account-id ID] [--idempotency-key K] [--fixture] [--org-id UUID]
+
+--fixture uses the labeled SYNTHETIC operator set (not live).
+Without --fixture, PRIMARY_DB must be set. Missing env fails closed as BLOCKED.
+`)
+		return 2
+	}
+	switch args[0] {
+	case "list":
+		return runIntelExceptionList(args[1:], stdout, stderr)
+	case "show":
+		return runIntelExceptionShow(args[1:], stdout, stderr)
+	case "resolve":
+		return runIntelExceptionResolve(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown intel-exceptions command %q\n", args[0])
+		return 2
+	}
+}
+
+func openIntelQueue(orgID string, fixture bool, stderr io.Writer) (intel.Store, time.Time, int) {
+	if fixture {
+		st := intel.NewMemoryStore()
+		intel.LoadOperatorQueue(st, orgID)
+		return st, intel.OperatorQueueNow, 0
+	}
+	dsn := strings.TrimSpace(os.Getenv("PRIMARY_DB"))
+	if dsn == "" {
+		fmt.Fprintf(stderr, "BLOCKED: PRIMARY_DB is unset and --fixture was not passed.\n")
+		fmt.Fprintf(stderr, "prerequisite: export PRIMARY_DB to the operator Postgres DSN, or pass --fixture for the labeled SYNTHETIC queue.\n")
+		fmt.Fprintf(stderr, "next: PRIMARY_DB=postgres://... go run ./cmd/confenge intel-exceptions list --format json\n")
+		fmt.Fprintf(stderr, "  or: go run ./cmd/confenge intel-exceptions list --fixture --format json\n")
+		return nil, time.Time{}, 2
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		fmt.Fprintf(stderr, "BLOCKED: PRIMARY_DB open failed: %v\n", err)
+		fmt.Fprintf(stderr, "prerequisite: reachable Postgres at PRIMARY_DB.\n")
+		fmt.Fprintf(stderr, "next: go run ./cmd/confenge intel-exceptions list --format json\n")
+		return nil, time.Time{}, 2
+	}
+	return intel.NewPGStore(pool, orgID), time.Now().UTC(), 0
+}
+
+func runIntelExceptionList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("intel-exceptions list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	orgStr := fs.String("org-id", intel.OperatorQueueOrgID, "organization UUID")
+	typ := fs.String("type", "", "exception type/code")
+	lane := fs.String("lane", "", "route family")
+	source := fs.String("source", "", "source")
+	severity := fs.String("severity", "", "high|medium|low")
+	status := fs.String("status", "", "open|deferred|rejected|linked|external_evidence_required")
+	ageMin := fs.Int64("age-min", 0, "minimum age in seconds")
+	ageMax := fs.Int64("age-max", 0, "maximum age in seconds")
+	format := fs.String("format", "json", "json|md")
+	fixture := fs.Bool("fixture", false, "labeled SYNTHETIC operator set")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	st, now, code := openIntelQueue(*orgStr, *fixture, stderr)
+	if code != 0 {
+		return code
+	}
+	filter := intel.ExceptionFilter{
+		Type: *typ, Lane: *lane, Source: *source, Severity: *severity,
+		Status: *status, AgeMin: *ageMin, AgeMax: *ageMax,
+	}
+	xs, err := intel.ListQueue(st, *orgStr, filter, now)
+	if err != nil {
+		fmt.Fprintf(stderr, "list: %v\n", err)
+		return 1
+	}
+	return writeIntelQueue(stdout, stderr, *format, map[string]any{
+		"data":   xs,
+		"filter": filter,
+		"count":  len(xs),
+		"now":    now.UTC().Format(time.RFC3339),
+	}, formatExceptionListMD(xs, filter))
+}
+
+func runIntelExceptionShow(args []string, stdout, stderr io.Writer) int {
+	id, args := takePositionalID(args)
+	fs := flag.NewFlagSet("intel-exceptions show", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	orgStr := fs.String("org-id", intel.OperatorQueueOrgID, "organization UUID")
+	format := fs.String("format", "json", "json|md")
+	fixture := fs.Bool("fixture", false, "labeled SYNTHETIC operator set")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if id == "" && fs.NArg() > 0 {
+		id = strings.TrimSpace(fs.Arg(0))
+	}
+	if id == "" {
+		fmt.Fprintln(stderr, "usage: confenge intel-exceptions show <id>")
+		return 2
+	}
+	st, now, code := openIntelQueue(*orgStr, *fixture, stderr)
+	if code != 0 {
+		return code
+	}
+	ex, err := intel.GetQueueItem(st, *orgStr, id, now)
+	if err != nil {
+		fmt.Fprintf(stderr, "show: %v\n", err)
+		return 1
+	}
+	if ex == nil {
+		fmt.Fprintln(stderr, "exception not found")
+		return 1
+	}
+	return writeIntelQueue(stdout, stderr, *format, map[string]any{"data": ex}, formatExceptionMD(*ex))
+}
+
+func takePositionalID(args []string) (string, []string) {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		return strings.TrimSpace(args[0]), args[1:]
+	}
+	return "", args
+}
+
+func runIntelExceptionResolve(args []string, stdout, stderr io.Writer) int {
+	id, args := takePositionalID(args)
+	fs := flag.NewFlagSet("intel-exceptions resolve", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	orgStr := fs.String("org-id", intel.OperatorQueueOrgID, "organization UUID")
+	action := fs.String("action", "", "link|defer|reject|mark_external_evidence_required")
+	actor := fs.String("actor", "", "operator identity")
+	reason := fs.String("reason", "", "why this action")
+	linkIdentity := fs.String("link-identity", "", "existing chain identity")
+	linkLead := fs.String("link-lead-id", "", "existing lead_id")
+	linkAction := fs.String("link-action-id", "", "existing action_id")
+	linkAccount := fs.String("link-account-id", "", "existing account_id")
+	idem := fs.String("idempotency-key", "", "replay key")
+	format := fs.String("format", "json", "json|md")
+	fixture := fs.Bool("fixture", false, "labeled SYNTHETIC operator set")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if id == "" && fs.NArg() > 0 {
+		id = strings.TrimSpace(fs.Arg(0))
+	}
+	if id == "" || strings.TrimSpace(*action) == "" || strings.TrimSpace(*actor) == "" || strings.TrimSpace(*reason) == "" {
+		fmt.Fprintln(stderr, "usage: confenge intel-exceptions resolve <id> --action ... --actor ... --reason ...")
+		return 2
+	}
+	st, now, code := openIntelQueue(*orgStr, *fixture, stderr)
+	if code != 0 {
+		return code
+	}
+	res, err := intel.Resolve(st, *orgStr, id, intel.ResolveRequest{
+		Action:         *action,
+		Actor:          *actor,
+		Reason:         *reason,
+		IdempotencyKey: *idem,
+		LinkIdentity:   *linkIdentity,
+		LinkLeadID:     *linkLead,
+		LinkActionID:   *linkAction,
+		LinkAccountID:  *linkAccount,
+	}, now)
+	if err != nil {
+		fmt.Fprintf(stderr, "resolve: %v\n", err)
+		return 1
+	}
+	if res.Refused {
+		_ = writeIntelQueue(stdout, stderr, *format, map[string]any{"data": res}, formatResolveMD(res))
+		return 1
+	}
+	return writeIntelQueue(stdout, stderr, *format, map[string]any{"data": res}, formatResolveMD(res))
+}
+
+func writeIntelQueue(stdout, stderr io.Writer, format string, payload any, md string) int {
+	switch strings.ToLower(strings.TrimSpace(format)) {
+	case "md", "markdown":
+		fmt.Fprint(stdout, md)
+		return 0
+	default:
+		raw, err := json.MarshalIndent(payload, "", "  ")
+		if err != nil {
+			fmt.Fprintf(stderr, "json: %v\n", err)
+			return 1
+		}
+		fmt.Fprintln(stdout, string(raw))
+		return 0
+	}
+}
+
+func formatExceptionListMD(xs []intel.Exception, filter intel.ExceptionFilter) string {
+	var b strings.Builder
+	b.WriteString("# Intel exception queue\n\n")
+	b.WriteString(fmt.Sprintf("count: %d\n", len(xs)))
+	if filter.Type != "" {
+		b.WriteString("type: " + filter.Type + "\n")
+	}
+	if filter.Lane != "" {
+		b.WriteString("lane: " + filter.Lane + "\n")
+	}
+	if filter.Source != "" {
+		b.WriteString("source: " + filter.Source + "\n")
+	}
+	if filter.Severity != "" {
+		b.WriteString("severity: " + filter.Severity + "\n")
+	}
+	b.WriteString("\n")
+	for _, ex := range xs {
+		b.WriteString(fmt.Sprintf("- %s code=%s lane=%s source=%s severity=%s age_s=%d status=%s next=%q\n",
+			ex.ID, ex.Code, ex.Lane, ex.Source, ex.Severity, ex.AgeSeconds, ex.Status, ex.NextAction))
+	}
+	return b.String()
+}
+
+func formatExceptionMD(ex intel.Exception) string {
+	var b strings.Builder
+	b.WriteString("# Exception " + ex.ID + "\n\n")
+	b.WriteString("code: " + ex.Code + "\n")
+	b.WriteString("lane: " + ex.Lane + "\n")
+	b.WriteString("source: " + ex.Source + "\n")
+	b.WriteString("severity: " + ex.Severity + "\n")
+	b.WriteString("status: " + ex.Status + "\n")
+	b.WriteString("age_seconds: " + strconv.FormatInt(ex.AgeSeconds, 10) + "\n")
+	b.WriteString("next_action: " + ex.NextAction + "\n")
+	b.WriteString("reason: " + ex.Reason + "\n")
+	b.WriteString("\n## Evidence\n")
+	for _, ev := range ex.Evidence {
+		b.WriteString(fmt.Sprintf("- %s %s=%s\n", ev.Kind, ev.Key, ev.Value))
+	}
+	b.WriteString("\n## History\n")
+	for _, ev := range ex.History {
+		b.WriteString(fmt.Sprintf("- %s %s %s %s\n", ev.At.UTC().Format(time.RFC3339), ev.Kind, ev.Action, ev.Reason))
+	}
+	b.WriteString("\n## Allowed actions\n")
+	if len(ex.AllowedActions) == 0 {
+		b.WriteString("- remain open nominally (no further legal action, or already resolved)\n")
+	}
+	for _, a := range ex.AllowedActions {
+		b.WriteString("- " + a + "\n")
+	}
+	return b.String()
+}
+
+func formatResolveMD(res intel.ResolveResult) string {
+	var b strings.Builder
+	b.WriteString("# Resolve\n\n")
+	b.WriteString("action: " + res.Action + "\n")
+	b.WriteString("actor: " + res.Actor + "\n")
+	b.WriteString("reason: " + res.Reason + "\n")
+	b.WriteString("replay: " + strconv.FormatBool(res.Replay) + "\n")
+	b.WriteString("refused: " + strconv.FormatBool(res.Refused) + "\n")
+	b.WriteString(fmt.Sprintf("before: status=%s next=%q\n", res.Before.Status, res.Before.NextAction))
+	b.WriteString(fmt.Sprintf("after: status=%s next=%q\n", res.After.Status, res.After.NextAction))
+	return b.String()
+}

--- a/cmd/confenge/intel_exceptions_test.go
+++ b/cmd/confenge/intel_exceptions_test.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+)
+
+func TestIntelExceptionsCLIListShowResolveTwice(t *testing.T) {
+	var out1, err1 bytes.Buffer
+	if code := runIntelExceptions([]string{"list", "--fixture", "--format", "json", "--type", "orphan"}, &out1, &err1); code != 0 {
+		t.Fatalf("list1 code=%d stderr=%s", code, err1.String())
+	}
+	var wrap1 struct {
+		Data []intel.Exception `json:"data"`
+	}
+	if err := json.Unmarshal(out1.Bytes(), &wrap1); err != nil {
+		t.Fatalf("list1 json: %v body=%s", err, out1.String())
+	}
+	if len(wrap1.Data) == 0 {
+		t.Fatal("list1 empty")
+	}
+	ex := wrap1.Data[0]
+	if ex.Code != intel.ExceptionOrphan || ex.Lane == "" || ex.Source == "" || ex.Severity == "" {
+		t.Fatalf("list item incomplete: %+v", ex)
+	}
+	if ex.NextAction == "" && ex.Status != intel.StatusOpen {
+		t.Fatal("list item has no next action and is not open")
+	}
+
+	var out2, err2 bytes.Buffer
+	if code := runIntelExceptions([]string{"list", "--fixture", "--format", "json", "--type", "orphan"}, &out2, &err2); code != 0 {
+		t.Fatalf("list2 code=%d stderr=%s", code, err2.String())
+	}
+	if out1.String() != out2.String() {
+		t.Fatalf("two fixture list runs disagreed\nrun1=%s\nrun2=%s", out1.String(), out2.String())
+	}
+
+	var show1, showErr bytes.Buffer
+	if code := runIntelExceptions([]string{"show", ex.ID, "--fixture", "--format", "json"}, &show1, &showErr); code != 0 {
+		t.Fatalf("show code=%d stderr=%s", code, showErr.String())
+	}
+	if !strings.Contains(show1.String(), `"evidence"`) || !strings.Contains(show1.String(), `"history"`) {
+		t.Fatalf("show missing evidence/history: %s", show1.String())
+	}
+
+	missing, _ := listFixture(t, "missing_version")
+	var res1, resErr bytes.Buffer
+	args := []string{
+		"resolve", missing.ID, "--fixture", "--format", "json",
+		"--action", "defer", "--actor", "cli-op", "--reason", "wait for extra-cli version",
+		"--idempotency-key", "cli-defer-1",
+	}
+	if code := runIntelExceptions(args, &res1, &resErr); code != 0 {
+		t.Fatalf("resolve code=%d stderr=%s stdout=%s", code, resErr.String(), res1.String())
+	}
+	var resolved struct {
+		Data intel.ResolveResult `json:"data"`
+	}
+	if err := json.Unmarshal(res1.Bytes(), &resolved); err != nil {
+		t.Fatalf("resolve json: %v body=%s", err, res1.String())
+	}
+	if resolved.Data.After.Status != intel.StatusDeferred || resolved.Data.Actor != "cli-op" || resolved.Data.Reason == "" {
+		t.Fatalf("resolve payload: %+v", resolved.Data)
+	}
+	if resolved.Data.Before.Status != intel.StatusOpen {
+		t.Fatalf("before status=%s", resolved.Data.Before.Status)
+	}
+
+	var blocked, blockedErr bytes.Buffer
+	if code := runIntelExceptions([]string{"list", "--format", "json"}, &blocked, &blockedErr); code == 0 {
+		t.Fatal("list without PRIMARY_DB and without --fixture must fail closed")
+	}
+	if !strings.Contains(blockedErr.String(), "BLOCKED") || !strings.Contains(blockedErr.String(), "PRIMARY_DB") {
+		t.Fatalf("expected BLOCKED PRIMARY_DB, got %s", blockedErr.String())
+	}
+}
+
+func listFixture(t *testing.T, typ string) (intel.Exception, []intel.Exception) {
+	t.Helper()
+	var out, errBuf bytes.Buffer
+	if code := runIntelExceptions([]string{"list", "--fixture", "--format", "json", "--type", typ}, &out, &errBuf); code != 0 {
+		t.Fatalf("list %s: %s", typ, errBuf.String())
+	}
+	var wrap struct {
+		Data []intel.Exception `json:"data"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &wrap); err != nil {
+		t.Fatal(err)
+	}
+	if len(wrap.Data) == 0 {
+		t.Fatalf("no %s fixtures", typ)
+	}
+	return wrap.Data[0], wrap.Data
+}

--- a/cmd/confenge/main.go
+++ b/cmd/confenge/main.go
@@ -44,6 +44,8 @@ func main() {
 		os.Exit(cmdResumeSending())
 	case "intel-report":
 		os.Exit(cmdIntelReport(os.Args[2:]))
+	case "intel-exceptions":
+		os.Exit(cmdIntelExceptions(os.Args[2:]))
 	case "help", "-h", "--help":
 		usage()
 	default:
@@ -64,6 +66,7 @@ Usage:
   confenge stop-sending
   confenge resume-sending
   confenge intel-report [--month YYYY-MM] [--include-synthetic] [--json PATH] [--md PATH]
+  confenge intel-exceptions list|show|resolve [flags]
 
 Env: PRIMARY_DB, CONFENGE_*, REDIS, NATS_URL (see .env.confenge.example).
 `)

--- a/docs/confenge/commercial-intelligence.md
+++ b/docs/confenge/commercial-intelligence.md
@@ -41,6 +41,30 @@ is fail-closed. Additive IDs (action, then outcome) merge onto the first
 chain. Outcomes join only by `lead_id` / `receipt_id` / `action_id` /
 `outcome_id`, never by email or CNPJ.
 
+Operators list, open, and filter by type, lane, age, source, and
+severity. Each item shows evidence, event history, and a next action, or
+stays nominally open. Legal resolutions are only `link`, `defer`,
+`reject`, and `mark_external_evidence_required`. They are replay-safe,
+record before/after plus actor/reason, and refuse any move that would
+invent WON, LOST, revenue, or identity, or overwrite a conflicting
+account, or reorder an out-of-order path.
+
+```
+GET  /confenge/intel/exceptions
+GET  /confenge/intel/exceptions/:id
+POST /confenge/intel/exceptions/:id/resolve
+```
+
+CLI without a UI:
+
+```
+go run ./cmd/confenge intel-exceptions list --fixture --format json
+go run ./cmd/confenge intel-exceptions show <id> --fixture
+go run ./cmd/confenge intel-exceptions resolve <id> --action defer --actor op --reason "wait" --fixture
+```
+
+`--fixture` is the labeled SYNTHETIC set. Live use requires `PRIMARY_DB`.
+
 ## Executive view
 
 `GET /confenge/intel/executive?month=YYYY-MM&include_synthetic=0`

--- a/docs/confenge/local-ops.md
+++ b/docs/confenge/local-ops.md
@@ -87,7 +87,15 @@ go run ./cmd/confenge reconcile-target-fit --dry-run --org-id <uuid>
 go run ./cmd/confenge reconcile-target-fit --org-id <uuid>
 go run ./cmd/confenge stop-sending
 go run ./cmd/confenge resume-sending
+go run ./cmd/confenge intel-exceptions list --fixture --format json
+go run ./cmd/confenge intel-exceptions show <id> --fixture --format json
+go run ./cmd/confenge intel-exceptions resolve <id> --action defer --actor op --reason "wait" --fixture
 ```
+
+`intel-exceptions` without `--fixture` requires `PRIMARY_DB`. Missing env
+prints `BLOCKED` and the next command. The fixture path is labeled
+SYNTHETIC and is not live inbound/action/outcome proof.
+
 
 ## Readiness panel
 

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -86,6 +86,8 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | GET | `/confenge/intel/executive` | `READ_CONTACTS` |
 | GET | `/confenge/intel/report` | `READ_CONTACTS` |
 | GET | `/confenge/intel/exceptions` | `READ_CONTACTS` |
+| GET | `/confenge/intel/exceptions/:id` | `READ_CONTACTS` |
+| POST | `/confenge/intel/exceptions/:id/resolve` | `WRITE_CONTACTS` |
 | POST | `/confenge/intel/learning` | `WRITE_CONTACTS` |
 | POST | `/confenge/intel/events` | `WRITE_CONTACTS` |
 | POST | `/confenge/manual-queue/:id/action` | `WRITE_CONTACTS` |
@@ -97,6 +99,8 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 `POST /confenge/intel/events` ingests one versioned commercial event (`confenge.commercial_event.v1`). Same `event_id` or idempotency key is a replay. Lead, page view, citation, and X-Ray completion never become pipeline. Pipeline never becomes revenue.
 
 `GET /confenge/intel/report` is the inbound learning observability payload (IQP, lanes, exceptions, latency baseline, learning candidates, `READY_FOR_REAL_EVENTS` / `ADJUST` / `NO_GO`). It is not a CRM and not a forecast.
+
+`GET /confenge/intel/exceptions` is the operator queue. Filter with `type`, `lane`, `source`, `severity`, `status`, `age_min_seconds`, and `age_max_seconds`. Each row includes evidence, history, `next_action` or an explicit open status, and only the legal actions `link`, `defer`, `reject`, and `mark_external_evidence_required`. `GET /confenge/intel/exceptions/:id` is the detail. `POST /confenge/intel/exceptions/:id/resolve` records before/after, actor, and reason. Send `Idempotency-Key`. The same command replays the first result. Illegal lifecycle moves and any attempt to invent WON, LOST, revenue, or identity are refused and the exception stays open.
 
 AI contact research charges credits (2 per run, billable even when it finds nothing) and only saves cited findings. See the [AI contact research](/guides/ai-contact-research/) guide. The batch endpoint accepts up to 500 contact ids and drains in the background.
 

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -142,6 +142,9 @@ Target-fit is updated only by a current authoritative decision. A downgrade take
 | `POST /confenge/touchpoints/:id/decision` | Skip or reject |
 | `POST /confenge/touchpoints/:id/queue` | CAS queue then transport |
 | `POST /confenge/accounts/:id/dnc` | DNC and cancel open futures |
+| `GET /confenge/intel/exceptions` | Operator exception queue (filter by type, lane, age, source, severity) |
+| `GET /confenge/intel/exceptions/:id` | Exception evidence and history |
+| `POST /confenge/intel/exceptions/:id/resolve` | `link`, `defer`, `reject`, or `mark_external_evidence_required` |
 
 Permissions follow contacts: view for reads, manage for import, plan, review, and send actions.
 
@@ -152,6 +155,8 @@ The CONFENGE page is a PT-BR commercial operations center. It uses the CONFENGE 
 Feed freshness uses the upstream manifest's durable `source_generated_at`, not the time at which Warmbly downloaded it. The API retains `feed_last_success_at` as a backward-compatible alias for that authoritative source time and exposes `feed_synced_at` separately for operational diagnostics. The dashboard, API and VPS status script use the same `CONFENGE_FEED_MAX_AGE` threshold, which defaults to 24 hours. Missing, stale, corrupt, or rolled-back feed state blocks cohort preparation.
 
 The page opens with **INBOUND NOW**: web-cfg leads that already have a durable receipt, recommended next action, owner or explicit UNKNOWN, and commercial-latency timestamps. Then **O que fazer agora**: only executable human work (calls, routed calls, emails to review, role mailboxes, WhatsApp, professional profiles, forms). Each card shows company, person or target role, route class, why now, offer, channel, reachability class, confidence, factual hook, evidence, warnings, channel-appropriate copy, last outcome, and next action, plus a Revisar / copiar control. Call, routed-call, WhatsApp, and generic-mailbox copy is written for that route: short, accented PT-BR, one public fact, one question. It does not reuse the email template, dump `objeto`/`órgão`/`UF`/`R$` fields, or label `comercial@` as "área de contratos". A corporate switchboard is labeled as the company number, never as the person's direct phone. Calls, WhatsApp, social, and forms are human-executed only. They never auto-send and never bypass the email `VALIDATED + READY → NEEDS_REVIEW → human approval → dispatch` path. Inbound classification may recommend `SEND_EMAIL` in review. It never dispatches.
+
+The commercial-intelligence panel is followed by **Fila de exceções**: orphans, conflicts, and impossible transitions. The operator can filter by type, lane, age, source, and severity, open evidence and history, and take only `link`, `defer`, `reject`, or `mark_external_evidence_required`. There is no control that invents WON, LOST, revenue, or identity. UNKNOWN stays UNKNOWN. The same actions exist on `confenge intel-exceptions` when there is no UI.
 
 The operational funnel counts imported tiers, `NEEDS_REVIEW`, the manual lanes, planned and actionable work, approvals, and post-send outcomes (`SENT` as contacted, `REPLIED`, `MEETING`) from `GET /confenge/cockpit`. Each manual-lane card shows why now, the factual hook, the recommended action, confidence, and a Copy text control. The per-message review queue shows company, exact recipient, channel, service, fact and evidence, stage number, short history, and the exact send preview. The operator can approve without dispatch, skip the stage, reject with a reason, or mark the account as do not contact.
 

--- a/internal/api/handler/confenge_intel.go
+++ b/internal/api/handler/confenge_intel.go
@@ -2,12 +2,16 @@ package handler
 
 import (
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 
+	"github.com/warmbly/warmbly/internal/api/middleware"
 	"github.com/warmbly/warmbly/internal/app/confenge/intel"
 	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
 )
 
 // GetConfengeExecutiveIntel — GET /confenge/intel/executive
@@ -27,18 +31,103 @@ func (h *Handler) GetConfengeExecutiveIntel(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": view})
 }
 
+func intelExceptionFilter(c *gin.Context) intel.ExceptionFilter {
+	f := intel.ExceptionFilter{
+		Type:     firstNonEmptyQuery(c, "type", "code"),
+		Lane:     strings.TrimSpace(c.Query("lane")),
+		Source:   strings.TrimSpace(c.Query("source")),
+		Severity: strings.TrimSpace(c.Query("severity")),
+		Status:   strings.TrimSpace(c.Query("status")),
+	}
+	if v := strings.TrimSpace(c.Query("age_min_seconds")); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			f.AgeMin = n
+		}
+	}
+	if v := strings.TrimSpace(c.Query("age_max_seconds")); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			f.AgeMax = n
+		}
+	}
+	return f
+}
+
+func firstNonEmptyQuery(c *gin.Context, keys ...string) string {
+	for _, k := range keys {
+		if v := strings.TrimSpace(c.Query(k)); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
 // ListConfengeIntelExceptions — GET /confenge/intel/exceptions
 func (h *Handler) ListConfengeIntelExceptions(c *gin.Context) {
 	orgID, ok := h.confengeOrg(c)
 	if !ok {
 		return
 	}
-	xs, xerr := h.ConfengeService.ListIntelExceptions(c.Request.Context(), orgID)
+	xs, xerr := h.ConfengeService.ListIntelExceptions(c.Request.Context(), orgID, intelExceptionFilter(c))
 	if xerr != nil {
 		errx.JSON(c, xerr)
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"data": xs})
+}
+
+// GetConfengeIntelException — GET /confenge/intel/exceptions/:id
+func (h *Handler) GetConfengeIntelException(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	ex, xerr := h.ConfengeService.GetIntelException(c.Request.Context(), orgID, c.Param("id"))
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": ex})
+}
+
+// ResolveConfengeIntelException — POST /confenge/intel/exceptions/:id/resolve
+func (h *Handler) ResolveConfengeIntelException(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	var body intel.ResolveRequest
+	if err := c.ShouldBindJSON(&body); err != nil {
+		errx.JSON(c, errx.New(errx.BadRequest, "invalid body"))
+		return
+	}
+	if strings.TrimSpace(body.Actor) == "" {
+		if uid, err := middleware.GetUserUUID(c); err == nil {
+			body.Actor = uid.String()
+		}
+	}
+	if strings.TrimSpace(body.IdempotencyKey) == "" {
+		body.IdempotencyKey = strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	}
+	res, xerr := h.ConfengeService.ResolveIntelException(c.Request.Context(), orgID, c.Param("id"), body)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	if h.AuditService != nil {
+		if parsed, err := uuid.Parse(res.Exception.ID); err == nil {
+			h.auditOrg(c, models.AuditActionUpdate, models.AuditEntityOutreachIntelException, &parsed,
+				map[string]string{
+					"before_status": res.Before.Status,
+					"after_status":  res.After.Status,
+				},
+				map[string]string{
+					"action": res.Action,
+					"reason": res.Reason,
+					"replay": strconv.FormatBool(res.Replay),
+				})
+		}
+	}
+	c.JSON(http.StatusOK, gin.H{"data": res})
 }
 
 // RecordConfengeIntelLearning — POST /confenge/intel/learning

--- a/internal/api/handler/confenge_intel_test.go
+++ b/internal/api/handler/confenge_intel_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/gin-gonic/gin"
@@ -73,6 +74,159 @@ func TestGetConfengeExecutiveIntelBody(t *testing.T) {
 	}
 	fmt.Printf("HTTP_EXEC status=%d iqp=%d qco=%d won=%d lost=%d unknown=%d\n",
 		w.Code, wrap.Data.InboundQualifiedPipeline, wrap.Data.QCO, wrap.Data.Won, wrap.Data.Lost, wrap.Data.Unknown)
+}
+
+type intelQueueHTTPStub struct {
+	confenge.Service
+	svc confenge.Service
+}
+
+func (s *intelQueueHTTPStub) Enabled() bool { return true }
+func (s *intelQueueHTTPStub) ListIntelExceptions(ctx context.Context, orgID uuid.UUID, filter intel.ExceptionFilter) ([]intel.Exception, *errx.Error) {
+	return s.svc.ListIntelExceptions(ctx, orgID, filter)
+}
+func (s *intelQueueHTTPStub) GetIntelException(ctx context.Context, orgID uuid.UUID, id string) (*intel.Exception, *errx.Error) {
+	return s.svc.GetIntelException(ctx, orgID, id)
+}
+func (s *intelQueueHTTPStub) ResolveIntelException(ctx context.Context, orgID uuid.UUID, id string, req intel.ResolveRequest) (intel.ResolveResult, *errx.Error) {
+	return s.svc.ResolveIntelException(ctx, orgID, id, req)
+}
+
+func newIntelQueueService(t *testing.T) (confenge.Service, uuid.UUID) {
+	t.Helper()
+	cfg := confenge.Config{Enabled: true, RequireHumanApproval: true}
+	svc := confenge.NewService(cfg, nil, nil)
+	svc.WireIntel(nil)
+	org := uuid.MustParse(intel.OperatorQueueOrgID)
+	// Seed through the shipped reconcile + fixture put by listing after
+	// a service-level load is not exported; drive Reconcile for a live path
+	// and List/Get/Resolve for the operator path via the service methods
+	// after putting fixtures through intel.LoadOperatorQueue on a memory
+	// store the service owns. Reconcile an orphan so classify is exercised.
+	complete := intel.ObservedFacts{
+		Keys: intel.JoinKeys{
+			OrganizationID: org.String(), Source: "web-cfg", LeadID: "webcfg-syn-in-1",
+			ReceiptID: "rcpt-syn-in-1", AccountID: "extra-acc-norte", ActionID: "act-syn-in-1",
+			OutcomeID: "out-syn-in-1", RouteFamily: intel.FamilyInbound,
+			TargetFitVersion: "tf-v1", ActivationPolicyVersion: "ap-v1",
+		},
+		OutcomeType: intel.OutcomeQualifiedConversation, Qualified: true,
+		Synthetic: true, Label: intel.LabelSynthetic,
+	}
+	if _, xerr := svc.ReconcileCommercialIntel(context.Background(), org, complete); xerr != nil {
+		t.Fatal(xerr)
+	}
+	orphan := complete
+	orphan.Keys.LeadID = ""
+	orphan.Keys.ReceiptID = ""
+	orphan.Keys.ActionID = ""
+	orphan.Keys.IdempotencyKey = ""
+	orphan.Keys.OutcomeID = "out-http-orphan"
+	orphan.OutcomeType = intel.OutcomeMeeting
+	if _, xerr := svc.ReconcileCommercialIntel(context.Background(), org, orphan); xerr != nil {
+		t.Fatal(xerr)
+	}
+	return svc, org
+}
+
+func TestListAndResolveIntelExceptionsHTTP(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc, org := newIntelQueueService(t)
+	h := &Handler{ConfengeService: &intelQueueHTTPStub{svc: svc}}
+
+	req := httptest.NewRequest(http.MethodGet, "/confenge/intel/exceptions?type=orphan&lane=inbound&source=web-cfg&severity=high", nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	c.Set(middleware.OrganizationIDKey, org)
+	h.ListConfengeIntelExceptions(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("list status=%d body=%s", w.Code, w.Body.String())
+	}
+	var listed struct {
+		Data []intel.Exception `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &listed); err != nil {
+		t.Fatal(err)
+	}
+	if len(listed.Data) == 0 {
+		t.Fatalf("filtered list empty: %s", w.Body.String())
+	}
+	ex := listed.Data[0]
+	if ex.Code != intel.ExceptionOrphan || ex.Lane != intel.FamilyInbound || ex.Severity != intel.SeverityHigh {
+		t.Fatalf("filter mismatch: %+v", ex)
+	}
+	if ex.NextAction == "" || len(ex.Evidence) == 0 {
+		t.Fatalf("list item missing next/evidence: %+v", ex)
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/confenge/intel/exceptions/"+ex.ID, nil)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = req
+	c.Params = gin.Params{{Key: "id", Value: ex.ID}}
+	c.Set(middleware.OrganizationIDKey, org)
+	h.GetConfengeIntelException(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("detail status=%d body=%s", w.Code, w.Body.String())
+	}
+
+	body := `{"action":"defer","actor":"http-op","reason":"wait for action"}`
+	req = httptest.NewRequest(http.MethodPost, "/confenge/intel/exceptions/"+ex.ID+"/resolve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "defer-"+ex.ID)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = req
+	c.Params = gin.Params{{Key: "id", Value: ex.ID}}
+	c.Set(middleware.OrganizationIDKey, org)
+	h.ResolveConfengeIntelException(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("resolve status=%d body=%s", w.Code, w.Body.String())
+	}
+	var resolved struct {
+		Data intel.ResolveResult `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resolved); err != nil {
+		t.Fatal(err)
+	}
+	if resolved.Data.After.Status != intel.StatusDeferred || resolved.Data.Actor != "http-op" {
+		t.Fatalf("resolve payload: %+v", resolved.Data)
+	}
+
+	req = httptest.NewRequest(http.MethodPost, "/confenge/intel/exceptions/"+ex.ID+"/resolve", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Idempotency-Key", "defer-"+ex.ID)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = req
+	c.Params = gin.Params{{Key: "id", Value: ex.ID}}
+	c.Set(middleware.OrganizationIDKey, org)
+	h.ResolveConfengeIntelException(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("replay status=%d body=%s", w.Code, w.Body.String())
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resolved); err != nil {
+		t.Fatal(err)
+	}
+	if !resolved.Data.Replay {
+		t.Fatal("HTTP replay was not a no-op")
+	}
+
+	invent := `{"action":"defer","actor":"http-op","reason":"book it","outcome_type":"WON"}`
+	req = httptest.NewRequest(http.MethodPost, "/confenge/intel/exceptions/"+ex.ID+"/resolve", strings.NewReader(invent))
+	req.Header.Set("Content-Type", "application/json")
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = req
+	c.Params = gin.Params{{Key: "id", Value: ex.ID}}
+	c.Set(middleware.OrganizationIDKey, org)
+	h.ResolveConfengeIntelException(c)
+	if w.Code != http.StatusUnprocessableEntity {
+		t.Fatalf("invent WON status=%d body=%s", w.Code, w.Body.String())
+	}
+	fmt.Printf("HTTP_QUEUE list=%d defer=%s replay=%v invent=%d\n",
+		len(listed.Data), resolved.Data.After.Status, resolved.Data.Replay, w.Code)
 }
 
 func jsonHasKey(body, key string) bool {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -537,6 +537,7 @@ func Run(
 				confengeGroup.GET("/intel/executive", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeExecutiveIntel)
 				confengeGroup.GET("/intel/report", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeIntelReport)
 				confengeGroup.GET("/intel/exceptions", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeIntelExceptions)
+				confengeGroup.GET("/intel/exceptions/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeIntelException)
 				confengeGroup.GET("/attention", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeAttention)
 				confengeGroup.GET("/attention/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeAttention)
 				confengeGroup.GET("/accounts", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeAccounts)
@@ -586,6 +587,7 @@ func Run(
 					confengeWrite.POST("/inbound/:leadId/outcome", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.RecordConfengeInboundOutcome)
 					confengeWrite.POST("/intel/learning", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.RecordConfengeIntelLearning)
 					confengeWrite.POST("/intel/events", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.IngestConfengeIntelEvent)
+					confengeWrite.POST("/intel/exceptions/:id/resolve", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ResolveConfengeIntelException)
 					confengeWrite.POST("/dispatch/pause", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.PauseConfengeDispatch)
 					confengeWrite.POST("/dispatch/resume", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ResumeConfengeDispatch)
 				}

--- a/internal/app/confenge/intel/exceptions.go
+++ b/internal/app/confenge/intel/exceptions.go
@@ -23,6 +23,8 @@ func ClassifyExceptions(in ObservedFacts, existing *Chain) []Exception {
 		At:             now,
 	}
 
+	base.ReceiptID = strings.TrimSpace(in.Keys.ReceiptID)
+
 	var out []Exception
 	add := func(code, reason, next string, held bool) {
 		ex := base
@@ -30,6 +32,7 @@ func ClassifyExceptions(in ObservedFacts, existing *Chain) []Exception {
 		ex.Reason = reason
 		ex.NextAction = next
 		ex.Held = held
+		enrichException(&ex, in)
 		out = append(out, ex)
 	}
 

--- a/internal/app/confenge/intel/fixtures.go
+++ b/internal/app/confenge/intel/fixtures.go
@@ -1,6 +1,9 @@
 package intel
 
-import "time"
+import (
+	"strings"
+	"time"
+)
 
 // SyntheticMonth is the fixture window used by tests and the labeled demo.
 const SyntheticMonth = "2026-08"
@@ -122,4 +125,73 @@ func LoadSynthetic(store Store, orgID string) []JoinResult {
 		out = append(out, Reconcile(store, f))
 	}
 	return out
+}
+
+// LoadOperatorQueue loads labeled SYNTHETIC chains plus a representative
+// exception set with stable IDs and ages. CLI --fixture uses this path.
+func LoadOperatorQueue(store Store, orgID string) {
+	if strings.TrimSpace(orgID) == "" {
+		orgID = OperatorQueueOrgID
+	}
+	LoadSynthetic(store, orgID)
+	for _, ex := range OperatorQueueFixtures(orgID) {
+		_ = store.PutException(ex)
+	}
+}
+
+// OperatorQueueFixtures is the labeled operator-queue sample. Not live.
+func OperatorQueueFixtures(orgID string) []Exception {
+	now := OperatorQueueNow
+	item := func(code, reason, next, lane, source, identity, lead, action, outcome string, held bool, age time.Duration, extra ObservedFacts) Exception {
+		in := extra
+		in.Keys.OrganizationID = orgID
+		in.Keys.RouteFamily = lane
+		in.Keys.Source = source
+		in.Synthetic = true
+		in.Label = LabelSynthetic
+		ex := Exception{
+			ID:             StableExceptionID(orgID, code, identity, lead, action, outcome),
+			OrganizationID: orgID,
+			Code:           code,
+			Reason:         reason,
+			NextAction:     next,
+			Identity:       identity,
+			ActionID:       action,
+			OutcomeID:      outcome,
+			LeadID:         lead,
+			Held:           held,
+			Synthetic:      true,
+			At:             now.Add(-age),
+			Lane:           lane,
+			Source:         source,
+		}
+		enrichException(&ex, in)
+		ex.At = now.Add(-age)
+		return ex
+	}
+	return []Exception{
+		item(ExceptionOrphan, "outcome without action", "hold on exception queue until action arrives",
+			FamilyInbound, "web-cfg", "", "", "", "out-orphan-1", true, 2*time.Hour, ObservedFacts{}),
+		item(ExceptionConflictingAccount, "incoming account_id disagrees with the first chain",
+			"keep the first extra-cli account; do not overwrite", FamilyInbound, "web-cfg",
+			"lead:webcfg-syn-in-1", "webcfg-syn-in-1", "act-syn-in-1", "out-syn-in-1", false, 26*time.Hour, ObservedFacts{}),
+		item(ExceptionOutOfOrder, "outcome timestamp precedes action or inbound; order is not invented",
+			"hold; do not reorder into a fake chain", FamilyInbound, "web-cfg",
+			"lead:oo-1", "lead-oo-1", "act-oo-1", "out-oo-1", true, 8*24*time.Hour, ObservedFacts{}),
+		item(ExceptionUnconfirmedWon, "WON cannot be inferred",
+			"require human or document confirmation; keep UNKNOWN", FamilyInbound, "web-cfg",
+			"lead:won-1", "lead-won-1", "act-won-1", "out-won-1", true, 3*time.Hour, ObservedFacts{}),
+		item(ExceptionUnconfirmedLost, "LOST cannot be inferred",
+			"require human or document confirmation; keep UNKNOWN", FamilyOutbound, "extra-cli",
+			"action:act-lost-1", "", "act-lost-1", "out-lost-1", true, 5*time.Hour, ObservedFacts{}),
+		item(ExceptionMissingVersion, "no extra-cli version on the observed path",
+			"leave version UNKNOWN", FamilyPartner, "partner",
+			"lead:mv-1", "lead-mv-1", "act-mv-1", "", false, 30*time.Minute, ObservedFacts{}),
+		item(ExceptionStaleAttribution, "attribution or target-fit freshness is stale",
+			"keep the observed IDs; do not invent a newer source/asset", FamilyExpansion, "expansion",
+			"lead:stale-1", "lead-stale-1", "act-stale-1", "", false, 4*24*time.Hour, ObservedFacts{}),
+		item(ExceptionDuplicate, "same join IDs already have a chain",
+			"return the first chain; do not insert a second", FamilyInbound, "web-cfg",
+			"lead:webcfg-syn-in-2", "webcfg-syn-in-2", "act-syn-in-2", "out-syn-in-2", false, 10*time.Minute, ObservedFacts{}),
+	}
 }

--- a/internal/app/confenge/intel/pg.go
+++ b/internal/app/confenge/intel/pg.go
@@ -126,9 +126,7 @@ func (s *PGStore) PutException(ex Exception) error {
 	if s == nil || s.db == nil {
 		return errors.New("intel pg store unavailable")
 	}
-	if strings.TrimSpace(ex.ID) == "" {
-		ex.ID = uuid.NewString()
-	}
+	ex = assignExceptionID(ex)
 	if ex.At.IsZero() {
 		ex.At = time.Now().UTC()
 	}
@@ -140,8 +138,54 @@ func (s *PGStore) PutException(ex Exception) error {
 	_, err = s.db.Exec(context.Background(), `
 		INSERT INTO outreach_intel_exceptions (
 			id, organization_id, code, identity, metric_key, held, payload, created_at
-		) VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7::jsonb, $8)`,
+		) VALUES ($1::uuid, $2::uuid, $3, $4, $5, $6, $7::jsonb, $8)
+		ON CONFLICT (id) DO NOTHING`,
 		ex.ID, org, ex.Code, ex.Identity, ex.MetricKey, ex.Held, raw, ex.At,
+	)
+	return err
+}
+
+func (s *PGStore) GetException(orgID, id string) (*Exception, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("intel pg store unavailable")
+	}
+	org := firstNonEmpty(orgID, s.orgID)
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, nil
+	}
+	var raw []byte
+	err := s.db.QueryRow(context.Background(), `
+		SELECT payload FROM outreach_intel_exceptions
+		WHERE organization_id = $1::uuid AND id = $2::uuid`, org, id).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var ex Exception
+	if err := json.Unmarshal(raw, &ex); err != nil {
+		return nil, err
+	}
+	return &ex, nil
+}
+
+func (s *PGStore) UpdateException(ex Exception) error {
+	if s == nil || s.db == nil {
+		return errors.New("intel pg store unavailable")
+	}
+	ex = assignExceptionID(ex)
+	org := firstNonEmpty(ex.OrganizationID, s.orgID)
+	raw, err := json.Marshal(ex)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(context.Background(), `
+		UPDATE outreach_intel_exceptions
+		SET held = $3, payload = $4::jsonb
+		WHERE organization_id = $1::uuid AND id = $2::uuid`,
+		org, ex.ID, ex.Held, raw,
 	)
 	return err
 }

--- a/internal/app/confenge/intel/queue.go
+++ b/internal/app/confenge/intel/queue.go
@@ -1,0 +1,615 @@
+package intel
+
+import (
+	"crypto/sha1"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ExceptionFilter selects durable queue rows. Empty fields match any.
+type ExceptionFilter struct {
+	Type     string `json:"type,omitempty"`
+	Lane     string `json:"lane,omitempty"`
+	Source   string `json:"source,omitempty"`
+	Severity string `json:"severity,omitempty"`
+	Status   string `json:"status,omitempty"`
+	AgeMin   int64  `json:"age_min_seconds,omitempty"`
+	AgeMax   int64  `json:"age_max_seconds,omitempty"`
+}
+
+// ResolveRequest is one operator action. Only the four named actions are legal.
+type ResolveRequest struct {
+	Action         string `json:"action"`
+	Actor          string `json:"actor"`
+	Reason         string `json:"reason"`
+	IdempotencyKey string `json:"idempotency_key,omitempty"`
+	LinkIdentity   string `json:"link_identity,omitempty"`
+	LinkLeadID     string `json:"link_lead_id,omitempty"`
+	LinkActionID   string `json:"link_action_id,omitempty"`
+	LinkAccountID  string `json:"link_account_id,omitempty"`
+
+	// Presence of any of these is an attempt to invent outcome or identity.
+	OutcomeType    string `json:"outcome_type,omitempty"`
+	Revenue        string `json:"revenue,omitempty"`
+	Identity       string `json:"identity,omitempty"`
+	HumanConfirmed *bool  `json:"human_confirmed,omitempty"`
+}
+
+// ExceptionSnapshot is the audited before/after surface.
+type ExceptionSnapshot struct {
+	ID         string `json:"id"`
+	Status     string `json:"status"`
+	Code       string `json:"code"`
+	Held       bool   `json:"held"`
+	NextAction string `json:"next_action"`
+	Identity   string `json:"identity,omitempty"`
+	OutcomeID  string `json:"outcome_id,omitempty"`
+}
+
+// ResolveResult is the shipped resolve outcome. Replay returns the first result.
+type ResolveResult struct {
+	Exception Exception         `json:"exception"`
+	Replay    bool              `json:"replay"`
+	Refused   bool              `json:"refused"`
+	Reason    string            `json:"reason,omitempty"`
+	Before    ExceptionSnapshot `json:"before"`
+	After     ExceptionSnapshot `json:"after"`
+	Actor     string            `json:"actor,omitempty"`
+	Action    string            `json:"action,omitempty"`
+}
+
+// OperatorQueueNow is the pinned clock for labeled fixture presentation.
+var OperatorQueueNow = time.Date(2026, 8, 16, 12, 0, 0, 0, time.UTC)
+
+// OperatorQueueOrgID is the labeled fixture organization.
+const OperatorQueueOrgID = "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"
+
+func allowedResolveActions() []string {
+	return []string{ResolveLink, ResolveDefer, ResolveReject, ResolveExternalEvidence}
+}
+
+func isAllowedResolve(action string) bool {
+	switch strings.TrimSpace(action) {
+	case ResolveLink, ResolveDefer, ResolveReject, ResolveExternalEvidence:
+		return true
+	default:
+		return false
+	}
+}
+
+func severityFor(code string) string {
+	switch strings.TrimSpace(code) {
+	case ExceptionOrphan, ExceptionConflictingAccount, ExceptionOutOfOrder,
+		ExceptionUnconfirmedWon, ExceptionUnconfirmedLost, ExceptionUnavailable:
+		return SeverityHigh
+	case ExceptionMissingVersion, ExceptionStaleAttribution:
+		return SeverityMedium
+	case ExceptionDuplicate:
+		return SeverityLow
+	default:
+		return SeverityMedium
+	}
+}
+
+func statusAfter(action string) string {
+	switch action {
+	case ResolveLink:
+		return StatusLinked
+	case ResolveDefer:
+		return StatusDeferred
+	case ResolveReject:
+		return StatusRejected
+	case ResolveExternalEvidence:
+		return StatusExternalEvidence
+	default:
+		return StatusOpen
+	}
+}
+
+func nextActionFor(status, classified string) string {
+	switch status {
+	case StatusLinked:
+		return "linked to an existing identity; do not invent a new one"
+	case StatusDeferred:
+		return "deferred; remain open until a legal operator action"
+	case StatusRejected:
+		return "rejected; exception stays closed without an invented outcome"
+	case StatusExternalEvidence:
+		return "await external evidence; remain open"
+	default:
+		if strings.TrimSpace(classified) != "" {
+			return classified
+		}
+		return "remain open until a legal operator action"
+	}
+}
+
+func isOpenStatus(status string) bool {
+	switch strings.TrimSpace(status) {
+	case "", StatusOpen, StatusDeferred, StatusExternalEvidence:
+		return true
+	default:
+		return false
+	}
+}
+
+func allowedActionsFor(ex Exception) []string {
+	status := strings.TrimSpace(ex.Status)
+	if status == "" {
+		status = StatusOpen
+	}
+	if !isOpenStatus(status) {
+		if ex.Resolution != nil && ex.Resolution.Action != "" {
+			return []string{ex.Resolution.Action}
+		}
+		return nil
+	}
+	out := []string{ResolveDefer, ResolveReject, ResolveExternalEvidence}
+	if ex.Code == ExceptionOrphan {
+		out = append([]string{ResolveLink}, out...)
+	}
+	return out
+}
+
+func actionAllowedOn(ex Exception, action string) bool {
+	for _, a := range allowedActionsFor(ex) {
+		if a == action {
+			return true
+		}
+	}
+	return false
+}
+
+func snapshotOf(ex Exception) ExceptionSnapshot {
+	return ExceptionSnapshot{
+		ID:         ex.ID,
+		Status:     presentStatus(ex.Status),
+		Code:       ex.Code,
+		Held:       ex.Held,
+		NextAction: ex.NextAction,
+		Identity:   ex.Identity,
+		OutcomeID:  ex.OutcomeID,
+	}
+}
+
+func presentStatus(status string) string {
+	if strings.TrimSpace(status) == "" {
+		return StatusOpen
+	}
+	return status
+}
+
+func buildEvidence(ex Exception, in ObservedFacts) []EvidenceItem {
+	items := []EvidenceItem{
+		{Kind: "exception", Key: "code", Value: ex.Code},
+		{Kind: "exception", Key: "reason", Value: ex.Reason},
+		{Kind: "exception", Key: "held", Value: fmt.Sprintf("%v", ex.Held)},
+	}
+	add := func(kind, key, val string) {
+		if strings.TrimSpace(val) == "" {
+			return
+		}
+		items = append(items, EvidenceItem{Kind: kind, Key: key, Value: val})
+	}
+	add("join_id", "identity", ex.Identity)
+	add("join_id", "lead_id", firstNonEmpty(ex.LeadID, in.Keys.LeadID))
+	add("join_id", "receipt_id", firstNonEmpty(ex.ReceiptID, in.Keys.ReceiptID))
+	add("join_id", "action_id", firstNonEmpty(ex.ActionID, in.Keys.ActionID))
+	add("join_id", "outcome_id", firstNonEmpty(ex.OutcomeID, in.Keys.OutcomeID))
+	add("join_id", "account_id", firstNonEmpty(ex.AccountID, in.Keys.AccountID))
+	add("join_id", "metric_key", ex.MetricKey)
+	add("event", "source", in.Keys.Source)
+	add("event", "route_family", in.Keys.RouteFamily)
+	if in.Synthetic || ex.Synthetic {
+		add("event", "label", LabelSynthetic)
+	}
+	return items
+}
+
+func enrichException(ex *Exception, in ObservedFacts) {
+	if ex == nil {
+		return
+	}
+	if ex.Lane == "" {
+		ex.Lane = normalizeFamily(in.Keys.RouteFamily)
+	}
+	if ex.Source == "" {
+		ex.Source = idOrUnknown(in.Keys.Source)
+	}
+	if ex.ReceiptID == "" {
+		ex.ReceiptID = strings.TrimSpace(in.Keys.ReceiptID)
+	}
+	ex.Severity = severityFor(ex.Code)
+	if ex.Status == "" {
+		ex.Status = StatusOpen
+	}
+	if strings.TrimSpace(ex.NextAction) == "" {
+		ex.NextAction = nextActionFor(ex.Status, "")
+	}
+	if len(ex.Evidence) == 0 {
+		ex.Evidence = buildEvidence(*ex, in)
+	}
+	if len(ex.History) == 0 {
+		at := ex.At
+		if at.IsZero() {
+			at = time.Now().UTC()
+		}
+		ex.History = []QueueEvent{{
+			At:     at,
+			Kind:   "classified",
+			Detail: ex.Reason,
+		}}
+	}
+	ex.AllowedActions = allowedActionsFor(*ex)
+}
+
+// PresentException fills age and defaults so old payload rows stay readable.
+func PresentException(ex Exception, now time.Time) Exception {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if ex.Status == "" {
+		ex.Status = StatusOpen
+	}
+	if ex.Severity == "" {
+		ex.Severity = severityFor(ex.Code)
+	}
+	if ex.Lane == "" {
+		ex.Lane = Unknown
+	}
+	if ex.Source == "" {
+		ex.Source = Unknown
+	}
+	if strings.TrimSpace(ex.NextAction) == "" {
+		ex.NextAction = nextActionFor(ex.Status, "")
+	}
+	if !ex.At.IsZero() {
+		age := int64(now.Sub(ex.At).Seconds())
+		if age < 0 {
+			age = 0
+		}
+		ex.AgeSeconds = age
+	}
+	ex.AllowedActions = allowedActionsFor(ex)
+	return ex
+}
+
+// FilterExceptions applies type/lane/age/source/severity/status. Presentation first.
+func FilterExceptions(xs []Exception, filter ExceptionFilter, now time.Time) []Exception {
+	out := make([]Exception, 0, len(xs))
+	wantType := strings.TrimSpace(filter.Type)
+	wantLane := strings.TrimSpace(filter.Lane)
+	wantSource := strings.TrimSpace(filter.Source)
+	wantSev := strings.TrimSpace(filter.Severity)
+	wantStatus := strings.TrimSpace(filter.Status)
+	for _, ex := range xs {
+		item := PresentException(ex, now)
+		if wantType != "" && item.Code != wantType {
+			continue
+		}
+		if wantLane != "" && item.Lane != wantLane {
+			continue
+		}
+		if wantSource != "" && item.Source != wantSource {
+			continue
+		}
+		if wantSev != "" && item.Severity != wantSev {
+			continue
+		}
+		if wantStatus != "" && item.Status != wantStatus {
+			continue
+		}
+		if filter.AgeMin > 0 && item.AgeSeconds < filter.AgeMin {
+			continue
+		}
+		if filter.AgeMax > 0 && item.AgeSeconds > filter.AgeMax {
+			continue
+		}
+		out = append(out, item)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		if !out[i].At.Equal(out[j].At) {
+			return out[i].At.Before(out[j].At)
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// ListQueue is the shipped list/filter path used by HTTP and CLI.
+func ListQueue(store Store, orgID string, filter ExceptionFilter, now time.Time) ([]Exception, error) {
+	if store == nil {
+		return nil, fmt.Errorf("commercial intelligence store unavailable")
+	}
+	xs, err := store.ListExceptions(orgID)
+	if err != nil {
+		return nil, err
+	}
+	return FilterExceptions(xs, filter, now), nil
+}
+
+// GetQueueItem is the shipped detail path.
+func GetQueueItem(store Store, orgID, id string, now time.Time) (*Exception, error) {
+	if store == nil {
+		return nil, fmt.Errorf("commercial intelligence store unavailable")
+	}
+	ex, err := store.GetException(orgID, id)
+	if err != nil {
+		return nil, err
+	}
+	if ex == nil {
+		return nil, nil
+	}
+	presented := PresentException(*ex, now)
+	return &presented, nil
+}
+
+func inventAttempt(req ResolveRequest) string {
+	if strings.TrimSpace(req.OutcomeType) != "" {
+		return "cannot invent outcome_type; UNKNOWN stays UNKNOWN"
+	}
+	if strings.TrimSpace(req.Revenue) != "" {
+		return "cannot invent revenue"
+	}
+	if strings.TrimSpace(req.Identity) != "" {
+		return "cannot invent identity; use link_identity of an existing chain"
+	}
+	if req.HumanConfirmed != nil {
+		return "cannot invent human confirmation through the exception queue"
+	}
+	return ""
+}
+
+func sameResolveCommand(prev *ExceptionResolution, req ResolveRequest) bool {
+	if prev == nil {
+		return false
+	}
+	if prev.Action != strings.TrimSpace(req.Action) {
+		return false
+	}
+	if k := strings.TrimSpace(req.IdempotencyKey); k != "" {
+		return strings.TrimSpace(prev.IdempotencyKey) == k
+	}
+	return strings.TrimSpace(prev.Actor) == strings.TrimSpace(req.Actor) &&
+		strings.TrimSpace(prev.Reason) == strings.TrimSpace(req.Reason)
+}
+
+func findLinkTarget(store Store, orgID string, req ResolveRequest) (Chain, error) {
+	orgID = strings.TrimSpace(orgID)
+	if id := strings.TrimSpace(req.LinkIdentity); id != "" {
+		c, err := store.GetChain(orgID, id)
+		if err != nil {
+			return Chain{}, err
+		}
+		if c == nil {
+			return Chain{}, fmt.Errorf("link target identity does not exist; will not invent one")
+		}
+		return *c, nil
+	}
+	lead := strings.TrimSpace(req.LinkLeadID)
+	action := strings.TrimSpace(req.LinkActionID)
+	account := strings.TrimSpace(req.LinkAccountID)
+	if lead == "" && action == "" && account == "" {
+		return Chain{}, fmt.Errorf("link requires an existing link_identity, link_lead_id, link_action_id, or link_account_id")
+	}
+	chains, err := store.ListChains(orgID)
+	if err != nil {
+		return Chain{}, err
+	}
+	var match *Chain
+	for i := range chains {
+		c := &chains[i]
+		if lead != "" && (c.LeadID == lead || c.Keys.LeadID == lead) {
+			match = c
+			break
+		}
+		if action != "" && (c.ActionID == action || c.Keys.ActionID == action) {
+			match = c
+			break
+		}
+		if account != "" && (c.AccountID == account || c.Keys.AccountID == account) {
+			match = c
+			break
+		}
+	}
+	if match == nil {
+		return Chain{}, fmt.Errorf("no existing chain matches the supplied IDs; will not invent identity")
+	}
+	return *match, nil
+}
+
+// Resolve is the shipped resolve path. Same command replays the first result.
+func Resolve(store Store, orgID, id string, req ResolveRequest, now time.Time) (ResolveResult, error) {
+	if store == nil {
+		return ResolveResult{Refused: true, Reason: "commercial intelligence store unavailable"}, nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	req.Action = strings.TrimSpace(req.Action)
+	req.Actor = strings.TrimSpace(req.Actor)
+	req.Reason = strings.TrimSpace(req.Reason)
+	orgID = strings.TrimSpace(orgID)
+	id = strings.TrimSpace(id)
+
+	ex, err := store.GetException(orgID, id)
+	if err != nil {
+		return ResolveResult{}, err
+	}
+	if ex == nil {
+		return ResolveResult{Refused: true, Reason: "exception not found"}, nil
+	}
+	current := PresentException(*ex, now)
+	before := snapshotOf(current)
+
+	if msg := inventAttempt(req); msg != "" {
+		current.History = append(current.History, QueueEvent{
+			At: now, Kind: "refused", Actor: req.Actor, Action: req.Action, Reason: msg,
+		})
+		_ = store.UpdateException(current)
+		return ResolveResult{
+			Exception: PresentException(current, now),
+			Refused:   true,
+			Reason:    msg,
+			Before:    before,
+			After:     snapshotOf(current),
+			Actor:     req.Actor,
+			Action:    req.Action,
+		}, nil
+	}
+	if !isAllowedResolve(req.Action) {
+		msg := "action is not one of link, defer, reject, mark_external_evidence_required"
+		return ResolveResult{
+			Exception: current,
+			Refused:   true,
+			Reason:    msg,
+			Before:    before,
+			After:     before,
+			Actor:     req.Actor,
+			Action:    req.Action,
+		}, nil
+	}
+	if req.Actor == "" || req.Reason == "" {
+		return ResolveResult{
+			Exception: current,
+			Refused:   true,
+			Reason:    "actor and reason are required",
+			Before:    before,
+			After:     before,
+			Actor:     req.Actor,
+			Action:    req.Action,
+		}, nil
+	}
+
+	if current.Resolution != nil && (sameResolveCommand(current.Resolution, req) || current.Resolution.Action == req.Action && !isOpenStatus(current.Status)) {
+		return ResolveResult{
+			Exception: current,
+			Replay:    true,
+			Before: ExceptionSnapshot{
+				ID: current.ID, Status: current.Resolution.BeforeStatus, Code: current.Code,
+				Held: current.Held, NextAction: current.NextAction, Identity: current.Identity,
+				OutcomeID: current.OutcomeID,
+			},
+			After:  snapshotOf(current),
+			Actor:  current.Resolution.Actor,
+			Action: current.Resolution.Action,
+			Reason: current.Resolution.Reason,
+		}, nil
+	}
+
+	if !actionAllowedOn(current, req.Action) {
+		msg := "resolution violates lifecycle; exception stays open"
+		if !isOpenStatus(current.Status) {
+			msg = "exception is already resolved with a different action; replay the first command"
+		}
+		if req.Action == ResolveLink {
+			switch current.Code {
+			case ExceptionConflictingAccount:
+				msg = "link would overwrite a conflicting extra-cli account; refused"
+			case ExceptionOutOfOrder:
+				msg = "link would invent order on an out-of-order exception; refused"
+			case ExceptionUnconfirmedWon, ExceptionUnconfirmedLost:
+				msg = "link cannot confirm WON/LOST; UNKNOWN stays UNKNOWN"
+			}
+		}
+		current.History = append(current.History, QueueEvent{
+			At: now, Kind: "refused", Actor: req.Actor, Action: req.Action, Reason: msg,
+		})
+		_ = store.UpdateException(current)
+		return ResolveResult{
+			Exception: PresentException(current, now),
+			Refused:   true,
+			Reason:    msg,
+			Before:    before,
+			After:     snapshotOf(current),
+			Actor:     req.Actor,
+			Action:    req.Action,
+		}, nil
+	}
+
+	var linked Chain
+	if req.Action == ResolveLink {
+		linked, err = findLinkTarget(store, orgID, req)
+		if err != nil {
+			msg := err.Error()
+			current.History = append(current.History, QueueEvent{
+				At: now, Kind: "refused", Actor: req.Actor, Action: req.Action, Reason: msg,
+			})
+			_ = store.UpdateException(current)
+			return ResolveResult{
+				Exception: PresentException(current, now),
+				Refused:   true,
+				Reason:    msg,
+				Before:    before,
+				After:     snapshotOf(current),
+				Actor:     req.Actor,
+				Action:    req.Action,
+			}, nil
+		}
+	}
+
+	afterStatus := statusAfter(req.Action)
+	res := ExceptionResolution{
+		Action:         req.Action,
+		Actor:          req.Actor,
+		Reason:         req.Reason,
+		At:             now,
+		IdempotencyKey: strings.TrimSpace(req.IdempotencyKey),
+		BeforeStatus:   before.Status,
+		AfterStatus:    afterStatus,
+	}
+	if req.Action == ResolveLink {
+		res.LinkIdentity = linked.Identity
+		res.LinkLeadID = firstNonEmpty(req.LinkLeadID, linked.LeadID)
+		res.LinkActionID = firstNonEmpty(req.LinkActionID, linked.ActionID)
+		res.LinkAccountID = firstNonEmpty(req.LinkAccountID, linked.AccountID)
+		current.LinkedIdentity = linked.Identity
+	}
+	current.Status = afterStatus
+	current.NextAction = nextActionFor(afterStatus, "")
+	current.Resolution = &res
+	current.History = append(current.History, QueueEvent{
+		At:     now,
+		Kind:   "resolved",
+		Actor:  req.Actor,
+		Action: req.Action,
+		Reason: req.Reason,
+		Detail: "before=" + before.Status + " after=" + afterStatus,
+	})
+	current.AllowedActions = allowedActionsFor(current)
+	if err := store.UpdateException(current); err != nil {
+		return ResolveResult{}, err
+	}
+	presented := PresentException(current, now)
+	return ResolveResult{
+		Exception: presented,
+		Before:    before,
+		After:     snapshotOf(presented),
+		Actor:     req.Actor,
+		Action:    req.Action,
+		Reason:    req.Reason,
+	}, nil
+}
+
+// StableExceptionID is a deterministic UUID so classify/fixture replay is stable.
+func StableExceptionID(parts ...string) string {
+	sum := sha1.Sum([]byte(strings.Join(parts, "\x00")))
+	id, err := uuid.FromBytes(sum[:16])
+	if err != nil {
+		return uuid.NewSHA1(uuid.NameSpaceOID, sum[:]).String()
+	}
+	id[6] = (id[6] & 0x0f) | 0x50
+	id[8] = (id[8] & 0x3f) | 0x80
+	return id.String()
+}
+
+func assignExceptionID(ex Exception) Exception {
+	if strings.TrimSpace(ex.ID) == "" {
+		ex.ID = StableExceptionID(ex.OrganizationID, ex.Code, ex.Identity, ex.MetricKey, ex.Reason, ex.LeadID, ex.ActionID, ex.OutcomeID)
+	}
+	return ex
+}

--- a/internal/app/confenge/intel/queue_test.go
+++ b/internal/app/confenge/intel/queue_test.go
@@ -1,0 +1,360 @@
+package intel
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestListQueueFiltersTypeLaneAgeSourceSeverity(t *testing.T) {
+	st := NewMemoryStore()
+	LoadOperatorQueue(st, OperatorQueueOrgID)
+	now := OperatorQueueNow
+
+	all, err := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) < 8 {
+		t.Fatalf("want at least 8 fixture exceptions, got %d", len(all))
+	}
+	for _, ex := range all {
+		if ex.OrganizationID != OperatorQueueOrgID {
+			t.Fatalf("org leak: %+v", ex)
+		}
+		if ex.Code == "" || ex.Lane == "" || ex.Source == "" || ex.Severity == "" || ex.Status == "" {
+			t.Fatalf("presentation incomplete: %+v", ex)
+		}
+		if strings.TrimSpace(ex.NextAction) == "" {
+			t.Fatal("next_action empty")
+		}
+		if len(ex.Evidence) == 0 || len(ex.History) == 0 {
+			t.Fatalf("missing evidence/history on %s", ex.ID)
+		}
+	}
+
+	orphans, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionOrphan}, now)
+	if len(orphans) == 0 {
+		t.Fatal("type=orphan empty")
+	}
+	for _, ex := range orphans {
+		if ex.Code != ExceptionOrphan {
+			t.Fatalf("type filter leaked %s", ex.Code)
+		}
+	}
+
+	inbound, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Lane: FamilyInbound}, now)
+	if len(inbound) == 0 {
+		t.Fatal("lane=inbound empty")
+	}
+	for _, ex := range inbound {
+		if ex.Lane != FamilyInbound {
+			t.Fatalf("lane filter leaked %s", ex.Lane)
+		}
+	}
+
+	webcfg, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Source: "web-cfg"}, now)
+	if len(webcfg) == 0 {
+		t.Fatal("source=web-cfg empty")
+	}
+	for _, ex := range webcfg {
+		if ex.Source != "web-cfg" {
+			t.Fatalf("source filter leaked %s", ex.Source)
+		}
+	}
+
+	high, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Severity: SeverityHigh}, now)
+	if len(high) == 0 {
+		t.Fatal("severity=high empty")
+	}
+	for _, ex := range high {
+		if ex.Severity != SeverityHigh {
+			t.Fatalf("severity filter leaked %s", ex.Severity)
+		}
+	}
+
+	aged, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{AgeMin: 24 * 3600}, now)
+	if len(aged) == 0 {
+		t.Fatal("age_min=24h empty")
+	}
+	for _, ex := range aged {
+		if ex.AgeSeconds < 24*3600 {
+			t.Fatalf("age filter leaked %d", ex.AgeSeconds)
+		}
+	}
+
+	other, _ := ListQueue(st, "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", ExceptionFilter{}, now)
+	if len(other) != 0 {
+		t.Fatalf("org-scoped list leaked %d rows", len(other))
+	}
+
+	fmt.Printf("QUEUE_FILTER all=%d orphan=%d inbound=%d webcfg=%d high=%d aged24h=%d\n",
+		len(all), len(orphans), len(inbound), len(webcfg), len(high), len(aged))
+}
+
+func TestGetQueueItemShowsEvidenceAndNextAction(t *testing.T) {
+	st := NewMemoryStore()
+	LoadOperatorQueue(st, OperatorQueueOrgID)
+	all, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionOrphan}, OperatorQueueNow)
+	if len(all) == 0 {
+		t.Fatal("no orphan")
+	}
+	got, err := GetQueueItem(st, OperatorQueueOrgID, all[0].ID, OperatorQueueNow)
+	if err != nil || got == nil {
+		t.Fatalf("detail: %v %+v", err, got)
+	}
+	if got.NextAction == "" && got.Status != StatusOpen {
+		t.Fatal("detail missing next_action and is not open")
+	}
+	if got.Status != StatusOpen {
+		t.Fatalf("fresh item status=%s want open", got.Status)
+	}
+	if len(got.Evidence) == 0 || len(got.History) == 0 {
+		t.Fatal("detail missing evidence/history")
+	}
+	if !containsAction(got.AllowedActions, ResolveLink) {
+		t.Fatalf("orphan should allow link: %v", got.AllowedActions)
+	}
+	fmt.Printf("QUEUE_DETAIL id=%s code=%s next=%q open=%s\n", got.ID, got.Code, got.NextAction, got.Status)
+}
+
+func TestResolveLegalActionsIdempotentAndAudited(t *testing.T) {
+	st := NewMemoryStore()
+	LoadOperatorQueue(st, OperatorQueueOrgID)
+	now := OperatorQueueNow
+	orphans, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionOrphan}, now)
+	if len(orphans) == 0 {
+		t.Fatal("no orphan")
+	}
+	orphanID := orphans[0].ID
+
+	link, err := Resolve(st, OperatorQueueOrgID, orphanID, ResolveRequest{
+		Action:       ResolveLink,
+		Actor:        "operator@confenge",
+		Reason:       "matches existing inbound receipt",
+		LinkIdentity: "lead:webcfg-syn-in-1",
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if link.Refused {
+		t.Fatalf("legal link refused: %s", link.Reason)
+	}
+	if link.After.Status != StatusLinked || link.Before.Status != StatusOpen {
+		t.Fatalf("link before/after = %s -> %s", link.Before.Status, link.After.Status)
+	}
+	if link.Actor != "operator@confenge" || link.Reason == "" {
+		t.Fatal("link missing actor/reason")
+	}
+	if link.Exception.LinkedIdentity != "lead:webcfg-syn-in-1" {
+		t.Fatalf("linked identity=%s", link.Exception.LinkedIdentity)
+	}
+
+	replay, err := Resolve(st, OperatorQueueOrgID, orphanID, ResolveRequest{
+		Action:       ResolveLink,
+		Actor:        "operator@confenge",
+		Reason:       "matches existing inbound receipt",
+		LinkIdentity: "lead:webcfg-syn-in-1",
+	}, now.Add(time.Minute))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !replay.Replay || replay.Refused {
+		t.Fatalf("same command must replay: replay=%v refused=%v %s", replay.Replay, replay.Refused, replay.Reason)
+	}
+	if replay.After.Status != StatusLinked {
+		t.Fatalf("replay changed status to %s", replay.After.Status)
+	}
+
+	missing, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionMissingVersion}, now)
+	if len(missing) == 0 {
+		t.Fatal("no missing_version")
+	}
+	deferRes, err := Resolve(st, OperatorQueueOrgID, missing[0].ID, ResolveRequest{
+		Action: ResolveDefer, Actor: "operator@confenge", Reason: "wait for extra-cli watermark",
+	}, now)
+	if err != nil || deferRes.Refused {
+		t.Fatalf("defer: %v %s", err, deferRes.Reason)
+	}
+	if deferRes.After.Status != StatusDeferred {
+		t.Fatalf("defer status=%s", deferRes.After.Status)
+	}
+	if !isOpenStatus(deferRes.After.Status) {
+		t.Fatal("defer must stay nominally open")
+	}
+
+	stale, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionStaleAttribution}, now)
+	if len(stale) == 0 {
+		t.Fatal("no stale")
+	}
+	ext, err := Resolve(st, OperatorQueueOrgID, stale[0].ID, ResolveRequest{
+		Action: ResolveExternalEvidence, Actor: "operator@confenge", Reason: "need source system screenshot",
+	}, now)
+	if err != nil || ext.Refused {
+		t.Fatalf("external evidence: %v %s", err, ext.Reason)
+	}
+	if ext.After.Status != StatusExternalEvidence {
+		t.Fatalf("external status=%s", ext.After.Status)
+	}
+
+	dup, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionDuplicate}, now)
+	if len(dup) == 0 {
+		t.Fatal("no duplicate")
+	}
+	rej, err := Resolve(st, OperatorQueueOrgID, dup[0].ID, ResolveRequest{
+		Action: ResolveReject, Actor: "operator@confenge", Reason: "duplicate of first chain; no second insert",
+	}, now)
+	if err != nil || rej.Refused {
+		t.Fatalf("reject: %v %s", err, rej.Reason)
+	}
+	if rej.After.Status != StatusRejected {
+		t.Fatalf("reject status=%s", rej.After.Status)
+	}
+
+	fmt.Printf("QUEUE_RESOLVE link=%s defer=%s external=%s reject=%s replay=%v\n",
+		link.After.Status, deferRes.After.Status, ext.After.Status, rej.After.Status, replay.Replay)
+}
+
+func TestResolveRefusesLifecycleAndInventedOutcomes(t *testing.T) {
+	st := NewMemoryStore()
+	LoadOperatorQueue(st, OperatorQueueOrgID)
+	now := OperatorQueueNow
+
+	won, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionUnconfirmedWon}, now)
+	if len(won) == 0 {
+		t.Fatal("no unconfirmed_won")
+	}
+	inventWon, err := Resolve(st, OperatorQueueOrgID, won[0].ID, ResolveRequest{
+		Action: ResolveReject, Actor: "operator@confenge", Reason: "force won", OutcomeType: OutcomeWon,
+	}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !inventWon.Refused || !strings.Contains(inventWon.Reason, "outcome") {
+		t.Fatalf("invent WON must refuse: %+v", inventWon)
+	}
+	still, _ := GetQueueItem(st, OperatorQueueOrgID, won[0].ID, now)
+	if still == nil || !isOpenStatus(still.Status) {
+		t.Fatalf("invent WON closed the exception: %+v", still)
+	}
+
+	inventLost, _ := Resolve(st, OperatorQueueOrgID, won[0].ID, ResolveRequest{
+		Action: ResolveReject, Actor: "operator@confenge", Reason: "force lost", OutcomeType: OutcomeLost,
+	}, now)
+	if !inventLost.Refused {
+		t.Fatal("invent LOST must refuse")
+	}
+
+	inventRev, _ := Resolve(st, OperatorQueueOrgID, won[0].ID, ResolveRequest{
+		Action: ResolveReject, Actor: "operator@confenge", Reason: "book revenue", Revenue: "12000",
+	}, now)
+	if !inventRev.Refused || !strings.Contains(inventRev.Reason, "revenue") {
+		t.Fatalf("invent revenue must refuse: %+v", inventRev)
+	}
+
+	inventID, _ := Resolve(st, OperatorQueueOrgID, won[0].ID, ResolveRequest{
+		Action: ResolveLink, Actor: "operator@confenge", Reason: "mint identity", Identity: "lead:brand-new",
+	}, now)
+	if !inventID.Refused {
+		t.Fatal("invent identity must refuse")
+	}
+
+	linkWon, _ := Resolve(st, OperatorQueueOrgID, won[0].ID, ResolveRequest{
+		Action: ResolveLink, Actor: "operator@confenge", Reason: "try to confirm via link",
+		LinkIdentity: "lead:webcfg-syn-in-1",
+	}, now)
+	if !linkWon.Refused {
+		t.Fatal("link on unconfirmed_won must refuse")
+	}
+	afterLink, _ := GetQueueItem(st, OperatorQueueOrgID, won[0].ID, now)
+	if afterLink == nil || !isOpenStatus(afterLink.Status) {
+		t.Fatal("illegal link closed unconfirmed_won")
+	}
+
+	conflict, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionConflictingAccount}, now)
+	if len(conflict) == 0 {
+		t.Fatal("no conflict")
+	}
+	linkConflict, _ := Resolve(st, OperatorQueueOrgID, conflict[0].ID, ResolveRequest{
+		Action: ResolveLink, Actor: "operator@confenge", Reason: "overwrite account",
+		LinkIdentity: "lead:webcfg-syn-in-1",
+	}, now)
+	if !linkConflict.Refused {
+		t.Fatal("link on conflicting_account must refuse")
+	}
+
+	oo, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionOutOfOrder}, now)
+	if len(oo) == 0 {
+		t.Fatal("no out_of_order")
+	}
+	linkOO, _ := Resolve(st, OperatorQueueOrgID, oo[0].ID, ResolveRequest{
+		Action: ResolveLink, Actor: "operator@confenge", Reason: "reorder",
+		LinkIdentity: "lead:webcfg-syn-in-1",
+	}, now)
+	if !linkOO.Refused {
+		t.Fatal("link on out_of_order must refuse")
+	}
+
+	bogus, _ := Resolve(st, OperatorQueueOrgID, won[0].ID, ResolveRequest{
+		Action: "mark_won", Actor: "operator@confenge", Reason: "invent",
+	}, now)
+	if !bogus.Refused {
+		t.Fatal("unknown action must refuse")
+	}
+
+	fmt.Printf("QUEUE_REFUSE won=%q conflict=%q out_of_order=%q invent_identity=%q\n",
+		linkWon.Reason, linkConflict.Reason, linkOO.Reason, inventID.Reason)
+}
+
+func TestResolveLinkMissingTargetRefused(t *testing.T) {
+	st := NewMemoryStore()
+	LoadOperatorQueue(st, OperatorQueueOrgID)
+	orphans, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{Type: ExceptionOrphan}, OperatorQueueNow)
+	got, err := Resolve(st, OperatorQueueOrgID, orphans[0].ID, ResolveRequest{
+		Action: ResolveLink, Actor: "operator@confenge", Reason: "guess",
+		LinkIdentity: "lead:does-not-exist",
+	}, OperatorQueueNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !got.Refused {
+		t.Fatal("missing link target must refuse")
+	}
+	open, _ := GetQueueItem(st, OperatorQueueOrgID, orphans[0].ID, OperatorQueueNow)
+	if open == nil || open.Status != StatusOpen {
+		t.Fatalf("missing target closed orphan: %+v", open)
+	}
+}
+
+func TestQueueJSONHasRequiredOperatorFields(t *testing.T) {
+	st := NewMemoryStore()
+	LoadOperatorQueue(st, OperatorQueueOrgID)
+	xs, _ := ListQueue(st, OperatorQueueOrgID, ExceptionFilter{}, OperatorQueueNow)
+	raw, err := json.Marshal(xs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	for _, key := range []string{
+		"code", "lane", "source", "severity", "age_seconds", "next_action",
+		"status", "evidence", "history", "allowed_actions",
+	} {
+		if !strings.Contains(body, `"`+key+`"`) {
+			t.Fatalf("json missing %s", key)
+		}
+	}
+	if strings.Contains(body, `"mark_won"`) || strings.Contains(body, `"invent"`) {
+		t.Fatal("json advertised an invent action")
+	}
+}
+
+func containsAction(xs []string, want string) bool {
+	for _, a := range xs {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/confenge/intel/store.go
+++ b/internal/app/confenge/intel/store.go
@@ -17,6 +17,8 @@ type Store interface {
 	UpdateChain(c Chain) error
 	ListChains(orgID string) ([]Chain, error)
 	PutException(ex Exception) error
+	GetException(orgID, id string) (*Exception, error)
+	UpdateException(ex Exception) error
 	ListExceptions(orgID string) ([]Exception, error)
 	PutLearning(c LearningCandidate) (LearningCandidate, error)
 	ListLearning(orgID string) ([]LearningCandidate, error)
@@ -121,13 +123,61 @@ func (m *MemoryStore) PutException(ex Exception) error {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if strings.TrimSpace(ex.ID) == "" {
-		ex.ID = uuid.NewString()
-	}
+	ex = assignExceptionID(ex)
 	if ex.At.IsZero() {
 		ex.At = time.Now().UTC()
 	}
+	for _, existing := range m.exceptions {
+		if existing.ID == ex.ID {
+			return nil
+		}
+	}
 	m.exceptions = append(m.exceptions, ex)
+	return nil
+}
+
+func (m *MemoryStore) GetException(orgID, id string) (*Exception, error) {
+	if m == nil {
+		return nil, nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	orgID = strings.TrimSpace(orgID)
+	id = strings.TrimSpace(id)
+	if id == "" {
+		return nil, nil
+	}
+	for i := range m.exceptions {
+		ex := m.exceptions[i]
+		if ex.ID != id {
+			continue
+		}
+		if orgID != "" && ex.OrganizationID != orgID {
+			continue
+		}
+		cp := ex
+		return &cp, nil
+	}
+	return nil, nil
+}
+
+func (m *MemoryStore) UpdateException(ex Exception) error {
+	if m == nil {
+		return nil
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	ex = assignExceptionID(ex)
+	for i := range m.exceptions {
+		if m.exceptions[i].ID != ex.ID {
+			continue
+		}
+		if org := strings.TrimSpace(ex.OrganizationID); org != "" && m.exceptions[i].OrganizationID != org {
+			continue
+		}
+		m.exceptions[i] = ex
+		return nil
+	}
 	return nil
 }
 
@@ -137,8 +187,13 @@ func (m *MemoryStore) ListExceptions(orgID string) ([]Exception, error) {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	out := make([]Exception, len(m.exceptions))
-	copy(out, m.exceptions)
+	orgID = strings.TrimSpace(orgID)
+	out := make([]Exception, 0, len(m.exceptions))
+	for _, ex := range m.exceptions {
+		if orgID == "" || ex.OrganizationID == orgID {
+			out = append(out, ex)
+		}
+	}
 	return out, nil
 }
 

--- a/internal/app/confenge/intel/types.go
+++ b/internal/app/confenge/intel/types.go
@@ -291,6 +291,55 @@ type Versions struct {
 	Fresh              bool   `json:"target_fit_fresh"`
 }
 
+const (
+	ResolveLink             = "link"
+	ResolveDefer            = "defer"
+	ResolveReject           = "reject"
+	ResolveExternalEvidence = "mark_external_evidence_required"
+
+	StatusOpen             = "open"
+	StatusDeferred         = "deferred"
+	StatusRejected         = "rejected"
+	StatusLinked           = "linked"
+	StatusExternalEvidence = "external_evidence_required"
+
+	SeverityHigh   = "high"
+	SeverityMedium = "medium"
+	SeverityLow    = "low"
+)
+
+// EvidenceItem is one observed join ID or classification fact. Nothing is invented.
+type EvidenceItem struct {
+	Kind  string `json:"kind"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+// QueueEvent is one audited step on an exception (classify, resolve, replay, refuse).
+type QueueEvent struct {
+	At     time.Time `json:"at"`
+	Kind   string    `json:"kind"`
+	Actor  string    `json:"actor,omitempty"`
+	Action string    `json:"action,omitempty"`
+	Reason string    `json:"reason,omitempty"`
+	Detail string    `json:"detail,omitempty"`
+}
+
+// ExceptionResolution is the last legal operator action. Replay returns this.
+type ExceptionResolution struct {
+	Action         string    `json:"action"`
+	Actor          string    `json:"actor"`
+	Reason         string    `json:"reason"`
+	At             time.Time `json:"at"`
+	IdempotencyKey string    `json:"idempotency_key,omitempty"`
+	BeforeStatus   string    `json:"before_status"`
+	AfterStatus    string    `json:"after_status"`
+	LinkIdentity   string    `json:"link_identity,omitempty"`
+	LinkLeadID     string    `json:"link_lead_id,omitempty"`
+	LinkActionID   string    `json:"link_action_id,omitempty"`
+	LinkAccountID  string    `json:"link_account_id,omitempty"`
+}
+
 // Exception is a durable queue item. Out-of-order items are held.
 type Exception struct {
 	ID             string    `json:"id"`
@@ -304,9 +353,22 @@ type Exception struct {
 	OutcomeID      string    `json:"outcome_id,omitempty"`
 	AccountID      string    `json:"account_id,omitempty"`
 	LeadID         string    `json:"lead_id,omitempty"`
+	ReceiptID      string    `json:"receipt_id,omitempty"`
 	Held           bool      `json:"held"`
 	Synthetic      bool      `json:"synthetic,omitempty"`
 	At             time.Time `json:"at"`
+
+	// Operator queue presentation. Additive; old payload rows get defaults on read.
+	Lane           string               `json:"lane,omitempty"`
+	Source         string               `json:"source,omitempty"`
+	Severity       string               `json:"severity,omitempty"`
+	Status         string               `json:"status,omitempty"`
+	AgeSeconds     int64                `json:"age_seconds"`
+	Evidence       []EvidenceItem       `json:"evidence,omitempty"`
+	History        []QueueEvent         `json:"history,omitempty"`
+	AllowedActions []string             `json:"allowed_actions,omitempty"`
+	Resolution     *ExceptionResolution `json:"resolution,omitempty"`
+	LinkedIdentity string               `json:"linked_identity,omitempty"`
 }
 
 // JoinResult is the shipped reconcile outcome.

--- a/internal/app/confenge/intel_service.go
+++ b/internal/app/confenge/intel_service.go
@@ -3,6 +3,7 @@ package confenge
 import (
 	"context"
 	"strings"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -100,16 +101,49 @@ func (s *service) CommercialIntelReport(_ context.Context, orgID uuid.UUID, mont
 	return &rep, nil
 }
 
-// ListIntelExceptions returns the durable exception queue.
-func (s *service) ListIntelExceptions(_ context.Context, orgID uuid.UUID) ([]intel.Exception, *errx.Error) {
+// ListIntelExceptions returns the durable exception queue with operator filters.
+func (s *service) ListIntelExceptions(_ context.Context, orgID uuid.UUID, filter intel.ExceptionFilter) ([]intel.Exception, *errx.Error) {
 	if xerr := s.requireEnabled(); xerr != nil {
 		return nil, xerr
 	}
-	xs, err := s.intelStore().ListExceptions(orgID.String())
+	xs, err := intel.ListQueue(s.intelStore(), orgID.String(), filter, time.Now().UTC())
 	if err != nil {
 		return nil, errx.New(errx.Internal, "commercial intel exceptions: "+err.Error())
 	}
 	return xs, nil
+}
+
+// GetIntelException returns one presented queue item.
+func (s *service) GetIntelException(_ context.Context, orgID uuid.UUID, id string) (*intel.Exception, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	ex, err := intel.GetQueueItem(s.intelStore(), orgID.String(), id, time.Now().UTC())
+	if err != nil {
+		return nil, errx.New(errx.Internal, "commercial intel exception: "+err.Error())
+	}
+	if ex == nil {
+		return nil, errx.New(errx.NotFound, "intel exception not found")
+	}
+	return ex, nil
+}
+
+// ResolveIntelException applies one legal operator action. Replay is a no-op.
+func (s *service) ResolveIntelException(_ context.Context, orgID uuid.UUID, id string, req intel.ResolveRequest) (intel.ResolveResult, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return intel.ResolveResult{}, xerr
+	}
+	res, err := intel.Resolve(s.intelStore(), orgID.String(), id, req, time.Now().UTC())
+	if err != nil {
+		return intel.ResolveResult{}, errx.New(errx.Internal, "commercial intel resolve: "+err.Error())
+	}
+	if res.Refused && res.Reason == "exception not found" {
+		return res, errx.New(errx.NotFound, res.Reason)
+	}
+	if res.Refused {
+		return res, errx.New(errx.Unprocessable, res.Reason)
+	}
+	return res, nil
 }
 
 func (s *service) observeExisting(ctx context.Context, orgID uuid.UUID) {

--- a/internal/app/confenge/intel_service_test.go
+++ b/internal/app/confenge/intel_service_test.go
@@ -267,6 +267,48 @@ func TestObserveExistingJoinsOutcomeByLeadIDOnly(t *testing.T) {
 	fmt.Printf("OBSERVE_EXISTING a=%s b=%s email_or_rejected=true qco_visible=true\n", a.OutcomeType, b.OutcomeType)
 }
 
+func TestIntelExceptionQueueListAndResolve(t *testing.T) {
+	svc, _, org := inboundTestService(t)
+	intel.LoadOperatorQueue(svc.intelStore(), org.String())
+	ctx := context.Background()
+	orphans, xerr := svc.ListIntelExceptions(ctx, org, intel.ExceptionFilter{Type: intel.ExceptionOrphan})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if len(orphans) == 0 {
+		t.Fatal("service list missed orphans")
+	}
+	got, xerr := svc.GetIntelException(ctx, org, orphans[0].ID)
+	if xerr != nil || got == nil {
+		t.Fatalf("get: %v", xerr)
+	}
+	if got.NextAction == "" || len(got.Evidence) == 0 {
+		t.Fatalf("detail incomplete: %+v", got)
+	}
+	res, xerr := svc.ResolveIntelException(ctx, org, orphans[0].ID, intel.ResolveRequest{
+		Action: intel.ResolveDefer, Actor: "svc-test", Reason: "wait for action id",
+	})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.After.Status != intel.StatusDeferred {
+		t.Fatalf("defer status=%s", res.After.Status)
+	}
+	replay, xerr := svc.ResolveIntelException(ctx, org, orphans[0].ID, intel.ResolveRequest{
+		Action: intel.ResolveDefer, Actor: "svc-test", Reason: "wait for action id",
+	})
+	if xerr != nil || !replay.Replay {
+		t.Fatalf("replay: %v %+v", xerr, replay)
+	}
+	_, xerr = svc.ResolveIntelException(ctx, org, orphans[0].ID, intel.ResolveRequest{
+		Action: intel.ResolveReject, Actor: "svc-test", Reason: "force", OutcomeType: intel.OutcomeWon,
+	})
+	if xerr == nil {
+		t.Fatal("invent WON must fail closed")
+	}
+	fmt.Printf("SERVICE_QUEUE orphan=%s deferred=%s replay=%v\n", orphans[0].ID, res.After.Status, replay.Replay)
+}
+
 func containsAny(s string, parts ...string) bool {
 	for _, p := range parts {
 		if len(p) > 0 && indexOfStr(s, p) >= 0 {

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -122,7 +122,9 @@ type Service interface {
 	ReconcileCommercialIntel(ctx context.Context, orgID uuid.UUID, in intel.ObservedFacts) (intel.JoinResult, *errx.Error)
 	CommercialExecutiveView(ctx context.Context, orgID uuid.UUID, month string, includeSynthetic bool) (*intel.ExecutiveView, *errx.Error)
 	RecordIntelLearning(ctx context.Context, orgID uuid.UUID, in intel.LearningInput) (intel.LearningCandidate, *errx.Error)
-	ListIntelExceptions(ctx context.Context, orgID uuid.UUID) ([]intel.Exception, *errx.Error)
+	ListIntelExceptions(ctx context.Context, orgID uuid.UUID, filter intel.ExceptionFilter) ([]intel.Exception, *errx.Error)
+	GetIntelException(ctx context.Context, orgID uuid.UUID, id string) (*intel.Exception, *errx.Error)
+	ResolveIntelException(ctx context.Context, orgID uuid.UUID, id string, req intel.ResolveRequest) (intel.ResolveResult, *errx.Error)
 	IngestCommercialEvent(ctx context.Context, orgID uuid.UUID, ev intel.CommercialEvent) (intel.JoinResult, *errx.Error)
 	CommercialIntelReport(ctx context.Context, orgID uuid.UUID, month string, includeSynthetic bool) (*intel.ObservabilityReport, *errx.Error)
 }

--- a/internal/models/audit.go
+++ b/internal/models/audit.go
@@ -122,6 +122,7 @@ const (
 	AuditEntityOutreachAccount          AuditEntityType = "outreach_account"
 	AuditEntityOutreachCommercialAction AuditEntityType = "outreach_commercial_action"
 	AuditEntityOutreachInboundLead      AuditEntityType = "outreach_inbound_lead"
+	AuditEntityOutreachIntelException   AuditEntityType = "outreach_intel_exception"
 )
 
 // AuditActor is the minimal identity of the member who performed an action,

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
 import {
   AlertTriangle,
   ArrowRight,
@@ -28,6 +29,9 @@ import {
   useApplyConfengeManualAction,
   useConfengeCockpit,
   useConfengeExecutiveIntel,
+  useConfengeIntelException,
+  useConfengeIntelExceptions,
+  useResolveConfengeIntelException,
   useRecordConfengeActionOutcome,
   useRecordConfengeInboundOutcome,
   useConfengeWorkingOverview,
@@ -48,6 +52,8 @@ import type {
   ConfengeActionCopy,
   ConfengeInboundNowItem,
   ConfengeExecutiveView,
+  ConfengeIntelException,
+  ConfengeIntelExceptionFilter,
   ConfengeAttentionFilter,
   ConfengeTouchpoint,
   ConfengeWorkingQueueItem,
@@ -373,6 +379,8 @@ export default function ConfengePage() {
         {executive.data && (
           <ExecutiveIntelPanel view={executive.data} />
         )}
+
+        <ExceptionQueuePanel enabled={enabled} />
 
         {cockpit.data?.today && (
           <section id="hoje" data-testid="confenge-today" className="rounded-md border border-slate-200 bg-white">
@@ -1430,6 +1438,183 @@ const OUTCOME_OPTIONS = [
   "DNC",
   "SKIPPED",
 ];
+
+const EXCEPTION_TYPES = ["", "orphan", "duplicate", "conflicting_account", "missing_version", "stale_attribution", "out_of_order", "unconfirmed_won", "unconfirmed_lost", "ledger_unavailable"];
+const EXCEPTION_LANES = ["", "inbound", "outbound", "partner", "expansion", "UNKNOWN"];
+const EXCEPTION_SOURCES = ["", "web-cfg", "extra-cli", "partner", "expansion", "UNKNOWN"];
+const EXCEPTION_SEVERITIES = ["", "high", "medium", "low"];
+const EXCEPTION_AGES: { id: number; label: string }[] = [
+  { id: 0, label: "qualquer idade" },
+  { id: 3600, label: ">1h" },
+  { id: 86400, label: ">24h" },
+  { id: 604800, label: ">7d" },
+];
+
+function ExceptionQueuePanel({ enabled }: { enabled: boolean }) {
+  const confirm = useConfirm();
+  const [filter, setFilter] = useState<ConfengeIntelExceptionFilter>({});
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [reason, setReason] = useState("");
+  const [linkIdentity, setLinkIdentity] = useState("");
+  const list = useConfengeIntelExceptions(filter, enabled);
+  const detail = useConfengeIntelException(selectedId);
+  const resolve = useResolveConfengeIntelException();
+  const items = list.data ?? [];
+  const current: ConfengeIntelException | undefined = detail.data ?? items.find((x) => x.id === selectedId);
+
+  const act = (action: "link" | "defer" | "reject" | "mark_external_evidence_required") => {
+    if (!current) return;
+    const why = reason.trim();
+    if (!why) {
+      toast.error("Informe o motivo. A fila não inventa outcome.");
+      return;
+    }
+    if (action === "link" && !linkIdentity.trim()) {
+      toast.error("Informe um identity já existente. A fila não inventa identidade.");
+      return;
+    }
+    const label = action === "link" ? "vincular ao identity existente" : action === "defer" ? "adiar" : action === "reject" ? "rejeitar" : "marcar evidência externa";
+    void confirm.show(`Confirmar ${label}? Isso não cria WON, LOST, receita ou identidade.`, async () => {
+      await resolve.mutateAsync({
+        id: current.id,
+        action,
+        reason: why,
+        link_identity: action === "link" ? linkIdentity.trim() : undefined,
+      });
+    });
+  };
+
+  return (
+    <section id="fila-excecoes" data-testid="confenge-intel-exceptions" className="rounded-md border border-slate-200 bg-white">
+      <div className="px-3 h-10 flex items-center border-b border-slate-200">
+        <span className="text-[12.5px] font-medium text-slate-900">Fila de exceções</span>
+        <span className="ml-2 text-[12.5px] text-slate-500 tabular-nums">{items.length}</span>
+      </div>
+      <p className="px-3 pt-2 text-[11.5px] text-slate-500">
+        Órfãos, conflitos e transições impossíveis. Cada item mostra evidência e a próxima ação, ou permanece aberto.
+        Sem botão para inventar WON, LOST, receita ou identidade.
+      </p>
+      <div className="px-3 py-2 flex flex-wrap gap-1.5" data-testid="confenge-intel-exception-filters">
+        <FilterChips label="tipo" value={filter.type ?? ""} options={EXCEPTION_TYPES} onChange={(type) => setFilter((f) => ({ ...f, type: type || undefined }))} />
+        <FilterChips label="lane" value={filter.lane ?? ""} options={EXCEPTION_LANES} onChange={(lane) => setFilter((f) => ({ ...f, lane: lane || undefined }))} />
+        <FilterChips label="fonte" value={filter.source ?? ""} options={EXCEPTION_SOURCES} onChange={(source) => setFilter((f) => ({ ...f, source: source || undefined }))} />
+        <FilterChips label="severidade" value={filter.severity ?? ""} options={EXCEPTION_SEVERITIES} onChange={(severity) => setFilter((f) => ({ ...f, severity: severity || undefined }))} />
+        <div className="flex flex-wrap items-center gap-1">
+          <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400">idade</span>
+          {EXCEPTION_AGES.map((opt) => (
+            <button
+              key={opt.id}
+              type="button"
+              className={`h-7 px-2 rounded-md border text-[11.5px] ${ (filter.ageMinSeconds ?? 0) === opt.id ? "border-sky-400 bg-sky-50 text-sky-700" : "border-slate-200 text-slate-600"}`}
+              onClick={() => setFilter((f) => ({ ...f, ageMinSeconds: opt.id || undefined }))}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <ul className="divide-y divide-slate-100 max-h-72 overflow-auto" data-testid="confenge-intel-exception-list">
+        {items.map((ex) => (
+          <li key={ex.id}>
+            <button
+              type="button"
+              className={`w-full text-left px-3 py-2 text-[12.5px] ${selectedId === ex.id ? "bg-sky-50" : ""}`}
+              onClick={() => setSelectedId(ex.id)}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <span className="font-medium text-slate-900">{ex.code}</span>
+                <span className="text-[11px] text-slate-500">{ex.severity} · {ex.lane} · {ex.status || "open"}</span>
+              </div>
+              <div className="text-slate-500 truncate">{ex.next_action || "permanece aberta"}</div>
+              <div className="text-[11px] text-slate-400">{ex.source} · {formatAge(ex.age_seconds)}</div>
+            </button>
+          </li>
+        ))}
+        {!items.length && (
+          <li className="px-3 py-8 text-center text-slate-400 text-[12.5px]">
+            Nenhuma exceção persistida. Sem evento real a fila fica vazia e UNKNOWN permanece UNKNOWN.
+          </li>
+        )}
+      </ul>
+      {current && (
+        <div className="border-t border-slate-200 px-3 py-3 space-y-2" data-testid="confenge-intel-exception-detail">
+          <div className="text-[12.5px] font-medium text-slate-900">{current.code} · {current.status || "open"}</div>
+          <p className="text-[12px] text-slate-600">{current.reason}</p>
+          <p className="text-[12px] text-slate-700">Próxima ação: {current.next_action || "permanece aberta"}</p>
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Evidência</div>
+            <ul className="mt-1 space-y-0.5 text-[11.5px] text-slate-600">
+              {(current.evidence ?? []).map((ev) => (
+                <li key={`${ev.kind}-${ev.key}`}>{ev.kind}: {ev.key}={ev.value}</li>
+              ))}
+            </ul>
+          </div>
+          <div>
+            <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Histórico</div>
+            <ul className="mt-1 space-y-0.5 text-[11.5px] text-slate-600">
+              {(current.history ?? []).map((ev, i) => (
+                <li key={`${ev.at}-${i}`}>{ev.kind}{ev.action ? ` · ${ev.action}` : ""}{ev.actor ? ` · ${ev.actor}` : ""}{ev.reason ? ` · ${ev.reason}` : ""}</li>
+              ))}
+            </ul>
+          </div>
+          <TextInput value={reason} onChange={setReason} placeholder="Motivo obrigatório (ator vem da sessão)" />
+          {(current.allowed_actions ?? []).includes("link") && (
+            <TextInput value={linkIdentity} onChange={setLinkIdentity} placeholder="Identity existente para vincular" />
+          )}
+          <div className="flex flex-wrap gap-1.5" data-testid="confenge-intel-exception-actions">
+            {(current.allowed_actions ?? []).includes("link") && (
+              <button type="button" className="h-7 px-2.5 rounded-md border border-slate-200 text-[12px] text-slate-700" onClick={() => act("link")}>Vincular</button>
+            )}
+            {(current.allowed_actions ?? []).includes("defer") && (
+              <button type="button" className="h-7 px-2.5 rounded-md border border-slate-200 text-[12px] text-slate-700" onClick={() => act("defer")}>Adiar</button>
+            )}
+            {(current.allowed_actions ?? []).includes("reject") && (
+              <button type="button" className="h-7 px-2.5 rounded-md border border-slate-200 text-[12px] text-slate-700" onClick={() => act("reject")}>Rejeitar</button>
+            )}
+            {(current.allowed_actions ?? []).includes("mark_external_evidence_required") && (
+              <button type="button" className="h-7 px-2.5 rounded-md border border-slate-200 text-[12px] text-slate-700" onClick={() => act("mark_external_evidence_required")}>Evidência externa</button>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function formatAge(seconds: number): string {
+  if (!seconds || seconds < 60) return `${seconds || 0}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+function FilterChips({
+  label,
+  value,
+  options,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  options: string[];
+  onChange: (next: string) => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-1">
+      <span className="text-[10px] uppercase tracking-[0.14em] text-slate-400">{label}</span>
+      {options.map((opt) => (
+        <button
+          key={opt || "any"}
+          type="button"
+          className={`h-7 px-2 rounded-md border text-[11.5px] ${value === opt ? "border-sky-400 bg-sky-50 text-sky-700" : "border-slate-200 text-slate-600"}`}
+          onClick={() => onChange(opt)}
+        >
+          {opt || "todas"}
+        </button>
+      ))}
+    </div>
+  );
+}
 
 function ExecutiveIntelPanel({ view }: { view: ConfengeExecutiveView }) {
   const unknownLabel = view.real_empty ? "UNKNOWN" : String(view.unknown);

--- a/web/src/hooks/useRealtimeEvents.ts
+++ b/web/src/hooks/useRealtimeEvents.ts
@@ -330,6 +330,7 @@ export function useRealtimeEvents() {
           outreach_account: [['confenge']],
           outreach_commercial_action: [['confenge']],
           outreach_inbound_lead: [['confenge']],
+          outreach_intel_exception: [['confenge']],
           settings: [['organizations', 'current']],
           unibox: [['unibox']],
           crm_note: [['crm'], ['contacts']],

--- a/web/src/lib/api/client/app/confenge/confenge.ts
+++ b/web/src/lib/api/client/app/confenge/confenge.ts
@@ -14,6 +14,9 @@ import type {
     ConfengeWorkingQueueItem,
     ConfengeWorkingQueueSummary,
     ConfengeExecutiveView,
+    ConfengeIntelException,
+    ConfengeIntelExceptionFilter,
+    ConfengeIntelResolveResult,
 } from "@/lib/api/models/app/confenge/Confenge";
 import Request from "../../Request";
 
@@ -71,6 +74,55 @@ export async function getConfengeExecutiveIntel(params?: {
         method: "GET",
         url: `/confenge/intel/executive${qs ? `?${qs}` : ""}`,
         authorization: true,
+    });
+    return res.data;
+}
+
+export async function listConfengeIntelExceptions(
+    filter?: ConfengeIntelExceptionFilter,
+): Promise<ConfengeIntelException[]> {
+    const sp = new URLSearchParams();
+    if (filter?.type) sp.set("type", filter.type);
+    if (filter?.lane) sp.set("lane", filter.lane);
+    if (filter?.source) sp.set("source", filter.source);
+    if (filter?.severity) sp.set("severity", filter.severity);
+    if (filter?.status) sp.set("status", filter.status);
+    if (filter?.ageMinSeconds) sp.set("age_min_seconds", String(filter.ageMinSeconds));
+    const qs = sp.toString();
+    const res = await Request<{ data: ConfengeIntelException[] }>({
+        method: "GET",
+        url: `/confenge/intel/exceptions${qs ? `?${qs}` : ""}`,
+        authorization: true,
+    });
+    return res.data ?? [];
+}
+
+export async function getConfengeIntelException(id: string): Promise<ConfengeIntelException> {
+    const res = await Request<{ data: ConfengeIntelException }>({
+        method: "GET",
+        url: `/confenge/intel/exceptions/${id}`,
+        authorization: true,
+    });
+    return res.data;
+}
+
+export async function resolveConfengeIntelException(
+    id: string,
+    payload: {
+        action: "link" | "defer" | "reject" | "mark_external_evidence_required";
+        reason: string;
+        link_identity?: string;
+        link_lead_id?: string;
+        link_action_id?: string;
+        link_account_id?: string;
+    },
+): Promise<ConfengeIntelResolveResult> {
+    const res = await Request<{ data: ConfengeIntelResolveResult }>({
+        method: "POST",
+        url: `/confenge/intel/exceptions/${id}/resolve`,
+        authorization: true,
+        data: payload,
+        headers: { "Idempotency-Key": `intel-ex-${id}-${payload.action}-${payload.reason}` },
     });
     return res.data;
 }

--- a/web/src/lib/api/hooks/app/confenge/useConfenge.ts
+++ b/web/src/lib/api/hooks/app/confenge/useConfenge.ts
@@ -19,6 +19,9 @@ import {
     applyConfengeManualAction,
     getConfengeCockpit,
     getConfengeExecutiveIntel,
+    getConfengeIntelException,
+    listConfengeIntelExceptions,
+    resolveConfengeIntelException,
     getConfengeToday,
     recordConfengeActionOutcome,
     recordConfengeInboundOutcome,
@@ -38,7 +41,7 @@ import {
     reviewConfengeDraft,
     syncConfengeFeed,
 } from "@/lib/api/client/app/confenge/confenge";
-import type { ConfengeAttentionFilter } from "@/lib/api/models/app/confenge/Confenge";
+import type { ConfengeAttentionFilter, ConfengeIntelExceptionFilter } from "@/lib/api/models/app/confenge/Confenge";
 import type { AppError } from "@/lib/api/client/normalizeError";
 
 const KEY = ["confenge"] as const;
@@ -81,6 +84,44 @@ export function useConfengeExecutiveIntel(enabled = true) {
         queryFn: () => getConfengeExecutiveIntel({ includeSynthetic: false }),
         enabled,
         staleTime: 15_000,
+    });
+}
+
+export function useConfengeIntelExceptions(filter: ConfengeIntelExceptionFilter, enabled = true) {
+    return useQuery({
+        queryKey: [...KEY, "intel", "exceptions", filter],
+        queryFn: () => listConfengeIntelExceptions(filter),
+        enabled,
+        staleTime: 10_000,
+    });
+}
+
+export function useConfengeIntelException(id: string | null) {
+    return useQuery({
+        queryKey: [...KEY, "intel", "exceptions", "detail", id],
+        queryFn: () => getConfengeIntelException(id!),
+        enabled: !!id,
+    });
+}
+
+export function useResolveConfengeIntelException() {
+    const qc = useQueryClient();
+    return useMutation({
+        mutationFn: (args: {
+            id: string;
+            action: "link" | "defer" | "reject" | "mark_external_evidence_required";
+            reason: string;
+            link_identity?: string;
+        }) => resolveConfengeIntelException(args.id, args),
+        onSuccess: (res) => {
+            void qc.invalidateQueries({ queryKey: KEY });
+            if (res.replay) {
+                toast.success("Ação já registrada. Replay sem nova mudança.");
+                return;
+            }
+            toast.success("Exceção atualizada. Sem inventar WON, LOST, receita ou identidade.");
+        },
+        onError: (e) => toast.error(confengeError(e, "A resolução foi recusada. A exceção permanece aberta.")),
     });
 }
 

--- a/web/src/lib/api/models/app/confenge/Confenge.ts
+++ b/web/src/lib/api/models/app/confenge/Confenge.ts
@@ -254,6 +254,77 @@ export type ConfengeExecutiveFamily = {
     unknown: number;
 };
 
+export type ConfengeIntelEvidence = {
+    kind: string;
+    key: string;
+    value: string;
+};
+
+export type ConfengeIntelQueueEvent = {
+    at: string;
+    kind: string;
+    actor?: string;
+    action?: string;
+    reason?: string;
+    detail?: string;
+};
+
+export type ConfengeIntelResolution = {
+    action: string;
+    actor: string;
+    reason: string;
+    at: string;
+    before_status: string;
+    after_status: string;
+    link_identity?: string;
+};
+
+export type ConfengeIntelException = {
+    id: string;
+    organization_id?: string;
+    code: string;
+    reason: string;
+    next_action: string;
+    identity?: string;
+    action_id?: string;
+    outcome_id?: string;
+    account_id?: string;
+    lead_id?: string;
+    held: boolean;
+    synthetic?: boolean;
+    at: string;
+    lane?: string;
+    source?: string;
+    severity?: string;
+    status?: string;
+    age_seconds: number;
+    evidence?: ConfengeIntelEvidence[];
+    history?: ConfengeIntelQueueEvent[];
+    allowed_actions?: string[];
+    resolution?: ConfengeIntelResolution;
+    linked_identity?: string;
+};
+
+export type ConfengeIntelResolveResult = {
+    exception: ConfengeIntelException;
+    replay: boolean;
+    refused: boolean;
+    reason?: string;
+    before: { id: string; status: string; code: string; held: boolean; next_action: string };
+    after: { id: string; status: string; code: string; held: boolean; next_action: string };
+    actor?: string;
+    action?: string;
+};
+
+export type ConfengeIntelExceptionFilter = {
+    type?: string;
+    lane?: string;
+    source?: string;
+    severity?: string;
+    status?: string;
+    ageMinSeconds?: number;
+};
+
 export type ConfengeExecutiveView = {
     month: string;
     include_synthetic: boolean;


### PR DESCRIPTION
## Outcome

Operator queue for durable intel exceptions so orphans, conflicts, and impossible transitions can be understood and resolved without editing the database or inventing an outcome.

Decision: `READY_BEHIND_HUMAN_GATE`

## Scope

- List, detail, and filter persisted intel exceptions by type, lane, age, source, and severity.
- Each item shows evidence, event history, and a next action, or stays nominally open.
- Legal resolutions only: `link`, `defer`, `reject`, `mark_external_evidence_required`.
- Resolve is replay-safe and idempotent, records before/after plus actor/reason, and refuses lifecycle violations.
- Attempts to invent WON, LOST, revenue, or identity are refused. UNKNOWN stays UNKNOWN.
- HTTP: `GET /confenge/intel/exceptions` (filters), `GET /confenge/intel/exceptions/:id`, `POST /confenge/intel/exceptions/:id/resolve` with `Idempotency-Key`.
- CLI: `confenge intel-exceptions list|show|resolve` (`--fixture` for labeled SYNTHETIC; live requires `PRIMARY_DB`).
- Dashboard CONFENGE panel with the same filters and only the four actions.
- Org-scoped `ListExceptions` (the in-memory store no longer leaks across orgs).
- Docs: API map, CONFENGE guide, commercial-intelligence, local-ops.

## Out of scope

- Reimplement synthetic reconcile / `IngestEvent` / `intel-report` (PR #80 / WARMBLY-001).
- Close issue #47.
- Live inbound, action, or outcome proof.
- AUTO_SEND, bulk approval, identity/consent inference.
- CRM, forecast, or a second truth plane.
- Merge, deploy, DNS, spend, messaging, or mass approve.

## Risks

- Queue items already persisted without the new payload fields get defaults on read (`status=open`, severity from code, lane/source `UNKNOWN` if missing).
- `link` records a pointer to an existing chain identity. It does not rewrite extra-cli identity or invent IDs.
- PR #80 may later change exception shape. This change is additive JSON on the existing payload.
- `--fixture` is labeled SYNTHETIC. It is not live evidence.

## Rollback

Revert this branch. Exception rows remain readable as the previous `{id,code,reason,next_action,...}` payload. No migration.

## Refs

- Issue #47
- PR #80 (do not reimplement; unmerged synthetic ingest)
- WARMBLY-001 (real events still required)
- Base SHA `2444058ef3a64774b84eea57425b731700946b84`

## Evidence

- `go test` on `intel`, service, handler, and `cmd/confenge` queue paths: pass
- CLI `--fixture` list run twice: byte-identical (`LIST_RUNS_AGREE=true`)
- CLI resolve prints before/after, actor, reason
- `gofmt -l` empty on touched Go
- `golangci-lint v1.64.8`: pass on touched packages
- `pnpm typecheck` in `web/`: pass
- `pnpm lint` in `web/`: 0 errors (pre-existing warnings only)
- UI static check: filters present; only the four actions; no invent WON/LOST/revenue/identity control

## Residual (still open)

- Issue #47 stays open.
- No live inbound/action/outcome crossed the queue. Empty-real behavior stays empty/UNKNOWN.
- Live `PRIMARY_DB` operator run was not claimed. CLI without `--fixture` fails closed with `BLOCKED` when `PRIMARY_DB` is unset.
- Manual dashboard click-through is the operator's job (browser e2e is forbidden here).
- Merge, deploy, and live-event proof are not claimed.

## Final decision

`READY_BEHIND_HUMAN_GATE`
