### PR TITLE
feat: persist versioned intel exception codes in 000102 and keep intel-report byte-stable

### DIFF
--- a/internal/app/confenge/intel/event_loop_test.go
+++ b/internal/app/confenge/intel/event_loop_test.go
@@ -444,16 +444,30 @@ func TestRunFixtureReportTwiceStable(t *testing.T) {
 	if !found {
 		t.Fatal("no learning candidates")
 	}
-	raw, _ := ReportJSON(a)
-	md := ReportMarkdown(a)
-	if !strings.Contains(md, "INBOUND QUALIFIED PIPELINE") {
+	rawA, err := ReportJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawB, err := ReportJSON(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(rawA) != string(rawB) {
+		t.Fatal("JSON reports are not byte-stable across two RunFixtureReport calls")
+	}
+	mdA := ReportMarkdown(a)
+	mdB := ReportMarkdown(b)
+	if mdA != mdB {
+		t.Fatal("markdown reports are not byte-stable across two RunFixtureReport calls")
+	}
+	if !strings.Contains(mdA, "INBOUND QUALIFIED PIPELINE") {
 		t.Fatal("markdown missing IQP")
 	}
-	if ReportHasPII(raw) {
+	if ReportHasPII(rawA) {
 		t.Fatal("report JSON flagged as PII")
 	}
-	fmt.Printf("REPORT_STABLE iqp=%d won=%d lost=%d unknown=%d baseline=%s rec=%s\n",
-		a.InboundQualifiedPipeline, a.Won, a.Lost, a.Unknown, a.Latency.Baseline, a.Recommendation)
+	fmt.Printf("REPORT_STABLE iqp=%d won=%d lost=%d unknown=%d baseline=%s rec=%s json_bytes=%d md_bytes=%d\n",
+		a.InboundQualifiedPipeline, a.Won, a.Lost, a.Unknown, a.Latency.Baseline, a.Recommendation, len(rawA), len(mdA))
 }
 
 func TestOrderingOutOfOrderHeld(t *testing.T) {

--- a/internal/app/confenge/intel/exception_codes_persist_test.go
+++ b/internal/app/confenge/intel/exception_codes_persist_test.go
@@ -1,0 +1,198 @@
+package intel
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func versionedExceptionCodes() []string {
+	return []string{
+		ExceptionOrphan,
+		ExceptionDuplicate,
+		ExceptionConflictingAccount,
+		ExceptionMissingVersion,
+		ExceptionStaleAttribution,
+		ExceptionOutOfOrder,
+		ExceptionUnconfirmedWon,
+		ExceptionUnconfirmedLost,
+		ExceptionUnavailable,
+		ExceptionImpossibleTransition,
+		ExceptionNegativeLatency,
+		ExceptionOverlappingLatency,
+		ExceptionOutboundAsInbound,
+		ExceptionInvalidAssetFamily,
+		ExceptionMissingAttribution,
+	}
+}
+
+func TestMemoryStorePersistsAndListsEveryVersionedExceptionCode(t *testing.T) {
+	st := NewMemoryStore()
+	org := "org-exception-codes"
+	for i, code := range versionedExceptionCodes() {
+		err := st.PutException(Exception{
+			OrganizationID: org,
+			Code:           code,
+			Identity:       fmt.Sprintf("id-%s", code),
+			Reason:         "persist-proof-" + code,
+			Held:           i%2 == 0,
+		})
+		if err != nil {
+			t.Fatalf("PutException %s: %v", code, err)
+		}
+	}
+	listed, err := st.ListExceptions(org)
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]Exception{}
+	for _, ex := range listed {
+		if want := "persist-proof-" + ex.Code; ex.Reason != want {
+			t.Fatalf("CHECK-failing rewrite: code=%s reason=%q want %q", ex.Code, ex.Reason, want)
+		}
+		seen[ex.Code] = ex
+	}
+	for _, code := range versionedExceptionCodes() {
+		if _, ok := seen[code]; !ok {
+			t.Fatalf("ListExceptions missing %s (have %d)", code, len(seen))
+		}
+	}
+	fmt.Printf("EXCEPTION_PERSIST_LIST codes=%d store=MemoryStore\n", len(versionedExceptionCodes()))
+}
+
+func TestMigration102CHECKContainsEveryVersionedExceptionCode(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "infrastructure", "db", "migrations", "000102_outreach_intel_event_exception_codes.up.sql")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	for _, code := range versionedExceptionCodes() {
+		quoted := "'" + code + "'"
+		if !strings.Contains(body, quoted) {
+			t.Fatalf("migration 000102 missing exception code %s", code)
+		}
+	}
+	fmt.Printf("MIGRATION_102 exception_codes_present=true bytes=%d\n", len(raw))
+}
+
+func TestRunFixtureReportJSONAndMarkdownByteStable(t *testing.T) {
+	a := RunFixtureReport(loopOrg, SyntheticMonth, true)
+	b := RunFixtureReport(loopOrg, SyntheticMonth, true)
+	rawA, err := ReportJSON(a)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rawB, err := ReportJSON(b)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(rawA) != string(rawB) {
+		t.Fatal("JSON reports are not byte-stable")
+	}
+	mdA := ReportMarkdown(a)
+	mdB := ReportMarkdown(b)
+	if mdA != mdB {
+		t.Fatal("markdown reports are not byte-stable")
+	}
+	if strings.Contains(mdA, "Generated at") {
+		t.Fatal("markdown still embeds a generated-at clock")
+	}
+	if a.Latency.Baseline != BaselineSynthetic || strings.Contains(string(rawA), BaselineObserved) {
+		t.Fatalf("synthetic report claimed observed baseline=%s", a.Latency.Baseline)
+	}
+	if a.CausalProof || strings.Contains(string(rawA), `"causal_proof": true`) {
+		t.Fatal("synthetic report claimed causal_proof")
+	}
+	if !strings.Contains(string(rawA), BaselineSynthetic) {
+		t.Fatal("synthetic report missing BASELINE_SYNTHETIC")
+	}
+	fmt.Printf("REPORT_STABLE json_bytes=%d md_bytes=%d baseline=%s\n", len(rawA), len(mdA), a.Latency.Baseline)
+}
+
+func TestRunFixtureReportRealEmptyNotObserved(t *testing.T) {
+	rep := RunFixtureReport(loopOrg, SyntheticMonth, false)
+	raw, err := ReportJSON(rep)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !rep.RealEmpty {
+		t.Fatalf("fixture-only store with include_synthetic=false must be real_empty: %+v", rep)
+	}
+	if rep.InboundQualifiedPipeline != 0 || rep.Won != 0 || rep.ValidLeads != 0 {
+		t.Fatalf("synthetics leaked into real report: iqp=%d won=%d leads=%d", rep.InboundQualifiedPipeline, rep.Won, rep.ValidLeads)
+	}
+	if rep.Latency.Baseline == BaselineObserved || strings.Contains(string(raw), BaselineObserved) {
+		t.Fatal("real_empty report claimed BASELINE_OBSERVED")
+	}
+	if !strings.Contains(strings.ToLower(strings.Join(rep.Blockers, " ")), "real_empty") {
+		t.Fatalf("real_empty blocker missing: %+v", rep.Blockers)
+	}
+	fmt.Printf("REAL_EMPTY iqp=%d baseline=%s real_empty=%v\n", rep.InboundQualifiedPipeline, rep.Latency.Baseline, rep.RealEmpty)
+}
+
+func TestPGStorePersistsAndListsEveryVersionedExceptionCode(t *testing.T) {
+	dsn := os.Getenv("WARMBLY_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		dsn = os.Getenv("INTEL_PG_TEST_URL")
+	}
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	userID, orgID := uuid.New(), uuid.New()
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id, first_name, last_name, email) VALUES ($1,'Ex','Codes',$2)`, userID, "ex-codes-"+userID.String()+"@example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id, name, slug, owner_user_id) VALUES ($1,'Ex Codes',$2,$3)`, orgID, "ex-codes-"+orgID.String(), userID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM outreach_intel_exceptions WHERE organization_id=$1`, orgID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM organizations WHERE id=$1`, orgID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM users WHERE id=$1`, userID)
+		pool.Close()
+	})
+
+	st := NewPGStore(pool, orgID.String())
+	for i, code := range versionedExceptionCodes() {
+		err := st.PutException(Exception{
+			OrganizationID: orgID.String(),
+			Code:           code,
+			Identity:       fmt.Sprintf("pg-%s", code),
+			Reason:         "persist-proof-" + code,
+			Held:           i%2 == 0,
+		})
+		if err != nil {
+			t.Fatalf("PG PutException %s: %v", code, err)
+		}
+	}
+	listed, err := st.ListExceptions(orgID.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	seen := map[string]bool{}
+	for _, ex := range listed {
+		seen[ex.Code] = true
+	}
+	for _, code := range versionedExceptionCodes() {
+		if !seen[code] {
+			t.Fatalf("PG ListExceptions missing %s (have %d)", code, len(seen))
+		}
+	}
+	fmt.Printf("EXCEPTION_PERSIST_LIST codes=%d store=PGStore\n", len(versionedExceptionCodes()))
+}

--- a/internal/app/confenge/intel/pg.go
+++ b/internal/app/confenge/intel/pg.go
@@ -102,7 +102,7 @@ func (s *PGStore) ListChains(orgID string) ([]Chain, error) {
 	}
 	org := firstNonEmpty(orgID, s.orgID)
 	rows, err := s.db.Query(context.Background(), `
-		SELECT payload FROM outreach_intel_chains WHERE organization_id = $1::uuid`, org)
+		SELECT payload FROM outreach_intel_chains WHERE organization_id = $1::uuid ORDER BY identity`, org)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/app/confenge/intel/report.go
+++ b/internal/app/confenge/intel/report.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
-	"time"
 )
 
 // RunFixtureReport loads named SYNTHETIC fixtures through IngestEvent
@@ -163,6 +163,16 @@ func BuildObservabilityReport(store Store, orgID, month string, includeSynthetic
 			Synthetic:      cand.Synthetic,
 		})
 	}
+	sort.Slice(rep.LearningCandidates, func(i, j int) bool {
+		a, b := rep.LearningCandidates[i], rep.LearningCandidates[j]
+		if a.Identity == b.Identity {
+			if a.Recommendation == b.Recommendation {
+				return a.Reason < b.Reason
+			}
+			return a.Recommendation < b.Recommendation
+		}
+		return a.Identity < b.Identity
+	})
 
 	rep.EventsConsumed = countConsumedEvents(chains, includeSynthetic)
 	if !includeSynthetic && view.RealEmpty {
@@ -277,8 +287,13 @@ func ReportMarkdown(rep ObservabilityReport) string {
 	if len(rep.ExceptionCounts) == 0 {
 		fmt.Fprintf(&b, "- none\n")
 	} else {
-		for k, n := range rep.ExceptionCounts {
-			fmt.Fprintf(&b, "- %s: %d\n", k, n)
+		codes := make([]string, 0, len(rep.ExceptionCounts))
+		for k := range rep.ExceptionCounts {
+			codes = append(codes, k)
+		}
+		sort.Strings(codes)
+		for _, k := range codes {
+			fmt.Fprintf(&b, "- %s: %d\n", k, rep.ExceptionCounts[k])
 		}
 	}
 	fmt.Fprintf(&b, "\n## Learning candidates\n\n")
@@ -291,7 +306,7 @@ func ReportMarkdown(rep ObservabilityReport) string {
 			fmt.Fprintf(&b, "- %s\n", bl)
 		}
 	}
-	fmt.Fprintf(&b, "\nGenerated at %s. This is not a CRM and not a forecast.\n", time.Now().UTC().Format(time.RFC3339))
+	fmt.Fprintf(&b, "\nThis is not a CRM and not a forecast.\n")
 	return b.String()
 }
 

--- a/internal/app/confenge/intel/store.go
+++ b/internal/app/confenge/intel/store.go
@@ -1,6 +1,7 @@
 package intel
 
 import (
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -105,6 +106,12 @@ func (m *MemoryStore) ListChains(orgID string) ([]Chain, error) {
 			out = append(out, c)
 		}
 	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Identity == out[j].Identity {
+			return out[i].CreatedAt.Before(out[j].CreatedAt)
+		}
+		return out[i].Identity < out[j].Identity
+	})
 	return out, nil
 }
 

--- a/internal/infrastructure/db/migrations/000102_outreach_intel_event_exception_codes.down.sql
+++ b/internal/infrastructure/db/migrations/000102_outreach_intel_event_exception_codes.down.sql
@@ -1,0 +1,15 @@
+ALTER TABLE outreach_intel_exceptions
+    DROP CONSTRAINT IF EXISTS outreach_intel_exceptions_code_check;
+
+ALTER TABLE outreach_intel_exceptions
+    ADD CONSTRAINT outreach_intel_exceptions_code_check CHECK (code IN (
+        'orphan',
+        'duplicate',
+        'conflicting_account',
+        'missing_version',
+        'stale_attribution',
+        'out_of_order',
+        'unconfirmed_won',
+        'unconfirmed_lost',
+        'ledger_unavailable'
+    ));

--- a/internal/infrastructure/db/migrations/000102_outreach_intel_event_exception_codes.up.sql
+++ b/internal/infrastructure/db/migrations/000102_outreach_intel_event_exception_codes.up.sql
@@ -1,0 +1,25 @@
+-- Widen the commercial-intel exception CHECK so versioned-event codes
+-- persist. 000101 only allowed the original join-queue codes; held
+-- transitions would otherwise vanish from the PG exception queue.
+
+ALTER TABLE outreach_intel_exceptions
+    DROP CONSTRAINT IF EXISTS outreach_intel_exceptions_code_check;
+
+ALTER TABLE outreach_intel_exceptions
+    ADD CONSTRAINT outreach_intel_exceptions_code_check CHECK (code IN (
+        'orphan',
+        'duplicate',
+        'conflicting_account',
+        'missing_version',
+        'stale_attribution',
+        'out_of_order',
+        'unconfirmed_won',
+        'unconfirmed_lost',
+        'ledger_unavailable',
+        'impossible_transition',
+        'negative_latency',
+        'overlapping_latency',
+        'outbound_as_inbound',
+        'invalid_asset_family',
+        'missing_attribution'
+    ));


### PR DESCRIPTION
## Summary

Thin residual after #80 landed on main (`3539419c`). This replaces the monolithic rehearsal in #81. It does **not** reintroduce the versioned ingest engine, fixtures, CLI, handlers, or contracts already merged.

Issue #47 stays **open**: there is still no live inbound / approved action / observed outcome. Synthetic fixtures are not production.

## What this PR contains

- Migration `000102` widens `outreach_intel_exceptions_code_check` so every versioned engine code persists on Postgres:
  `orphan`, `duplicate`, `conflicting_account`, `missing_version`, `stale_attribution`, `out_of_order`, `unconfirmed_won`, `unconfirmed_lost`, `ledger_unavailable`, `impossible_transition`, `negative_latency`, `overlapping_latency`, `outbound_as_inbound`, `invalid_asset_family`, `missing_attribution`.
- Down migration restores the 000101 CHECK. It does not delete CHECK-failing rows; a transactional down with widened rows present aborts and leaves the wide CHECK + rows intact.
- `report.go` / `store.go` / `pg.go`: sort chains, learning candidates, and exception codes; drop the `Generated at` clock so `intel-report` JSON/MD is byte-stable across two runs.
- Tests drive shipped `PutException` / `ListExceptions` / `RunFixtureReport` / `ReportJSON` / `ReportMarkdown`.

## Explicitly not in this PR

- The #80 engine (`event.go`, fixtures, handlers, contracts).
- #81 `join.go` held-QCO rewrite (it breaks `TestHeldOrphanKeepsObservedQCOOffPipeline` on main).
- Last-mile `000102_outreach_inbound_learning_loop`.
- Closing #47. No live inbound claim. No `BASELINE_OBSERVED`.

## Proof (local, isolated Postgres)

- Clean apply through 000102: schema version 102, CHECK includes all 15 codes.
- Upgrade 000101 → 000102: old `orphan` row kept; `impossible_transition` rejected at 101, accepted at 102; `ListExceptions` returns both.
- Rollback: clean DB CHECK returns to the 000101 set; widened insert fails. With widened rows present, transactional down aborts and does not delete those rows.
- `go test -count=1 ./internal/app/confenge/intel/` twice: PASS. `EXCEPTION_PERSIST_LIST codes=15` on MemoryStore and PGStore. `REPORT_STABLE` JSON/MD byte-identical. `REAL_EMPTY` is not `BASELINE_OBSERVED`.
- Dual CLI `confenge intel-report`: synth JSON/MD identical (`BASELINE_SYNTHETIC`, `causal_proof=false`); `--include-synthetic=false` identical (`real_empty`, zeros, `UNKNOWN`, `insufficient_data`).
- `gofmt -l` empty. `make lint` (golangci-lint v1.64.8) pass.
- `go test ./...` fails only on pre-existing `TestProductAcceptanceMultichannelSum` (Mailpit not running on this host; same test exists on main). Remainder PASS.

## Supersedes

Closes the residual of https://github.com/tjsasakifln/warmbly/pull/81 (do not merge #81). Pointer will be posted on #81 after this lands.

## Refs

- PR #80 (engine already on main)
- Issue #47 (live inbound/action/outcome still pending; stays open)
