### PR TITLE
feat: hold unsourced payment_received and persist capacity holds on the intel PG store

### DIFF
--- a/docs/ops/campaigns/CONFENGE-WARMBLY-OFFER-REVENUE-04/EVIDENCE.md
+++ b/docs/ops/campaigns/CONFENGE-WARMBLY-OFFER-REVENUE-04/EVIDENCE.md
@@ -69,6 +69,16 @@ EXEC real_empty=true syn_received=9800000 syn_mrr=0 syn_contracted=9800000 pay_l
 - `gofmt -l` empty on touched Go
 - golangci-lint on intel/confenge/handler/api: pass
 
+## Follow-up gates (unsourced payment / PG capacity)
+
+```
+RX_NO_SNAPSHOT held=true received=0 real=0 syn=0
+WEBHOOK_NO_REVENUE acked=true held=true received=0 real_empty=true synthetic=true
+PG_CAPACITY_STORE hold_err="intel pg store unavailable" limit=50 table=true
+```
+
+`payment_received` uses the same prior-snapshot/checkout gate as `payment_confirmed`. Sandbox `MapEvent` sets `synthetic=true` and does not pre-apply received cents. Held chains do not increment received/MRR/contracted. `PGStore` implements `CapacityStore` on `outreach_intel_capacity_holds`.
+
 ## Deploy / canary
 
 Not deployed from this environment. Adapter default is sandbox/disabled. No production Asaas key. No public real-money mutation. `LIVE_PROVEN` is BLOCKED.

--- a/internal/app/confenge/intel/capacity.go
+++ b/internal/app/confenge/intel/capacity.go
@@ -8,6 +8,20 @@ import (
 	"github.com/google/uuid"
 )
 
+// CapacityStore is the versioned 50-unit pool. MemoryStore and PGStore
+// both implement it so WireIntel is operational after deploy.
+type CapacityStore interface {
+	HoldCapacity(orgID, leadID string, units int, now time.Time) (CapacityHold, error)
+	ReleaseCapacity(orgID, holdID string) error
+	FinalizeCapacity(orgID, holdID string, now time.Time) error
+	GetCapacityPool(orgID string, now time.Time) CapacityPool
+}
+
+var (
+	_ CapacityStore = (*MemoryStore)(nil)
+	_ CapacityStore = (*PGStore)(nil)
+)
+
 // DefaultCapacityPolicy is the versioned 50-unit pool.
 func DefaultCapacityPolicy() CapacitySnapshot {
 	return CapacitySnapshot{
@@ -128,11 +142,19 @@ func (m *MemoryStore) GetHold(holdID string) *CapacityHold {
 
 func capacityPoolLocked(m *MemoryStore, orgID string, now time.Time) CapacityPool {
 	orgID = strings.TrimSpace(orgID)
-	p := CapacityPool{PolicyVersion: CapacityPolicyV1, Limit: CapacityLimitV1}
+	var holds []CapacityHold
 	for _, h := range m.holds {
 		if orgID != "" && h.OrgID != orgID {
 			continue
 		}
+		holds = append(holds, h)
+	}
+	return capacityPoolFromHolds(holds, now)
+}
+
+func capacityPoolFromHolds(holds []CapacityHold, now time.Time) CapacityPool {
+	p := CapacityPool{PolicyVersion: CapacityPolicyV1, Limit: CapacityLimitV1}
+	for _, h := range holds {
 		switch {
 		case h.State == CapacityStateFinal:
 			p.Used += h.Units

--- a/internal/app/confenge/intel/commercial.go
+++ b/internal/app/confenge/intel/commercial.go
@@ -130,15 +130,11 @@ func ApplyCommercialTransition(existing *Chain, ev CommercialEvent) TransitionRe
 	case EventPaymentCreated, EventPaymentPending, EventSubscriptionCreated:
 		// created objects never increment received or contracted-as-received
 	case EventPaymentConfirmed:
-		hasCheckout := st.Provider.CheckoutID != "" || ev.Provider.CheckoutID != "" || hasTimelineType(st, EventCheckoutCreated)
-		if existing != nil {
-			hasCheckout = hasCheckout || existing.Commercial.Provider.CheckoutID != "" || hasTimelineType(existing.Commercial, EventCheckoutCreated)
-		}
-		if !hasCheckout {
-			add(ExceptionOutOfOrder, "payment before checkout", "hold; do not reorder into a fake chain", true)
+		if blocked, why := paymentFinancialGate(existing, ev, st); blocked {
+			add(ExceptionOutOfOrder, why, "hold; do not infer confirmed payment or revenue", true)
 			res.Held = true
 			res.Rejected = true
-			res.Reason = "payment_before_checkout"
+			res.Reason = why
 			return res
 		}
 		if ev.OccurredAt.Before(checkoutTime(existing)) && !checkoutTime(existing).IsZero() {
@@ -157,6 +153,14 @@ func ApplyCommercialTransition(existing *Chain, ev CommercialEvent) TransitionRe
 			st.Payment.MRRCents = st.Offer.AmountCents
 		}
 	case EventPaymentReceived:
+		if blocked, why := paymentFinancialGate(existing, ev, st); blocked {
+			add(ExceptionOutOfOrder, why, "hold; do not apply received revenue", true)
+			res.Held = true
+			res.Rejected = true
+			res.Reason = why
+			st.Payment.CanonicalStatus = firstNonEmpty(st.Payment.CanonicalStatus, PaymentStatusUnknown)
+			return res
+		}
 		t := ev.OccurredAt
 		st.Payment.CanonicalStatus = PaymentStatusReceived
 		st.Payment.ReceivedAt = &t
@@ -668,6 +672,47 @@ func copyCommercialKeys(in *ObservedFacts, st CommercialState) {
 	if in.Keys.HoldID == "" {
 		in.Keys.HoldID = st.Capacity.HoldID
 	}
+}
+
+func hasCommercialSnapshot(existing *Chain) bool {
+	if existing == nil {
+		return false
+	}
+	st := existing.Commercial
+	if strings.TrimSpace(st.Offer.OfferID) != "" && st.Offer.OfferID != Unknown {
+		return true
+	}
+	if hasTimelineType(st, EventTermsAccepted) || hasTimelineType(st, EventCheckoutCreated) || hasTimelineType(st, EventOfferSelected) {
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(st.Capacity.State)) {
+	case CapacityStateOK, CapacityStateHold, CapacityStateFinal:
+		return true
+	default:
+		return false
+	}
+}
+
+func hasCheckoutOn(existing *Chain, ev CommercialEvent, st CommercialState) bool {
+	if st.Provider.CheckoutID != "" || hasTimelineType(st, EventCheckoutCreated) {
+		return true
+	}
+	if existing != nil && (existing.Commercial.Provider.CheckoutID != "" || hasTimelineType(existing.Commercial, EventCheckoutCreated)) {
+		return true
+	}
+	// An inbound checkout id without a prior snapshot is not a gate pass.
+	_ = ev
+	return false
+}
+
+func paymentFinancialGate(existing *Chain, ev CommercialEvent, st CommercialState) (blocked bool, reason string) {
+	if !hasCommercialSnapshot(existing) {
+		return true, "payment without prior offer/capacity/checkout snapshot"
+	}
+	if !hasCheckoutOn(existing, ev, st) {
+		return true, "payment before checkout"
+	}
+	return false, ""
 }
 
 func paymentConfirmed(p PaymentState) bool {

--- a/internal/app/confenge/intel/offer_revenue_test.go
+++ b/internal/app/confenge/intel/offer_revenue_test.go
@@ -218,6 +218,91 @@ func TestConflictingExternalReferenceHeld(t *testing.T) {
 	fmt.Printf("CONFLICT_EXT held=%v\n", res.Held)
 }
 
+func TestPaymentReceivedWithoutSnapshotIsNotRevenue(t *testing.T) {
+	st := NewMemoryStore()
+	ev := diagEnv(offerOrg, "lead-rx-orphan", "ev-rx-orphan", EventPaymentReceived, time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC))
+	ev.Payment.ReceivedCents = 800000
+	ev.Provider.CheckoutID = "chk-forged"
+	ev.Capacity.State = CapacityStateNone
+	res := IngestEvent(st, ev)
+	if !res.Held {
+		t.Fatal("payment_received without snapshot was accepted")
+	}
+	if res.Chain.Commercial.Payment.ReceivedCents != 0 {
+		t.Fatalf("received applied without snapshot: %d", res.Chain.Commercial.Payment.ReceivedCents)
+	}
+	chains, _ := st.ListChains(offerOrg)
+	real := Rollup(chains, SyntheticMonth, false)
+	if real.Commercial.ReceivedCents != 0 {
+		t.Fatalf("real rollup invented received=%d", real.Commercial.ReceivedCents)
+	}
+	syn := Rollup(chains, SyntheticMonth, true)
+	if syn.Commercial.ReceivedCents != 0 {
+		t.Fatalf("held received counted in synthetic rollup: %d", syn.Commercial.ReceivedCents)
+	}
+	fmt.Printf("RX_NO_SNAPSHOT held=%v received=%d real=%d syn=%d\n",
+		res.Held, res.Chain.Commercial.Payment.ReceivedCents, real.Commercial.ReceivedCents, syn.Commercial.ReceivedCents)
+}
+
+func TestSandboxWebhookDoesNotInventRealRevenue(t *testing.T) {
+	st := NewMemoryStore()
+	ad := NewFakeAdapter()
+	body := []byte(`{"id":"evt-unsourced","event":"PAYMENT_RECEIVED","externalReference":"ext-unsourced","payment":{"id":"pay-unsourced","status":"RECEIVED","value":8000.00},"dateCreated":"2026-08-04T12:00:00Z"}`)
+	now := time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC)
+	sig := SignProviderHMAC("secret-a", now, body)
+	ack, err := IngestProviderWebhook(st, ad, offerOrg, "secret-a", "", sig, body, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ack.Acked {
+		t.Fatal("durable receipt missing")
+	}
+	if !ack.Held && ack.Join.Chain.Commercial.Payment.ReceivedCents > 0 && !ack.Join.Chain.Synthetic {
+		t.Fatal("sandbox webhook invented real received revenue")
+	}
+	if ack.Join.Chain.Identity != "" && !ack.Join.Chain.Synthetic && ack.Join.Chain.Label != LabelSynthetic {
+		t.Fatal("sandbox adapter event was not labeled synthetic")
+	}
+	if ack.Join.Chain.Commercial.Payment.ReceivedCents != 0 {
+		t.Fatalf("unsourced webhook received=%d", ack.Join.Chain.Commercial.Payment.ReceivedCents)
+	}
+	chains, _ := st.ListChains(offerOrg)
+	real := Rollup(chains, SyntheticMonth, false)
+	if real.Commercial.ReceivedCents != 0 || !real.RealEmpty {
+		t.Fatalf("include_synthetic=0 counted webhook revenue: %+v", real.Commercial)
+	}
+	mapped := ad.MapEvent(ProviderEvent{ProviderEventID: "x", RawType: "PAYMENT_RECEIVED", AmountCents: 800000, OccurredAt: now}, offerOrg)
+	if !mapped.Synthetic {
+		t.Fatal("MapEvent did not mark sandbox event synthetic")
+	}
+	if mapped.Payment.ReceivedCents != 0 {
+		t.Fatalf("MapEvent pre-applied received=%d", mapped.Payment.ReceivedCents)
+	}
+	fmt.Printf("WEBHOOK_NO_REVENUE acked=%v held=%v received=%d real_empty=%v synthetic=%v\n",
+		ack.Acked, ack.Held, ack.Join.Chain.Commercial.Payment.ReceivedCents, real.RealEmpty, mapped.Synthetic)
+}
+
+func TestPGStoreImplementsCapacityStore(t *testing.T) {
+	var cs CapacityStore = NewPGStore(nil, "")
+	_, holdErr := cs.HoldCapacity("org", "lead", 1, time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC))
+	if holdErr == nil {
+		t.Fatal("nil PG store accepted a capacity hold")
+	}
+	pool := cs.GetCapacityPool("org", time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC))
+	if pool.Limit != CapacityLimitV1 || pool.PolicyVersion != CapacityPolicyV1 {
+		t.Fatalf("policy missing on nil PG pool: %+v", pool)
+	}
+	path := filepath.Join("..", "..", "..", "infrastructure", "db", "migrations", "000103_outreach_intel_offer_revenue.up.sql")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), "outreach_intel_capacity_holds") {
+		t.Fatal("migration missing capacity holds table")
+	}
+	fmt.Printf("PG_CAPACITY_STORE hold_err=%q limit=%d table=true\n", holdErr.Error(), pool.Limit)
+}
+
 func TestOutOfOrderPaymentBeforeCheckoutHeld(t *testing.T) {
 	st := NewMemoryStore()
 	ev := diagEnv(offerOrg, "lead-ooo", "ev-ooo-pay", EventPaymentConfirmed, time.Date(2026, 8, 4, 12, 0, 0, 0, time.UTC))

--- a/internal/app/confenge/intel/pg.go
+++ b/internal/app/confenge/intel/pg.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"strings"
 	"time"
 
@@ -335,4 +336,198 @@ func (s *PGStore) MarkReceiptProcessed(orgID, providerEventID string) {
 	_, _ = s.db.Exec(context.Background(), `
 		UPDATE outreach_intel_event_receipts SET processed = true
 		WHERE organization_id = $1::uuid AND provider_event_id = $2`, org, providerEventID)
+}
+
+func (s *PGStore) HoldCapacity(orgID, leadID string, units int, now time.Time) (CapacityHold, error) {
+	if s == nil || s.db == nil {
+		return CapacityHold{}, errors.New("intel pg store unavailable")
+	}
+	if units <= 0 {
+		units = 1
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	org := firstNonEmpty(orgID, s.orgID)
+	tx, err := s.db.Begin(context.Background())
+	if err != nil {
+		return CapacityHold{}, err
+	}
+	defer func() { _ = tx.Rollback(context.Background()) }()
+	if _, err := tx.Exec(context.Background(), `SELECT pg_advisory_xact_lock(hashtext($1))`, org); err != nil {
+		return CapacityHold{}, err
+	}
+	holds, err := s.listHoldsTx(tx, org)
+	if err != nil {
+		return CapacityHold{}, err
+	}
+	pool := capacityPoolFromHolds(holds, now)
+	if pool.Available < units {
+		return CapacityHold{}, fmt.Errorf("no capacity: available=%d need=%d", pool.Available, units)
+	}
+	h := CapacityHold{
+		HoldID:    uuid.NewString(),
+		OrgID:     org,
+		LeadID:    strings.TrimSpace(leadID),
+		Units:     units,
+		State:     CapacityStateHold,
+		CreatedAt: now,
+		ExpiresAt: now.Add(CapacityHoldTTL),
+	}
+	raw, err := json.Marshal(h)
+	if err != nil {
+		return CapacityHold{}, err
+	}
+	_, err = tx.Exec(context.Background(), `
+		INSERT INTO outreach_intel_capacity_holds (
+			hold_id, organization_id, lead_id, units, state, created_at, expires_at, payload
+		) VALUES ($1, $2::uuid, $3, $4, $5, $6, $7, $8::jsonb)`,
+		h.HoldID, org, h.LeadID, h.Units, h.State, h.CreatedAt, h.ExpiresAt, raw,
+	)
+	if err != nil {
+		return CapacityHold{}, err
+	}
+	if err := tx.Commit(context.Background()); err != nil {
+		return CapacityHold{}, err
+	}
+	return h, nil
+}
+
+func (s *PGStore) ReleaseCapacity(orgID, holdID string) error {
+	if s == nil || s.db == nil {
+		return errors.New("intel pg store unavailable")
+	}
+	org := firstNonEmpty(orgID, s.orgID)
+	h, err := s.GetHold(holdID)
+	if err != nil || h == nil {
+		return err
+	}
+	if org != "" && h.OrgID != org {
+		return nil
+	}
+	h.State = CapacityStateRelease
+	return s.updateHold(*h)
+}
+
+func (s *PGStore) FinalizeCapacity(orgID, holdID string, now time.Time) error {
+	if s == nil || s.db == nil {
+		return errors.New("intel pg store unavailable")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	org := firstNonEmpty(orgID, s.orgID)
+	h, err := s.GetHold(holdID)
+	if err != nil {
+		return err
+	}
+	if h == nil || (org != "" && h.OrgID != org) {
+		return fmt.Errorf("hold not found")
+	}
+	if h.State == CapacityStateExpired || (!h.ExpiresAt.IsZero() && now.After(h.ExpiresAt) && h.State != CapacityStateFinal) {
+		h.State = CapacityStateExpired
+		_ = s.updateHold(*h)
+		return fmt.Errorf("hold expired")
+	}
+	if h.State == CapacityStateRelease {
+		return fmt.Errorf("hold released")
+	}
+	t := now
+	h.State = CapacityStateFinal
+	h.FinalizedAt = &t
+	return s.updateHold(*h)
+}
+
+func (s *PGStore) GetCapacityPool(orgID string, now time.Time) CapacityPool {
+	if s == nil || s.db == nil {
+		return CapacityPool{PolicyVersion: CapacityPolicyV1, Limit: CapacityLimitV1, Available: CapacityLimitV1}
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	org := firstNonEmpty(orgID, s.orgID)
+	holds, err := s.listHolds(org)
+	if err != nil {
+		return CapacityPool{PolicyVersion: CapacityPolicyV1, Limit: CapacityLimitV1, Available: CapacityLimitV1}
+	}
+	return capacityPoolFromHolds(holds, now)
+}
+
+func (s *PGStore) GetHold(holdID string) (*CapacityHold, error) {
+	if s == nil || s.db == nil || strings.TrimSpace(holdID) == "" {
+		return nil, nil
+	}
+	var raw []byte
+	err := s.db.QueryRow(context.Background(), `
+		SELECT payload FROM outreach_intel_capacity_holds WHERE hold_id = $1`, strings.TrimSpace(holdID)).Scan(&raw)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var h CapacityHold
+	if err := json.Unmarshal(raw, &h); err != nil {
+		return nil, err
+	}
+	return &h, nil
+}
+
+func (s *PGStore) updateHold(h CapacityHold) error {
+	raw, err := json.Marshal(h)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.Exec(context.Background(), `
+		UPDATE outreach_intel_capacity_holds
+		SET state = $2, finalized_at = $3, payload = $4::jsonb
+		WHERE hold_id = $1`, h.HoldID, h.State, h.FinalizedAt, raw)
+	return err
+}
+
+func (s *PGStore) listHolds(orgID string) ([]CapacityHold, error) {
+	if s == nil || s.db == nil {
+		return nil, errors.New("intel pg store unavailable")
+	}
+	rows, err := s.db.Query(context.Background(), `
+		SELECT payload FROM outreach_intel_capacity_holds WHERE organization_id = $1::uuid`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []CapacityHold
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var h CapacityHold
+		if err := json.Unmarshal(raw, &h); err != nil {
+			return nil, err
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
+}
+
+func (s *PGStore) listHoldsTx(tx pgx.Tx, orgID string) ([]CapacityHold, error) {
+	rows, err := tx.Query(context.Background(), `
+		SELECT payload FROM outreach_intel_capacity_holds WHERE organization_id = $1::uuid`, orgID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []CapacityHold
+	for rows.Next() {
+		var raw []byte
+		if err := rows.Scan(&raw); err != nil {
+			return nil, err
+		}
+		var h CapacityHold
+		if err := json.Unmarshal(raw, &h); err != nil {
+			return nil, err
+		}
+		out = append(out, h)
+	}
+	return out, rows.Err()
 }

--- a/internal/app/confenge/intel/provider.go
+++ b/internal/app/confenge/intel/provider.go
@@ -137,6 +137,7 @@ func (a *FakeAdapter) MapEvent(p ProviderEvent, orgID string) CommercialEvent {
 		OrganizationID:    orgID,
 		ProviderEventID:   p.ProviderEventID,
 		ExternalReference: p.ExternalRef,
+		Synthetic:         true,
 		Provider: ProviderRefs{
 			CustomerID:      p.CustomerID,
 			CheckoutID:      p.CheckoutID,
@@ -149,20 +150,14 @@ func (a *FakeAdapter) MapEvent(p ProviderEvent, orgID string) CommercialEvent {
 		Payment: PaymentState{
 			RawProviderStatus: p.RawStatus,
 			PrincipalCents:    p.AmountCents,
-			ReceivedCents:     receivedIf(typ, p.AmountCents),
+			// Amount is principal only. Received revenue is applied by
+			// ApplyCommercialTransition after a prior commercial snapshot.
+			ReceivedCents: 0,
 		},
 		Offer: OfferSnapshot{
-			AmountCents: p.AmountCents,
-			Currency:    firstNonEmpty(p.Currency, CurrencyBRL),
+			Currency: firstNonEmpty(p.Currency, CurrencyBRL),
 		},
 	}
-}
-
-func receivedIf(typ string, cents int64) int64 {
-	if typ == EventPaymentReceived {
-		return cents
-	}
-	return 0
 }
 
 func mapProviderType(rawType, rawStatus string) string {
@@ -282,6 +277,7 @@ func IngestProviderWebhook(store Store, adapter ProviderAdapter, orgID, secret, 
 			return ack, nil
 		}
 		ev := adapter.MapEvent(parsed, orgID)
+		ev.Synthetic = true
 		join := IngestEvent(store, ev)
 		ack.Processed = !join.Held || join.Chain.Identity != ""
 		ack.Held = join.Held
@@ -294,6 +290,7 @@ func IngestProviderWebhook(store Store, adapter ProviderAdapter, orgID, secret, 
 		return ack, nil
 	}
 	ev := adapter.MapEvent(parsed, orgID)
+	ev.Synthetic = true
 	join := IngestEvent(store, ev)
 	return WebhookAck{ReceiptID: ev.EventID, Acked: true, Processed: true, Held: join.Held, Join: join}, nil
 }

--- a/internal/app/confenge/intel/rollup.go
+++ b/internal/app/confenge/intel/rollup.go
@@ -378,6 +378,15 @@ func firstNonZeroTime(vs ...time.Time) time.Time {
 
 func addCommercialCounts(comm *CommercialCounts, c Chain) {
 	st := c.Commercial
+	if c.Held {
+		if strings.EqualFold(st.Capacity.State, CapacityStateHold) {
+			comm.CapacityHeld++
+		}
+		if strings.EqualFold(st.Capacity.State, CapacityStateExpired) {
+			comm.CapacityExpired++
+		}
+		return
+	}
 	if st.Offer.OfferID != "" || hasTimelineType(st, EventOfferViewed) || hasTimelineType(st, EventOfferSelected) {
 		comm.OfferViewed++
 	}


### PR DESCRIPTION
Follow-up to #90. Closes three skeptic gaps on the shipped #47 offer/revenue plane.

## Fixes
- `payment_received` uses the same prior-snapshot/checkout gate as `payment_confirmed`. Out-of-order received is held and does not increment `ReceivedCents`.
- Sandbox `FakeAdapter.MapEvent` marks events `synthetic=true` and does not pre-apply received cents. `IngestProviderWebhook` forces synthetic. `include_synthetic=0` stays empty.
- Held chains no longer increment contracted/MRR/received on the executive rollup.
- `PGStore` implements `CapacityStore` against `outreach_intel_capacity_holds` (advisory lock, policy limit 50, 72h TTL). `WireIntel` is no longer memory-only for the pool.

## Proof (shipped functions)
```
RX_NO_SNAPSHOT held=true received=0 real=0 syn=0
WEBHOOK_NO_REVENUE acked=true held=true received=0 real_empty=true synthetic=true
PG_CAPACITY_STORE hold_err="intel pg store unavailable" limit=50 table=true
DIAG_COMPLETE received=800000 onboarded=true
DIR180_END received_count=6 seventh_held=true
```

Not #47 DoD. No production Asaas. No real money. #47 stays OPEN.