### PR TITLE
feat(confenge): split payment_confirmed from cash and queue manual NFS-e/counsel

### DIFF
--- a/docs/ops/campaigns/CONFENGE-LEGAL-RISK-ACCEPTANCE-ASAAS-PRODUCTION-01/WARMBLY_COMPAT.md
+++ b/docs/ops/campaigns/CONFENGE-LEGAL-RISK-ACCEPTANCE-ASAAS-PRODUCTION-01/WARMBLY_COMPAT.md
@@ -1,0 +1,45 @@
+# WARMBLY_COMPAT — CONFENGE-LEGAL-RISK-ACCEPTANCE-ASAAS-PRODUCTION-01
+
+Status: **PARTIAL**. Consumer is deployable as a listener. This is not live Asaas proof.
+
+## What this SHA added
+
+- Tests in `internal/app/confenge/intel/offer_revenue_test.go` drive shipped `IngestEvent` → `ApplyCommercialTransition` (same `DiagnosticoSequence` / `Rollup` helpers):
+  - `payment_confirmed` is not received cash (`CanonicalStatus=confirmed`, `ReceivedCents=0`)
+  - `payment_received` is the only cash increment (R$ 8.000,00; MRR=0 on diagnóstico)
+  - `checkout_created` / `payment_created` are not payment or revenue
+  - confirmed/received do not auto-onboard or infer WON; onboarding needs an explicit event
+  - raw `CHARGEBACK` opens `payment_chargeback`, never auto-WON/LOST
+- On first `payment_received` for `CFG-DIAG-EXP-v1`: reminder exception `counsel_review_due` (target 10 business days). Not a kill switch. Does not block cash or onboarding.
+- On `payment_confirmed`: finance exception `nfse_manual_queue` (manual NFS-e queue). Does not auto-issue. Does not change price. Does not hold the commercial chain closed.
+- Chargeback is no longer remapped only to `payment_refund`. Existing code `payment_chargeback` is emitted.
+
+## Unchanged / already shipped
+
+- `checkout_created` / `payment_created` ≠ revenue
+- `payment_confirmed` increments `ConfirmedCount` only
+- `payment_received` is the only `ReceivedCents` increment
+- synthetics stay off the real scoreboard (`include_synthetic=0`)
+- `CONFENGE_AUTO_SEND_ENABLED` remains **false**. Isolated env cannot reactivate auto-send.
+- WON/LOST still require human or document evidence
+- No second billing ledger. No SmartLic / extra-cli edits.
+
+## Deploy posture
+
+- Consumer can be deployed as a **listener** on `confenge.commercial_event.v1`.
+- Provider adapter default remains sandbox/disabled. No production Asaas key is assumed.
+- No public real-money mutation. No live checkout, charge, refund, or NFS-e issuance from this SHA.
+- `LIVE_PROVEN` is **not** claimed.
+
+## Classification
+
+| Label | Status |
+| --- | --- |
+| CODE_PROVEN | yes (intel tests) |
+| CI_PROVEN | pending remote CI |
+| MERGED | no |
+| DEPLOYED | no |
+| LIVE_PROVEN | no |
+| SANDBOX | yes |
+| REAL_EXTERNAL | no |
+| auto-send | false |

--- a/internal/app/confenge/intel/commercial.go
+++ b/internal/app/confenge/intel/commercial.go
@@ -152,6 +152,29 @@ func ApplyCommercialTransition(existing *Chain, ev CommercialEvent) TransitionRe
 		if recurringActive(st) {
 			st.Payment.MRRCents = st.Offer.AmountCents
 		}
+		// Manual NFS-e queue only. Do not auto-issue and do not change price.
+		st.Payment.FinanceReviewReq = true
+		if st.Gates.Finance == "" {
+			st.Gates.Finance = ReviewRequired
+		}
+		res.Exceptions = append(res.Exceptions, Exception{
+			OrganizationID: strings.TrimSpace(ev.OrganizationID),
+			Code:           ExceptionNfseManualQueue,
+			CodeVersion:    ExceptionCodeVersion,
+			Reason:         "manual NFS-e queue; do not auto-issue or change price",
+			NextAction:     "human finance issues NFS-e; do not mutate amount_cents",
+			Identity:       ChainIdentity(facts.Keys),
+			MetricKey:      MetricKey(facts.Keys),
+			LeadID:         facts.Keys.LeadID,
+			ReceiptID:      facts.Keys.ReceiptID,
+			Held:           true,
+			Synthetic:      ev.Synthetic,
+			Owner:          OwnerFinance,
+			EvidenceRefs:   evidenceRefs(ev),
+			OpenedAt:       now,
+			At:             now,
+			RetryState:     "pending",
+		})
 	case EventPaymentReceived:
 		if blocked, why := paymentFinancialGate(existing, ev, st); blocked {
 			add(ExceptionOutOfOrder, why, "hold; do not apply received revenue", true)
@@ -184,6 +207,10 @@ func ApplyCommercialTransition(existing *Chain, ev CommercialEvent) TransitionRe
 		}
 		st.Payment.ReceivedCents += inc
 		st.Payment.ReceivedCount++
+		if st.Payment.ReceivedCount == 1 && st.Offer.OfferID == OfferDiagnostico {
+			// Reminder only. Not a kill switch; cash and onboarding stay open.
+			add(ExceptionCounselReviewDue, "counsel review due within 10 business days of first payment_received", "hire/review counsel; do not block cash or onboarding", false)
+		}
 		if st.Offer.TotalCommitmentCents > 0 {
 			st.Payment.ContractedCents = st.Offer.TotalCommitmentCents
 		}
@@ -210,7 +237,11 @@ func ApplyCommercialTransition(existing *Chain, ev CommercialEvent) TransitionRe
 			ref = ev.Offer.AmountCents
 		}
 		st.Payment.RefundedCents += ref
-		add(ExceptionPaymentRefund, "payment refunded", "finance review; do not infer WON", false)
+		if isChargebackEvent(ev) {
+			add(ExceptionChargeback, "payment chargeback", "finance review; do not infer WON or LOST; do not auto-mutate the provider", false)
+		} else {
+			add(ExceptionPaymentRefund, "payment refunded", "finance review; do not infer WON", false)
+		}
 	case EventPaymentFailed:
 		st.Payment.CanonicalStatus = PaymentStatusFailed
 	case EventSubscriptionEnded, EventSubscriptionCanceled:
@@ -720,6 +751,11 @@ func paymentConfirmed(p PaymentState) bool {
 	return s == PaymentStatusConfirmed || s == PaymentStatusReceived
 }
 
+func isChargebackEvent(ev CommercialEvent) bool {
+	blob := strings.ToUpper(strings.TrimSpace(ev.RawEventType + " " + ev.RawProviderStatus + " " + ev.Type))
+	return strings.Contains(blob, "CHARGEBACK")
+}
+
 func capacityAllowsCheckout(c CapacitySnapshot, now time.Time) bool {
 	if strings.EqualFold(c.State, CapacityStateOK) || strings.EqualFold(c.State, CapacityStateFinal) {
 		return true
@@ -904,6 +940,8 @@ func NormalizeEventType(t string) (canonical, raw string, unknown bool) {
 	case "PAYMENT_OVERDUE":
 		return EventPaymentOverdue, raw, false
 	case "PAYMENT_REFUNDED":
+		return EventPaymentRefunded, raw, false
+	case "CHARGEBACK", "PAYMENT_CHARGEBACK":
 		return EventPaymentRefunded, raw, false
 	case "PAYMENT_FAILED":
 		return EventPaymentFailed, raw, false

--- a/internal/app/confenge/intel/commercial_types.go
+++ b/internal/app/confenge/intel/commercial_types.go
@@ -109,6 +109,8 @@ const (
 	ExceptionPaymentOverdue       = "payment_overdue"
 	ExceptionPaymentRefund        = "payment_refund"
 	ExceptionChargeback           = "payment_chargeback"
+	ExceptionCounselReviewDue     = "counsel_review_due"
+	ExceptionNfseManualQueue      = "nfse_manual_queue"
 	ExceptionSubscriptionEnded    = "subscription_ended"
 	ExceptionUnknownProviderEvent = "unknown_provider_event"
 	ExceptionInvalidSecret        = "invalid_secret"

--- a/internal/app/confenge/intel/offer_revenue_test.go
+++ b/internal/app/confenge/intel/offer_revenue_test.go
@@ -702,6 +702,161 @@ func TestMigration103MentionsNewCodes(t *testing.T) {
 	fmt.Printf("MIGRATION_103 up_bytes=%d down_bytes=%d\n", len(raw), len(down))
 }
 
+func TestConfirmedIsNotReceivedRevenue(t *testing.T) {
+	st := NewMemoryStore()
+	seq := DiagnosticoSequence(offerOrg, "lead-conf-not-rx", false)
+	last := ingestSeq(st, seq[:8]) // through payment_confirmed only
+	pay := last.Chain.Commercial.Payment
+	if pay.CanonicalStatus != PaymentStatusConfirmed {
+		t.Fatalf("canonical=%s want %s", pay.CanonicalStatus, PaymentStatusConfirmed)
+	}
+	if pay.ConfirmedCount < 1 {
+		t.Fatalf("confirmed_count=%d", pay.ConfirmedCount)
+	}
+	if pay.ReceivedCents != 0 || pay.ReceivedCount != 0 {
+		t.Fatalf("confirmed counted as received cents=%d count=%d", pay.ReceivedCents, pay.ReceivedCount)
+	}
+	if last.Chain.Commercial.Offer.AmountCents != 800000 {
+		t.Fatalf("price mutated on confirm: %d", last.Chain.Commercial.Offer.AmountCents)
+	}
+	if !hasCode(last.Exceptions, ExceptionNfseManualQueue) {
+		t.Fatalf("nfse_manual_queue missing: %v", exceptionCodes(last.Exceptions))
+	}
+	view := Rollup([]Chain{last.Chain}, SyntheticMonth, true)
+	if view.Commercial.ReceivedCents != 0 {
+		t.Fatalf("rollup received=%d", view.Commercial.ReceivedCents)
+	}
+	fmt.Printf("CONFIRMED_NOT_RECEIVED status=%s confirmed=%d received=%d nfse=%v\n",
+		pay.CanonicalStatus, pay.ConfirmedCount, pay.ReceivedCents, hasCode(last.Exceptions, ExceptionNfseManualQueue))
+}
+
+func TestReceivedIsOnlyCashBasis(t *testing.T) {
+	st := NewMemoryStore()
+	seq := DiagnosticoSequence(offerOrg, "lead-rx-cash", false)
+	ingestSeq(st, seq[:8])
+	last := IngestEvent(st, seq[8]) // payment_received
+	pay := last.Chain.Commercial.Payment
+	if pay.ReceivedCents != 800000 {
+		t.Fatalf("received=%d want 800000", pay.ReceivedCents)
+	}
+	if pay.MRRCents != 0 {
+		t.Fatalf("diagnostico invented MRR=%d", pay.MRRCents)
+	}
+	if pay.CanonicalStatus != PaymentStatusReceived {
+		t.Fatalf("canonical=%s", pay.CanonicalStatus)
+	}
+	if !hasCode(last.Exceptions, ExceptionCounselReviewDue) {
+		t.Fatalf("counsel_review_due missing: %v", exceptionCodes(last.Exceptions))
+	}
+	if last.Held {
+		t.Fatal("counsel reminder held cash/onboarding")
+	}
+	fmt.Printf("RECEIVED_CASH received=%d mrr=%d counsel=%v held=%v\n",
+		pay.ReceivedCents, pay.MRRCents, hasCode(last.Exceptions, ExceptionCounselReviewDue), last.Held)
+}
+
+func TestCheckoutAndCreatedNotPaymentOrRevenue(t *testing.T) {
+	st := NewMemoryStore()
+	seq := DiagnosticoSequence(offerOrg, "lead-chk-created", false)
+	chk := ingestSeq(st, seq[:6]) // through checkout_created
+	if chk.Chain.Commercial.Payment.ReceivedCents != 0 || chk.Chain.Commercial.Payment.ReceivedCount != 0 {
+		t.Fatalf("checkout counted as cash: %+v", chk.Chain.Commercial.Payment)
+	}
+	if chk.Chain.Commercial.Payment.CanonicalStatus == PaymentStatusConfirmed || chk.Chain.Commercial.Payment.CanonicalStatus == PaymentStatusReceived {
+		t.Fatalf("checkout promoted to %s", chk.Chain.Commercial.Payment.CanonicalStatus)
+	}
+	created := IngestEvent(st, seq[6]) // payment_created
+	if created.Chain.Commercial.Payment.ReceivedCents != 0 || created.Chain.Commercial.Payment.ReceivedCount != 0 {
+		t.Fatalf("payment_created counted as cash: %+v", created.Chain.Commercial.Payment)
+	}
+	if created.Chain.Commercial.Payment.CanonicalStatus != PaymentStatusCreated {
+		t.Fatalf("created status=%s", created.Chain.Commercial.Payment.CanonicalStatus)
+	}
+	view := Rollup([]Chain{created.Chain}, SyntheticMonth, true)
+	if view.Commercial.ReceivedCents != 0 {
+		t.Fatalf("rollup received=%d", view.Commercial.ReceivedCents)
+	}
+	fmt.Printf("CHECKOUT_CREATED_NOT_REVENUE checkout_status=%s created_status=%s received=%d\n",
+		chk.Chain.Commercial.Payment.CanonicalStatus, created.Chain.Commercial.Payment.CanonicalStatus,
+		created.Chain.Commercial.Payment.ReceivedCents)
+}
+
+func TestPaymentDoesNotAutoOnboardOrWon(t *testing.T) {
+	st := NewMemoryStore()
+	seq := DiagnosticoSequence(offerOrg, "lead-no-auto", false)
+	conf := ingestSeq(st, seq[:8])
+	if conf.Chain.Commercial.Delivery.OnboardingStartedAt != nil {
+		t.Fatal("onboarding started on payment_confirmed")
+	}
+	if isWonType(conf.Chain.OutcomeType) {
+		t.Fatalf("confirmed inferred WON: %s", conf.Chain.OutcomeType)
+	}
+	rx := IngestEvent(st, seq[8])
+	if rx.Chain.Commercial.Delivery.OnboardingStartedAt != nil {
+		t.Fatal("onboarding started on payment_received")
+	}
+	if isWonType(rx.Chain.OutcomeType) {
+		t.Fatalf("received inferred WON: %s", rx.Chain.OutcomeType)
+	}
+	onb := diagEnv(offerOrg, "lead-no-auto", "ev-no-auto-onb", EventOnboardingStarted, time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC))
+	onb.Offer, _ = FrozenOffer(OfferDiagnostico)
+	onb.Capacity = rx.Chain.Commercial.Capacity
+	onb.Provider.CheckoutID = rx.Chain.Commercial.Provider.CheckoutID
+	ok := IngestEvent(st, onb)
+	if ok.Held || ok.Chain.Commercial.Delivery.OnboardingStartedAt == nil {
+		t.Fatalf("explicit onboarding failed held=%v", ok.Held)
+	}
+	if isWonType(ok.Chain.OutcomeType) {
+		t.Fatalf("onboarding inferred WON: %s", ok.Chain.OutcomeType)
+	}
+	fmt.Printf("NO_AUTO_ONBOARD_WON confirmed_onb=%v received_onb=%v explicit=%v outcome=%s\n",
+		conf.Chain.Commercial.Delivery.OnboardingStartedAt != nil,
+		rx.Chain.Commercial.Delivery.OnboardingStartedAt != nil,
+		ok.Chain.Commercial.Delivery.OnboardingStartedAt != nil, ok.Chain.OutcomeType)
+}
+
+func TestChargebackOpensExceptionNotClose(t *testing.T) {
+	st := NewMemoryStore()
+	seq := DiagnosticoSequence(offerOrg, "lead-cbk", false)
+	ingestSeq(st, seq)
+	cb := diagEnv(offerOrg, "lead-cbk", "ev-cbk", "CHARGEBACK", time.Date(2026, 8, 5, 0, 0, 0, 0, time.UTC))
+	cb.RawProviderStatus = "CHARGEBACK"
+	cb.RawEventType = "CHARGEBACK"
+	cb.Provider.CheckoutID = "chk-lead-cbk"
+	cb.ProviderEventID = "asaas-cbk-1"
+	cb.Payment.RefundedCents = 800000
+	res := IngestEvent(st, cb)
+	if !hasCode(res.Exceptions, ExceptionChargeback) {
+		t.Fatalf("CHARGEBACK did not open payment_chargeback: %v", exceptionCodes(res.Exceptions))
+	}
+	if hasCode(res.Exceptions, ExceptionPaymentRefund) && !hasCode(res.Exceptions, ExceptionChargeback) {
+		t.Fatal("CHARGEBACK remapped only to refund")
+	}
+	if isWonType(res.Chain.OutcomeType) || isLostType(res.Chain.OutcomeType) {
+		t.Fatalf("CHARGEBACK auto-closed as %s", res.Chain.OutcomeType)
+	}
+	if res.Chain.OutcomeType == OutcomeWon || res.Chain.OutcomeType == OutcomeLost {
+		t.Fatalf("CHARGEBACK stored close %s", res.Chain.OutcomeType)
+	}
+	fmt.Printf("CHARGEBACK_EXCEPTION codes=%v outcome=%s status=%s\n",
+		exceptionCodes(res.Exceptions), res.Chain.OutcomeType, res.Chain.Commercial.Payment.CanonicalStatus)
+}
+
+func TestMigration104CounselAndNfseCodes(t *testing.T) {
+	path := filepath.Join("..", "..", "..", "infrastructure", "db", "migrations", "000104_outreach_intel_legal_risk_acceptance.up.sql")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := string(raw)
+	for _, code := range []string{ExceptionCounselReviewDue, ExceptionNfseManualQueue, ExceptionChargeback} {
+		if !strings.Contains(body, "'"+code+"'") {
+			t.Fatalf("000104 missing %s", code)
+		}
+	}
+	fmt.Printf("MIGRATION_104 up_bytes=%d\n", len(raw))
+}
+
 func exceptionCodes(xs []Exception) []string {
 	out := make([]string, 0, len(xs))
 	for _, x := range xs {

--- a/internal/app/confenge/intel/scoreboard.go
+++ b/internal/app/confenge/intel/scoreboard.go
@@ -475,8 +475,10 @@ func ExceptionOwner(code string) string {
 		return OwnerExtraCLI
 	case ExceptionStaleAttribution, ExceptionMissingAttribution:
 		return OwnerWebCfg
-	case ExceptionCreatedAsRevenue, ExceptionOnboardingBeforePay:
+	case ExceptionCreatedAsRevenue, ExceptionOnboardingBeforePay, ExceptionNfseManualQueue, ExceptionChargeback, ExceptionPaymentRefund:
 		return OwnerFinance
+	case ExceptionCounselReviewDue:
+		return OwnerFounder
 	case ExceptionUnknownProviderEvent:
 		return OwnerCommercial
 	default:

--- a/internal/infrastructure/db/migrations/000104_outreach_intel_legal_risk_acceptance.down.sql
+++ b/internal/infrastructure/db/migrations/000104_outreach_intel_legal_risk_acceptance.down.sql
@@ -1,0 +1,46 @@
+-- Reverse 000104. Restores the 000103 exception CHECK.
+
+ALTER TABLE outreach_intel_exceptions
+    DROP CONSTRAINT IF EXISTS outreach_intel_exceptions_code_check;
+
+ALTER TABLE outreach_intel_exceptions
+    ADD CONSTRAINT outreach_intel_exceptions_code_check CHECK (code IN (
+        'orphan',
+        'duplicate',
+        'conflicting_account',
+        'missing_version',
+        'stale_attribution',
+        'out_of_order',
+        'unconfirmed_won',
+        'unconfirmed_lost',
+        'ledger_unavailable',
+        'impossible_transition',
+        'negative_latency',
+        'overlapping_latency',
+        'outbound_as_inbound',
+        'invalid_asset_family',
+        'missing_attribution',
+        'terms_price_version_drift',
+        'capacity_expired',
+        'capacity_lost',
+        'no_capacity',
+        'duplicate_cnpj',
+        'payment_overdue',
+        'payment_refund',
+        'payment_chargeback',
+        'subscription_ended',
+        'unknown_provider_event',
+        'invalid_secret',
+        'provider_unavailable',
+        'onboarding_before_payment',
+        'silent_renewal_refused',
+        'private_extra_as_offer',
+        'conflicting_external_reference',
+        'created_object_as_revenue',
+        'impossible_commercial_transition',
+        'pii_rejected',
+        'capacity_waitlisted',
+        'capacity_rejected',
+        'checkout_expired',
+        'recurring_end_state'
+    ));

--- a/internal/infrastructure/db/migrations/000104_outreach_intel_legal_risk_acceptance.up.sql
+++ b/internal/infrastructure/db/migrations/000104_outreach_intel_legal_risk_acceptance.up.sql
@@ -1,0 +1,50 @@
+-- Additive legal-risk-acceptance exception codes for the commercial
+-- intel queue. Not a billing ledger. Counsel reminder and manual NFS-e
+-- queue must persist; payment_chargeback already existed in 000103.
+
+ALTER TABLE outreach_intel_exceptions
+    DROP CONSTRAINT IF EXISTS outreach_intel_exceptions_code_check;
+
+ALTER TABLE outreach_intel_exceptions
+    ADD CONSTRAINT outreach_intel_exceptions_code_check CHECK (code IN (
+        'orphan',
+        'duplicate',
+        'conflicting_account',
+        'missing_version',
+        'stale_attribution',
+        'out_of_order',
+        'unconfirmed_won',
+        'unconfirmed_lost',
+        'ledger_unavailable',
+        'impossible_transition',
+        'negative_latency',
+        'overlapping_latency',
+        'outbound_as_inbound',
+        'invalid_asset_family',
+        'missing_attribution',
+        'terms_price_version_drift',
+        'capacity_expired',
+        'capacity_lost',
+        'no_capacity',
+        'duplicate_cnpj',
+        'payment_overdue',
+        'payment_refund',
+        'payment_chargeback',
+        'subscription_ended',
+        'unknown_provider_event',
+        'invalid_secret',
+        'provider_unavailable',
+        'onboarding_before_payment',
+        'silent_renewal_refused',
+        'private_extra_as_offer',
+        'conflicting_external_reference',
+        'created_object_as_revenue',
+        'impossible_commercial_transition',
+        'pii_rejected',
+        'capacity_waitlisted',
+        'capacity_rejected',
+        'checkout_expired',
+        'recurring_end_state',
+        'counsel_review_due',
+        'nfse_manual_queue'
+    ));


### PR DESCRIPTION
## Summary
- Keep contracted / MRR / charge-created / cash-received separate
- `payment_confirmed` is financial confirmation, not receita
- `payment_received` is the only cash increment and opens `counsel_review_due` (10 business days, reminder, not a kill switch)
- `payment_confirmed` opens `nfse_manual_queue` (manual, no auto-issue, no price change)
- CHARGEBACK emits `payment_chargeback`, never auto-WON/LOST
- auto-send remains false
- Parent authority: tjsasakifln/Governance#6

## Test plan
- [x] `go test ./internal/app/confenge/intel/ -count=1`