### PR TITLE
feat(inbound): parse JWT string user_id for operator acknowledgement (#47)

### DIFF
--- a/internal/api/handler/confenge_inbound.go
+++ b/internal/api/handler/confenge_inbound.go
@@ -110,8 +110,7 @@ func (h *Handler) RecordConfengeInboundOutcome(c *gin.Context) {
 		errx.JSON(c, errx.New(errx.BadRequest, "lead_id is required"))
 		return
 	}
-	userID, _ := c.Get("user_id")
-	uid, _ := userID.(uuid.UUID)
+	uid := confengeActorUUID(c)
 	var body struct {
 		OutcomeCode    string `json:"outcome_code"`
 		Notes          string `json:"notes"`
@@ -147,8 +146,7 @@ func (h *Handler) AcknowledgeConfengeInboundAlert(c *gin.Context) {
 		errx.JSON(c, errx.New(errx.BadRequest, "lead_id is required"))
 		return
 	}
-	userID, _ := c.Get("user_id")
-	uid, _ := userID.(uuid.UUID)
+	uid := confengeActorUUID(c)
 	alert, xerr := h.ConfengeService.AcknowledgeInboundAlert(c.Request.Context(), orgID, uid, leadID, time.Now().UTC())
 	if xerr != nil {
 		errx.JSON(c, xerr)
@@ -168,8 +166,7 @@ func (h *Handler) ResolveConfengeInboundNoAction(c *gin.Context) {
 		errx.JSON(c, errx.New(errx.BadRequest, "lead_id is required"))
 		return
 	}
-	userID, _ := c.Get("user_id")
-	uid, _ := userID.(uuid.UUID)
+	uid := confengeActorUUID(c)
 	var body struct {
 		Reason string `json:"reason"`
 	}
@@ -183,6 +180,20 @@ func (h *Handler) ResolveConfengeInboundNoAction(c *gin.Context) {
 		return
 	}
 	c.JSON(http.StatusOK, gin.H{"data": alert})
+}
+
+func confengeActorUUID(c *gin.Context) uuid.UUID {
+	if s := strings.TrimSpace(c.GetString("user_id")); s != "" {
+		if id, err := uuid.Parse(s); err == nil {
+			return id
+		}
+	}
+	if v, ok := c.Get("user_id"); ok {
+		if id, ok := v.(uuid.UUID); ok {
+			return id
+		}
+	}
+	return uuid.Nil
 }
 
 func firstNonEmptyHeader(c *gin.Context, names ...string) string {

--- a/internal/api/handler/confenge_inbound_test.go
+++ b/internal/api/handler/confenge_inbound_test.go
@@ -234,3 +234,22 @@ func TestConfengeInboundHealthReadyBlockedNoPII(t *testing.T) {
 	}
 	fmt.Printf("HTTP_HEALTH_BLOCKED status=%s reasons=%v\n", blockedProbe.Status, blockedProbe.Reasons)
 }
+
+func TestConfengeActorUUIDParsesJWTString(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	actor := uuid.MustParse("11111111-0000-0000-0000-000000000001")
+	c.Set("user_id", actor.String())
+	if got := confengeActorUUID(c); got != actor {
+		t.Fatalf("string user_id: got %s want %s", got, actor)
+	}
+	c.Set("user_id", actor)
+	if got := confengeActorUUID(c); got != actor {
+		t.Fatalf("uuid user_id: got %s want %s", got, actor)
+	}
+	c.Set("user_id", "")
+	if got := confengeActorUUID(c); got != uuid.Nil {
+		t.Fatalf("empty user_id: got %s", got)
+	}
+}

--- a/internal/app/confenge/operator_alert_service.go
+++ b/internal/app/confenge/operator_alert_service.go
@@ -252,7 +252,14 @@ func actorRef(userID uuid.UUID, fallback string) string {
 }
 
 func requireAlertActor(userID uuid.UUID, fallback string) *errx.Error {
-	if userID == uuid.Nil && strings.TrimSpace(fallback) == "" {
+	if userID != uuid.Nil {
+		return nil
+	}
+	fb := strings.TrimSpace(fallback)
+	if fb == "" || fb == uuid.Nil.String() {
+		return errx.New(errx.Unauthorized, "actor required")
+	}
+	if parsed, err := uuid.Parse(fb); err == nil && parsed == uuid.Nil {
 		return errx.New(errx.Unauthorized, "actor required")
 	}
 	return nil

--- a/internal/app/confenge/operator_alert_test.go
+++ b/internal/app/confenge/operator_alert_test.go
@@ -519,6 +519,22 @@ func TestMigration105AddsOperatorAlertsAndAlertStoreFailed(t *testing.T) {
 	}
 }
 
+func TestRequireAlertActorRejectsNilUUIDString(t *testing.T) {
+	if xerr := requireAlertActor(uuid.Nil, ""); xerr == nil {
+		t.Fatal("empty actor must fail")
+	}
+	if xerr := requireAlertActor(uuid.Nil, uuid.Nil.String()); xerr == nil {
+		t.Fatal("nil uuid string must fail")
+	}
+	actor := uuid.MustParse("11111111-2222-4333-8444-555555555555")
+	if xerr := requireAlertActor(actor, ""); xerr != nil {
+		t.Fatal(xerr)
+	}
+	if xerr := requireAlertActor(uuid.Nil, actor.String()); xerr != nil {
+		t.Fatal(xerr)
+	}
+}
+
 func TestOperatorAlertEventsDoNotOpenPipeline(t *testing.T) {
 	raw, _ := json.Marshal(map[string]any{"ok": true})
 	_ = raw


### PR DESCRIPTION
Follow-up to #95. Auth middleware stores `user_id` as a string. Acknowledge was type-asserting it as `uuid.UUID`, so the operator session always looked like a missing actor (`401 actor required`).

Parse the JWT string (and reject the nil-UUID fallback so outcome cannot sneak through as `00000000-...`). Live synthetic canary already persisted; ack is the remaining operator path.

No lead contact. AUTO_SEND stays false.