### PR TITLE
feat: add organic attribution contract, unmixed cohort scoreboard, and editorial feedback export for #47

### DIFF
--- a/cmd/confenge/main.go
+++ b/cmd/confenge/main.go
@@ -44,6 +44,8 @@ func main() {
 		os.Exit(cmdResumeSending())
 	case "intel-report":
 		os.Exit(cmdIntelReport(os.Args[2:]))
+	case "intel-organic":
+		os.Exit(cmdIntelOrganic(os.Args[2:]))
 	case "intel-exceptions":
 		os.Exit(cmdIntelExceptions(os.Args[2:]))
 	case "help", "-h", "--help":
@@ -66,6 +68,7 @@ Usage:
   confenge stop-sending
   confenge resume-sending
   confenge intel-report [--month YYYY-MM] [--include-synthetic] [--json PATH] [--md PATH]
+  confenge intel-organic [--include-synthetic] [--scoreboard PATH] [--feedback PATH]
   confenge intel-exceptions list|show|resolve [flags]
 
 Env: PRIMARY_DB, CONFENGE_*, REDIS, NATS_URL (see .env.confenge.example).
@@ -103,6 +106,56 @@ func cmdIntelReport(args []string) int {
 		fmt.Fprintf(os.Stderr, "intel-report recommendation=%s iqp=%d baseline=%s\n",
 			rep.Recommendation, rep.InboundQualifiedPipeline, rep.Latency.Baseline)
 	}
+	return 0
+}
+
+func cmdIntelOrganic(args []string) int {
+	fs := flag.NewFlagSet("intel-organic", flag.ExitOnError)
+	include := fs.Bool("include-synthetic", true, "include labeled SYNTHETIC fixtures")
+	scoreboardPath := fs.String("scoreboard", "", "write organic scoreboard JSON to PATH")
+	feedbackPath := fs.String("feedback", "", "write organic feedback JSON to PATH")
+	orgStr := fs.String("org-id", "org-inbound-learning-47", "organization id for fixture ingest")
+	_ = fs.Parse(args)
+
+	st := intel.NewMemoryStore()
+	intel.LoadNamedEventFixtures(st, *orgStr)
+	now := time.Date(2026, 8, 19, 15, 0, 0, 0, time.UTC)
+	board := intel.ProjectOrganicScoreboard(intel.OrganicScoreboardSources{
+		Now: now, IncludeSynthetic: *include,
+	})
+	chains, _ := st.ListChains(*orgStr)
+	board = intel.ProjectOrganicScoreboard(intel.OrganicScoreboardSources{
+		Now: now, IncludeSynthetic: *include, Chains: chains,
+	})
+	exp := intel.ExportOrganicFeedback(st, *orgStr, now, *include)
+	sb, err := intel.OrganicScoreboardJSON(board)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "intel-organic scoreboard: %v\n", err)
+		return 1
+	}
+	fb, err := intel.OrganicFeedbackJSON(exp)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "intel-organic feedback: %v\n", err)
+		return 1
+	}
+	if *scoreboardPath != "" && *scoreboardPath != "-" {
+		if err := os.WriteFile(*scoreboardPath, sb, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "intel-organic scoreboard write: %v\n", err)
+			return 1
+		}
+	} else {
+		fmt.Println(string(sb))
+	}
+	if *feedbackPath != "" && *feedbackPath != "-" {
+		if err := os.WriteFile(*feedbackPath, fb, 0o644); err != nil {
+			fmt.Fprintf(os.Stderr, "intel-organic feedback write: %v\n", err)
+			return 1
+		}
+	} else if *scoreboardPath != "" {
+		fmt.Println(string(fb))
+	}
+	fmt.Fprintf(os.Stderr, "intel-organic recommendation=%s windows=%d rows=%d real_empty=%v causal_proof=%v\n",
+		board.Recommendation, len(board.Windows), len(exp.Rows), board.RealEmpty, board.CausalProof)
 	return 0
 }
 

--- a/docs/confenge/commercial-intelligence.md
+++ b/docs/confenge/commercial-intelligence.md
@@ -73,6 +73,14 @@ ingest exists. CTA, lead, conversation, proposal, and receita stay
 distinct. Contracted pipeline, MRR, charge created, and cash received
 are `separate_metrics`. Default excludes synthetic.
 
+`GET /confenge/intel/organic-scoreboard` and
+`GET /confenge/intel/organic-feedback` are the organic learning residual
+of this plane (`confenge.organic_attribution.v1`). Source taxonomy is
+`organic_search|direct|referral|ai_referral|partner|outbound|unknown`.
+Individual GSC queries never join a lead. Discovery layers stay BLOCKED
+without a web-cfg aggregate. Feedback is REPEAT/CHANGE/STOP/NEED_MORE_DATA
+with empty `upstream_writes`. This does not close #47.
+
 `GET /confenge/intel/executive?month=YYYY-MM&include_synthetic=0`
 
 Monthly payload, families kept separate (`inbound` / `outbound` /

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -87,6 +87,8 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | POST | `/confenge/inbound/:leadId/resolve` | `WRITE_CONTACTS` |
 | GET | `/confenge/intel/executive` | `READ_CONTACTS` |
 | GET | `/confenge/intel/scoreboard` | `READ_CONTACTS` |
+| GET | `/confenge/intel/organic-scoreboard` | `READ_CONTACTS` |
+| GET | `/confenge/intel/organic-feedback` | `READ_CONTACTS` |
 | GET | `/confenge/intel/human-envelopes` | `READ_CONTACTS` |
 | POST | `/confenge/intel/human-outcomes` | `WRITE_CONTACTS` |
 | GET | `/confenge/intel/report` | `READ_CONTACTS` |
@@ -108,6 +110,10 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 `GET /confenge/intel/executive` is the monthly commercial-intelligence query (not a CRM board). Families stay separate. Real counts stay empty or `UNKNOWN` until a human-approved action exists. `include_synthetic=1` is the labeled fixture path. WON is never inferred. `causal_proof` is always false.
 
 `GET /confenge/intel/scoreboard` is the seven-stage inbound truth placar (URLs live/indexable, non-branded impressions/clicks, CTA completed, lead persisted, qualified conversation, proposal emitted, revenue received). Default `include_synthetic=0`. Pipeline contracted, MRR, charge created, and cash received stay on `separate_metrics`. Missing GSC or URL-index ingest stays `BLOCKED`. `POST /confenge/intel/human-outcomes` records a founder action/outcome. WON, LOST, and received revenue require human/document evidence. `GET /confenge/intel/human-envelopes` returns empty EXTRA / ACCOUNT_1 / ACCOUNT_2 / ACCOUNT_3 slots with blank IDs.
+
+`GET /confenge/intel/organic-scoreboard` is the organic cohort/asset/landing placar (`confenge.organic_learning_scoreboard.v1`). Layers stay separate: discovery (ELIGIBLE/APPEARED/CLICKED/ENGAGED only when web-cfg aggregates arrive, otherwise BLOCKED), lead, qualification, first action, conversation, meeting, proposal, pipeline, WON/LOST/UNKNOWN, contracted vs received revenue. Windows are complete 7d, complete 28d, 90d, and open/censored cohorts. `organic_search`, `ai_referral`, `direct`, `partner`, `outbound`, `referral`, and `unknown` never mix. Individual GSC queries are not stored. Organic ROAS/CAC stay BLOCKED without complete cost and observed received revenue.
+
+`GET /confenge/intel/organic-feedback` is the versioned editorial export (`confenge.organic_editorial_feedback.v1`) with `REPEAT` / `CHANGE` / `STOP` / `NEED_MORE_DATA`, denominators, freshness, reason codes, and explicit uncertainty. `causal_proof` is always false. `upstream_writes` is always empty. Warmbly does not write web-cfg.
 
 `POST /confenge/intel/events` ingests one versioned commercial event (`confenge.commercial_event.v1`). Same `event_id` or idempotency key is a replay. Lead, page view, citation, and X-Ray completion never become pipeline. Pipeline never becomes revenue. Checkout, payment, subscription, and provider object creation are not received revenue. Onboarding starts only after a reconciled financial confirmation.
 

--- a/docs/contracts/inbound-learning/README.md
+++ b/docs/contracts/inbound-learning/README.md
@@ -3,6 +3,7 @@
 Versioned commercial events for Warmbly issue #47.
 
 - `event-schema.md` — envelope and types
+- `organic-attribution.md` — closed source taxonomy and GSC/query prohibition
 - `INTEGRATION_NOTES.md` — web-cfg producer notes
 - `fixtures/events.v1.json` — labeled SYNTHETIC sequences
 

--- a/docs/contracts/inbound-learning/organic-attribution.md
+++ b/docs/contracts/inbound-learning/organic-attribution.md
@@ -1,0 +1,50 @@
+# Organic attribution contract `confenge.organic_attribution.v1`
+
+Warmbly consumes organic source/asset fields on `confenge.commercial_event.v1`.
+This is not a CRM object, not a GSC warehouse, and not a write into web-cfg.
+
+## Authority
+
+| Plane | Owns |
+| --- | --- |
+| web-cfg | source, referrer class, landing path, asset/CTA versions, consent, GSC/site aggregates |
+| extra-cli | facts, entities, evidence |
+| Warmbly | approved action, acknowledgement, reply, meeting, proposal, observed outcome |
+
+Individual Search Console queries never join a person or lead. `query_hash`
+is aggregate / k-anonymous only. Page view is not a lead. Lead is not
+pipeline. Pipeline is not revenue. `unknown` is never rewritten to
+`direct` or `organic_search`.
+
+## Source taxonomy
+
+Exactly one of:
+
+`organic_search` | `direct` | `referral` | `ai_referral` | `partner` | `outbound` | `unknown`
+
+Producer identities such as `web-cfg` or `CONFENGE_WEB` stay on `source`
+and map to `organic_source=UNKNOWN` unless an explicit organic token is
+provided. Slices never mix.
+
+## Preserved when supplied
+
+`medium`, `campaign`, `referrer_class` (never a sensitive URL), canonical
+`landing_path`, `asset_family`, `asset_id`/`asset_version`, CTA id/version,
+aggregate `intent_class`/`query_class`, `correlation_id`/`lead_id`/`account_id`,
+`record_kind` real vs synthetic, consent/version, observed first_touch and
+last_touch, clocks, page/content version, deploy SHA.
+
+## Exceptions (no silent drop)
+
+`lead_without_asset_id`, `unknown_asset_version`, `contradictory_source`,
+`synthetic_treated_as_real`, `missing_consent`, `pipeline_without_evidence`,
+`revenue_without_financial_event`, `gsc_query_on_lead`, `query_hash_on_lead`,
+plus the existing join codes (duplicate, out_of_order, negative_latency).
+
+## Exports
+
+- `GET /confenge/intel/organic-scoreboard` (`confenge.organic_learning_scoreboard.v1`)
+- `GET /confenge/intel/organic-feedback` (`confenge.organic_editorial_feedback.v1`)
+
+Feedback verdicts are exactly `REPEAT` | `CHANGE` | `STOP` | `NEED_MORE_DATA`.
+`causal_proof` is always false. `upstream_writes` is always empty.

--- a/docs/ops/campaigns/CONFENGE-WARMBLY-SEO-REVENUE-LEARNING-02/README.md
+++ b/docs/ops/campaigns/CONFENGE-WARMBLY-SEO-REVENUE-LEARNING-02/README.md
@@ -1,0 +1,10 @@
+# CONFENGE-WARMBLY-SEO-REVENUE-LEARNING-02
+
+Organic inbound learning loop on the existing #47 intel plane. Isolated
+worktree from `origin/main` at SPEED-TO-LEAD-01. Does not close #47.
+
+Contract: `docs/contracts/inbound-learning/organic-attribution.md`.
+
+Recommendation: `NEEDS_WEB_CFG_EVENT` until discovery aggregates arrive,
+and `NEEDS_REAL_EVENT` until a live consented organic commercial event
+exists. Code complete is not LIVE_PROVEN.

--- a/internal/api/handler/confenge_intel.go
+++ b/internal/api/handler/confenge_intel.go
@@ -283,6 +283,38 @@ func (h *Handler) ReopenConfengeIntelException(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": res})
 }
 
+// GetConfengeOrganicScoreboard — GET /confenge/intel/organic-scoreboard
+// Ten-layer organic cohort/asset/landing placar. Default excludes synthetic.
+func (h *Handler) GetConfengeOrganicScoreboard(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	includeSynthetic := queryBool(c, "include_synthetic")
+	board, xerr := h.ConfengeService.OrganicScoreboard(c.Request.Context(), orgID, includeSynthetic)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": board})
+}
+
+// GetConfengeOrganicFeedback — GET /confenge/intel/organic-feedback
+// Versioned REPEAT|CHANGE|STOP|NEED_MORE_DATA export. No upstream write.
+func (h *Handler) GetConfengeOrganicFeedback(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	includeSynthetic := queryBool(c, "include_synthetic")
+	exp, xerr := h.ConfengeService.OrganicFeedback(c.Request.Context(), orgID, includeSynthetic)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": exp})
+}
+
 // GetConfengeTruthScoreboard — GET /confenge/intel/scoreboard
 // Seven-stage executive placar. Default excludes synthetic.
 func (h *Handler) GetConfengeTruthScoreboard(c *gin.Context) {

--- a/internal/api/handler/confenge_intel_test.go
+++ b/internal/api/handler/confenge_intel_test.go
@@ -315,6 +315,16 @@ func (s *scoreboardHTTPStub) TruthScoreboard(_ context.Context, _ uuid.UUID, _ s
 	b.IncludeSynthetic = includeSynthetic
 	return &b, nil
 }
+func (s *scoreboardHTTPStub) OrganicScoreboard(_ context.Context, _ uuid.UUID, includeSynthetic bool) (*intel.OrganicScoreboard, *errx.Error) {
+	board := intel.ProjectOrganicScoreboard(intel.OrganicScoreboardSources{
+		Now: time.Date(2026, 8, 19, 15, 0, 0, 0, time.UTC), IncludeSynthetic: includeSynthetic,
+	})
+	return &board, nil
+}
+func (s *scoreboardHTTPStub) OrganicFeedback(_ context.Context, _ uuid.UUID, includeSynthetic bool) (*intel.OrganicFeedbackExport, *errx.Error) {
+	exp := intel.ExportOrganicFeedback(intel.NewMemoryStore(), "org", time.Date(2026, 8, 19, 15, 0, 0, 0, time.UTC), includeSynthetic)
+	return &exp, nil
+}
 func (s *scoreboardHTTPStub) HumanOutcomeEnvelopes() []intel.HumanOutcomeEnvelope {
 	return intel.EmptyEnvelopes()
 }
@@ -355,6 +365,69 @@ func TestGetConfengeTruthScoreboardBody(t *testing.T) {
 		t.Fatal("HTTP scoreboard leaked synthetic or causal_proof")
 	}
 	fmt.Printf("HTTP_SCOREBOARD status=%d stages=%d path=%s\n", w.Code, len(wrap.Data.Stages), wrap.Data.ProductionPath)
+}
+
+func TestGetConfengeOrganicScoreboardAndFeedbackBody(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+	h := &Handler{ConfengeService: &scoreboardHTTPStub{}}
+	req := httptest.NewRequest(http.MethodGet, "/confenge/intel/organic-scoreboard?include_synthetic=0", nil)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	c.Set(middleware.OrganizationIDKey, org)
+	h.GetConfengeOrganicScoreboard(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("scoreboard status=%d body=%s", w.Code, w.Body.String())
+	}
+	var boardWrap struct {
+		Data intel.OrganicScoreboard `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &boardWrap); err != nil {
+		t.Fatal(err)
+	}
+	if boardWrap.Data.SchemaVersion != intel.OrganicScoreboardSchemaV1 || boardWrap.Data.CausalProof {
+		t.Fatalf("board=%+v", boardWrap.Data)
+	}
+	if len(boardWrap.Data.Windows) != 4 {
+		t.Fatalf("windows=%d", len(boardWrap.Data.Windows))
+	}
+	unknownVisible := false
+	for _, sl := range boardWrap.Data.Windows[0].BySource {
+		if sl.OrganicSource == intel.Unknown {
+			unknownVisible = true
+		}
+		if sl.ROAS != intel.TruthBlocked {
+			t.Fatal("HTTP invented organic ROAS")
+		}
+	}
+	if !unknownVisible {
+		t.Fatal("UNKNOWN source slice missing")
+	}
+
+	req = httptest.NewRequest(http.MethodGet, "/confenge/intel/organic-feedback?include_synthetic=0", nil)
+	w = httptest.NewRecorder()
+	c, _ = gin.CreateTestContext(w)
+	c.Request = req
+	c.Set(middleware.OrganizationIDKey, org)
+	h.GetConfengeOrganicFeedback(c)
+	if w.Code != http.StatusOK {
+		t.Fatalf("feedback status=%d body=%s", w.Code, w.Body.String())
+	}
+	var fbWrap struct {
+		Data intel.OrganicFeedbackExport `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &fbWrap); err != nil {
+		t.Fatal(err)
+	}
+	if fbWrap.Data.SchemaVersion != intel.OrganicFeedbackSchemaV1 || fbWrap.Data.CausalProof || len(fbWrap.Data.UpstreamWrites) != 0 {
+		t.Fatalf("feedback=%+v", fbWrap.Data)
+	}
+	if len(fbWrap.Data.Rows) == 0 || fbWrap.Data.Rows[0].Verdict != intel.LearningNeedMore {
+		t.Fatalf("rows=%+v", fbWrap.Data.Rows)
+	}
+	fmt.Printf("HTTP_ORGANIC scoreboard=%s windows=%d feedback=%s verdict=%s unknown=%v\n",
+		boardWrap.Data.SchemaVersion, len(boardWrap.Data.Windows), fbWrap.Data.SchemaVersion, fbWrap.Data.Rows[0].Verdict, unknownVisible)
 }
 
 func TestListConfengeHumanEnvelopes(t *testing.T) {

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -536,6 +536,8 @@ func Run(
 				confengeGroup.GET("/inbound", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeInboundNow)
 				confengeGroup.GET("/intel/executive", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeExecutiveIntel)
 				confengeGroup.GET("/intel/scoreboard", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeTruthScoreboard)
+				confengeGroup.GET("/intel/organic-scoreboard", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeOrganicScoreboard)
+				confengeGroup.GET("/intel/organic-feedback", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeOrganicFeedback)
 				confengeGroup.GET("/intel/human-envelopes", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeHumanEnvelopes)
 				confengeGroup.GET("/intel/report", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeIntelReport)
 				confengeGroup.GET("/intel/exceptions", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeIntelExceptions)

--- a/internal/app/confenge/inbound.go
+++ b/internal/app/confenge/inbound.go
@@ -43,6 +43,14 @@ type InboundLeadV1 struct {
 	Message        string
 	CorrelationID  string
 	Query          string
+	QueryClass     string
+	IntentClass    string
+	OrganicSource  string
+	LandingPath    string
+	AssetVersion   string
+	CTAVersion     string
+	RecordKind     string
+	ConsentVersion string
 	Consent        InboundConsent
 	UTM            map[string]string
 	HighIntentHint bool
@@ -106,27 +114,46 @@ func ParseInboundLead(raw []byte, now time.Time) (InboundLeadV1, *errx.Error) {
 		return InboundLeadV1{}, errx.New(errx.BadRequest, "inbound body must be JSON")
 	}
 	lead := InboundLeadV1{
-		LeadID:        firstNonEmpty(strAny(m, "lead_id", "id"), strAny(m, "receipt_id", "receipt")),
-		ReceiptID:     firstNonEmpty(strAny(m, "receipt_id", "receipt"), strAny(m, "lead_id", "id")),
-		Source:        SanitizeText(strAny(m, "source"), 120),
-		RouteFamily:   SanitizeText(strAny(m, "route_family", "route"), 80),
-		AssetID:       SanitizeText(strAny(m, "asset_id", "asset"), 120),
-		CTAID:         SanitizeText(strAny(m, "cta_id", "cta"), 120),
-		LandingURL:    sanitizeInboundURL(strAny(m, "landing_url", "url", "page_url")),
-		ContractID:    SanitizeText(strAny(m, "contract_public_id", "contract_id", "contrato_id"), 120),
-		EntityID:      SanitizeText(strAny(m, "entity_public_id", "entity_id", "account_public_id"), 120),
-		CompanyName:   SanitizeText(strAny(m, "company_name", "company", "empresa", "razao_social"), 200),
-		Name:          SanitizeText(strAny(m, "name", "nome", "lead_name"), 160),
-		Email:         strings.ToLower(strings.TrimSpace(strAny(m, "email", "lead_email"))),
-		Phone:         SanitizeText(strAny(m, "phone", "telefone", "tel", "lead_phone"), 40),
-		Referrer:      sanitizeInboundURL(strAny(m, "referrer", "referer")),
-		Message:       SanitizeText(strAny(m, "message", "contexto", "notes", "context"), 4000),
-		CorrelationID: SanitizeText(strAny(m, "correlation_id", "attribution_correlation_id"), 160),
-		Query:         SanitizeText(strAny(m, "query", "search_query", "q"), 200),
-		UTM:           parseUTM(m),
+		LeadID:         firstNonEmpty(strAny(m, "lead_id", "id"), strAny(m, "receipt_id", "receipt")),
+		ReceiptID:      firstNonEmpty(strAny(m, "receipt_id", "receipt"), strAny(m, "lead_id", "id")),
+		Source:         SanitizeText(strAny(m, "source"), 120),
+		RouteFamily:    SanitizeText(strAny(m, "route_family", "route"), 80),
+		AssetID:        SanitizeText(strAny(m, "asset_id", "asset"), 120),
+		CTAID:          SanitizeText(strAny(m, "cta_id", "cta"), 120),
+		LandingURL:     sanitizeInboundURL(strAny(m, "landing_url", "url", "page_url")),
+		ContractID:     SanitizeText(strAny(m, "contract_public_id", "contract_id", "contrato_id"), 120),
+		EntityID:       SanitizeText(strAny(m, "entity_public_id", "entity_id", "account_public_id"), 120),
+		CompanyName:    SanitizeText(strAny(m, "company_name", "company", "empresa", "razao_social"), 200),
+		Name:           SanitizeText(strAny(m, "name", "nome", "lead_name"), 160),
+		Email:          strings.ToLower(strings.TrimSpace(strAny(m, "email", "lead_email"))),
+		Phone:          SanitizeText(strAny(m, "phone", "telefone", "tel", "lead_phone"), 40),
+		Referrer:       sanitizeInboundURL(strAny(m, "referrer", "referer")),
+		Message:        SanitizeText(strAny(m, "message", "contexto", "notes", "context"), 4000),
+		CorrelationID:  SanitizeText(strAny(m, "correlation_id", "attribution_correlation_id"), 160),
+		QueryClass:     SanitizeText(strAny(m, "query_class", "intent_class"), 80),
+		IntentClass:    SanitizeText(strAny(m, "intent_class"), 80),
+		OrganicSource:  SanitizeText(strAny(m, "organic_source", "attribution_source"), 80),
+		LandingPath:    SanitizeText(strAny(m, "landing_path"), 200),
+		AssetVersion:   SanitizeText(strAny(m, "asset_version"), 80),
+		CTAVersion:     SanitizeText(strAny(m, "cta_version"), 80),
+		RecordKind:     SanitizeText(strAny(m, "record_kind"), 40),
+		ConsentVersion: SanitizeText(strAny(m, "consent_version"), 80),
+		UTM:            parseUTM(m),
 	}
-	if lead.Query == "" && lead.UTM != nil {
-		lead.Query = firstNonEmpty(lead.UTM["term"], lead.UTM["query"])
+	// Individual GSC/search queries are not a lead attribute. query_class may stay.
+	rawQuery := SanitizeText(strAny(m, "query", "search_query", "q"), 200)
+	if inboundQueryClassOK(rawQuery) {
+		lead.Query = rawQuery
+		if lead.QueryClass == "" {
+			lead.QueryClass = rawQuery
+		}
+	}
+	if lead.QueryClass == "" && lead.UTM != nil && inboundQueryClassOK(lead.UTM["query"]) {
+		lead.QueryClass = lead.UTM["query"]
+		lead.Query = lead.UTM["query"]
+	}
+	if lead.LandingPath == "" {
+		lead.LandingPath = lead.LandingURL
 	}
 	lead.CNPJ = NormalizeCNPJ14(strAny(m, "cnpj14", "cnpj"))
 	if ts := parseFlexibleTime(strAny(m, "created_at", "lead_created_at")); !ts.IsZero() {
@@ -209,6 +236,14 @@ func inboundHighIntent(lead InboundLeadV1) bool {
 		}
 	}
 	return false
+}
+
+func inboundQueryClassOK(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" || strings.ContainsAny(v, " \t\n@/?#") || len(v) > 80 {
+		return false
+	}
+	return true
 }
 
 func sanitizeInboundURL(raw string) string {

--- a/internal/app/confenge/inbound_cockpit.go
+++ b/internal/app/confenge/inbound_cockpit.go
@@ -256,7 +256,10 @@ func ProjectInboundNowItem(lead models.OutreachInboundLead, acc *models.Outreach
 const inboundUnknown = "UNKNOWN"
 
 func inboundQueryOf(lead models.OutreachInboundLead) string {
-	if q := strings.TrimSpace(utmField(lead.UTMJSON, "query", "search_query", "q", "utm_term", "term")); q != "" {
+	if q := strings.TrimSpace(utmField(lead.UTMJSON, "query_class", "intent_class")); inboundQueryClassOK(q) {
+		return q
+	}
+	if q := strings.TrimSpace(utmField(lead.UTMJSON, "query")); inboundQueryClassOK(q) {
 		return q
 	}
 	return inboundUnknown

--- a/internal/app/confenge/inbound_ingest.go
+++ b/internal/app/confenge/inbound_ingest.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
@@ -311,8 +312,37 @@ func inboundRowFromParsed(orgID uuid.UUID, lead InboundLeadV1, raw []byte, now t
 	if utmMap == nil {
 		utmMap = map[string]string{}
 	}
-	if q := strings.TrimSpace(lead.Query); q != "" {
+	if q := strings.TrimSpace(lead.QueryClass); inboundQueryClassOK(q) {
+		utmMap["query_class"] = q
+	}
+	if q := strings.TrimSpace(lead.Query); inboundQueryClassOK(q) {
 		utmMap["query"] = q
+	}
+	delete(utmMap, "search_query")
+	delete(utmMap, "q")
+	delete(utmMap, "term")
+	delete(utmMap, "utm_term")
+	delete(utmMap, "query_hash")
+	if v := strings.TrimSpace(lead.OrganicSource); v != "" {
+		utmMap["organic_source"] = v
+	}
+	if v := strings.TrimSpace(lead.IntentClass); v != "" {
+		utmMap["intent_class"] = v
+	}
+	if v := strings.TrimSpace(lead.AssetVersion); v != "" {
+		utmMap["asset_version"] = v
+	}
+	if v := strings.TrimSpace(lead.CTAVersion); v != "" {
+		utmMap["cta_version"] = v
+	}
+	if v := strings.TrimSpace(lead.RecordKind); v != "" {
+		utmMap["record_kind"] = v
+	}
+	if v := strings.TrimSpace(lead.ConsentVersion); v != "" {
+		utmMap["consent_version"] = v
+	}
+	if v := strings.TrimSpace(lead.LandingPath); v != "" {
+		utmMap["landing_path"] = v
 	}
 	utm, _ := json.Marshal(utmMap)
 	if len(utm) == 0 {
@@ -334,7 +364,7 @@ func inboundRowFromParsed(orgID uuid.UUID, lead InboundLeadV1, raw []byte, now t
 		RouteFamily:       lead.RouteFamily,
 		AssetID:           lead.AssetID,
 		CTAID:             lead.CTAID,
-		LandingURL:        lead.LandingURL,
+		LandingURL:        firstNonEmpty(lead.LandingURL, lead.LandingPath),
 		ContractID:        lead.ContractID,
 		EntityID:          lead.EntityID,
 		CNPJ14:            lead.CNPJ,
@@ -442,4 +472,65 @@ func (s *service) enqueueInboundImported(ctx context.Context, orgID uuid.UUID, r
 		OccurredAt:     row.WarmblyIngestedAt,
 		Payload:        meta,
 	})
+	intel.IngestEvent(s.intelStore(), inboundLeadToCommercialEvent(orgID, row))
+}
+
+func inboundLeadToCommercialEvent(orgID uuid.UUID, row *models.OutreachInboundLead) intel.CommercialEvent {
+	if row == nil {
+		return intel.CommercialEvent{}
+	}
+	synthetic := InboundCommercialSkipReason(*row) != ""
+	ev := intel.CommercialEvent{
+		EventID:        "inbound_imported:" + row.LeadID,
+		Version:        "1",
+		Schema:         intel.EventSchemaV1,
+		Type:           intel.EventLeadReceived,
+		OccurredAt:     row.LeadCreatedAt,
+		IngestedAt:     row.WarmblyIngestedAt,
+		Timezone:       "UTC",
+		CorrelationID:  row.CorrelationID,
+		IdempotencyKey: "inbound_imported:" + row.LeadID,
+		Source:         row.Source,
+		OrganicSource:  utmField(row.UTMJSON, "organic_source"),
+		Medium:         utmField(row.UTMJSON, "medium"),
+		Campaign:       utmField(row.UTMJSON, "campaign"),
+		Referrer:       row.Referrer,
+		ReferrerClass:  utmField(row.UTMJSON, "referrer_class"),
+		QueryClass:     utmField(row.UTMJSON, "query_class", "intent_class"),
+		IntentClass:    utmField(row.UTMJSON, "intent_class"),
+		CTAID:          row.CTAID,
+		CTAVersion:     utmField(row.UTMJSON, "cta_version"),
+		AssetID:        row.AssetID,
+		AssetVersion:   utmField(row.UTMJSON, "asset_version"),
+		LandingPath:    firstNonEmpty(utmField(row.UTMJSON, "landing_path"), row.LandingURL),
+		LeadID:         row.LeadID,
+		ReceiptID:      firstNonEmpty(row.ReceiptID, row.LeadID),
+		RouteFamily:    firstNonEmpty(row.RouteFamily, intel.FamilyInbound),
+		OrganizationID: orgID.String(),
+		Synthetic:      synthetic,
+		RecordKind:     utmField(row.UTMJSON, "record_kind"),
+		ConsentVersion: utmField(row.UTMJSON, "consent_version"),
+		Consent:        inboundConsentRef(row.ConsentJSON),
+	}
+	if inboundQueryClassOK(utmField(row.UTMJSON, "query")) {
+		ev.Query = utmField(row.UTMJSON, "query")
+	}
+	return ev
+}
+
+func inboundConsentRef(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ""
+	}
+	if v, ok := m["source"].(string); ok && strings.TrimSpace(v) != "" {
+		return strings.TrimSpace(v)
+	}
+	if granted, ok := m["granted"].(bool); ok && granted {
+		return "granted"
+	}
+	return ""
 }

--- a/internal/app/confenge/inbound_test.go
+++ b/internal/app/confenge/inbound_test.go
@@ -284,19 +284,27 @@ func TestParseInboundLeadQueryVsCampaign(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if realQ.Query != "segunda leitura contrato" {
-		t.Fatalf("real query=%q", realQ.Query)
+	if realQ.Query != "" {
+		t.Fatalf("GSC phrase must not join the lead: query=%q", realQ.Query)
 	}
 	if realQ.UTM["campaign"] != "brand-aug" {
 		t.Fatalf("campaign not preserved: %+v", realQ.UTM)
+	}
+
+	classQ, err := ParseInboundLead([]byte(`{"lead_id":"q1c","source":"CONFENGE_WEB","query_class":"segunda-leitura-preco","utm_campaign":"brand-aug"}`), now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if classQ.QueryClass != "segunda-leitura-preco" {
+		t.Fatalf("query_class=%q", classQ.QueryClass)
 	}
 
 	term, err := ParseInboundLead([]byte(`{"lead_id":"q2","source":"CONFENGE_WEB","utm_term":"segunda-leitura","utm_campaign":"brand-aug"}`), now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if term.Query != "segunda-leitura" {
-		t.Fatalf("utm_term query=%q", term.Query)
+	if term.Query != "" {
+		t.Fatalf("utm_term must not become a lead query: %q", term.Query)
 	}
 	if term.UTM["campaign"] != "brand-aug" {
 		t.Fatalf("campaign lost on utm_term: %+v", term.UTM)
@@ -328,16 +336,21 @@ func TestParseInboundLeadQueryVsCampaign(t *testing.T) {
 
 	realRow := inboundRowFromParsed(uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"), realQ, []byte(`{"lead_id":"q1","query":"segunda leitura contrato"}`), now)
 	realItem := ProjectInboundNowItem(*realRow, nil, nil, now)
-	if realItem.Query != "segunda leitura contrato" {
-		t.Fatalf("real query projection=%q", realItem.Query)
+	if realItem.Query != inboundUnknown {
+		t.Fatalf("GSC phrase leaked into INBOUND NOW: %q", realItem.Query)
+	}
+	classRow := inboundRowFromParsed(uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"), classQ, []byte(`{"lead_id":"q1c","query_class":"segunda-leitura-preco"}`), now)
+	classItem := ProjectInboundNowItem(*classRow, nil, nil, now)
+	if classItem.Query != "segunda-leitura-preco" {
+		t.Fatalf("query_class projection=%q", classItem.Query)
 	}
 	termRow := inboundRowFromParsed(uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee"), term, []byte(`{"lead_id":"q2","utm_term":"segunda-leitura"}`), now)
 	termItem := ProjectInboundNowItem(*termRow, nil, nil, now)
-	if termItem.Query != "segunda-leitura" {
-		t.Fatalf("utm_term projection=%q", termItem.Query)
+	if termItem.Query != inboundUnknown {
+		t.Fatalf("utm_term projection leaked: %q", termItem.Query)
 	}
-	fmt.Printf("QUERY_VS_CAMPAIGN query=%q utm_term=%q campaign_only=%s campaign=%s\n",
-		realItem.Query, termItem.Query, item.Query, utm["campaign"])
+	fmt.Printf("QUERY_VS_CAMPAIGN gsc=%q class=%q utm_term=%q campaign_only=%s campaign=%s\n",
+		realItem.Query, classItem.Query, termItem.Query, item.Query, utm["campaign"])
 }
 
 func TestParseInboundLeadRequiresReceipt(t *testing.T) {

--- a/internal/app/confenge/intel/event.go
+++ b/internal/app/confenge/intel/event.go
@@ -51,7 +51,7 @@ func knownEventType(t string) bool {
 		EventPipelineCreated, EventPipelineUpdated,
 		EventWon, EventLost, EventUnknownState, EventRevenueEvidenced,
 		EventLearningCandidate, EventXRayCompleted, EventPageView,
-		EventCitation, EventCorrection,
+		EventCitation, EventCorrection, EventSearchObservation,
 		EventOperatorAlertCreated, EventOperatorAlertEmitted, EventOperatorAlertFailed,
 		EventOperatorAlertAcknowledged, EventFirstHumanActionRecorded, EventInboundResolvedNoAction:
 		return true
@@ -63,6 +63,12 @@ func knownEventType(t string) bool {
 // EventToFacts maps one envelope onto ObservedFacts. PIIPointer is
 // discarded. Pipeline and revenue flags are set only from their events.
 func EventToFacts(ev CommercialEvent) ObservedFacts {
+	strippedQuery := LooksLikeIndividualSearchQuery(ev.Query) || LooksLikeIndividualSearchQuery(ev.GSCQuery)
+	strippedHash := strings.TrimSpace(ev.QueryHash) != "" || LooksLikeQueryHash(ev.Query)
+	producerKind := strings.ToLower(strings.TrimSpace(ev.RecordKind))
+	producerSaidReal := producerKind == RecordKindReal || producerKind == "live" || producerKind == strings.ToLower(LabelReal)
+	invalidVersion := strings.TrimSpace(ev.AssetVersion) != "" && !validAssetVersion(ev.AssetVersion)
+	ev = SanitizeCommercialEvent(ev)
 	typ, _, _ := NormalizeEventType(ev.Type)
 	if typ == "" {
 		typ = strings.ToLower(strings.TrimSpace(ev.Type))
@@ -114,23 +120,41 @@ func EventToFacts(ev CommercialEvent) ObservedFacts {
 			HoldID:            strings.TrimSpace(ev.Capacity.HoldID),
 			QueryClass:        strings.TrimSpace(ev.QueryClass),
 			ReferrerClass:     strings.TrimSpace(ev.ReferrerClass),
+			OrganicSource:     ev.OrganicSource,
+			Medium:            strings.TrimSpace(ev.Medium),
+			Campaign:          strings.TrimSpace(ev.Campaign),
+			LandingPath:       ev.LandingPath,
+			AssetVersion:      strings.TrimSpace(ev.AssetVersion),
+			CTAVersion:        strings.TrimSpace(ev.CTAVersion),
+			RecordKind:        ev.RecordKind,
+			ConsentVersion:    strings.TrimSpace(ev.ConsentVersion),
+			PageVersion:       strings.TrimSpace(ev.PageVersion),
+			ContentVersion:    strings.TrimSpace(ev.ContentVersion),
+			FirstTouchAt:      ev.FirstTouchAt,
+			LastTouchAt:       ev.LastTouchAt,
 		},
-		LeadCreatedAt:     leadStamp(typ, occurred),
-		IngestedAt:        ingested,
-		ActionOccurredAt:  actionStamp(typ, occurred),
-		OutcomeOccurredAt: outcomeStamp(typ, occurred),
-		EventType:         typ,
-		Qualified:         ev.Qualified || typ == EventLeadValidated,
-		HumanConfirmed:    ev.HumanConfirmed,
-		Correction:        ev.Correction || typ == EventCorrection,
-		HandRaise:         ev.HandRaise,
-		Suppression:       ev.Suppression,
-		Timezone:          firstNonEmpty(ev.Timezone, "UTC"),
-		PublishedAt:       ev.PublishedAt,
-		DetectedAt:        ev.DetectedAt,
-		FollowUpAt:        ev.FollowUpAt,
-		Synthetic:         ev.Synthetic,
-		Label:             labelFor(ev.Synthetic),
+		LeadCreatedAt:        leadStamp(typ, occurred),
+		IngestedAt:           ingested,
+		ActionOccurredAt:     actionStamp(typ, occurred),
+		OutcomeOccurredAt:    outcomeStamp(typ, occurred),
+		EventType:            typ,
+		Qualified:            ev.Qualified || typ == EventLeadValidated,
+		HumanConfirmed:       ev.HumanConfirmed,
+		Correction:           ev.Correction || typ == EventCorrection,
+		HandRaise:            ev.HandRaise,
+		Suppression:          ev.Suppression,
+		Timezone:             firstNonEmpty(ev.Timezone, "UTC"),
+		PublishedAt:          ev.PublishedAt,
+		DetectedAt:           ev.DetectedAt,
+		FollowUpAt:           ev.FollowUpAt,
+		Synthetic:            ev.Synthetic,
+		Label:                labelFor(ev.Synthetic),
+		RecordKind:           ev.RecordKind,
+		ConsentValid:         strings.TrimSpace(ev.Consent) != "",
+		StrippedGSCQuery:     strippedQuery,
+		StrippedQueryHash:    strippedHash,
+		SyntheticLabeledReal: ev.Synthetic && producerSaidReal,
+		InvalidAssetVersion:  invalidVersion,
 	}
 	if ev.Synthetic {
 		in.Label = LabelSynthetic
@@ -186,7 +210,7 @@ func EventToFacts(ev CommercialEvent) ObservedFacts {
 			in.RevenueEvidenced = true
 			in.RevenueCents = ev.RevenueCents
 		}
-	case EventXRayCompleted, EventPageView, EventCitation:
+	case EventXRayCompleted, EventPageView, EventCitation, EventSearchObservation:
 		in.NotALead = true
 		in.PipelineOpen = false
 		in.Qualified = false
@@ -599,7 +623,7 @@ func hasFinancialType(t string) bool {
 
 func isNonLeadEvent(typ string) bool {
 	switch strings.ToLower(strings.TrimSpace(typ)) {
-	case EventXRayCompleted, EventPageView, EventCitation,
+	case EventXRayCompleted, EventPageView, EventCitation, EventSearchObservation,
 		EventOperatorAlertCreated, EventOperatorAlertEmitted, EventOperatorAlertFailed,
 		EventOperatorAlertAcknowledged, EventFirstHumanActionRecorded, EventInboundResolvedNoAction:
 		return true

--- a/internal/app/confenge/intel/exceptions.go
+++ b/internal/app/confenge/intel/exceptions.go
@@ -89,7 +89,34 @@ func ClassifyExceptions(in ObservedFacts, existing *Chain) []Exception {
 		add(ExceptionInvalidAssetFamily, "asset_family is not market_answer, contract_analysis, or b2g_xray", "exclude from assisted slices; do not invent a family", false)
 	}
 	if missingInboundAttribution(in) {
-		add(ExceptionMissingAttribution, "inbound path missing source/query/asset", "keep UNKNOWN attribution; do not invent a source or asset", false)
+		add(ExceptionMissingAttribution, "inbound path missing source/asset", "keep UNKNOWN attribution; do not invent a source or asset", false)
+	}
+	if inboundLeadMissingAsset(in) {
+		add(ExceptionLeadWithoutAssetID, "inbound lead missing asset_id", "keep UNKNOWN asset; do not invent an asset from the landing", false)
+	}
+	if unknownAssetVersion(in) {
+		add(ExceptionUnknownAssetVersion, "asset_version is not a usable version token", "leave version UNKNOWN; do not invent a catalog version", false)
+	}
+	if contradictoryOrganicSource(in, existing) {
+		add(ExceptionContradictorySource, "incoming organic source disagrees with the first chain", "keep the first observed source; do not mix slices", true)
+	}
+	if syntheticTreatedAsReal(in) {
+		add(ExceptionSyntheticTreatedAsReal, "synthetic/test record labeled real", "hold; do not notify or mix into real denominators", true)
+	}
+	if missingConsentForAction(in) {
+		add(ExceptionMissingConsent, "inbound action without a valid consent ref", "hold commercial action; operator may still see the receipt", true)
+	}
+	if pipelineWithoutEvidence(in, existing) {
+		add(ExceptionPipelineWithoutEvidence, "pipeline/outcome without evidence", "hold; do not invent pipeline from a lead or page view", true)
+	}
+	if revenueWithoutFinancial(in) {
+		add(ExceptionRevenueWithoutFinancial, "revenue claimed without a reconciled financial event", "hold; contracted and received stay distinct and UNKNOWN", true)
+	}
+	if in.StrippedGSCQuery || LooksLikeIndividualSearchQuery(in.Keys.Query) {
+		add(ExceptionGSCQueryOnLead, "individual GSC/search query cannot join a person/lead", "strip the query; keep query_class aggregate only", true)
+	}
+	if in.StrippedQueryHash || LooksLikeQueryHash(in.Keys.Query) {
+		add(ExceptionQueryHashOnLead, "query_hash is not an individually queryable lead attribute", "keep hash off the lead; aggregate/k-anonymous only", true)
 	}
 	if outboundLabeledInbound(in) {
 		add(ExceptionOutboundAsInbound, "outbound action labeled inbound without a receipt", "hold off inbound denominators", true)
@@ -111,7 +138,114 @@ func missingInboundAttribution(in ObservedFacts) bool {
 	if isNonLeadEvent(in.EventType) {
 		return false
 	}
-	return knownID(in.Keys.Source) == "" || knownID(in.Keys.Query) == "" || knownID(in.Keys.AssetID) == ""
+	return knownID(in.Keys.Source) == "" && organicSourceOf(in.Keys) == Unknown
+}
+
+func inboundLeadMissingAsset(in ObservedFacts) bool {
+	if normalizeFamily(in.Keys.RouteFamily) != FamilyInbound || in.NotALead {
+		return false
+	}
+	if isNonLeadEvent(in.EventType) {
+		return false
+	}
+	typ := strings.ToLower(strings.TrimSpace(in.EventType))
+	if typ != "" && typ != EventLeadReceived && typ != EventLeadValidated && typ != EventLeadRejected {
+		return false
+	}
+	return knownID(in.Keys.AssetID) == ""
+}
+
+func unknownAssetVersion(in ObservedFacts) bool {
+	if in.InvalidAssetVersion {
+		return true
+	}
+	v := strings.TrimSpace(in.Keys.AssetVersion)
+	if v == "" {
+		return false
+	}
+	return !validAssetVersion(v)
+}
+
+func contradictoryOrganicSource(in ObservedFacts, existing *Chain) bool {
+	if existing == nil {
+		return false
+	}
+	a := organicSourceOf(existing.Keys)
+	b := organicSourceOf(in.Keys)
+	if a == Unknown || b == Unknown {
+		return false
+	}
+	return a != b
+}
+
+func syntheticTreatedAsReal(in ObservedFacts) bool {
+	if in.SyntheticLabeledReal {
+		return true
+	}
+	kind := recordKindOf(in)
+	if in.Synthetic && (kind == RecordKindReal || strings.EqualFold(in.Label, LabelReal)) {
+		return true
+	}
+	if !in.Synthetic && kind == RecordKindSynthetic && strings.EqualFold(in.Label, LabelReal) {
+		return true
+	}
+	return false
+}
+
+func missingConsentForAction(in ObservedFacts) bool {
+	typ := strings.ToLower(strings.TrimSpace(in.EventType))
+	switch typ {
+	case EventActionApproved, EventActionExecuted, EventFirstHumanActionRecorded:
+	default:
+		return false
+	}
+	if normalizeFamily(in.Keys.RouteFamily) != FamilyInbound {
+		return false
+	}
+	if in.NotALead || in.Synthetic {
+		return false
+	}
+	return strings.TrimSpace(in.Keys.Consent) == "" && !in.ConsentValid
+}
+
+func pipelineWithoutEvidence(in ObservedFacts, existing *Chain) bool {
+	typ := strings.ToLower(strings.TrimSpace(in.EventType))
+	if typ != EventPipelineCreated && typ != EventPipelineUpdated && !in.PipelineOpen {
+		return false
+	}
+	if !in.PipelineOpen && typ != EventPipelineCreated && typ != EventPipelineUpdated {
+		return false
+	}
+	if in.NotALead {
+		return true
+	}
+	hasEvidence := strings.TrimSpace(in.Keys.EvidenceRef) != "" || in.HumanConfirmed
+	hasAction := knownID(in.Keys.ActionID) != "" || chainHasAction(existing)
+	hasLead := knownID(in.Keys.LeadID) != "" || knownID(in.Keys.ReceiptID) != ""
+	if existing != nil && (knownID(existing.LeadID) != "" || knownID(existing.Keys.LeadID) != "") {
+		hasLead = true
+	}
+	if typ == EventPipelineCreated || typ == EventPipelineUpdated {
+		return !hasEvidence && !hasAction
+	}
+	return in.PipelineOpen && !hasLead && !hasAction && !hasEvidence
+}
+
+func revenueWithoutFinancial(in ObservedFacts) bool {
+	typ := strings.ToLower(strings.TrimSpace(in.EventType))
+	claimed := in.RevenueEvidenced || in.RevenueCents > 0 || typ == EventRevenueEvidenced
+	if !claimed {
+		return false
+	}
+	hasDoc := strings.TrimSpace(in.Keys.RevenueDocumentID) != ""
+	financial := typ == EventRevenueEvidenced || hasFinancialType(typ)
+	if typ == EventRevenueEvidenced && (!hasDoc || in.RevenueCents <= 0) {
+		return true
+	}
+	if in.RevenueCents > 0 && !financial && !hasDoc {
+		return true
+	}
+	return false
 }
 
 func outboundLabeledInbound(in ObservedFacts) bool {

--- a/internal/app/confenge/intel/join.go
+++ b/internal/app/confenge/intel/join.go
@@ -347,8 +347,30 @@ func mergeIntoChain(existing Chain, in ObservedFacts, closeBlocked, held bool) (
 	fill(&merged.IntentClass, in.Keys.IntentClass)
 	fill(&merged.Keys.CTAID, in.Keys.CTAID)
 	fill(&merged.CTAID, in.Keys.CTAID)
+	fill(&merged.Keys.OrganicSource, in.Keys.OrganicSource)
+	fill(&merged.Keys.Medium, in.Keys.Medium)
+	fill(&merged.Keys.Campaign, in.Keys.Campaign)
+	fill(&merged.Keys.LandingPath, in.Keys.LandingPath)
+	fill(&merged.Keys.AssetVersion, in.Keys.AssetVersion)
+	fill(&merged.Keys.CTAVersion, in.Keys.CTAVersion)
+	fill(&merged.Keys.RecordKind, in.Keys.RecordKind)
+	fill(&merged.Keys.ConsentVersion, in.Keys.ConsentVersion)
+	fill(&merged.Keys.PageVersion, in.Keys.PageVersion)
+	fill(&merged.Keys.ContentVersion, in.Keys.ContentVersion)
+	fill(&merged.Keys.QueryClass, in.Keys.QueryClass)
+	fill(&merged.Keys.ReferrerClass, in.Keys.ReferrerClass)
 	if !held {
 		fill(&merged.Keys.RevenueDocumentID, in.Keys.RevenueDocumentID)
+	}
+	if merged.Keys.FirstTouchAt == nil && in.Keys.FirstTouchAt != nil {
+		merged.Keys.FirstTouchAt = in.Keys.FirstTouchAt
+		changed = true
+	}
+	if in.Keys.LastTouchAt != nil {
+		if merged.Keys.LastTouchAt == nil || in.Keys.LastTouchAt.After(*merged.Keys.LastTouchAt) {
+			merged.Keys.LastTouchAt = in.Keys.LastTouchAt
+			changed = true
+		}
 	}
 	if !conflictAccount(existing.Keys, in.Keys) {
 		fill(&merged.Keys.AccountID, in.Keys.AccountID)

--- a/internal/app/confenge/intel/observe.go
+++ b/internal/app/confenge/intel/observe.go
@@ -16,7 +16,8 @@ func ObserveFromInbound(lead models.OutreachInboundLead, acc *models.OutreachAcc
 		Keys: JoinKeys{
 			OrganizationID: lead.OrganizationID.String(),
 			Source:         strings.TrimSpace(lead.Source),
-			Query:          utmQuery(lead.UTMJSON),
+			Query:          utmQueryClass(lead.UTMJSON),
+			QueryClass:     utmQueryClass(lead.UTMJSON),
 			AssetID:        strings.TrimSpace(lead.AssetID),
 			CTAID:          strings.TrimSpace(lead.CTAID),
 			CorrelationID:  strings.TrimSpace(lead.CorrelationID),
@@ -26,6 +27,19 @@ func ObserveFromInbound(lead models.OutreachInboundLead, acc *models.OutreachAcc
 			PersonID:       strings.TrimSpace(lead.PersonID),
 			EventIDs:       append([]string{}, lead.Evidence...),
 			RouteFamily:    strings.TrimSpace(lead.RouteFamily),
+			LandingPath:    CanonicalLandingPath(lead.LandingURL),
+			OrganicSource:  ComposeOrganicSource(utmFieldAny(lead.UTMJSON, "organic_source"), lead.Source, utmFieldAny(lead.UTMJSON, "medium", "utm_medium")),
+			Medium:         utmFieldAny(lead.UTMJSON, "medium", "utm_medium"),
+			Campaign:       utmFieldAny(lead.UTMJSON, "campaign", "utm_campaign"),
+			AssetVersion:   utmFieldAny(lead.UTMJSON, "asset_version"),
+			CTAVersion:     utmFieldAny(lead.UTMJSON, "cta_version"),
+			ConsentVersion: utmFieldAny(lead.UTMJSON, "consent_version"),
+			PageVersion:    utmFieldAny(lead.UTMJSON, "page_version"),
+			ContentVersion: utmFieldAny(lead.UTMJSON, "content_version"),
+			ReferrerClass:  ClassifyReferrerClass(lead.Referrer, utmFieldAny(lead.UTMJSON, "referrer_class")),
+			IntentClass:    utmFieldAny(lead.UTMJSON, "intent_class"),
+			Consent:        inboundConsentRef(lead.ConsentJSON),
+			RecordKind:     NormalizeRecordKind(utmFieldAny(lead.UTMJSON, "record_kind"), false),
 		},
 		LeadCreatedAt:  lead.LeadCreatedAt,
 		IngestedAt:     lead.WarmblyIngestedAt,
@@ -39,6 +53,18 @@ func ObserveFromInbound(lead models.OutreachInboundLead, acc *models.OutreachAcc
 	if InboundCommercialSkipReason(lead) != "" {
 		in.Synthetic = true
 		in.Label = LabelSynthetic
+		in.RecordKind = RecordKindSynthetic
+		in.Keys.RecordKind = RecordKindSynthetic
+	} else if in.Keys.RecordKind == "" {
+		in.RecordKind = RecordKindReal
+		in.Keys.RecordKind = RecordKindReal
+	}
+	in.ConsentValid = strings.TrimSpace(in.Keys.Consent) != ""
+	if raw := utmFieldAny(lead.UTMJSON, "query", "search_query", "q", "utm_term", "term"); LooksLikeIndividualSearchQuery(raw) {
+		in.StrippedGSCQuery = true
+	}
+	if raw := utmFieldAny(lead.UTMJSON, "query_hash"); raw != "" || LooksLikeQueryHash(utmFieldAny(lead.UTMJSON, "query")) {
+		in.StrippedQueryHash = true
 	}
 	if acc != nil {
 		if in.Keys.AccountID == "" {
@@ -179,6 +205,10 @@ func ObserveFromAction(action models.OutreachCommercialAction, acc *models.Outre
 }
 
 func utmQuery(raw []byte) string {
+	return utmQueryClass(raw)
+}
+
+func utmQueryClass(raw []byte) string {
 	if len(raw) == 0 {
 		return ""
 	}
@@ -186,11 +216,56 @@ func utmQuery(raw []byte) string {
 	if err := json.Unmarshal(raw, &m); err != nil {
 		return ""
 	}
-	// Query is never backfilled from campaign or utm_source.
-	for _, key := range []string{"query", "search_query", "q", "utm_term", "term"} {
+	// Individual GSC/search terms never become a lead attribute.
+	for _, key := range []string{"query_class", "intent_class"} {
+		if v := strings.TrimSpace(asString(m[key])); IsAllowedQueryClass(v) {
+			return v
+		}
+	}
+	if v := strings.TrimSpace(asString(m["query"])); IsAllowedQueryClass(v) {
+		return v
+	}
+	return ""
+}
+
+func utmFieldAny(raw []byte, keys ...string) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		var sm map[string]string
+		if err2 := json.Unmarshal(raw, &sm); err2 != nil {
+			return ""
+		}
+		for _, key := range keys {
+			if v := strings.TrimSpace(sm[key]); v != "" {
+				return v
+			}
+		}
+		return ""
+	}
+	for _, key := range keys {
 		if v := strings.TrimSpace(asString(m[key])); v != "" {
 			return v
 		}
+	}
+	return ""
+}
+
+func inboundConsentRef(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var m map[string]any
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ""
+	}
+	if v := strings.TrimSpace(asString(m["source"])); v != "" {
+		return v
+	}
+	if granted, ok := m["granted"].(bool); ok && granted {
+		return "granted"
 	}
 	return ""
 }

--- a/internal/app/confenge/intel/observe.go
+++ b/internal/app/confenge/intel/observe.go
@@ -144,7 +144,8 @@ func ObserveFromInbound(lead models.OutreachInboundLead, acc *models.OutreachAcc
 		}
 	}
 	in.Qualified = in.OutcomeType == OutcomeQualifiedConversation
-	in.PipelineOpen = lead.Status == models.InboundStatusOpen
+	// Inbound OPEN is a work-queue state, not commercial pipeline.
+	in.PipelineOpen = false
 	return in
 }
 
@@ -200,7 +201,8 @@ func ObserveFromAction(action models.OutreachCommercialAction, acc *models.Outre
 		in.Keys.EventIDs = append([]string{}, acc.MomentEvidenceIDs...)
 	}
 	in.Qualified = in.OutcomeType == OutcomeQualifiedConversation
-	in.PipelineOpen = !isWonType(in.OutcomeType) && !isLostType(in.OutcomeType)
+	// An action is not pipeline. Only EventPipelineCreated / evidenced pipeline opens it.
+	in.PipelineOpen = false
 	return in
 }
 

--- a/internal/app/confenge/intel/observe_test.go
+++ b/internal/app/confenge/intel/observe_test.go
@@ -65,11 +65,13 @@ func TestUtmQueryNeverReadsCampaign(t *testing.T) {
 		raw  string
 		want string
 	}{
-		{"real query", `{"query":"segunda leitura contrato","campaign":"brand"}`, "segunda leitura contrato"},
-		{"search_query", `{"search_query":"leitura contrato"}`, "leitura contrato"},
-		{"q", `{"q":"obra norte"}`, "obra norte"},
-		{"utm_term", `{"utm_term":"segunda-leitura","utm_campaign":"brand-aug"}`, "segunda-leitura"},
-		{"term", `{"term":"contrato","campaign":"ignored"}`, "contrato"},
+		{"gsc phrase stripped", `{"query":"segunda leitura contrato","campaign":"brand"}`, ""},
+		{"search_query stripped", `{"search_query":"leitura contrato"}`, ""},
+		{"q stripped", `{"q":"obra norte"}`, ""},
+		{"utm_term stripped", `{"utm_term":"segunda-leitura","utm_campaign":"brand-aug"}`, ""},
+		{"term stripped", `{"term":"contrato","campaign":"ignored"}`, ""},
+		{"query_class kept", `{"query_class":"segunda-leitura-preco","utm_campaign":"brand"}`, "segunda-leitura-preco"},
+		{"slug query kept", `{"query":"segunda-leitura-preco"}`, "segunda-leitura-preco"},
 		{"campaign only", `{"utm_campaign":"brand-aug","campaign":"brand-aug","utm_source":"google"}`, ""},
 		{"empty", `{}`, ""},
 	}
@@ -87,5 +89,16 @@ func TestUtmQueryNeverReadsCampaign(t *testing.T) {
 	if facts.Keys.Query != "" {
 		t.Fatalf("campaign-only Observe query=%q want empty", facts.Keys.Query)
 	}
-	fmt.Printf("UTM_QUERY campaign_only=empty query_keys=query,search_query,q,utm_term,term\n")
+	gscLead := models.OutreachInboundLead{
+		LeadID: "webcfg-utm-gsc", ReceiptID: "rcpt-utm-gsc", Source: "CONFENGE_WEB",
+		UTMJSON: []byte(`{"query":"segunda leitura contrato","search_query":"obra norte"}`),
+	}
+	gscFacts := ObserveFromInbound(gscLead, nil, nil, nil)
+	if gscFacts.Keys.Query != "" {
+		t.Fatalf("GSC Observe query=%q", gscFacts.Keys.Query)
+	}
+	if !gscFacts.StrippedGSCQuery {
+		t.Fatal("Observe must flag stripped GSC query")
+	}
+	fmt.Printf("UTM_QUERY campaign_only=empty gsc_stripped=true query_class_keys=query_class,intent_class\n")
 }

--- a/internal/app/confenge/intel/observe_test.go
+++ b/internal/app/confenge/intel/observe_test.go
@@ -59,6 +59,18 @@ func TestObserveFromInboundMarksOfficialSyntheticPreflight(t *testing.T) {
 	fmt.Printf("OBSERVE_SYNTHETIC official_preflight=SYNTHETIC real_label=%s\n", real.Label)
 }
 
+func TestObserveFromInboundOpenStatusIsNotPipeline(t *testing.T) {
+	facts := ObserveFromInbound(models.OutreachInboundLead{
+		LeadID: "webcfg-open-1", ReceiptID: "rcpt-open-1", Source: "organic_search",
+		AssetID: "landing-segunda-leitura", Status: models.InboundStatusOpen,
+		RouteFamily: FamilyInbound,
+	}, nil, nil, nil)
+	if facts.PipelineOpen {
+		t.Fatal("inbound OPEN must not become commercial pipeline")
+	}
+	fmt.Printf("OBSERVE_OPEN_NOT_PIPELINE status=OPEN pipeline=%v\n", facts.PipelineOpen)
+}
+
 func TestUtmQueryNeverReadsCampaign(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/app/confenge/intel/organic.go
+++ b/internal/app/confenge/intel/organic.go
@@ -1,0 +1,288 @@
+package intel
+
+import (
+	"net/url"
+	"strings"
+	"unicode"
+)
+
+// OrganicSources is the closed taxonomy. Slices never mix.
+func OrganicSources() []string {
+	return []string{
+		SourceOrganicSearch, SourceDirect, SourceReferral,
+		SourceAIReferral, SourcePartner, SourceOutbound, Unknown,
+	}
+}
+
+// NormalizeOrganicSource maps a provided token onto the closed taxonomy.
+// unknown, producer identities, and unlabeled values stay UNKNOWN.
+// Bare "google" is not rewritten to organic_search. unknown is never
+// rewritten to direct or organic_search.
+func NormalizeOrganicSource(v string) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case SourceOrganicSearch, "organic", "seo", "google_organic", "bing_organic",
+		"organic-search", "organicsearch":
+		return SourceOrganicSearch
+	case SourceDirect:
+		return SourceDirect
+	case SourceReferral, "referrer":
+		return SourceReferral
+	case SourceAIReferral, "ai-referral", "aireferral", "chatgpt", "perplexity",
+		"claude", "gemini", "copilot":
+		return SourceAIReferral
+	case SourcePartner, "parceiro":
+		return SourcePartner
+	case SourceOutbound, "outbound-pilot":
+		return SourceOutbound
+	default:
+		return Unknown
+	}
+}
+
+// ComposeOrganicSource prefers an explicit organic token. Medium alone
+// never invents organic_search from an unlabeled source.
+func ComposeOrganicSource(explicit, source, medium string) string {
+	if s := NormalizeOrganicSource(explicit); s != Unknown {
+		return s
+	}
+	if s := NormalizeOrganicSource(source); s != Unknown {
+		return s
+	}
+	_ = medium
+	return Unknown
+}
+
+// NormalizeRecordKind is real or synthetic. Empty stays empty so callers
+// can derive from the synthetic flag without inventing REAL.
+func NormalizeRecordKind(v string, synthetic bool) string {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case RecordKindReal, LabelReal, "live":
+		if synthetic {
+			return RecordKindSynthetic
+		}
+		return RecordKindReal
+	case RecordKindSynthetic, LabelSynthetic, "test", "canary", "infrastructure_canary":
+		return RecordKindSynthetic
+	default:
+		if synthetic {
+			return RecordKindSynthetic
+		}
+		if strings.TrimSpace(v) == "" {
+			return ""
+		}
+		return Unknown
+	}
+}
+
+// LooksLikeIndividualSearchQuery is a raw GSC/search phrase, not a class.
+func LooksLikeIndividualSearchQuery(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return false
+	}
+	if strings.ContainsAny(v, " \t\n@") {
+		return true
+	}
+	if len(v) > 80 {
+		return true
+	}
+	return false
+}
+
+// LooksLikeQueryHash is a hex digest presented as an individual attribute.
+func LooksLikeQueryHash(v string) bool {
+	v = strings.TrimSpace(v)
+	if len(v) < 16 || len(v) > 128 {
+		return false
+	}
+	for _, r := range v {
+		if !unicode.Is(unicode.ASCII_Hex_Digit, r) {
+			return false
+		}
+	}
+	return true
+}
+
+// IsAllowedQueryClass is an aggregate class slug, never a raw phrase.
+func IsAllowedQueryClass(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" || LooksLikeIndividualSearchQuery(v) || LooksLikeQueryHash(v) {
+		return false
+	}
+	if strings.ContainsAny(v, "/?&#") {
+		return false
+	}
+	return len(v) <= 80
+}
+
+// CanonicalLandingPath keeps the path only. Query strings are dropped
+// because they can carry PII or individual search terms.
+func CanonicalLandingPath(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if strings.Contains(raw, "://") {
+		u, err := url.Parse(raw)
+		if err != nil {
+			return ""
+		}
+		path := u.EscapedPath()
+		if path == "" {
+			path = "/"
+		}
+		return path
+	}
+	if i := strings.IndexAny(raw, "?#"); i >= 0 {
+		raw = raw[:i]
+	}
+	if raw == "" {
+		return ""
+	}
+	if !strings.HasPrefix(raw, "/") {
+		raw = "/" + raw
+	}
+	return raw
+}
+
+// ClassifyReferrerClass never stores a sensitive URL. Host hints only.
+func ClassifyReferrerClass(raw, provided string) string {
+	if c := strings.ToLower(strings.TrimSpace(provided)); c != "" {
+		switch c {
+		case "search", "organic", "organic_search":
+			return "search"
+		case "ai", "ai_referral":
+			return "ai"
+		case "direct":
+			return "direct"
+		case "referral", "referrer":
+			return "referral"
+		case "partner":
+			return "partner"
+		case "outbound":
+			return "outbound"
+		case "unknown":
+			return Unknown
+		default:
+			if IsAllowedQueryClass(c) {
+				return c
+			}
+			return Unknown
+		}
+	}
+	low := strings.ToLower(strings.TrimSpace(raw))
+	if low == "" {
+		return ""
+	}
+	switch {
+	case strings.Contains(low, "google.") || strings.Contains(low, "bing.") ||
+		strings.Contains(low, "search."):
+		return "search"
+	case strings.Contains(low, "chatgpt") || strings.Contains(low, "perplexity") ||
+		strings.Contains(low, "claude") || strings.Contains(low, "gemini"):
+		return "ai"
+	default:
+		return "referral"
+	}
+}
+
+func validAssetVersion(v string) bool {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		return true
+	}
+	if strings.ContainsAny(v, " \t\n@/?#") || len(v) > 80 {
+		return false
+	}
+	return true
+}
+
+// SanitizeCommercialEvent applies the organic attribution contract.
+// Individual GSC queries and query hashes never stay on the envelope.
+func SanitizeCommercialEvent(ev CommercialEvent) CommercialEvent {
+	if LooksLikeIndividualSearchQuery(ev.Query) {
+		ev.GSCQuery = ev.Query
+		ev.Query = ""
+	}
+	if LooksLikeIndividualSearchQuery(ev.GSCQuery) {
+		ev.Query = ""
+	}
+	if h := strings.TrimSpace(ev.QueryHash); h != "" {
+		ev.QueryHash = h
+		if ev.Query == h || LooksLikeQueryHash(ev.Query) {
+			ev.Query = ""
+		}
+	}
+	if LooksLikeQueryHash(ev.Query) {
+		ev.QueryHash = ev.Query
+		ev.Query = ""
+	}
+	if ev.QueryClass == "" && IsAllowedQueryClass(ev.Query) {
+		ev.QueryClass = ev.Query
+	}
+	if !IsAllowedQueryClass(ev.Query) {
+		ev.Query = ""
+	}
+	if !IsAllowedQueryClass(ev.QueryClass) {
+		ev.QueryClass = ""
+	}
+	ev.OrganicSource = ComposeOrganicSource(ev.OrganicSource, ev.Source, ev.Medium)
+	ev.LandingPath = CanonicalLandingPath(firstNonEmpty(ev.LandingPath, ev.LandingURL))
+	if ev.ReferrerClass == "" {
+		ev.ReferrerClass = ClassifyReferrerClass(ev.Referrer, "")
+	} else {
+		ev.ReferrerClass = ClassifyReferrerClass("", ev.ReferrerClass)
+	}
+	if strings.ContainsAny(ev.Referrer, "?#@") || LooksLikeIndividualSearchQuery(ev.Referrer) {
+		ev.Referrer = ""
+	}
+	ev.RecordKind = NormalizeRecordKind(ev.RecordKind, ev.Synthetic)
+	if ev.Synthetic && ev.RecordKind == RecordKindReal {
+		ev.RecordKind = RecordKindSynthetic
+	}
+	if !validAssetVersion(ev.AssetVersion) {
+		ev.AssetVersion = ""
+	}
+	return ev
+}
+
+// ApplyOrganicKeys copies sanitized organic fields onto join keys.
+func ApplyOrganicKeys(k JoinKeys, ev CommercialEvent) JoinKeys {
+	k.OrganicSource = ev.OrganicSource
+	k.Medium = strings.TrimSpace(ev.Medium)
+	k.Campaign = strings.TrimSpace(ev.Campaign)
+	k.LandingPath = ev.LandingPath
+	k.AssetVersion = strings.TrimSpace(ev.AssetVersion)
+	k.CTAVersion = strings.TrimSpace(ev.CTAVersion)
+	k.RecordKind = ev.RecordKind
+	k.ConsentVersion = strings.TrimSpace(ev.ConsentVersion)
+	k.PageVersion = strings.TrimSpace(ev.PageVersion)
+	k.ContentVersion = strings.TrimSpace(ev.ContentVersion)
+	k.FirstTouchAt = ev.FirstTouchAt
+	k.LastTouchAt = ev.LastTouchAt
+	k.QueryClass = firstNonEmpty(ev.QueryClass, k.QueryClass)
+	k.ReferrerClass = firstNonEmpty(ev.ReferrerClass, k.ReferrerClass)
+	k.Query = ev.Query
+	k.Referrer = ev.Referrer
+	if k.OrganicSource == "" {
+		k.OrganicSource = ComposeOrganicSource("", k.Source, k.Medium)
+	}
+	return k
+}
+
+func organicSourceOf(k JoinKeys) string {
+	if s := NormalizeOrganicSource(k.OrganicSource); s != Unknown {
+		return s
+	}
+	return ComposeOrganicSource("", k.Source, k.Medium)
+}
+
+func recordKindOf(in ObservedFacts) string {
+	if k := NormalizeRecordKind(firstNonEmpty(in.RecordKind, in.Keys.RecordKind), in.Synthetic); k != "" && k != Unknown {
+		return k
+	}
+	if in.Synthetic || in.Label == LabelSynthetic {
+		return RecordKindSynthetic
+	}
+	return RecordKindReal
+}

--- a/internal/app/confenge/intel/organic_exceptions_test.go
+++ b/internal/app/confenge/intel/organic_exceptions_test.go
@@ -1,0 +1,171 @@
+package intel
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func organicLeadEvent(id, source, asset string) CommercialEvent {
+	return CommercialEvent{
+		EventID: "ev-" + id, Version: "1", Schema: EventSchemaV1,
+		Type: EventLeadReceived, OccurredAt: time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+		IngestedAt: time.Date(2026, 8, 10, 12, 1, 0, 0, time.UTC), Timezone: "UTC",
+		LeadID: id, ReceiptID: "rcpt-" + id, IdempotencyKey: "idem-" + id,
+		Source: source, OrganicSource: source, AssetID: asset,
+		RouteFamily: FamilyInbound, OrganizationID: "org-organic-ex",
+		Consent: "web-cfg-consent-ref", RecordKind: RecordKindReal,
+	}
+}
+
+func TestOrganicConflictsEnterExceptionQueue(t *testing.T) {
+	st := NewMemoryStore()
+	now := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+	noAsset := organicLeadEvent("lead-no-asset", SourceOrganicSearch, "")
+	res := IngestEvent(st, noAsset)
+	if !hasCode(res.Exceptions, ExceptionLeadWithoutAssetID) {
+		t.Fatalf("lead_without_asset_id missing: %v", codesOf(res.Exceptions))
+	}
+
+	badVer := organicLeadEvent("lead-bad-ver", SourceOrganicSearch, "asset-1")
+	badVer.AssetVersion = "not a version token"
+	res = IngestEvent(st, badVer)
+	if !hasCode(res.Exceptions, ExceptionUnknownAssetVersion) {
+		t.Fatalf("unknown_asset_version missing: %v", codesOf(res.Exceptions))
+	}
+
+	first := organicLeadEvent("lead-conflict", SourceOrganicSearch, "asset-2")
+	IngestEvent(st, first)
+	second := first
+	second.EventID = "ev-lead-conflict-2"
+	second.IdempotencyKey = "idem-lead-conflict-2"
+	second.OrganicSource = SourceOutbound
+	second.Source = SourceOutbound
+	res = IngestEvent(st, second)
+	if !hasCode(res.Exceptions, ExceptionContradictorySource) {
+		t.Fatalf("contradictory_source missing: %v", codesOf(res.Exceptions))
+	}
+
+	synReal := organicLeadEvent("lead-syn-real", SourceOrganicSearch, "asset-3")
+	synReal.Synthetic = true
+	synReal.RecordKind = RecordKindReal
+	res = IngestEvent(st, synReal)
+	if !hasCode(res.Exceptions, ExceptionSyntheticTreatedAsReal) {
+		t.Fatalf("synthetic_treated_as_real missing: %v", codesOf(res.Exceptions))
+	}
+
+	act := organicLeadEvent("lead-nocon", SourceOrganicSearch, "asset-4")
+	act.Type = EventActionApproved
+	act.ActionID = "act-nocon"
+	act.Consent = ""
+	res = IngestEvent(st, act)
+	if !hasCode(res.Exceptions, ExceptionMissingConsent) {
+		t.Fatalf("missing_consent missing: %v", codesOf(res.Exceptions))
+	}
+
+	pipe := organicLeadEvent("lead-pipe", SourceOrganicSearch, "asset-5")
+	pipe.Type = EventPipelineCreated
+	// no action, no evidence
+	pipe.ActionID = ""
+	pipe.EvidenceRef = ""
+	res = IngestEvent(st, pipe)
+	if !hasCode(res.Exceptions, ExceptionPipelineWithoutEvidence) {
+		t.Fatalf("pipeline_without_evidence missing: %v", codesOf(res.Exceptions))
+	}
+
+	rev := organicLeadEvent("lead-rev", SourceOrganicSearch, "asset-6")
+	rev.Type = EventRevenueEvidenced
+	rev.RevenueCents = 180000
+	rev.RevenueDocumentID = ""
+	res = IngestEvent(st, rev)
+	if !hasCode(res.Exceptions, ExceptionRevenueWithoutFinancial) {
+		t.Fatalf("revenue_without_financial_event missing: %v", codesOf(res.Exceptions))
+	}
+
+	gsc := organicLeadEvent("lead-gsc", SourceOrganicSearch, "asset-7")
+	gsc.Query = "como reler contrato publico"
+	res = IngestEvent(st, gsc)
+	if !hasCode(res.Exceptions, ExceptionGSCQueryOnLead) {
+		t.Fatalf("gsc_query_on_lead missing: %v", codesOf(res.Exceptions))
+	}
+
+	leadFirst := organicLeadEvent("lead-oo", SourceOrganicSearch, "asset-8")
+	leadFirst.OccurredAt = now
+	IngestEvent(st, leadFirst)
+	oo := organicLeadEvent("lead-oo", SourceOrganicSearch, "asset-8")
+	oo.EventID = "ev-lead-oo-won"
+	oo.IdempotencyKey = "idem-lead-oo-won"
+	oo.Type = EventWon
+	oo.ActionID = "act-oo"
+	oo.OutcomeID = "out-oo"
+	oo.OccurredAt = now.Add(-48 * time.Hour)
+	oo.HumanConfirmed = true
+	res = IngestEvent(st, oo)
+	if !hasCode(res.Exceptions, ExceptionOutOfOrder) && !hasCode(res.Exceptions, ExceptionNegativeLatency) {
+		t.Fatalf("out_of_order/negative_latency missing: %v", codesOf(res.Exceptions))
+	}
+
+	dup := IngestEvent(st, first)
+	if !dup.Replay {
+		t.Fatal("duplicate replay not idempotent")
+	}
+
+	stored, _ := st.ListExceptions("org-organic-ex")
+	need := []string{
+		ExceptionLeadWithoutAssetID, ExceptionUnknownAssetVersion, ExceptionContradictorySource,
+		ExceptionSyntheticTreatedAsReal, ExceptionMissingConsent, ExceptionPipelineWithoutEvidence,
+		ExceptionRevenueWithoutFinancial, ExceptionGSCQueryOnLead,
+	}
+	seen := map[string]Exception{}
+	for _, ex := range stored {
+		seen[ex.Code] = ex
+		if ex.Owner == "" || ex.Severity == "" || ex.Status == "" || ex.NextAction == "" {
+			t.Fatalf("exception %s missing operator fields: %+v", ex.Code, ex)
+		}
+		if ex.RetryState == "" {
+			t.Fatalf("exception %s missing retry_state", ex.Code)
+		}
+	}
+	for _, code := range need {
+		ex, ok := seen[code]
+		if !ok {
+			t.Fatalf("queue missing %s (have %d)", code, len(seen))
+		}
+		if ex.Owner != ExceptionOwner(code) {
+			t.Fatalf("%s owner=%s want %s", code, ex.Owner, ExceptionOwner(code))
+		}
+	}
+	fmt.Printf("ORGANIC_EXCEPTIONS queued=%d codes=%d\n", len(stored), len(need))
+}
+
+func TestOrganicReplayDoesNotOpenSecondChain(t *testing.T) {
+	st := NewMemoryStore()
+	ev := organicLeadEvent("lead-replay", SourceAIReferral, "asset-ai-1")
+	ev.LandingPath = "/respostas/x"
+	first := IngestEvent(st, ev)
+	if !first.Created {
+		t.Fatal("first should create")
+	}
+	outOfOrder := ev
+	outOfOrder.EventID = "ev-lead-replay-late"
+	outOfOrder.IdempotencyKey = "idem-lead-replay-late"
+	outOfOrder.Type = EventReply
+	outOfOrder.OccurredAt = ev.OccurredAt.Add(-time.Hour)
+	IngestEvent(st, outOfOrder)
+	again := IngestEvent(st, ev)
+	if again.Created {
+		t.Fatal("replay created a second chain")
+	}
+	chains, _ := st.ListChains("org-organic-ex")
+	n := 0
+	for _, c := range chains {
+		if c.Identity == first.Chain.Identity {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Fatalf("identity copies=%d", n)
+	}
+	fmt.Printf("ORGANIC_REPLAY identity=%s chains=%d replay=%v\n", first.Chain.Identity, len(chains), again.Replay)
+}

--- a/internal/app/confenge/intel/organic_feedback.go
+++ b/internal/app/confenge/intel/organic_feedback.go
@@ -1,0 +1,240 @@
+package intel
+
+import (
+	"encoding/json"
+	"fmt"
+	"sort"
+	"time"
+)
+
+const organicFeedbackMinN = 5
+
+// OrganicFeedbackRow is one asset/cohort editorial recommendation.
+// Warmbly never writes web-cfg, extra-cli, or SmartLic.
+type OrganicFeedbackRow struct {
+	AssetID          string   `json:"asset_id"`
+	AssetFamily      string   `json:"asset_family"`
+	LandingPath      string   `json:"landing_path"`
+	OrganicSource    string   `json:"organic_source"`
+	IntentClass      string   `json:"intent_class,omitempty"`
+	QueryClass       string   `json:"query_class,omitempty"`
+	Window           string   `json:"window"`
+	Verdict          string   `json:"verdict"`
+	ReasonCodes      []string `json:"reason_codes"`
+	Confidence       string   `json:"confidence"`
+	Uncertainty      string   `json:"uncertainty"`
+	NextTest         string   `json:"next_test"`
+	DenominatorLeads int      `json:"denominator_leads"`
+	Qualified        int      `json:"qualified"`
+	Acknowledged     int      `json:"acknowledged"`
+	Conversations    int      `json:"conversations"`
+	Meetings         int      `json:"meetings"`
+	Proposals        int      `json:"proposals"`
+	Pipeline         int      `json:"pipeline"`
+	Won              int      `json:"won"`
+	Lost             int      `json:"lost"`
+	Unknown          int      `json:"unknown"`
+	OpenCensored     int      `json:"open_censored"`
+	ContractedCents  int64    `json:"contracted_revenue_cents"`
+	ReceivedCents    int64    `json:"received_revenue_cents"`
+	Freshness        string   `json:"freshness"`
+	DiscoveryStatus  string   `json:"discovery_status"`
+	CausalProof      bool     `json:"causal_proof"`
+	UpstreamWrites   []string `json:"upstream_writes"`
+}
+
+// OrganicFeedbackExport is the versioned read-only artifact.
+type OrganicFeedbackExport struct {
+	SchemaVersion    string               `json:"schema_version"`
+	GeneratedAt      string               `json:"generated_at"`
+	IncludeSynthetic bool                 `json:"include_synthetic"`
+	CausalProof      bool                 `json:"causal_proof"`
+	UpstreamWrites   []string             `json:"upstream_writes"`
+	RealEmpty        bool                 `json:"real_empty"`
+	Rows             []OrganicFeedbackRow `json:"rows"`
+	Recommendation   string               `json:"recommendation"`
+}
+
+// ExportOrganicFeedback projects REPEAT|CHANGE|STOP|NEED_MORE_DATA per
+// asset/cohort. It does not write upstream.
+func ExportOrganicFeedback(store Store, orgID string, now time.Time, includeSynthetic bool) OrganicFeedbackExport {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	out := OrganicFeedbackExport{
+		SchemaVersion:    OrganicFeedbackSchemaV1,
+		GeneratedAt:      now.UTC().Format(time.RFC3339),
+		IncludeSynthetic: includeSynthetic,
+		CausalProof:      false,
+		UpstreamWrites:   []string{},
+		Rows:             []OrganicFeedbackRow{},
+		Recommendation:   "NEEDS_WEB_CFG_EVENT",
+	}
+	if store == nil {
+		out.RealEmpty = true
+		return out
+	}
+	chains, _ := store.ListChains(orgID)
+	board := ProjectOrganicScoreboard(OrganicScoreboardSources{
+		Now: now, IncludeSynthetic: includeSynthetic, Chains: chains,
+	})
+	out.RealEmpty = board.RealEmpty
+	var w90 *OrganicWindow
+	for i := range board.Windows {
+		if board.Windows[i].ID == Window90d {
+			w90 = &board.Windows[i]
+			break
+		}
+	}
+	if w90 == nil && len(board.Windows) > 0 {
+		w90 = &board.Windows[len(board.Windows)-1]
+	}
+	if w90 != nil {
+		for _, sl := range w90.Slices {
+			out.Rows = append(out.Rows, feedbackFromSlice(sl, w90.ID, now))
+		}
+	}
+	if len(out.Rows) == 0 {
+		out.Rows = append(out.Rows, OrganicFeedbackRow{
+			AssetID:         Unknown,
+			AssetFamily:     Unknown,
+			LandingPath:     Unknown,
+			OrganicSource:   Unknown,
+			Window:          Window90d,
+			Verdict:         LearningNeedMore,
+			ReasonCodes:     []string{"no_observed_cohort"},
+			Confidence:      "low",
+			Uncertainty:     "no real consented organic events in the window",
+			NextTest:        "wait for a web-cfg attributed lead with organic_source and asset_id",
+			Freshness:       "empty",
+			DiscoveryStatus: TruthBlocked,
+			CausalProof:     false,
+			UpstreamWrites:  []string{},
+		})
+	}
+	sort.Slice(out.Rows, func(i, j int) bool {
+		if out.Rows[i].AssetID == out.Rows[j].AssetID {
+			if out.Rows[i].OrganicSource == out.Rows[j].OrganicSource {
+				return out.Rows[i].LandingPath < out.Rows[j].LandingPath
+			}
+			return out.Rows[i].OrganicSource < out.Rows[j].OrganicSource
+		}
+		return out.Rows[i].AssetID < out.Rows[j].AssetID
+	})
+	out.Recommendation = board.Recommendation
+	return out
+}
+
+func feedbackFromSlice(sl OrganicSlice, window string, now time.Time) OrganicFeedbackRow {
+	_ = now
+	leads := layerCount(sl, LayerLeadValid)
+	qualified := layerCount(sl, LayerQualifiedLead)
+	acked := layerCount(sl, LayerAcknowledged)
+	conv := layerCount(sl, LayerConversation)
+	meet := layerCount(sl, LayerMeeting)
+	prop := layerCount(sl, LayerProposal)
+	pipe := layerCount(sl, LayerQualifiedPipeline)
+	disc := layerByID(sl.Layers, LayerEligible)
+	discStatus := TruthBlocked
+	if disc != nil {
+		discStatus = disc.Status
+	}
+	row := OrganicFeedbackRow{
+		AssetID:          sl.AssetID,
+		AssetFamily:      sl.AssetFamily,
+		LandingPath:      sl.LandingPath,
+		OrganicSource:    sl.OrganicSource,
+		IntentClass:      sl.IntentClass,
+		Window:           window,
+		DenominatorLeads: leads,
+		Qualified:        qualified,
+		Acknowledged:     acked,
+		Conversations:    conv,
+		Meetings:         meet,
+		Proposals:        prop,
+		Pipeline:         pipe,
+		Won:              sl.Won,
+		Lost:             sl.Lost,
+		Unknown:          sl.Unknown,
+		OpenCensored:     sl.OpenCensored,
+		ContractedCents:  sl.ContractedCents,
+		ReceivedCents:    sl.ReceivedCents,
+		Freshness:        firstNonEmpty(sl.DiscoveryFreshness, "month_window="+window),
+		DiscoveryStatus:  discStatus,
+		CausalProof:      false,
+		UpstreamWrites:   []string{},
+	}
+	row.Verdict, row.ReasonCodes, row.Confidence, row.Uncertainty, row.NextTest = decideOrganicVerdict(row, discStatus)
+	return row
+}
+
+func decideOrganicVerdict(row OrganicFeedbackRow, discStatus string) (verdict string, reasons []string, confidence, uncertainty, next string) {
+	if row.DenominatorLeads < organicFeedbackMinN {
+		reasons = []string{"insufficient_n", "NEED_MORE_DATA"}
+		if discStatus == TruthBlocked {
+			reasons = append(reasons, "discovery_blocked")
+		}
+		return LearningNeedMore, reasons, "low",
+			fmt.Sprintf("n below %d or discovery aggregates missing", organicFeedbackMinN),
+			"collect more complete-window leads before changing the asset"
+	}
+	if row.ReceivedCents > 0 && row.Won > 0 {
+		return LearningRepeat, []string{"received_revenue", "confirmed_won"}, "medium",
+			"observed association only; causal_proof stays false",
+			"repeat the asset family and keep source slices unmixed"
+	}
+	if row.Won > 0 && row.Lost == 0 && row.Pipeline > 0 {
+		return LearningRepeat, []string{"confirmed_won", "qualified_pipeline"}, "low",
+			"no received revenue yet; do not claim SEO sold",
+			"keep the asset; wait for a reconciled financial event"
+	}
+	if row.Lost > 0 && row.Won == 0 && row.Conversations == 0 {
+		return LearningStop, []string{"confirmed_lost", "no_conversation"}, "medium",
+			"lost without a conversation; do not infer a better query",
+			"stop promoting this asset until a human reviews the offer"
+	}
+	if row.Lost > 0 && row.Won == 0 && row.Conversations > 0 {
+		return LearningChange, []string{"confirmed_lost", "conversation_no_close"}, "low",
+			"conversation happened; close is UNKNOWN or lost",
+			"change CTA or offer framing; do not rewrite the query class"
+	}
+	if row.Unknown == row.DenominatorLeads || row.Won+row.Lost == 0 {
+		return LearningNeedMore, []string{"unknown_outcome", "NEED_MORE_DATA"}, "low",
+			"outcomes still UNKNOWN or open/censored",
+			"record a human outcome before expanding or killing the asset"
+	}
+	if row.Acknowledged == 0 {
+		return LearningChange, []string{"no_first_action"}, "low",
+			"leads exist without first human action",
+			"change speed-to-lead handling; do not auto-send"
+	}
+	return LearningNeedMore, []string{"NEED_MORE_DATA"}, "low",
+		"not enough observed closes to recommend REPEAT/CHANGE/STOP",
+		"keep observing; do not auto-change content or indexation"
+}
+
+func layerCount(sl OrganicSlice, id string) int {
+	if ly := layerByID(sl.Layers, id); ly != nil {
+		return ly.Count
+	}
+	return 0
+}
+
+func layerByID(layers []OrganicLayer, id string) *OrganicLayer {
+	for i := range layers {
+		if layers[i].ID == id {
+			return &layers[i]
+		}
+	}
+	return nil
+}
+
+// OrganicFeedbackJSON encodes the export.
+func OrganicFeedbackJSON(rep OrganicFeedbackExport) ([]byte, error) {
+	return json.MarshalIndent(rep, "", "  ")
+}
+
+// OrganicScoreboardJSON encodes the scoreboard.
+func OrganicScoreboardJSON(board OrganicScoreboard) ([]byte, error) {
+	return json.MarshalIndent(board, "", "  ")
+}

--- a/internal/app/confenge/intel/organic_feedback_test.go
+++ b/internal/app/confenge/intel/organic_feedback_test.go
@@ -1,0 +1,136 @@
+package intel
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestExportOrganicFeedbackSchemaAndVerdicts(t *testing.T) {
+	now := time.Date(2026, 8, 19, 15, 0, 0, 0, time.UTC)
+	st := NewMemoryStore()
+	for i := 0; i < 6; i++ {
+		id := fmt.Sprintf("lead-fb-%d", i)
+		at := now.AddDate(0, 0, -8)
+		IngestEvent(st, CommercialEvent{
+			EventID: "ev-" + id, Version: "1", Schema: EventSchemaV1,
+			Type: EventLeadReceived, OccurredAt: at, OrganizationID: "org-fb",
+			LeadID: id, ReceiptID: "rcpt-" + id, Source: SourceOrganicSearch,
+			OrganicSource: SourceOrganicSearch, AssetID: "asset-fb",
+			AssetFamily: AssetFamilyContractAnalysis, LandingPath: "/guias/x",
+			RouteFamily: FamilyInbound, Consent: "c1", Qualified: true,
+		})
+		act := at.Add(time.Hour)
+		IngestEvent(st, CommercialEvent{
+			EventID: "ev-act-" + id, Version: "1", Schema: EventSchemaV1,
+			Type: EventActionExecuted, OccurredAt: act, OrganizationID: "org-fb",
+			LeadID: id, ActionID: "act-" + id, Source: SourceOrganicSearch,
+			OrganicSource: SourceOrganicSearch, AssetID: "asset-fb",
+			RouteFamily: FamilyInbound, Consent: "c1",
+		})
+		if i < 2 {
+			IngestEvent(st, CommercialEvent{
+				EventID: "ev-won-" + id, Version: "1", Schema: EventSchemaV1,
+				Type: EventWon, OccurredAt: act.Add(24 * time.Hour), OrganizationID: "org-fb",
+				LeadID: id, ActionID: "act-" + id, Source: SourceOrganicSearch,
+				OrganicSource: SourceOrganicSearch, AssetID: "asset-fb",
+				RouteFamily: FamilyInbound, HumanConfirmed: true, Consent: "c1",
+				RevenueDocumentID: "nf-1", RevenueCents: 1000,
+			})
+		}
+	}
+	chains, _ := st.ListChains("org-fb")
+	for i := range chains {
+		if isWonType(chains[i].OutcomeType) {
+			chains[i].RevenueEvidenced = true
+			chains[i].RevenueCents = 1000
+			chains[i].Commercial.Payment.ReceivedCents = 1000
+			_ = st.UpdateChain(chains[i])
+		}
+	}
+
+	exp := ExportOrganicFeedback(st, "org-fb", now, false)
+	if exp.SchemaVersion != OrganicFeedbackSchemaV1 {
+		t.Fatalf("schema=%s", exp.SchemaVersion)
+	}
+	if exp.CausalProof || len(exp.UpstreamWrites) != 0 {
+		t.Fatalf("causal or upstream: %+v", exp)
+	}
+	if len(exp.Rows) == 0 {
+		t.Fatal("no rows")
+	}
+	found := false
+	for _, row := range exp.Rows {
+		if row.CausalProof || len(row.UpstreamWrites) != 0 {
+			t.Fatalf("row wrote upstream: %+v", row)
+		}
+		switch row.Verdict {
+		case LearningRepeat, LearningChange, LearningStop, LearningNeedMore:
+		default:
+			t.Fatalf("verdict=%s", row.Verdict)
+		}
+		if row.AssetID == "asset-fb" && row.OrganicSource == SourceOrganicSearch {
+			found = true
+			if row.DenominatorLeads < 5 {
+				t.Fatalf("denominator=%d", row.DenominatorLeads)
+			}
+			if row.Verdict == "" || row.Confidence == "" || row.Uncertainty == "" || row.NextTest == "" {
+				t.Fatalf("incomplete row: %+v", row)
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("asset-fb row missing: %+v", exp.Rows)
+	}
+
+	empty := ExportOrganicFeedback(NewMemoryStore(), "org-none", now, false)
+	if empty.Rows[0].Verdict != LearningNeedMore {
+		t.Fatalf("empty verdict=%s", empty.Rows[0].Verdict)
+	}
+
+	raw, err := OrganicFeedbackJSON(exp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ReportHasPII(raw) {
+		t.Fatal("feedback PII")
+	}
+	if strings.Contains(strings.ToLower(string(raw)), "query_hash") {
+		t.Fatal("query_hash leaked into feedback")
+	}
+	fmt.Printf("ORGANIC_FEEDBACK schema=%s rows=%d verdict=%s causal_proof=%v upstream=%d\n",
+		exp.SchemaVersion, len(exp.Rows), exp.Rows[0].Verdict, exp.CausalProof, len(exp.UpstreamWrites))
+}
+
+func TestMigration106CHECKContainsOrganicExceptionCodes(t *testing.T) {
+	up := filepath.Join("..", "..", "..", "infrastructure", "db", "migrations", "000106_outreach_intel_organic_learning.up.sql")
+	down := filepath.Join("..", "..", "..", "infrastructure", "db", "migrations", "000106_outreach_intel_organic_learning.down.sql")
+	upRaw, err := os.ReadFile(up)
+	if err != nil {
+		t.Fatal(err)
+	}
+	downRaw, err := os.ReadFile(down)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, code := range []string{
+		ExceptionLeadWithoutAssetID, ExceptionUnknownAssetVersion, ExceptionContradictorySource,
+		ExceptionSyntheticTreatedAsReal, ExceptionMissingConsent, ExceptionPipelineWithoutEvidence,
+		ExceptionRevenueWithoutFinancial, ExceptionGSCQueryOnLead, ExceptionQueryHashOnLead,
+		"alert_store_failed",
+	} {
+		if !strings.Contains(string(upRaw), "'"+code+"'") {
+			t.Fatalf("000106 up missing %s", code)
+		}
+	}
+	if strings.Contains(string(downRaw), "'"+ExceptionGSCQueryOnLead+"'") {
+		t.Fatal("000106 down must restore 000105 CHECK without organic codes")
+	}
+	if !strings.Contains(string(downRaw), "'alert_store_failed'") {
+		t.Fatal("000106 down must keep alert_store_failed")
+	}
+	fmt.Printf("MIGRATION_106 up=%d down=%d organic_codes=9\n", len(upRaw), len(downRaw))
+}

--- a/internal/app/confenge/intel/organic_scoreboard.go
+++ b/internal/app/confenge/intel/organic_scoreboard.go
@@ -1,0 +1,578 @@
+package intel
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+)
+
+const organicLatencyMinN = 5
+
+// OrganicDiscoveryAggregate is a web-cfg GSC/site snapshot. It is never
+// inferred from lead volume.
+type OrganicDiscoveryAggregate struct {
+	OrganicSource string    `json:"organic_source,omitempty"`
+	AssetFamily   string    `json:"asset_family,omitempty"`
+	AssetID       string    `json:"asset_id,omitempty"`
+	LandingPath   string    `json:"landing_path,omitempty"`
+	IntentClass   string    `json:"intent_class,omitempty"`
+	QueryClass    string    `json:"query_class,omitempty"`
+	Window        string    `json:"window,omitempty"`
+	Eligible      int       `json:"eligible,omitempty"`
+	Appeared      int       `json:"appeared,omitempty"`
+	Clicked       int       `json:"clicked,omitempty"`
+	Engaged       int       `json:"engaged,omitempty"`
+	Freshness     string    `json:"freshness,omitempty"`
+	At            time.Time `json:"at,omitempty"`
+	Synthetic     bool      `json:"synthetic,omitempty"`
+}
+
+// OrganicLatency is median/p75/p90 only when n allows. Missing is UNKNOWN.
+type OrganicLatency struct {
+	N      int    `json:"n"`
+	Median string `json:"median"`
+	P75    string `json:"p75"`
+	P90    string `json:"p90"`
+}
+
+// OrganicLayer is one of the ten honest layers. Discovery stays BLOCKED
+// without a web-cfg aggregate.
+type OrganicLayer struct {
+	ID          string `json:"id"`
+	Status      string `json:"status"`
+	Count       int    `json:"count"`
+	Denominator int    `json:"denominator"`
+	Conversion  string `json:"conversion,omitempty"`
+	Unknown     int    `json:"unknown"`
+	Observation string `json:"observation"`
+}
+
+// OrganicSlice is one source/asset/landing cohort cell.
+type OrganicSlice struct {
+	Key                string         `json:"key"`
+	OrganicSource      string         `json:"organic_source"`
+	AssetFamily        string         `json:"asset_family"`
+	AssetID            string         `json:"asset_id"`
+	LandingPath        string         `json:"landing_path"`
+	IntentClass        string         `json:"intent_class,omitempty"`
+	Attribution        string         `json:"attribution"`
+	Layers             []OrganicLayer `json:"layers"`
+	Won                int            `json:"won"`
+	Lost               int            `json:"lost"`
+	Unknown            int            `json:"unknown"`
+	ContractedCents    int64          `json:"contracted_revenue_cents"`
+	ReceivedCents      int64          `json:"received_revenue_cents"`
+	ROAS               string         `json:"organic_roas"`
+	CAC                string         `json:"organic_cac"`
+	LeadToAction       OrganicLatency `json:"lead_to_first_action"`
+	OpenCensored       int            `json:"open_censored"`
+	DiscoveryFreshness string         `json:"discovery_freshness"`
+}
+
+// OrganicWindow is one complete or open window.
+type OrganicWindow struct {
+	ID       string         `json:"id"`
+	Complete bool           `json:"complete"`
+	Censored bool           `json:"censored"`
+	From     string         `json:"from"`
+	To       string         `json:"to"`
+	Slices   []OrganicSlice `json:"slices"`
+	BySource []OrganicSlice `json:"by_source"`
+}
+
+// OrganicScoreboard is the PII-free organic cohort placar.
+type OrganicScoreboard struct {
+	SchemaVersion    string          `json:"schema_version"`
+	GeneratedAt      string          `json:"generated_at"`
+	IncludeSynthetic bool            `json:"include_synthetic"`
+	CausalProof      bool            `json:"causal_proof"`
+	RealEmpty        bool            `json:"real_empty"`
+	Windows          []OrganicWindow `json:"windows"`
+	Sources          []string        `json:"sources"`
+	Recommendation   string          `json:"recommendation"`
+}
+
+// OrganicScoreboardSources is the existing-plane input.
+type OrganicScoreboardSources struct {
+	Now              time.Time
+	IncludeSynthetic bool
+	Chains           []Chain
+	Discovery        []OrganicDiscoveryAggregate
+}
+
+// ProjectOrganicScoreboard keeps discovery, lead, pipeline, and revenue
+// on separate layers. GSC numbers are never inferred from leads.
+func ProjectOrganicScoreboard(src OrganicScoreboardSources) OrganicScoreboard {
+	now := src.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	board := OrganicScoreboard{
+		SchemaVersion:    OrganicScoreboardSchemaV1,
+		GeneratedAt:      now.UTC().Format(time.RFC3339),
+		IncludeSynthetic: src.IncludeSynthetic,
+		CausalProof:      false,
+		Sources:          OrganicSources(),
+		Recommendation:   "NEEDS_WEB_CFG_EVENT",
+	}
+	chains := filterOrganicChains(src.Chains, src.IncludeSynthetic)
+	realN := 0
+	for _, c := range chains {
+		if !c.Synthetic && c.Label != LabelSynthetic {
+			realN++
+		}
+	}
+	board.RealEmpty = realN == 0
+	specs := organicWindowSpecs(now)
+	for _, spec := range specs {
+		board.Windows = append(board.Windows, projectOrganicWindow(spec, chains, src.Discovery, src.IncludeSynthetic))
+	}
+	if hasDiscovery(src.Discovery, src.IncludeSynthetic) && !board.RealEmpty {
+		board.Recommendation = "NEEDS_REAL_EVENT"
+	}
+	if hasDiscovery(src.Discovery, src.IncludeSynthetic) && realN > 0 {
+		board.Recommendation = "READY_FOR_INTEGRATION"
+	}
+	if board.RealEmpty && !hasDiscovery(src.Discovery, src.IncludeSynthetic) {
+		board.Recommendation = "NEEDS_WEB_CFG_EVENT"
+	}
+	return board
+}
+
+type organicWindowSpec struct {
+	id       string
+	from, to time.Time
+	complete bool
+	censored bool
+}
+
+func organicWindowSpecs(now time.Time) []organicWindowSpec {
+	now = now.UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+	w7to := today
+	w7from := today.AddDate(0, 0, -7)
+	w28from := today.AddDate(0, 0, -28)
+	w90from := today.AddDate(0, 0, -90)
+	return []organicWindowSpec{
+		{id: Window7dComplete, from: w7from, to: w7to, complete: true},
+		{id: Window28dComplete, from: w28from, to: w7to, complete: true},
+		{id: Window90d, from: w90from, to: now, complete: false},
+		{id: WindowOpen, from: w90from, to: now, complete: false, censored: true},
+	}
+}
+
+func filterOrganicChains(in []Chain, includeSynthetic bool) []Chain {
+	var out []Chain
+	for _, c := range in {
+		if !includeSynthetic && (c.Synthetic || c.Label == LabelSynthetic) {
+			continue
+		}
+		if c.NotALead && c.EventType == EventSearchObservation {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+func hasDiscovery(rows []OrganicDiscoveryAggregate, includeSynthetic bool) bool {
+	for _, r := range rows {
+		if !includeSynthetic && r.Synthetic {
+			continue
+		}
+		if r.Eligible+r.Appeared+r.Clicked+r.Engaged > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func projectOrganicWindow(spec organicWindowSpec, chains []Chain, discovery []OrganicDiscoveryAggregate, includeSynthetic bool) OrganicWindow {
+	w := OrganicWindow{
+		ID:       spec.id,
+		Complete: spec.complete,
+		Censored: spec.censored,
+		From:     spec.from.UTC().Format(time.RFC3339),
+		To:       spec.to.UTC().Format(time.RFC3339),
+	}
+	var inWindow []Chain
+	for _, c := range chains {
+		if !chainInWindow(c, spec) {
+			continue
+		}
+		if spec.censored && organicTerminal(c) {
+			continue
+		}
+		inWindow = append(inWindow, c)
+	}
+	groups := map[string][]Chain{}
+	sourceGroups := map[string][]Chain{}
+	for _, c := range inWindow {
+		key := organicSliceKey(c)
+		groups[key] = append(groups[key], c)
+		src := organicSourceOf(c.Keys)
+		sourceGroups[src] = append(sourceGroups[src], c)
+	}
+	for _, key := range sortedKeys(groups) {
+		w.Slices = append(w.Slices, projectOrganicSlice(key, groups[key], discovery, spec, includeSynthetic))
+	}
+	for _, src := range OrganicSources() {
+		cs := sourceGroups[src]
+		if len(cs) == 0 && src != Unknown {
+			// still emit an empty UNKNOWN-free source so slices never mix
+			w.BySource = append(w.BySource, emptySourceSlice(src, spec, discovery, includeSynthetic))
+			continue
+		}
+		if len(cs) == 0 {
+			w.BySource = append(w.BySource, emptySourceSlice(src, spec, discovery, includeSynthetic))
+			continue
+		}
+		sl := projectOrganicSlice("source:"+src, cs, discovery, spec, includeSynthetic)
+		sl.OrganicSource = src
+		w.BySource = append(w.BySource, sl)
+	}
+	return w
+}
+
+func chainInWindow(c Chain, spec organicWindowSpec) bool {
+	t := c.LeadCreatedAt
+	if t.IsZero() {
+		t = c.CreatedAt
+	}
+	if t.IsZero() {
+		return false
+	}
+	if t.Before(spec.from) {
+		return false
+	}
+	if !t.Before(spec.to) && !t.Equal(spec.to) {
+		// complete windows exclude the open end; 90d/open include now
+		if spec.complete {
+			return false
+		}
+		if t.After(spec.to) {
+			return false
+		}
+	}
+	if spec.complete && !t.Before(spec.to) {
+		return false
+	}
+	return true
+}
+
+func organicTerminal(c Chain) bool {
+	if isWonType(c.OutcomeType) || isLostType(c.OutcomeType) {
+		return c.HumanConfirmed
+	}
+	return false
+}
+
+func organicSliceKey(c Chain) string {
+	return strings.Join([]string{
+		organicSourceOf(c.Keys),
+		idOrUnknown(c.AssetFamily),
+		idOrUnknown(c.AssetID),
+		idOrUnknown(c.Keys.LandingPath),
+		organicAttributionKind(c),
+	}, "|")
+}
+
+func organicAttributionKind(c Chain) string {
+	if knownID(c.Keys.OrganicSource) != "" && knownID(c.Keys.AssetID) != "" {
+		if c.Keys.RecordKind == RecordKindReal || (!c.Synthetic && c.Label != LabelSynthetic) {
+			return AttributionDirect
+		}
+	}
+	if knownID(c.AssetID) != "" || knownID(c.Keys.LandingPath) != "" {
+		return AttributionAssisted
+	}
+	return Unknown
+}
+
+func projectOrganicSlice(key string, chains []Chain, discovery []OrganicDiscoveryAggregate, spec organicWindowSpec, includeSynthetic bool) OrganicSlice {
+	src := Unknown
+	family := Unknown
+	asset := Unknown
+	landing := Unknown
+	intent := Unknown
+	attr := Unknown
+	if len(chains) > 0 {
+		src = organicSourceOf(chains[0].Keys)
+		family = idOrUnknown(chains[0].AssetFamily)
+		asset = idOrUnknown(chains[0].AssetID)
+		landing = idOrUnknown(chains[0].Keys.LandingPath)
+		intent = idOrUnknown(chains[0].IntentClass)
+		attr = organicAttributionKind(chains[0])
+	}
+	sl := OrganicSlice{
+		Key:                key,
+		OrganicSource:      src,
+		AssetFamily:        family,
+		AssetID:            asset,
+		LandingPath:        landing,
+		IntentClass:        intent,
+		Attribution:        attr,
+		ROAS:               TruthBlocked,
+		CAC:                TruthBlocked,
+		DiscoveryFreshness: "no consumer",
+	}
+	disc := matchDiscovery(discovery, src, family, asset, landing, spec.id, includeSynthetic)
+	if disc != nil {
+		sl.DiscoveryFreshness = firstNonEmpty(disc.Freshness, "snapshot")
+	}
+	leads, qualified, acked, conv, meet, prop, pipe := 0, 0, 0, 0, 0, 0, 0
+	won, lost, unk := 0, 0, 0
+	open := 0
+	var contracted, received int64
+	var latencies []int64
+	for _, c := range chains {
+		if c.NotALead {
+			continue
+		}
+		leads++
+		if c.Qualified {
+			qualified++
+		}
+		if c.FirstActionAt != nil {
+			acked++
+			if !c.LeadCreatedAt.IsZero() && !c.FirstActionAt.Before(c.LeadCreatedAt) {
+				latencies = append(latencies, c.FirstActionAt.Sub(c.LeadCreatedAt).Milliseconds())
+			}
+		}
+		if c.Conversation {
+			conv++
+		}
+		if c.OutcomeType == OutcomeMeeting || (c.ConversationAt != nil && c.OutcomeType == OutcomeMeeting) {
+			meet++
+		}
+		if c.OutcomeType == OutcomeProposal || c.ProposalAt != nil {
+			prop++
+		}
+		if c.PipelineOpen {
+			pipe++
+		}
+		switch {
+		case isWonType(c.OutcomeType) && c.HumanConfirmed:
+			won++
+		case isLostType(c.OutcomeType) && c.HumanConfirmed:
+			lost++
+		default:
+			unk++
+		}
+		if !organicTerminal(c) {
+			open++
+		}
+		contracted += c.Commercial.Payment.ContractedCents
+		switch {
+		case c.RevenueEvidenced && c.RevenueCents > 0:
+			received += c.RevenueCents
+		case c.Commercial.Payment.ReceivedCents > 0:
+			received += c.Commercial.Payment.ReceivedCents
+		}
+	}
+	if c := countMeetings(chains); c > meet {
+		meet = c
+	}
+	sl.Won, sl.Lost, sl.Unknown = won, lost, unk
+	sl.ContractedCents = contracted
+	sl.ReceivedCents = received
+	sl.OpenCensored = open
+	sl.LeadToAction = organicLatencyOf(latencies)
+	sl.Layers = []OrganicLayer{
+		discoveryLayer(LayerEligible, disc, func(d *OrganicDiscoveryAggregate) int { return d.Eligible }, leads),
+		discoveryLayer(LayerAppeared, disc, func(d *OrganicDiscoveryAggregate) int { return d.Appeared }, leads),
+		discoveryLayer(LayerClicked, disc, func(d *OrganicDiscoveryAggregate) int { return d.Clicked }, leads),
+		discoveryLayer(LayerEngaged, disc, func(d *OrganicDiscoveryAggregate) int { return d.Engaged }, leads),
+		countLayer(LayerLeadValid, leads, leads, unk),
+		countLayer(LayerQualifiedLead, qualified, leads, 0),
+		countLayer(LayerAcknowledged, acked, leads, 0),
+		countLayer(LayerConversation, conv, maxInt(qualified, conv), 0),
+		countLayer(LayerMeeting, meet, maxInt(conv, meet), 0),
+		countLayer(LayerProposal, prop, maxInt(meet, prop), 0),
+		countLayer(LayerQualifiedPipeline, pipe, maxInt(prop, pipe), 0),
+		wonLostLayer(won, lost, unk, maxInt(pipe, won+lost+unk)),
+		revenueLayer(contracted, received, pipe),
+	}
+	return sl
+}
+
+func countMeetings(chains []Chain) int {
+	n := 0
+	for _, c := range chains {
+		if c.OutcomeType == OutcomeMeeting {
+			n++
+		}
+	}
+	return n
+}
+
+func emptySourceSlice(src string, spec organicWindowSpec, discovery []OrganicDiscoveryAggregate, includeSynthetic bool) OrganicSlice {
+	sl := OrganicSlice{
+		Key:                "source:" + src,
+		OrganicSource:      src,
+		AssetFamily:        Unknown,
+		AssetID:            Unknown,
+		LandingPath:        Unknown,
+		Attribution:        Unknown,
+		ROAS:               TruthBlocked,
+		CAC:                TruthBlocked,
+		DiscoveryFreshness: "no consumer",
+	}
+	disc := matchDiscovery(discovery, src, "", "", "", spec.id, includeSynthetic)
+	if disc != nil {
+		sl.DiscoveryFreshness = firstNonEmpty(disc.Freshness, "snapshot")
+	}
+	sl.Layers = []OrganicLayer{
+		discoveryLayer(LayerEligible, disc, func(d *OrganicDiscoveryAggregate) int { return d.Eligible }, 0),
+		discoveryLayer(LayerAppeared, disc, func(d *OrganicDiscoveryAggregate) int { return d.Appeared }, 0),
+		discoveryLayer(LayerClicked, disc, func(d *OrganicDiscoveryAggregate) int { return d.Clicked }, 0),
+		discoveryLayer(LayerEngaged, disc, func(d *OrganicDiscoveryAggregate) int { return d.Engaged }, 0),
+		countLayer(LayerLeadValid, 0, 0, 0),
+		countLayer(LayerQualifiedLead, 0, 0, 0),
+		countLayer(LayerAcknowledged, 0, 0, 0),
+		countLayer(LayerConversation, 0, 0, 0),
+		countLayer(LayerMeeting, 0, 0, 0),
+		countLayer(LayerProposal, 0, 0, 0),
+		countLayer(LayerQualifiedPipeline, 0, 0, 0),
+		wonLostLayer(0, 0, 0, 0),
+		revenueLayer(0, 0, 0),
+	}
+	return sl
+}
+
+func matchDiscovery(rows []OrganicDiscoveryAggregate, src, family, asset, landing, window string, includeSynthetic bool) *OrganicDiscoveryAggregate {
+	for i := range rows {
+		r := rows[i]
+		if !includeSynthetic && r.Synthetic {
+			continue
+		}
+		if window != "" && r.Window != "" && r.Window != window {
+			continue
+		}
+		if src != "" && r.OrganicSource != "" && NormalizeOrganicSource(r.OrganicSource) != src {
+			continue
+		}
+		if asset != "" && asset != Unknown && r.AssetID != "" && r.AssetID != asset {
+			continue
+		}
+		if landing != "" && landing != Unknown && r.LandingPath != "" && r.LandingPath != landing {
+			continue
+		}
+		if family != "" && family != Unknown && r.AssetFamily != "" && r.AssetFamily != family {
+			continue
+		}
+		return &rows[i]
+	}
+	return nil
+}
+
+func discoveryLayer(id string, disc *OrganicDiscoveryAggregate, pick func(*OrganicDiscoveryAggregate) int, leadHint int) OrganicLayer {
+	ly := OrganicLayer{
+		ID:          id,
+		Status:      TruthBlocked,
+		Observation: "ELIGIBLE/APPEARED/CLICKED/ENGAGED are not inferred from lead volume. Future ingest is " + OrganicDiscoveryContract + ".",
+	}
+	_ = leadHint
+	if disc == nil {
+		return ly
+	}
+	n := pick(disc)
+	ly.Count = n
+	ly.Denominator = n
+	if n > 0 {
+		ly.Status = TruthTrue
+	} else {
+		ly.Status = TruthUnknown
+	}
+	ly.Observation = "web-cfg aggregate " + OrganicDiscoveryContract
+	return ly
+}
+
+func countLayer(id string, n, den, unk int) OrganicLayer {
+	st := TruthFalse
+	if n > 0 {
+		st = TruthTrue
+	} else if den == 0 {
+		st = TruthUnknown
+	}
+	return OrganicLayer{
+		ID:          id,
+		Status:      st,
+		Count:       n,
+		Denominator: den,
+		Conversion:  conversionText(n, den),
+		Unknown:     unk,
+	}
+}
+
+func wonLostLayer(won, lost, unk, den int) OrganicLayer {
+	return OrganicLayer{
+		ID:          LayerWonLostUnknown,
+		Status:      TruthUnknown,
+		Count:       won + lost,
+		Denominator: den,
+		Unknown:     unk,
+		Observation: "WON/LOST require human confirmation. UNKNOWN stays visible.",
+		Conversion:  conversionText(won, den),
+	}
+}
+
+func revenueLayer(contracted, received int64, pipe int) OrganicLayer {
+	st := TruthUnknown
+	if received > 0 {
+		st = TruthTrue
+	} else if contracted > 0 || pipe > 0 {
+		st = TruthFalse
+	}
+	return OrganicLayer{
+		ID:          LayerRevenue,
+		Status:      st,
+		Count:       int(received),
+		Denominator: int(contracted),
+		Observation: "CONTRACTED_REVENUE and RECEIVED_REVENUE stay distinct. No organic ROAS/CAC without complete cost and observed received revenue.",
+	}
+}
+
+func conversionText(n, den int) string {
+	if den <= 0 {
+		return Unknown
+	}
+	return fmt.Sprintf("%.3f", float64(n)/float64(den))
+}
+
+func organicLatencyOf(samples []int64) OrganicLatency {
+	out := OrganicLatency{N: len(samples), Median: Unknown, P75: Unknown, P90: Unknown}
+	if len(samples) < organicLatencyMinN {
+		return out
+	}
+	cp := append([]int64(nil), samples...)
+	sort.Slice(cp, func(i, j int) bool { return cp[i] < cp[j] })
+	out.Median = time.Duration(percentile(cp, 50) * int64(time.Millisecond)).String()
+	out.P75 = time.Duration(percentile(cp, 75) * int64(time.Millisecond)).String()
+	out.P90 = time.Duration(percentile(cp, 90) * int64(time.Millisecond)).String()
+	return out
+}
+
+func percentile(sorted []int64, p int) int64 {
+	if len(sorted) == 0 {
+		return 0
+	}
+	if p <= 0 {
+		return sorted[0]
+	}
+	if p >= 100 {
+		return sorted[len(sorted)-1]
+	}
+	idx := (p * (len(sorted) - 1)) / 100
+	return sorted[idx]
+}
+
+func sortedKeys(m map[string][]Chain) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/app/confenge/intel/organic_scoreboard_test.go
+++ b/internal/app/confenge/intel/organic_scoreboard_test.go
@@ -1,0 +1,224 @@
+package intel
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestOrganicScoreboardSeparatesLayersAndSources(t *testing.T) {
+	now := time.Date(2026, 8, 19, 15, 0, 0, 0, time.UTC)
+	leadAt := now.AddDate(0, 0, -10)
+	actionAt := leadAt.Add(20 * time.Minute)
+	st := NewMemoryStore()
+	organic := CommercialEvent{
+		EventID: "ev-sb-org", Version: "1", Schema: EventSchemaV1,
+		Type: EventLeadReceived, OccurredAt: leadAt, OrganizationID: "org-sb",
+		LeadID: "lead-sb-org", ReceiptID: "rcpt-sb-org", Source: SourceOrganicSearch,
+		OrganicSource: SourceOrganicSearch, AssetID: "asset-sl", AssetFamily: AssetFamilyContractAnalysis,
+		LandingPath: "/guias/segunda-leitura", RouteFamily: FamilyInbound,
+		Consent: "consent-1", Qualified: true,
+	}
+	IngestEvent(st, organic)
+	IngestEvent(st, CommercialEvent{
+		EventID: "ev-sb-act", Version: "1", Schema: EventSchemaV1,
+		Type: EventActionExecuted, OccurredAt: actionAt, OrganizationID: "org-sb",
+		LeadID: "lead-sb-org", ActionID: "act-sb-org", Source: SourceOrganicSearch,
+		OrganicSource: SourceOrganicSearch, AssetID: "asset-sl", RouteFamily: FamilyInbound,
+		Consent: "consent-1",
+	})
+	IngestEvent(st, CommercialEvent{
+		EventID: "ev-sb-ai", Version: "1", Schema: EventSchemaV1,
+		Type: EventLeadReceived, OccurredAt: leadAt, OrganizationID: "org-sb",
+		LeadID: "lead-sb-ai", ReceiptID: "rcpt-sb-ai", Source: SourceAIReferral,
+		OrganicSource: SourceAIReferral, AssetID: "asset-ma", AssetFamily: AssetFamilyMarketAnswer,
+		LandingPath: "/respostas/x", RouteFamily: FamilyInbound, Consent: "consent-1",
+	})
+	IngestEvent(st, CommercialEvent{
+		EventID: "ev-sb-out", Version: "1", Schema: EventSchemaV1,
+		Type: EventLeadReceived, OccurredAt: leadAt, OrganizationID: "org-sb",
+		LeadID: "lead-sb-out", ReceiptID: "rcpt-sb-out", Source: SourceOutbound,
+		OrganicSource: SourceOutbound, AssetID: "asset-out", RouteFamily: FamilyOutbound,
+		Consent: "consent-1",
+	})
+	syn := organic
+	syn.EventID, syn.LeadID, syn.ReceiptID = "ev-sb-syn", "lead-sb-syn", "rcpt-sb-syn"
+	syn.Synthetic = true
+	syn.RecordKind = RecordKindSynthetic
+	IngestEvent(st, syn)
+
+	chains, _ := st.ListChains("org-sb")
+	board := ProjectOrganicScoreboard(OrganicScoreboardSources{Now: now, Chains: chains})
+	if board.CausalProof || board.SchemaVersion != OrganicScoreboardSchemaV1 {
+		t.Fatalf("board=%+v", board)
+	}
+	if board.IncludeSynthetic {
+		t.Fatal("default included synthetic")
+	}
+	if len(board.Windows) != 4 {
+		t.Fatalf("windows=%d", len(board.Windows))
+	}
+
+	var w28 *OrganicWindow
+	for i := range board.Windows {
+		if board.Windows[i].ID == Window28dComplete {
+			w28 = &board.Windows[i]
+		}
+		if !board.Windows[i].Censored && board.Windows[i].ID == WindowOpen {
+			t.Fatal("open window not censored")
+		}
+	}
+	if w28 == nil {
+		t.Fatal("28d window missing")
+	}
+	sources := map[string]OrganicSlice{}
+	for _, sl := range w28.BySource {
+		sources[sl.OrganicSource] = sl
+		if sl.ROAS != TruthBlocked || sl.CAC != TruthBlocked {
+			t.Fatalf("invented ROAS/CAC on %s", sl.OrganicSource)
+		}
+	}
+	for _, src := range OrganicSources() {
+		if _, ok := sources[src]; !ok {
+			t.Fatalf("missing unmixed source slice %s", src)
+		}
+	}
+	if sources[SourceOrganicSearch].OrganicSource == sources[SourceAIReferral].OrganicSource {
+		t.Fatal("organic and ai mixed")
+	}
+	orgLead := layerCount(sources[SourceOrganicSearch], LayerLeadValid)
+	aiLead := layerCount(sources[SourceAIReferral], LayerLeadValid)
+	outLead := layerCount(sources[SourceOutbound], LayerLeadValid)
+	if orgLead == 0 || aiLead == 0 {
+		t.Fatalf("source leads org=%d ai=%d", orgLead, aiLead)
+	}
+	if orgLead != 1 || aiLead != 1 || outLead != 1 {
+		t.Fatalf("unmixed counts org=%d ai=%d out=%d", orgLead, aiLead, outLead)
+	}
+	elig := layerByID(sources[SourceOrganicSearch].Layers, LayerEligible)
+	if elig == nil || elig.Status != TruthBlocked {
+		t.Fatalf("discovery invented without web-cfg aggregate: %+v", elig)
+	}
+
+	withDisc := ProjectOrganicScoreboard(OrganicScoreboardSources{
+		Now: now, Chains: chains,
+		Discovery: []OrganicDiscoveryAggregate{{
+			OrganicSource: SourceOrganicSearch, AssetID: "asset-sl",
+			LandingPath: "/guias/segunda-leitura", Window: Window28dComplete,
+			Eligible: 100, Appeared: 40, Clicked: 8, Engaged: 3,
+			Freshness: "gsc-top-rows",
+		}},
+	})
+	var w28d *OrganicWindow
+	for i := range withDisc.Windows {
+		if withDisc.Windows[i].ID == Window28dComplete {
+			w28d = &withDisc.Windows[i]
+		}
+	}
+	clicked := layerByID(w28d.BySource[indexOfSource(w28d.BySource, SourceOrganicSearch)].Layers, LayerClicked)
+	if clicked == nil || clicked.Status == TruthBlocked || clicked.Count != 8 {
+		t.Fatalf("discovery aggregate not applied: %+v", clicked)
+	}
+
+	open := windowByID(board.Windows, WindowOpen)
+	if open == nil || !open.Censored {
+		t.Fatal("open cohorts not censored")
+	}
+
+	raw, err := OrganicScoreboardJSON(board)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if ReportHasPII(raw) {
+		t.Fatal("scoreboard PII")
+	}
+	fmt.Printf("ORGANIC_SCOREBOARD windows=%d org_leads=%d discovery=%s roas=%s real_empty=%v\n",
+		len(board.Windows), orgLead, elig.Status, sources[SourceOrganicSearch].ROAS, board.RealEmpty)
+}
+
+func indexOfSource(slices []OrganicSlice, src string) int {
+	for i := range slices {
+		if slices[i].OrganicSource == src {
+			return i
+		}
+	}
+	return 0
+}
+
+func windowByID(ws []OrganicWindow, id string) *OrganicWindow {
+	for i := range ws {
+		if ws[i].ID == id {
+			return &ws[i]
+		}
+	}
+	return nil
+}
+
+func TestOrganicScoreboardContractedVsReceivedAndUnknown(t *testing.T) {
+	now := time.Date(2026, 8, 19, 15, 0, 0, 0, time.UTC)
+	st := NewMemoryStore()
+	leadAt := now.AddDate(0, 0, -3)
+	IngestEvent(st, CommercialEvent{
+		EventID: "ev-rev-lead", Version: "1", Schema: EventSchemaV1,
+		Type: EventLeadReceived, OccurredAt: leadAt, OrganizationID: "org-rev",
+		LeadID: "lead-rev", ReceiptID: "rcpt-rev", Source: SourceOrganicSearch,
+		OrganicSource: SourceOrganicSearch, AssetID: "asset-rev", RouteFamily: FamilyInbound,
+		Consent: "c1",
+	})
+	won := CommercialEvent{
+		EventID: "ev-rev-won", Version: "1", Schema: EventSchemaV1,
+		Type: EventWon, OccurredAt: leadAt.Add(48 * time.Hour), OrganizationID: "org-rev",
+		LeadID: "lead-rev", ActionID: "act-rev", Source: SourceOrganicSearch,
+		OrganicSource: SourceOrganicSearch, AssetID: "asset-rev", RouteFamily: FamilyInbound,
+		HumanConfirmed: true, Consent: "c1",
+	}
+	IngestEvent(st, won)
+	chains, _ := st.ListChains("org-rev")
+	if len(chains) != 1 {
+		t.Fatalf("chains=%d", len(chains))
+	}
+	chains[0].Commercial.Payment.ContractedCents = 180000
+	chains[0].RevenueEvidenced = false
+	chains[0].RevenueCents = 0
+	board := ProjectOrganicScoreboard(OrganicScoreboardSources{Now: now, Chains: chains, IncludeSynthetic: true})
+	w90 := windowByID(board.Windows, Window90d)
+	if w90 == nil || len(w90.BySource) == 0 {
+		t.Fatal("90d missing")
+	}
+	org := w90.BySource[indexOfSource(w90.BySource, SourceOrganicSearch)]
+	if org.ContractedCents != 180000 {
+		t.Fatalf("contracted=%d", org.ContractedCents)
+	}
+	if org.ReceivedCents != 0 {
+		t.Fatalf("received invented=%d", org.ReceivedCents)
+	}
+	if org.Unknown == 0 && org.Won == 0 {
+		t.Fatalf("UNKNOWN/WON missing: %+v", org)
+	}
+	rev := layerByID(org.Layers, LayerRevenue)
+	if rev == nil || rev.Observation == "" {
+		t.Fatal("revenue layer missing")
+	}
+	fmt.Printf("REVENUE_SPLIT contracted=%d received=%d won=%d unknown=%d\n",
+		org.ContractedCents, org.ReceivedCents, org.Won, org.Unknown)
+}
+
+func TestOrganicLatencyCensoredWhenNTooSmall(t *testing.T) {
+	now := time.Date(2026, 8, 19, 12, 0, 0, 0, time.UTC)
+	var chains []Chain
+	for i := 0; i < 3; i++ {
+		lead := now.AddDate(0, 0, -5)
+		act := lead.Add(10 * time.Minute)
+		chains = append(chains, Chain{
+			Keys:    JoinKeys{OrganicSource: SourceOrganicSearch, AssetID: "a", LeadID: fmt.Sprintf("l%d", i), RecordKind: RecordKindReal},
+			AssetID: "a", LeadCreatedAt: lead, FirstActionAt: &act, Source: SourceOrganicSearch,
+		})
+	}
+	board := ProjectOrganicScoreboard(OrganicScoreboardSources{Now: now, Chains: chains})
+	w := windowByID(board.Windows, Window28dComplete)
+	sl := w.BySource[indexOfSource(w.BySource, SourceOrganicSearch)]
+	if sl.LeadToAction.Median != Unknown || sl.LeadToAction.N != 3 {
+		t.Fatalf("latency with n=3 must stay UNKNOWN: %+v", sl.LeadToAction)
+	}
+	fmt.Printf("LATENCY_CENSOR n=%d median=%s\n", sl.LeadToAction.N, sl.LeadToAction.Median)
+}

--- a/internal/app/confenge/intel/organic_test.go
+++ b/internal/app/confenge/intel/organic_test.go
@@ -1,0 +1,178 @@
+package intel
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNormalizeOrganicSourceNeverCoercesUnknown(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"organic_search", SourceOrganicSearch},
+		{"organic", SourceOrganicSearch},
+		{"direct", SourceDirect},
+		{"referral", SourceReferral},
+		{"ai_referral", SourceAIReferral},
+		{"chatgpt", SourceAIReferral},
+		{"partner", SourcePartner},
+		{"outbound", SourceOutbound},
+		{"unknown", Unknown},
+		{"", Unknown},
+		{"web-cfg", Unknown},
+		{"CONFENGE_WEB", Unknown},
+		{"google", Unknown},
+		{"cpc", Unknown},
+	}
+	for _, tc := range cases {
+		got := NormalizeOrganicSource(tc.in)
+		if got != tc.want {
+			t.Fatalf("NormalizeOrganicSource(%q)=%q want %q", tc.in, got, tc.want)
+		}
+	}
+	if ComposeOrganicSource("", "google", "organic") != Unknown {
+		t.Fatal("medium=organic must not invent organic_search from unlabeled source")
+	}
+	if ComposeOrganicSource("organic_search", "web-cfg", "") != SourceOrganicSearch {
+		t.Fatal("explicit organic_source lost")
+	}
+	fmt.Printf("ORGANIC_SOURCE unknown_stays=%s google_stays=%s explicit=%s\n",
+		NormalizeOrganicSource("unknown"), NormalizeOrganicSource("google"), ComposeOrganicSource("organic_search", "web-cfg", ""))
+}
+
+func TestSanitizeCommercialEventStripsGSCQueryAndQueryHash(t *testing.T) {
+	ev := CommercialEvent{
+		EventID: "ev-gsc-1", Version: "1", Schema: EventSchemaV1,
+		Type: EventLeadReceived, OccurredAt: time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+		LeadID: "lead-gsc-1", ReceiptID: "rcpt-gsc-1", RouteFamily: FamilyInbound,
+		Source: "organic_search", Query: "segunda leitura contrato preco",
+		QueryHash:  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		LandingURL: "https://www.confenge.com.br/segunda-leitura?q=secret&email=a@b.com",
+		Referrer:   "https://www.google.com/search?q=segunda+leitura",
+		AssetID:    "landing-segunda-leitura", OrganizationID: "org-gsc",
+	}
+	got := SanitizeCommercialEvent(ev)
+	if got.Query != "" {
+		t.Fatalf("raw GSC query stayed on event: %q", got.Query)
+	}
+	if got.QueryHash == "" {
+		// hash is input-only; Sanitize keeps it on the envelope field but EventToFacts must not copy it
+	}
+	if got.LandingPath != "/segunda-leitura" {
+		t.Fatalf("landing_path=%q", got.LandingPath)
+	}
+	if strings.Contains(got.Referrer, "?") || strings.Contains(got.Referrer, "q=") {
+		t.Fatalf("sensitive referrer kept: %q", got.Referrer)
+	}
+	if got.OrganicSource != SourceOrganicSearch {
+		t.Fatalf("organic_source=%s", got.OrganicSource)
+	}
+
+	facts := EventToFacts(ev)
+	if facts.Keys.Query != "" {
+		t.Fatalf("GSC query joined to lead keys: %q", facts.Keys.Query)
+	}
+	if !facts.StrippedGSCQuery {
+		t.Fatal("stripped_gsc_query unset")
+	}
+	if !facts.StrippedQueryHash {
+		t.Fatal("stripped_query_hash unset")
+	}
+	if facts.Keys.LandingPath != "/segunda-leitura" {
+		t.Fatalf("facts landing=%q", facts.Keys.LandingPath)
+	}
+	if facts.Keys.FirstTouchAt != nil {
+		// not provided
+	}
+	st := NewMemoryStore()
+	res := IngestEvent(st, ev)
+	if !hasCode(res.Exceptions, ExceptionGSCQueryOnLead) {
+		t.Fatalf("gsc_query_on_lead missing: %v", codesOf(res.Exceptions))
+	}
+	if !hasCode(res.Exceptions, ExceptionQueryHashOnLead) {
+		t.Fatalf("query_hash_on_lead missing: %v", codesOf(res.Exceptions))
+	}
+	if res.Chain.Keys.Query != "" {
+		t.Fatalf("chain stored GSC query: %q", res.Chain.Keys.Query)
+	}
+	if MetricKeyContainsPII(res.Chain.MetricKey) {
+		t.Fatal("metric key has PII")
+	}
+	fmt.Printf("GSC_STRIP query=%q hash_on_lead=%v landing=%s codes=%v\n",
+		res.Chain.Keys.Query, hasCode(res.Exceptions, ExceptionQueryHashOnLead), res.Chain.Keys.LandingPath, codesOf(res.Exceptions))
+}
+
+func TestIngestPreservesOrganicAttributionContract(t *testing.T) {
+	first := time.Date(2026, 8, 1, 10, 0, 0, 0, time.UTC)
+	last := time.Date(2026, 8, 10, 10, 0, 0, 0, time.UTC)
+	ev := CommercialEvent{
+		EventID: "ev-org-1", Version: "1", Schema: EventSchemaV1,
+		Type: EventLeadReceived, OccurredAt: last, IngestedAt: last.Add(time.Minute),
+		Timezone: "America/Sao_Paulo", OrganizationID: "org-attr",
+		LeadID: "lead-org-1", ReceiptID: "rcpt-org-1", CorrelationID: "corr-org-1",
+		Source: "organic_search", Medium: "organic", Campaign: "segunda-leitura-aug",
+		ReferrerClass: "search", LandingPath: "/guias/segunda-leitura",
+		AssetFamily: AssetFamilyContractAnalysis, AssetID: "landing-segunda-leitura",
+		AssetVersion: "v3", CTAID: "cta-sl-1", CTAVersion: "cta-v2",
+		IntentClass: "contract-margin", QueryClass: "segunda-leitura-preco",
+		Query: "segunda-leitura-preco", RecordKind: RecordKindReal,
+		Consent: "web-cfg-consent-v4", ConsentVersion: "consent-v4",
+		PageVersion: "page-9", ContentVersion: "copy-12", ProducerSHA: "abc123",
+		FirstTouchAt: &first, LastTouchAt: &last, RouteFamily: FamilyInbound,
+		Synthetic: false,
+	}
+	st := NewMemoryStore()
+	res := IngestEvent(st, ev)
+	k := res.Chain.Keys
+	if k.OrganicSource != SourceOrganicSearch {
+		t.Fatalf("organic_source=%s", k.OrganicSource)
+	}
+	if k.LandingPath != "/guias/segunda-leitura" || k.AssetVersion != "v3" || k.CTAVersion != "cta-v2" {
+		t.Fatalf("path/version dropped: %+v", k)
+	}
+	if k.QueryClass != "segunda-leitura-preco" || k.Query != "segunda-leitura-preco" {
+		t.Fatalf("query_class slug lost: query=%q class=%q", k.Query, k.QueryClass)
+	}
+	if k.Consent != "web-cfg-consent-v4" || k.ConsentVersion != "consent-v4" {
+		t.Fatalf("consent dropped: %+v", k)
+	}
+	if k.FirstTouchAt == nil || !k.FirstTouchAt.Equal(first) || k.LastTouchAt == nil || !k.LastTouchAt.Equal(last) {
+		t.Fatalf("touches dropped: first=%v last=%v", k.FirstTouchAt, k.LastTouchAt)
+	}
+	if k.PageVersion != "page-9" || k.ProducerSHA != "abc123" {
+		t.Fatalf("page/sha dropped: %+v", k)
+	}
+	if k.RecordKind != RecordKindReal {
+		t.Fatalf("record_kind=%s", k.RecordKind)
+	}
+	replay := IngestEvent(st, ev)
+	if !replay.Replay || replay.Created {
+		t.Fatalf("replay: %+v", replay)
+	}
+	chains, _ := st.ListChains("org-attr")
+	if len(chains) != 1 {
+		t.Fatalf("chains=%d", len(chains))
+	}
+	fmt.Printf("ATTR_PRESERVE source=%s landing=%s asset=%s@%s first=%s kind=%s replay=%v\n",
+		k.OrganicSource, k.LandingPath, k.AssetID, k.AssetVersion, k.FirstTouchAt.UTC().Format(time.RFC3339), k.RecordKind, replay.Replay)
+}
+
+func TestUnknownSourceNeverBecomesDirectOrOrganic(t *testing.T) {
+	st := NewMemoryStore()
+	ev := CommercialEvent{
+		EventID: "ev-unk-1", Version: "1", Schema: EventSchemaV1,
+		Type: EventLeadReceived, OccurredAt: time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+		LeadID: "lead-unk-1", ReceiptID: "rcpt-unk-1", Source: "unknown",
+		AssetID: "asset-1", RouteFamily: FamilyInbound, OrganizationID: "org-unk",
+	}
+	res := IngestEvent(st, ev)
+	if res.Chain.Keys.OrganicSource != Unknown {
+		t.Fatalf("unknown coerced to %s", res.Chain.Keys.OrganicSource)
+	}
+	if res.Chain.Keys.OrganicSource == SourceDirect || res.Chain.Keys.OrganicSource == SourceOrganicSearch {
+		t.Fatal("unknown rewritten")
+	}
+	fmt.Printf("UNKNOWN_STAYS source=%s organic=%s\n", res.Chain.Source, res.Chain.Keys.OrganicSource)
+}

--- a/internal/app/confenge/intel/queue.go
+++ b/internal/app/confenge/intel/queue.go
@@ -84,9 +84,13 @@ func isAllowedResolve(action string) bool {
 func severityFor(code string) string {
 	switch strings.TrimSpace(code) {
 	case ExceptionOrphan, ExceptionConflictingAccount, ExceptionOutOfOrder,
-		ExceptionUnconfirmedWon, ExceptionUnconfirmedLost, ExceptionUnavailable:
+		ExceptionUnconfirmedWon, ExceptionUnconfirmedLost, ExceptionUnavailable,
+		ExceptionSyntheticTreatedAsReal, ExceptionGSCQueryOnLead, ExceptionQueryHashOnLead,
+		ExceptionContradictorySource, ExceptionMissingConsent, ExceptionRevenueWithoutFinancial:
 		return SeverityHigh
-	case ExceptionMissingVersion, ExceptionStaleAttribution:
+	case ExceptionMissingVersion, ExceptionStaleAttribution,
+		ExceptionLeadWithoutAssetID, ExceptionUnknownAssetVersion,
+		ExceptionPipelineWithoutEvidence:
 		return SeverityMedium
 	case ExceptionDuplicate:
 		return SeverityLow
@@ -229,6 +233,12 @@ func enrichException(ex *Exception, in ObservedFacts) {
 	}
 	if strings.TrimSpace(ex.Owner) == "" {
 		ex.Owner = ExceptionOwner(ex.Code)
+	}
+	if strings.TrimSpace(ex.RetryState) == "" {
+		ex.RetryState = "pending"
+	}
+	if ex.OpenedAt.IsZero() {
+		ex.OpenedAt = ex.At
 	}
 	if strings.TrimSpace(ex.NextAction) == "" {
 		ex.NextAction = nextActionFor(ex.Status, "")

--- a/internal/app/confenge/intel/scoreboard.go
+++ b/internal/app/confenge/intel/scoreboard.go
@@ -473,10 +473,15 @@ func ExceptionOwner(code string) string {
 		return OwnerFounder
 	case ExceptionConflictingAccount, ExceptionMissingVersion:
 		return OwnerExtraCLI
-	case ExceptionStaleAttribution, ExceptionMissingAttribution:
+	case ExceptionStaleAttribution, ExceptionMissingAttribution,
+		ExceptionLeadWithoutAssetID, ExceptionUnknownAssetVersion,
+		ExceptionContradictorySource, ExceptionGSCQueryOnLead, ExceptionQueryHashOnLead:
 		return OwnerWebCfg
-	case ExceptionCreatedAsRevenue, ExceptionOnboardingBeforePay, ExceptionNfseManualQueue, ExceptionChargeback, ExceptionPaymentRefund:
+	case ExceptionCreatedAsRevenue, ExceptionOnboardingBeforePay, ExceptionNfseManualQueue, ExceptionChargeback, ExceptionPaymentRefund,
+		ExceptionRevenueWithoutFinancial:
 		return OwnerFinance
+	case ExceptionPipelineWithoutEvidence:
+		return OwnerFounder
 	case ExceptionCounselReviewDue:
 		return OwnerFounder
 	case ExceptionUnknownProviderEvent:

--- a/internal/app/confenge/intel/types.go
+++ b/internal/app/confenge/intel/types.go
@@ -115,6 +115,55 @@ const (
 	ExceptionMissingAttribution   = "missing_attribution"
 	ExceptionAlertStoreFailed     = "alert_store_failed"
 
+	ExceptionLeadWithoutAssetID      = "lead_without_asset_id"
+	ExceptionUnknownAssetVersion     = "unknown_asset_version"
+	ExceptionContradictorySource     = "contradictory_source"
+	ExceptionSyntheticTreatedAsReal  = "synthetic_treated_as_real"
+	ExceptionMissingConsent          = "missing_consent"
+	ExceptionPipelineWithoutEvidence = "pipeline_without_evidence"
+	ExceptionRevenueWithoutFinancial = "revenue_without_financial_event"
+	ExceptionGSCQueryOnLead          = "gsc_query_on_lead"
+	ExceptionQueryHashOnLead         = "query_hash_on_lead"
+
+	SourceOrganicSearch = "organic_search"
+	SourceDirect        = "direct"
+	SourceReferral      = "referral"
+	SourceAIReferral    = "ai_referral"
+	SourcePartner       = "partner"
+	SourceOutbound      = "outbound"
+
+	RecordKindReal      = "real"
+	RecordKindSynthetic = "synthetic"
+
+	OrganicAttributionV1      = "confenge.organic_attribution.v1"
+	OrganicScoreboardSchemaV1 = "confenge.organic_learning_scoreboard.v1"
+	OrganicFeedbackSchemaV1   = "confenge.organic_editorial_feedback.v1"
+	OrganicDiscoveryContract  = "confenge.search_observation.v1"
+
+	EventSearchObservation = "search_observation"
+
+	LayerEligible          = "ELIGIBLE"
+	LayerAppeared          = "APPEARED"
+	LayerClicked           = "CLICKED"
+	LayerEngaged           = "ENGAGED"
+	LayerLeadValid         = "LEAD_VALID"
+	LayerQualifiedLead     = "QUALIFIED_LEAD"
+	LayerAcknowledged      = "ACKNOWLEDGED"
+	LayerConversation      = "CONVERSATION"
+	LayerMeeting           = "MEETING"
+	LayerProposal          = "PROPOSAL"
+	LayerQualifiedPipeline = "QUALIFIED_PIPELINE"
+	LayerWonLostUnknown    = "WON_LOST_UNKNOWN"
+	LayerRevenue           = "REVENUE"
+
+	Window7dComplete  = "7d_complete"
+	Window28dComplete = "28d_complete"
+	Window90d         = "90d"
+	WindowOpen        = "open_censored"
+
+	AttributionDirect   = "direct"
+	AttributionAssisted = "assisted"
+
 	BaselineSynthetic = "BASELINE_SYNTHETIC"
 	BaselineObserved  = "BASELINE_OBSERVED"
 	BaselineNone      = "insufficient_data"
@@ -189,6 +238,22 @@ type JoinKeys struct {
 	HoldID            string `json:"hold_id,omitempty"`
 	QueryClass        string `json:"query_class,omitempty"`
 	ReferrerClass     string `json:"referrer_class,omitempty"`
+
+	// Organic attribution contract (confenge.organic_attribution.v1).
+	// OrganicSource is the unmixed taxonomy. Source may remain a producer
+	// identity (web-cfg / CONFENGE_WEB). Query hash is never stored here.
+	OrganicSource  string     `json:"organic_source,omitempty"`
+	Medium         string     `json:"medium,omitempty"`
+	Campaign       string     `json:"campaign,omitempty"`
+	LandingPath    string     `json:"landing_path,omitempty"`
+	AssetVersion   string     `json:"asset_version,omitempty"`
+	CTAVersion     string     `json:"cta_version,omitempty"`
+	RecordKind     string     `json:"record_kind,omitempty"`
+	ConsentVersion string     `json:"consent_version,omitempty"`
+	PageVersion    string     `json:"page_version,omitempty"`
+	ContentVersion string     `json:"content_version,omitempty"`
+	FirstTouchAt   *time.Time `json:"first_touch_at,omitempty"`
+	LastTouchAt    *time.Time `json:"last_touch_at,omitempty"`
 }
 
 // ObservedFacts is one observed commercial record. Missing optional IDs
@@ -233,6 +298,14 @@ type ObservedFacts struct {
 
 	Synthetic bool   `json:"synthetic,omitempty"`
 	Label     string `json:"label,omitempty"`
+
+	RecordKind           string `json:"record_kind,omitempty"`
+	ConsentValid         bool   `json:"consent_valid,omitempty"`
+	StrippedGSCQuery     bool   `json:"stripped_gsc_query,omitempty"`
+	StrippedQueryHash    bool   `json:"stripped_query_hash,omitempty"`
+	ContradictorySource  bool   `json:"contradictory_source,omitempty"`
+	SyntheticLabeledReal bool   `json:"synthetic_labeled_real,omitempty"`
+	InvalidAssetVersion  bool   `json:"invalid_asset_version,omitempty"`
 }
 
 // Chain is one reconstructed observed path. Replay of the same IDs
@@ -668,6 +741,22 @@ type CommercialEvent struct {
 	QueryClass        string           `json:"query_class,omitempty"`
 	ReferrerClass     string           `json:"referrer_class,omitempty"`
 	CallbackOnly      bool             `json:"callback_only,omitempty"`
+
+	Medium         string     `json:"medium,omitempty"`
+	Campaign       string     `json:"campaign,omitempty"`
+	LandingPath    string     `json:"landing_path,omitempty"`
+	LandingURL     string     `json:"landing_url,omitempty"`
+	AssetVersion   string     `json:"asset_version,omitempty"`
+	CTAVersion     string     `json:"cta_version,omitempty"`
+	RecordKind     string     `json:"record_kind,omitempty"`
+	ConsentVersion string     `json:"consent_version,omitempty"`
+	PageVersion    string     `json:"page_version,omitempty"`
+	ContentVersion string     `json:"content_version,omitempty"`
+	FirstTouchAt   *time.Time `json:"first_touch_at,omitempty"`
+	LastTouchAt    *time.Time `json:"last_touch_at,omitempty"`
+	OrganicSource  string     `json:"organic_source,omitempty"`
+	QueryHash      string     `json:"-"`
+	GSCQuery       string     `json:"-"`
 }
 
 // ObservabilityReport is the executive JSON/MD payload for the learning loop.

--- a/internal/app/confenge/intel_service.go
+++ b/internal/app/confenge/intel_service.go
@@ -247,6 +247,30 @@ func (s *service) HumanOutcomeEnvelopes() []intel.HumanOutcomeEnvelope {
 	return intel.EmptyEnvelopes()
 }
 
+func (s *service) OrganicScoreboard(ctx context.Context, orgID uuid.UUID, includeSynthetic bool) (*intel.OrganicScoreboard, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	s.observeExisting(ctx, orgID)
+	chains, err := s.intelStore().ListChains(orgID.String())
+	if err != nil {
+		return nil, errx.New(errx.Internal, "organic scoreboard list: "+err.Error())
+	}
+	board := intel.ProjectOrganicScoreboard(intel.OrganicScoreboardSources{
+		Now: time.Now().UTC(), IncludeSynthetic: includeSynthetic, Chains: chains,
+	})
+	return &board, nil
+}
+
+func (s *service) OrganicFeedback(ctx context.Context, orgID uuid.UUID, includeSynthetic bool) (*intel.OrganicFeedbackExport, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	s.observeExisting(ctx, orgID)
+	exp := intel.ExportOrganicFeedback(s.intelStore(), orgID.String(), time.Now().UTC(), includeSynthetic)
+	return &exp, nil
+}
+
 func (s *service) observeExisting(ctx context.Context, orgID uuid.UUID) {
 	st := s.intelStore()
 	seenActions := map[string]bool{}

--- a/internal/app/confenge/operator_alert.go
+++ b/internal/app/confenge/operator_alert.go
@@ -38,6 +38,7 @@ const (
 	AlertEmailBlockedNoTransport = "blocked_no_isolated_transport"
 	AlertEmailSendFailed         = "send_failed"
 	AlertEmailDisabled           = "disabled"
+	AlertEmailSyntheticSkipped   = "synthetic_skipped"
 )
 
 type OperatorAlert = models.OutreachOperatorAlert

--- a/internal/app/confenge/operator_alert_service.go
+++ b/internal/app/confenge/operator_alert_service.go
@@ -112,8 +112,11 @@ func (s *service) emitOperatorChannels(ctx context.Context, orgID uuid.UUID, row
 	if emailReason == "" {
 		emailReason = AlertEmailBlockedNoTransport
 	}
-	if s.operatorMail != nil && emailReason == AlertEmailBlockedNoTransport {
-		mail := BuildOperatorAlertEmail(now, row.Source, row.AssetID, now.Sub(row.WarmblyIngestedAt), "/app/confenge#inbound-agora")
+	if alert.Synthetic {
+		emailReason = AlertEmailSyntheticSkipped
+	} else if s.operatorMail != nil && emailReason == AlertEmailBlockedNoTransport {
+		origin := firstNonEmpty(utmField(row.UTMJSON, "organic_source"), row.Source)
+		mail := BuildOperatorAlertEmail(now, origin, row.AssetID, now.Sub(row.WarmblyIngestedAt), "/app/confenge#inbound-agora")
 		to := strings.TrimSpace(s.cfg.OperatorAlertEmail)
 		if OperatorAlertContainsPII(mail.Subject, *row) || OperatorAlertContainsPII(mail.Body, *row) {
 			emailReason = "pii_blocked"

--- a/internal/app/confenge/operator_alert_test.go
+++ b/internal/app/confenge/operator_alert_test.go
@@ -535,6 +535,77 @@ func TestRequireAlertActorRejectsNilUUIDString(t *testing.T) {
 	}
 }
 
+func TestOperatorAlertSyntheticNeverSendsEmailAndOrganicContextOnReal(t *testing.T) {
+	svc, repo, org := inboundTestService(t)
+	svc.cfg.OperatorAlertEmailEnabled = true
+	svc.cfg.OperatorAlertEmailKillSwitch = false
+	svc.cfg.OperatorAlertEmail = "ops@confenge.com.br"
+	sent := 0
+	var lastBody string
+	svc.operatorMail = func(to, subject, body string) error {
+		sent++
+		lastBody = body
+		if to != "ops@confenge.com.br" {
+			t.Fatalf("to=%s", to)
+		}
+		return nil
+	}
+	now := time.Date(2026, 8, 19, 15, 0, 0, 0, time.UTC)
+	organicBody := []byte(`{
+		"lead_id":"webcfg-organic-1",
+		"receipt_id":"rcpt-webcfg-organic-1",
+		"created_at":"2026-08-19T12:00:00Z",
+		"source":"organic_search",
+		"organic_source":"organic_search",
+		"route_family":"inbound",
+		"asset_id":"segunda-leitura",
+		"cta_id":"segunda-leitura-contrato",
+		"email":"ana.souza@norte.example",
+		"company":"Construtora Norte",
+		"consent":{"granted":true,"consent_source":"web-cfg-consent-v1"}
+	}`)
+	real, xerr := svc.IngestInboundLead(context.Background(), org, organicBody, IngestOptions{Now: now})
+	if xerr != nil || real.Lead == nil {
+		t.Fatalf("real ingest: %v %+v", xerr, real)
+	}
+	if sent != 1 {
+		t.Fatalf("real organic must notify once, sent=%d", sent)
+	}
+	if !strings.Contains(lastBody, "organic_search") || !strings.Contains(lastBody, "segunda-leitura") {
+		t.Fatalf("alert missing organic source/asset: %s", lastBody)
+	}
+	if real.DispatchAttempted || svc.cfg.AutoSendEnabled {
+		t.Fatal("auto-send/dispatch attempted")
+	}
+
+	synSent := sent
+	canary, xerr := svc.IngestInboundLead(context.Background(), org, syntheticInboundBody("synthetic-organic-canary"), IngestOptions{Now: now})
+	if xerr != nil || canary.Lead == nil {
+		t.Fatalf("synthetic must persist: %v %+v", xerr, canary)
+	}
+	if sent != synSent {
+		t.Fatalf("synthetic notified operator: sent=%d", sent)
+	}
+	synAlert, _ := repo.GetOperatorAlertByLead(context.Background(), org, "synthetic-organic-canary")
+	if synAlert == nil || synAlert.ChannelStates[AlertChannelEmail] != AlertEmailSyntheticSkipped {
+		t.Fatalf("synthetic email channel=%v", synAlert)
+	}
+	if !synAlert.Synthetic {
+		t.Fatal("canary alert not labeled synthetic")
+	}
+
+	actor := uuid.MustParse("11111111-2222-4333-8444-555555555555")
+	ack, xerr := svc.AcknowledgeInboundAlert(context.Background(), org, actor, "webcfg-organic-1", now.Add(2*time.Minute))
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if ack.AcknowledgedBy != actor.String() {
+		t.Fatalf("ack actor=%s", ack.AcknowledgedBy)
+	}
+	fmt.Printf("ALERT_ORGANIC sent=%d synthetic_skipped=1 actor=%s source=organic_search asset=segunda-leitura auto_send=%v\n",
+		sent, ack.AcknowledgedBy, svc.cfg.AutoSendEnabled)
+}
+
 func TestOperatorAlertEventsDoNotOpenPipeline(t *testing.T) {
 	raw, _ := json.Marshal(map[string]any{"ok": true})
 	_ = raw

--- a/internal/app/confenge/organic_scoreboard_path_test.go
+++ b/internal/app/confenge/organic_scoreboard_path_test.go
@@ -1,0 +1,72 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestOrganicScoreboardOpenInboundIsNotQualifiedPipeline(t *testing.T) {
+	svc, _, org := inboundTestService(t)
+	svc.cfg.AutoSendEnabled = false
+	svc.WireIntel(nil)
+	now := time.Now().UTC()
+	body := []byte(`{
+		"lead_id":"webcfg-organic-open-1",
+		"receipt_id":"rcpt-organic-open-1",
+		"source":"organic_search",
+		"organic_source":"organic_search",
+		"route_family":"inbound",
+		"asset_id":"landing-segunda-leitura",
+		"cta_id":"segunda-leitura-contrato",
+		"company":"Construtora Norte",
+		"email":"ana.souza@norte.example",
+		"consent":{"granted":true,"consent_source":"web-cfg-consent-v1"}
+	}`)
+	ing, xerr := svc.IngestInboundLead(context.Background(), org, body, IngestOptions{Now: now})
+	if xerr != nil || ing.Lead == nil {
+		t.Fatalf("ingest: %v %+v", xerr, ing)
+	}
+	if ing.Lead.Status != models.InboundStatusOpen {
+		t.Fatalf("status=%s want OPEN", ing.Lead.Status)
+	}
+	if ing.DispatchAttempted || svc.cfg.AutoSendEnabled {
+		t.Fatal("dispatch/auto-send must stay off")
+	}
+
+	board, xerr := svc.OrganicScoreboard(context.Background(), org, false)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	pipe := organicLayerTotal(*board, intel.LayerQualifiedPipeline)
+	leads := organicLayerTotal(*board, intel.LayerLeadValid)
+	if leads == 0 {
+		t.Fatalf("open inbound missing from LEAD_VALID: %+v", board.Windows)
+	}
+	if pipe != 0 {
+		t.Fatalf("OPEN inbound counted as QUALIFIED_PIPELINE=%d", pipe)
+	}
+	fmt.Printf("ORGANIC_OPEN_NOT_PIPELINE leads=%d pipeline=%d status=%s auto_send=%v\n",
+		leads, pipe, ing.Lead.Status, svc.cfg.AutoSendEnabled)
+}
+
+func organicLayerTotal(board intel.OrganicScoreboard, id string) int {
+	n := 0
+	for _, w := range board.Windows {
+		if w.ID != intel.Window90d {
+			continue
+		}
+		for _, sl := range w.BySource {
+			for _, ly := range sl.Layers {
+				if ly.ID == id {
+					n += ly.Count
+				}
+			}
+		}
+	}
+	return n
+}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -135,6 +135,8 @@ type Service interface {
 	IngestProviderWebhook(ctx context.Context, orgID uuid.UUID, secret, previous, header string, body []byte) (intel.WebhookAck, *errx.Error)
 	ReopenIntelException(ctx context.Context, orgID uuid.UUID, id, actor, reason string) (intel.ResolveResult, *errx.Error)
 	TruthScoreboard(ctx context.Context, orgID uuid.UUID, month string, includeSynthetic bool) (*intel.Scoreboard, *errx.Error)
+	OrganicScoreboard(ctx context.Context, orgID uuid.UUID, includeSynthetic bool) (*intel.OrganicScoreboard, *errx.Error)
+	OrganicFeedback(ctx context.Context, orgID uuid.UUID, includeSynthetic bool) (*intel.OrganicFeedbackExport, *errx.Error)
 	RegisterHumanOutcome(ctx context.Context, orgID uuid.UUID, in intel.HumanOutcomeEntry) (intel.JoinResult, *errx.Error)
 	HumanOutcomeEnvelopes() []intel.HumanOutcomeEnvelope
 }

--- a/internal/infrastructure/db/migrations/000106_outreach_intel_organic_learning.down.sql
+++ b/internal/infrastructure/db/migrations/000106_outreach_intel_organic_learning.down.sql
@@ -1,0 +1,50 @@
+-- Restore the 000105 exception CHECK (operator-alert era). Organic
+-- attribution codes are dropped from the allowed set.
+
+ALTER TABLE outreach_intel_exceptions
+    DROP CONSTRAINT IF EXISTS outreach_intel_exceptions_code_check;
+
+ALTER TABLE outreach_intel_exceptions
+    ADD CONSTRAINT outreach_intel_exceptions_code_check CHECK (code IN (
+        'orphan',
+        'duplicate',
+        'conflicting_account',
+        'missing_version',
+        'stale_attribution',
+        'out_of_order',
+        'unconfirmed_won',
+        'unconfirmed_lost',
+        'ledger_unavailable',
+        'impossible_transition',
+        'negative_latency',
+        'overlapping_latency',
+        'outbound_as_inbound',
+        'invalid_asset_family',
+        'missing_attribution',
+        'terms_price_version_drift',
+        'capacity_expired',
+        'capacity_lost',
+        'no_capacity',
+        'duplicate_cnpj',
+        'payment_overdue',
+        'payment_refund',
+        'payment_chargeback',
+        'subscription_ended',
+        'unknown_provider_event',
+        'invalid_secret',
+        'provider_unavailable',
+        'onboarding_before_payment',
+        'silent_renewal_refused',
+        'private_extra_as_offer',
+        'conflicting_external_reference',
+        'created_object_as_revenue',
+        'impossible_commercial_transition',
+        'pii_rejected',
+        'capacity_waitlisted',
+        'capacity_rejected',
+        'checkout_expired',
+        'recurring_end_state',
+        'counsel_review_due',
+        'nfse_manual_queue',
+        'alert_store_failed'
+    ));

--- a/internal/infrastructure/db/migrations/000106_outreach_intel_organic_learning.up.sql
+++ b/internal/infrastructure/db/migrations/000106_outreach_intel_organic_learning.up.sql
@@ -1,0 +1,63 @@
+-- Additive organic-attribution exception codes for the inbound learning
+-- loop (issue #47 residual). Own intel plane only. Not a CRM, GSC store,
+-- or second ledger. Individual search queries stay off lead rows.
+
+ALTER TABLE outreach_intel_exceptions
+    DROP CONSTRAINT IF EXISTS outreach_intel_exceptions_code_check;
+
+ALTER TABLE outreach_intel_exceptions
+    ADD CONSTRAINT outreach_intel_exceptions_code_check CHECK (code IN (
+        'orphan',
+        'duplicate',
+        'conflicting_account',
+        'missing_version',
+        'stale_attribution',
+        'out_of_order',
+        'unconfirmed_won',
+        'unconfirmed_lost',
+        'ledger_unavailable',
+        'impossible_transition',
+        'negative_latency',
+        'overlapping_latency',
+        'outbound_as_inbound',
+        'invalid_asset_family',
+        'missing_attribution',
+        'terms_price_version_drift',
+        'capacity_expired',
+        'capacity_lost',
+        'no_capacity',
+        'duplicate_cnpj',
+        'payment_overdue',
+        'payment_refund',
+        'payment_chargeback',
+        'subscription_ended',
+        'unknown_provider_event',
+        'invalid_secret',
+        'provider_unavailable',
+        'onboarding_before_payment',
+        'silent_renewal_refused',
+        'private_extra_as_offer',
+        'conflicting_external_reference',
+        'created_object_as_revenue',
+        'impossible_commercial_transition',
+        'pii_rejected',
+        'capacity_waitlisted',
+        'capacity_rejected',
+        'checkout_expired',
+        'recurring_end_state',
+        'counsel_review_due',
+        'nfse_manual_queue',
+        'alert_store_failed',
+        'lead_without_asset_id',
+        'unknown_asset_version',
+        'contradictory_source',
+        'synthetic_treated_as_real',
+        'missing_consent',
+        'pipeline_without_evidence',
+        'revenue_without_financial_event',
+        'gsc_query_on_lead',
+        'query_hash_on_lead'
+    ));
+
+COMMENT ON CONSTRAINT outreach_intel_exceptions_code_check ON outreach_intel_exceptions IS
+'Versioned intel exception codes including organic attribution conflicts. Individual GSC queries never join a person.';


### PR DESCRIPTION
Organic inbound learning loop on the existing commercial-intel plane (issue #47 residual). Isolated from `origin/main` at SPEED-TO-LEAD-01. Does not close #47. Live consented commercial event is still missing.

## Recommendation

**NEEDS_WEB_CFG_EVENT** (primary). Discovery layers ELIGIBLE/APPEARED/CLICKED/ENGAGED stay BLOCKED until web-cfg sends `confenge.search_observation.v1` aggregates. Also **NEEDS_REAL_EVENT**: no live consented organic revenue exists, so this cannot claim LIVE_PROVEN or close #47.

READY_FOR_INTEGRATION of the Warmbly consumer contract only. Not merge, not deploy, not auto-send.

## Attribution contract

Versioned as `confenge.organic_attribution.v1` on ingest of `confenge.commercial_event.v1`.

Closed `organic_source` taxonomy (never mixed):

`organic_search` | `direct` | `referral` | `ai_referral` | `partner` | `outbound` | `unknown`

`unknown`, `web-cfg`, `CONFENGE_WEB`, and bare `google` are not rewritten to `direct` or `organic_search`. Medium alone does not invent organic search.

Preserved when supplied: medium/campaign, referrer_class (never a sensitive URL), canonical landing_path, asset_family, asset_id/version, CTA id/version, aggregate intent_class/query_class, correlation_id/lead_id/account_id, record_kind real vs synthetic, consent/version, first_touch/last_touch, clocks, page/content version, producer SHA.

## Authority split

- web-cfg: source/referrer/asset/CTA, consent, GSC/site aggregates, lead capture
- Warmbly: approved action, acknowledgement, reply, meeting, proposal, observed outcome
- extra-cli: facts/entities/evidence, not commercial action
- Warmbly does not write web-cfg, extra-cli, or SmartLic

## Schema / migrations

Additive `000106_outreach_intel_organic_learning` widens the existing exception CHECK. Down restores the 000105 list. No new CRM, ledger, warehouse, or inbox. Same `outreach_intel_*` store.

New read-only routes:
- `GET /confenge/intel/organic-scoreboard` (`confenge.organic_learning_scoreboard.v1`)
- `GET /confenge/intel/organic-feedback` (`confenge.organic_editorial_feedback.v1`)

CLI: `confenge intel-organic`.

## Scoreboard

Ten layers kept separate: discovery (BLOCKED without web-cfg aggregates; never inferred from leads), LEAD_VALID, QUALIFIED_LEAD, ACKNOWLEDGED/FIRST_ACTION, CONVERSATION, MEETING, PROPOSAL, QUALIFIED_PIPELINE, WON/LOST/UNKNOWN, CONTRACTED_REVENUE vs RECEIVED_REVENUE.

Windows: complete 7d, complete 28d, 90d, open/censored cohorts. Source slices unmixed. Median/p75/p90 only when n>=5. Organic ROAS/CAC stay BLOCKED. UNKNOWN stays visible. `causal_proof` is always false.

Example from the fixture CLI path: `real_empty=true`, discovery BLOCKED, recommendation NEEDS_WEB_CFG_EVENT, contracted vs received distinct.

## Exceptions (no silent drop)

New codes on the existing queue (owner, severity, status, next action, evidence, retry/replay, resolution audit):

- lead_without_asset_id (web-cfg)
- unknown_asset_version (web-cfg)
- contradictory_source (web-cfg)
- synthetic_treated_as_real (inbound-ops)
- missing_consent (inbound-ops)
- pipeline_without_evidence (founder)
- revenue_without_financial_event (finance)
- gsc_query_on_lead (web-cfg)
- query_hash_on_lead (web-cfg)

Joins stay idempotent. Replay/out-of-order do not open a second chain.

## Privacy guardrails

- Individual GSC/search phrases are stripped on ParseInboundLead, utmQuery, EventToFacts, and INBOUND NOW display
- query_hash is never a lead attribute
- Metric keys remain hashes; report/feedback/scoreboard pass the existing PII scan
- Referrer query strings are dropped; landing_path is path-only

## Speed-to-lead residual

Proven leak: `emitOperatorChannels` sent email whenever a transporter existed. Synthetic/test now set `synthetic_skipped` and never call `operatorMail`. Real organic leads include `organic_source` and `asset_id` in the alert body. Ack still requires a real actor. Alert-store failure still keeps the receipt. `CONFENGE_AUTO_SEND_ENABLED` stays false. No auto-reply, auto-call, or auto-send.

## Feedback export

Per asset/cohort: observed outcomes, denominators, freshness, reason codes, exactly REPEAT | CHANGE | STOP | NEED_MORE_DATA, explicit confidence/uncertainty, next test. `causal_proof=false`. `upstream_writes=[]`. No automatic content or indexation change.

## Tests

Shipped entry points: `IngestEvent`, inbound persist, operator alert ensure/ack, `ProjectOrganicScoreboard`, `ExportOrganicFeedback`, HTTP GET handlers, `confenge intel-organic`.

Focused packages `./internal/app/confenge/intel/ ./internal/app/confenge/ ./internal/api/handler/` at `-count=2` plus the full intel suite, twice. `gofmt -l` empty. `golangci-lint` clean on touched packages. Docs `pnpm types:check` clean; eslint only pre-existing warnings.

## Commits

- `321b181b` feat: add organic attribution contract, unmixed cohort scoreboard, and read-only REPEAT/CHANGE/STOP/NEED_MORE_DATA export on the existing #47 intel plane

Cut from `origin/main` `ec8647e2` (SPEED-TO-LEAD-01). Not mixed with dirty `feat/confenge-inbound-last-mile`.