### PR TITLE
feat: require nonempty controlled-eligible mailbox when freezing a cohort

### DIFF
--- a/internal/app/confenge/cohort_operator_flow_test.go
+++ b/internal/app/confenge/cohort_operator_flow_test.go
@@ -79,6 +79,14 @@ func TestPreparePreviewFreezeDerivesHashesAndReconciles(t *testing.T) {
 	if snap.RealEmailSent || snap.AutoSendEnabled {
 		t.Fatal("prepare must not send or auto-send")
 	}
+	for _, m := range snap.Members {
+		if canonicalPilotEmail(m.Mailbox) == "" {
+			t.Fatal("frozen member mailbox must be non-empty")
+		}
+	}
+	if snap.RecipientSetHash == HashRecipientSet(nil) {
+		t.Fatal("recipient set hash must not be the empty-set digest")
+	}
 	if snap.Preview.ByRouteClass[RouteClassDirectPerson] != 1 || snap.Preview.ByRouteClass[RouteClassRoleOrDepartment] != 1 ||
 		snap.Preview.ByRouteClass[RouteClassGenericCompany] != 1 || snap.Preview.ByRouteClass[RouteClassPublicCompanyFreemail] != 1 {
 		t.Fatalf("classes %+v", snap.Preview.ByRouteClass)

--- a/internal/app/confenge/cohort_prepare.go
+++ b/internal/app/confenge/cohort_prepare.go
@@ -439,6 +439,12 @@ func controlledPrepareBlock(c *models.OutreachContactCandidate, allowed map[stri
 	if blk := classifyControlledRecipient(nil, c, now); blk != nil {
 		return blk.Code
 	}
+	if canonicalPilotEmail(c.Email) == "" {
+		return "missing_mailbox"
+	}
+	if !CandidateControlledEligible(c) {
+		return "no_controlled_eligible_route"
+	}
 	class := CandidateRouteClass(c)
 	if class == RouteClassProbabilisticOrRisky {
 		return "risky_outside_default_pilot"


### PR DESCRIPTION
Prepare was freezing the first empty mailbox as GENERIC and treating every later empty mailbox as a duplicate. Extra-cli contacts without `controlled_email_eligible` plus no email were being inferred into the cohort. Require a nonempty mailbox and extra-cli controlled eligibility before freeze. Recipient set hash must not be the empty digest.