### PR TITLE
feat: treat extra-cli route_suppression NONE as clear when freezing a controlled-email cohort

### DIFF
--- a/docs/confenge/controlled-email-cohort.md
+++ b/docs/confenge/controlled-email-cohort.md
@@ -25,6 +25,7 @@ Hashes (`cohort_id`, `cohort_hash`, `recipient_set_hash`, SHA, feed identity, po
 - Allows `ROLE_OR_DEPARTMENT`, `GENERIC_COMPANY`, `PUBLIC_COMPANY_FREEMAIL`
 - Keeps `PROBABILISTIC_OR_RISKY` out of the default pilot
 - Excludes hard bounce, opt-out, suppression, DNC, stale evidence, missing provenance, shotgun duplicates
+- Extra-cli `route_suppression: NONE` is not suppression. `provenance_chain_valid: false` does not by itself drop a contact extra-cli already stamped `controlled_email_eligible`. Demo or fixture taint still excludes.
 - Absence of a named person does **not** exclude a control-eligible route
 - Prints a reconciling preview (eligible + excluded = considered)
 

--- a/internal/app/confenge/cohort_feed.go
+++ b/internal/app/confenge/cohort_feed.go
@@ -135,14 +135,34 @@ func candidateFromFeedContact(fc FeedContact) models.OutreachContactCandidate {
 	case models.OutreachVerifyDoNotContact:
 		c.DoNotContact = true
 	}
-	if strings.TrimSpace(fc.RouteSuppression) != "" {
-		c.Blocked = true
-		c.BlockReason = fc.RouteSuppression
+	if routeSuppressionActive(fc.RouteSuppression) {
+		c.DoNotContact = true
+		if c.BlockReason == "" {
+			c.BlockReason = "route_suppression:" + strings.ToUpper(strings.TrimSpace(fc.RouteSuppression))
+		}
 	}
 	if fc.ProvenanceChainValid != nil && !*fc.ProvenanceChainValid {
+		c.EmailSendReady = false
+		if c.BlockReason == "" {
+			c.BlockReason = "provenance_chain_invalid"
+		}
+	}
+	derivedFixture := fc.DerivedFromFixture != nil && *fc.DerivedFromFixture
+	if t, reason := ContactProvenanceTainted(fc.Email, fc.SourceURL, "", fc.VerificationStatus, derivedFixture); t {
+		c.EmailSendReady = false
 		c.Blocked = true
-		c.BlockReason = "provenance"
+		c.BlockReason = "provenance_taint:" + reason
 	}
 	c.DiscoveryJSON = mergeControlledDiscovery(fc.DiscoveryJSON, fc)
 	return c
+}
+
+// routeSuppressionActive is extra-cli's suppression enum. NONE/CLEAR/empty are not suppressed.
+func routeSuppressionActive(v string) bool {
+	switch strings.ToUpper(strings.TrimSpace(v)) {
+	case "SUPPRESSED", "DO_NOT_CONTACT", "DNC":
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/app/confenge/cohort_operator_flow_test.go
+++ b/internal/app/confenge/cohort_operator_flow_test.go
@@ -3,6 +3,7 @@ package confenge
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -597,5 +598,128 @@ func TestPostFreezeAndContentDriftFailClosed(t *testing.T) {
 	in.ComposerVersion = "other"
 	if reasons := ValidateBoundedCohortAuthorization(auth, in); !containsStr(reasons, "copy_drift") {
 		t.Fatalf("content/composer drift: %v", reasons)
+	}
+}
+
+func extraCLIStampContact(email, class, sourceURL, suppression string) FeedContact {
+	eligible, unk, chain := true, true, false
+	preferred := class == RouteClassGenericCompany
+	return FeedContact{
+		Email: email, SourceURL: sourceURL, OwnershipStatus: "COMPANY_OWNED",
+		MailboxPurpose: "UNKNOWN", VerificationStatus: models.OutreachVerifyOfficialSource,
+		RouteClass: class, ControlledEmailEligible: &eligible, PreferredInitial: &preferred,
+		PersonUnknown: &unk, MailboxCompanyEvidence: "OBSERVED", RouteSuppression: suppression,
+		RouteFreshness: "FRESH", ProvenanceChainValid: &chain, RiskClass: "ALLOWED",
+	}
+}
+
+func extraCLIStampLead(ref, cnpj, email, class, sourceURL, suppression string) FeedLead {
+	return FeedLead{
+		SourceLeadID: ref,
+		Company:      FeedCompany{CNPJ14: cnpj, RazaoSocial: "EMPRESA " + ref + " LTDA"},
+		Moment:       FeedMoment{Code: "CONTRACT_EXTENSION", Summary: "Aditivo publicado"},
+		MessagingContext: FeedMessaging{
+			FactToMention: "Aditivo publicado no portal oficial", CTA: "Posso enviar o recorte?",
+		},
+		Contacts: []FeedContact{extraCLIStampContact(email, class, sourceURL, suppression)},
+	}
+}
+
+func TestPrepareFromExtraCLINoneSuppressionKeepsControlledEligible(t *testing.T) {
+	feed := &Feed{
+		SchemaVersion: models.OutreachSchemaV1,
+		Source:        FeedSource{System: "extra-cli", RunID: "run-none", SnapshotHash: "snap-none"},
+		Leads: []FeedLead{
+			extraCLIStampLead("lead-generic", "11111111000191", "contato@empresa-extra.com.br", RouteClassGenericCompany, "https://empresa-extra.com.br/contato", "NONE"),
+			extraCLIStampLead("lead-gmail", "22222222000192", "empresa@gmail.com", RouteClassPublicCompanyFreemail, "https://empresa-gmail.com.br/contato", "NONE"),
+		},
+	}
+	snap, err := PrepareControlledCohortFromFeed(feed, CohortPrepareOptions{
+		Now: time.Now().UTC(), Limit: 50, MaxDailyVolume: 50, TTL: 24 * time.Hour, RepositorySHA: "sha-none",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Preview.AccountsEligible != 2 || snap.Preview.RecipientsFinal != 2 {
+		t.Fatalf("extra-cli NONE + invalid chain must freeze stamped routes, preview=%+v exclusions=%+v", snap.Preview, snap.Exclusions)
+	}
+	if snap.RecipientSetHash == HashRecipientSet(nil) {
+		t.Fatal("recipient set must not be the empty digest")
+	}
+	for _, m := range snap.Members {
+		if canonicalPilotEmail(m.Mailbox) == "" {
+			t.Fatal("frozen mailbox empty")
+		}
+		if m.RouteClass != RouteClassGenericCompany && m.RouteClass != RouteClassPublicCompanyFreemail {
+			t.Fatalf("unexpected class %s", m.RouteClass)
+		}
+	}
+}
+
+func TestPrepareFromExtraCLIActiveSuppressionStillWins(t *testing.T) {
+	feed := &Feed{
+		SchemaVersion: models.OutreachSchemaV1,
+		Source:        FeedSource{System: "extra-cli", RunID: "run-supp", SnapshotHash: "snap-supp"},
+		Leads: []FeedLead{
+			extraCLIStampLead("lead-dnc", "33333333000193", "contato@empresa-dnc.com.br", RouteClassGenericCompany, "https://empresa-dnc.com.br/contato", "SUPPRESSED"),
+		},
+	}
+	snap, err := PrepareControlledCohortFromFeed(feed, CohortPrepareOptions{
+		Now: time.Now().UTC(), RepositorySHA: "sha-supp",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Preview.AccountsEligible != 0 {
+		t.Fatalf("active suppression must win, preview=%+v", snap.Preview)
+	}
+	if snap.Preview.OptOut < 1 && snap.Preview.ByExclusionReason["recipient_opt_out"] < 1 {
+		t.Fatalf("want recipient_opt_out, got %+v", snap.Preview.ByExclusionReason)
+	}
+}
+
+func TestPrepareFromExtraCLIFixtureTaintStillExcluded(t *testing.T) {
+	lead := extraCLIStampLead("lead-fix", "55555555000195", "contato@empresa-fix.com.br", RouteClassGenericCompany, "https://empresa-fix.com.br/contato", "NONE")
+	derived := true
+	lead.Contacts[0].DerivedFromFixture = &derived
+	feed := &Feed{
+		SchemaVersion: models.OutreachSchemaV1,
+		Source:        FeedSource{System: "extra-cli", RunID: "run-fix", SnapshotHash: "snap-fix"},
+		Leads:         []FeedLead{lead},
+	}
+	snap, err := PrepareControlledCohortFromFeed(feed, CohortPrepareOptions{
+		Now: time.Now().UTC(), RepositorySHA: "sha-fix",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Preview.AccountsEligible != 0 {
+		t.Fatalf("fixture taint must exclude, preview=%+v", snap.Preview)
+	}
+}
+
+func TestPrepareFromFiveClassCanaryPicksOneNonemptyRoute(t *testing.T) {
+	raw, err := os.ReadFile("testdata/controlled_email_five_class_canary.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	feed, err := ParseFeed(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snap, err := PrepareControlledCohortFromFeed(feed, CohortPrepareOptions{
+		Now: time.Now().UTC(), Limit: 50, MaxDailyVolume: 50, TTL: 24 * time.Hour, RepositorySHA: "sha-canary",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if snap.Preview.RecipientsFinal != 1 {
+		t.Fatalf("one account, one route, got eligible=%d reasons=%+v members=%d", snap.Preview.AccountsEligible, snap.Preview.ByExclusionReason, len(snap.Members))
+	}
+	if canonicalPilotEmail(snap.Members[0].Mailbox) == "" {
+		t.Fatal("canary frozen mailbox empty")
+	}
+	if snap.Members[0].RouteClass == RouteClassProbabilisticOrRisky {
+		t.Fatal("RISKY must not freeze")
 	}
 }

--- a/internal/app/confenge/cohort_prepare.go
+++ b/internal/app/confenge/cohort_prepare.go
@@ -471,10 +471,10 @@ func provenanceMissing(c *models.OutreachContactCandidate) bool {
 	if c == nil {
 		return true
 	}
-	if strings.TrimSpace(c.RouteSuppression) != "" {
+	if routeSuppressionActive(c.RouteSuppression) {
 		return true
 	}
-	if strings.Contains(strings.ToLower(c.BlockReason), "provenance") {
+	if strings.Contains(strings.ToLower(c.BlockReason), "provenance_taint") {
 		return true
 	}
 	return false

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -642,10 +642,10 @@ func leadToCandidate(orgID, accountID, runID uuid.UUID, fc FeedContact) *models.
 	if models.OutreachUnenrollableVerification[cand.VerificationStatus] || cand.VerificationStatus == models.OutreachVerifyInstitutionalGeneric {
 		cand.EmailSendReady = false
 	}
-	if supp := strings.ToUpper(strings.TrimSpace(cand.RouteSuppression)); supp == "SUPPRESSED" || supp == "DO_NOT_CONTACT" || supp == "DNC" {
+	if routeSuppressionActive(cand.RouteSuppression) {
 		cand.DoNotContact = true
 		if cand.BlockReason == "" {
-			cand.BlockReason = "route_suppression:" + supp
+			cand.BlockReason = "route_suppression:" + strings.ToUpper(strings.TrimSpace(cand.RouteSuppression))
 		}
 	}
 	if fc.MailboxPurposeSendBlocked != nil {


### PR DESCRIPTION
## Summary
- Production prepare of the fresh extra-cli feed froze N=0 because `candidateFromFeedContact` treated extra-cli `route_suppression: NONE` as blocked and `provenance_chain_valid: false` as missing provenance. Extra-cli publishes both on contacts it already stamped `controlled_email_eligible`.
- Align prepare-from-feed with import: only `SUPPRESSED` / `DO_NOT_CONTACT` / `DNC` suppress; `NONE` stays clear. Invalid provenance chain no longer blocks a stamped controlled-eligible route. Demo/fixture taint still excludes.
- Tests: extra-cli NONE + invalid chain freezes GENERIC and FREEMAIL; active suppression still wins; five-class canary freezes one nonempty non-RISKY route.

## Test plan
- [x] `gofmt -l` on touched Go (empty)
- [x] `golangci-lint run ./internal/app/confenge/...`
- [x] `go test ./internal/app/confenge/ -run TestPrepareFromExtraCLI|TestPrepareFromFiveClass|TestPreparePreviewFreeze|...`
- [ ] After merge, deploy SHA to Netcup and re-run `confenge cohort prepare --feed` on the private extra-cli feed; expect N>=1 nonempty mailboxes (hashes only)