### PR TITLE
feat: freeze a controlled-email cohort from postgres scoped to one extra-cli feed run

### DIFF
--- a/cmd/confenge/cohort.go
+++ b/cmd/confenge/cohort.go
@@ -50,7 +50,7 @@ func cmdCohortPrepare(args []string) int {
 	fs := flag.NewFlagSet("cohort prepare", flag.ExitOnError)
 	feedPath := fs.String("feed", "", "extra-cli feed JSON (preferred; hashes are derived)")
 	outPath := fs.String("out", "", "write frozen snapshot JSON to PATH")
-	orgStr := fs.String("org-id", "", "load accounts from postgres instead of --feed")
+	orgStr := fs.String("org-id", "", "load accounts from postgres; with --feed, scope to that feed run and keep its identity")
 	limit := fs.Int("limit", confenge.DefaultCohortLimit, "max accounts in the frozen set (1-100)")
 	volume := fs.Int("max-daily", confenge.DefaultCohortDailyVolume, "max daily volume bound into the grant")
 	ttl := fs.String("ttl", "24h", "authorization TTL")
@@ -78,6 +78,48 @@ func cmdCohortPrepare(args []string) int {
 
 	var snap *confenge.FrozenCohortSnapshot
 	switch {
+	case strings.TrimSpace(*feedPath) != "" && strings.TrimSpace(*orgStr) != "":
+		// Feed supplies identity and scope; Postgres supplies the real
+		// account/candidate ids the dispatch path needs.
+		raw, err := os.ReadFile(*feedPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "BLOCKED: feed: %v\n", err)
+			return 1
+		}
+		feed, err := confenge.ParseFeed(raw)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "BLOCKED: parse feed: %v\n", err)
+			return 1
+		}
+		runID := firstNonEmpty(feed.Source.RunID, feed.Source.SnapshotHash)
+		if strings.TrimSpace(runID) == "" {
+			fmt.Fprintln(os.Stderr, "BLOCKED: feed has no run id; cannot bind a frozen cohort to it")
+			return 1
+		}
+		opts.FeedIdentity = firstNonEmpty(opts.FeedIdentity, runID)
+		opts.SnapshotHash = firstNonEmpty(opts.SnapshotHash, feed.Source.SnapshotHash)
+		opts.FeedSchemaVersion = firstNonEmpty(feed.SchemaVersion, opts.FeedSchemaVersion)
+		opts.Source = firstNonEmpty(feed.Source.System, "extra-cli")
+		orgID := parseOrg(*orgStr)
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		pool, err := pgxpool.New(ctx, primaryDSN())
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "BLOCKED: postgres: %v\n", err)
+			return 1
+		}
+		defer pool.Close()
+		repo := repository.NewOutreachRepository(pool)
+		accounts, err := confenge.AccountsFromOrgForRun(ctx, repo, orgID, opts.Source, runID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "BLOCKED: load accounts: %v\n", err)
+			return 1
+		}
+		snap, err = confenge.PrepareControlledCohort(accounts, opts)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "BLOCKED: prepare: %v\n", err)
+			return 1
+		}
 	case strings.TrimSpace(*feedPath) != "":
 		raw, err := os.ReadFile(*feedPath)
 		if err != nil {
@@ -116,7 +158,7 @@ func cmdCohortPrepare(args []string) int {
 			return 1
 		}
 	default:
-		fmt.Fprintln(os.Stderr, "usage: confenge cohort prepare --feed PATH [--out PATH] or --org-id UUID")
+		fmt.Fprintln(os.Stderr, "usage: confenge cohort prepare --feed PATH [--org-id UUID] [--out PATH] or --org-id UUID")
 		return 2
 	}
 

--- a/docs/confenge/controlled-email-cohort.md
+++ b/docs/confenge/controlled-email-cohort.md
@@ -4,7 +4,7 @@ The founder path for the first real cohort is:
 
 ```text
 confenge import --feed PATH
-confenge cohort prepare --feed PATH --out /tmp/cohort.json
+confenge cohort prepare --feed PATH --org-id ORG_UUID --out /tmp/cohort.json
 confenge cohort preview --manifest /tmp/cohort.json
 confenge cohort authorize --manifest /tmp/cohort.json --actor UUID
 confenge cohort authorize --manifest /tmp/cohort.json --actor UUID --confirm
@@ -15,6 +15,8 @@ confenge cohort report --events PATH
 ```
 
 Hashes (`cohort_id`, `cohort_hash`, `recipient_set_hash`, SHA, feed identity, policy/composer/evidence versions) are derived by `prepare`. Do not copy them by hand.
+
+Pass `--feed` and `--org-id` together for a cohort you intend to dispatch. The feed supplies identity and scopes the freeze to that import run; Postgres supplies the real account and candidate ids the dispatch path needs. `--feed` alone freezes straight from the document and leaves those ids empty, so it previews but cannot dispatch. `--org-id` alone carries no feed identity, so the live GO review reports `feed_identity_missing` and never reaches `GO_FOR_CONTROLLED_EMAIL_PILOT`.
 
 `cohort-auth create|show|revoke` remains the low-level grant primitive.
 

--- a/internal/app/confenge/cohort_feed.go
+++ b/internal/app/confenge/cohort_feed.go
@@ -166,3 +166,27 @@ func routeSuppressionActive(v string) bool {
 		return false
 	}
 }
+
+// AccountsFromOrgForRun loads PG-bound accounts limited to one extra-cli feed
+// run. Freezing from Postgres keeps real account/candidate ids for dispatch;
+// scoping by run id keeps the frozen set tied to the imported feed.
+func AccountsFromOrgForRun(ctx context.Context, repo repository.OutreachRepository, orgID uuid.UUID, source, runID string) ([]CohortAccountInput, error) {
+	all, err := AccountsFromOrg(ctx, repo, orgID, source)
+	if err != nil {
+		return nil, err
+	}
+	runID = strings.TrimSpace(runID)
+	if runID == "" {
+		return all, nil
+	}
+	out := make([]CohortAccountInput, 0, len(all))
+	for i := range all {
+		if strings.TrimSpace(all[i].Account.SourceRunID) == runID {
+			out = append(out, all[i])
+		}
+	}
+	if len(out) == 0 {
+		return nil, fmt.Errorf("no imported accounts for feed run %q; import the feed first", runID)
+	}
+	return out, nil
+}

--- a/internal/app/confenge/cohort_feed_run_scope_test.go
+++ b/internal/app/confenge/cohort_feed_run_scope_test.go
@@ -1,0 +1,100 @@
+package confenge
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// A PG-bound freeze must still carry feed identity, otherwise the live GO
+// review reports feed_identity_missing and the cohort can never reach
+// GO_FOR_CONTROLLED_EMAIL_PILOT.
+func TestOrgBoundCohortWithoutFeedIdentityFailsReleaseComparison(t *testing.T) {
+	auth := &BoundedCohortAuthorization{
+		ID:                  uuid.New(),
+		RepositorySHA:       "sha-1",
+		FeedSchemaVersion:   "confenge.outreach.v1",
+		PolicyVersion:       BoundedCohortPolicyV1,
+		ComposerVersion:     ComposerVersion,
+		EvidenceVersion:     DefaultEvidenceVersion,
+		RecipientSetHash:    "recipients-1",
+		CohortHash:          "cohort-1",
+		MaxDailyVolume:      50,
+		AllowedRouteClasses: []string{RouteClassDirectPerson, RouteClassRoleOrDepartment, RouteClassGenericCompany, RouteClassPublicCompanyFreemail},
+		FrozenManifest: &FrozenCohortSnapshot{
+			Members: []FrozenCohortMember{{Mailbox: "a@example.com", RouteClass: RouteClassGenericCompany}},
+		},
+	}
+
+	want := expectedReleaseFromGrant(auth)
+	got := want
+	// Live collection derives FeedHash only from the snapshot's identity fields.
+	got.FeedHash = ""
+
+	cmp := CompareControlledEmailRelease(want, got)
+	var found bool
+	for _, ch := range cmp.Checks {
+		if ch.Name == "feed_hash" {
+			found = true
+			if ch.State.IsPass() {
+				t.Fatalf("feed_hash must not PASS when live identity is empty")
+			}
+			if ch.Reason != "feed_identity_missing" {
+				t.Fatalf("reason = %q, want feed_identity_missing", ch.Reason)
+			}
+		}
+	}
+	if !found {
+		t.Fatal("feed_hash check missing from comparison")
+	}
+	if cmp.Verdict.Verdict == ReleaseGOForControlledEmailPilot {
+		t.Fatal("missing feed identity must not reach GO_FOR_CONTROLLED_EMAIL_PILOT")
+	}
+}
+
+// Freezing from Postgres scoped to a feed run keeps the real account/candidate
+// ids AND the feed identity, so the same snapshot can pass review and dispatch.
+func TestPrepareFromOrgAccountsCarriesFeedIdentityAndDBIdentifiers(t *testing.T) {
+	unk := true
+	accID, candID := uuid.New(), uuid.New()
+	acc := cohortAccount("acc-generic", "33333333000193", "Contrato vigente")
+	acc.ID = accID
+	acc.SourceRunID = "run-fresh-1"
+	accounts := []CohortAccountInput{{
+		Account: acc,
+		Candidates: []models.OutreachContactCandidate{{
+			ID:              candID,
+			AccountID:       accID,
+			Email:           "contato@empresa3.com.br",
+			MailboxPurpose:  "GENERIC_CONTACT",
+			OwnershipStatus: "COMPANY_OWNED",
+			DiscoveryJSON:   eligibleDisc(t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unk}),
+		}},
+		Source: "extra-cli",
+	}}
+
+	snap, err := PrepareControlledCohort(accounts, CohortPrepareOptions{
+		RepositorySHA:  "sha-1",
+		FeedIdentity:   "run-fresh-1",
+		Limit:          50,
+		MaxDailyVolume: 50,
+	})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if snap.FeedIdentity != "run-fresh-1" {
+		t.Fatalf("feed identity = %q, want run-fresh-1", snap.FeedIdentity)
+	}
+	if len(snap.Members) != 1 {
+		t.Fatalf("members = %d, want 1", len(snap.Members))
+	}
+	m := snap.Members[0]
+	if m.AccountID != accID {
+		t.Fatalf("account id = %s, want %s", m.AccountID, accID)
+	}
+	if m.CandidateID != candID {
+		t.Fatalf("candidate id = %s, want %s", m.CandidateID, candID)
+	}
+}


### PR DESCRIPTION
A cohort frozen with `--feed` alone carries the feed identity the live GO review checks, but its members have no `account_id` / `candidate_id`, so `DispatchBoundedCohort` cannot bind a real account and enrollment fails. A cohort frozen with `--org-id` alone binds those ids but has no `feed_identity`, so `CollectLiveReleaseManifest` leaves `FeedHash` empty and `CompareControlledEmailRelease` reports `feed_identity_missing` — `GO_FOR_CONTROLLED_EMAIL_PILOT` is unreachable.

Neither shape can both pass review and dispatch. This adds the combination: `cohort prepare --feed PATH --org-id UUID` takes identity and scope from the feed and members from Postgres, restricted to that feed's run id via `AccountsFromOrgForRun`. Freezing against an unimported run is refused rather than silently freezing the whole org.

Verified on the production feed (`fresh-cohort-20260822T030709Z`): the feed-only and org-only paths already derive the same `cohort_hash` and `recipient_set_hash`, so scoping changes membership selection not at all — it only restores the two identity halves.

Tests: a PG-bound freeze without feed identity must not reach `GO_FOR_CONTROLLED_EMAIL_PILOT`, and a run-scoped freeze must keep both the feed identity and the DB ids.