### PR TITLE
feat: supersede stale cancelled initial touchpoints when authorizing a frozen cohort

### DIFF
--- a/internal/app/confenge/cohort_apply.go
+++ b/internal/app/confenge/cohort_apply.go
@@ -206,14 +206,35 @@ func locateOrBuildTouchpoint(ctx context.Context, repo repository.OutreachReposi
 		if err != nil {
 			return nil, false, err
 		}
+		var reusable *models.OutreachTouchpoint
 		for i := range list {
 			tp := &list[i]
-			if tp.Ordinal == 1 || tp.Purpose == models.TouchpointPurposeInitial {
-				if canonicalPilotEmail(tp.Recipient) == canonicalPilotEmail(m.Mailbox) || tp.Recipient == "" {
-					return tp, false, nil
-				}
+			if tp.Ordinal != 1 && tp.Purpose != models.TouchpointPurposeInitial {
+				continue
+			}
+			if canonicalPilotEmail(tp.Recipient) != canonicalPilotEmail(m.Mailbox) && tp.Recipient != "" {
+				continue
+			}
+			// A route already in flight or delivered must never be re-authorized
+			// into a second initial touch.
+			if terminalSentTouchpointState(tp.State) {
+				return nil, false, fmt.Errorf("route_already_dispatched:%s", strings.ToLower(tp.State))
+			}
+			// A stop that means "do not contact this recipient" still blocks,
+			// whatever the stop reason text says.
+			if suppressedTouchpointState(tp.State) {
+				return nil, false, fmt.Errorf("route_suppressed:%s", strings.ToLower(tp.State))
+			}
+			if reusableTouchpointState(tp.State) && reusable == nil {
+				reusable = tp
 			}
 		}
+		if reusable != nil {
+			return reusable, false, nil
+		}
+		// Only stale non-terminal artifacts remain (e.g. a CANCELLED row from an
+		// older composer version). Supersede them with a fresh initial touch
+		// rather than blocking the whole frozen cohort on one stale row.
 		tp := newFrozenTouchpoint(orgID, m, now)
 		return tp, true, nil
 	}
@@ -281,4 +302,36 @@ func FormatCohortAuthorize(res *CohortAuthorizeResult) string {
 		fmt.Fprintf(&b, "FAIL account=%s mailbox=%s reason=%s\n", f.AccountRef, RedactMailbox(f.Mailbox), f.Reason)
 	}
 	return b.String()
+}
+
+// reusableTouchpointState is a pre-send state a frozen cohort may authorize.
+func reusableTouchpointState(state string) bool {
+	switch state {
+	case models.TouchpointDrafted, models.TouchpointNeedsReview, models.TouchpointApproved,
+		models.TouchpointPlanned, models.TouchpointDue:
+		return true
+	default:
+		return false
+	}
+}
+
+// terminalSentTouchpointState means the route already reached transport.
+// Re-authorizing it would risk a duplicate send.
+func terminalSentTouchpointState(state string) bool {
+	switch state {
+	case models.TouchpointQueued, models.TouchpointSent, models.TouchpointReplied:
+		return true
+	default:
+		return false
+	}
+}
+
+// suppressedTouchpointState means the recipient itself is stopped.
+func suppressedTouchpointState(state string) bool {
+	switch state {
+	case models.TouchpointDNC, models.TouchpointBounced, models.TouchpointRejected:
+		return true
+	default:
+		return false
+	}
 }

--- a/internal/app/confenge/cohort_apply_stale_touchpoint_test.go
+++ b/internal/app/confenge/cohort_apply_stale_touchpoint_test.go
@@ -1,0 +1,119 @@
+package confenge
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func staleCohortMember(t *testing.T, accID, candID uuid.UUID, mailbox string) FrozenCohortMember {
+	t.Helper()
+	return FrozenCohortMember{
+		AccountID:   accID,
+		AccountRef:  "cnpj:33333333000193",
+		CandidateID: candID,
+		Mailbox:     mailbox,
+		RouteClass:  RouteClassGenericCompany,
+		Subject:     "objeto: contrato publicado",
+		BodyText:    "Olá, equipe,\n\nSou da CONFENGE.\n\nobjeto: contrato publicado.\n\nVocê consegue me indicar a pessoa responsável?",
+	}
+}
+
+// A CANCELLED row left by an older composer version must not block a fresh
+// frozen cohort: it is superseded by a new initial touch, not reused.
+func TestStaleCancelledTouchpointIsSupersededNotReused(t *testing.T) {
+	accID, candID := uuid.New(), uuid.New()
+	orgID := uuid.New()
+	mailbox := "contato@empresa3.com.br"
+
+	repo := newMemRepo()
+	seedTouchpoint(t, repo, &models.OutreachTouchpoint{
+		ID: uuid.New(), OrganizationID: orgID, AccountID: accID, Ordinal: 1,
+		Purpose: models.TouchpointPurposeInitial, Recipient: mailbox,
+		State: models.TouchpointCancelled, StopReason: "composer_version_stale",
+	})
+
+	tp, create, err := locateOrBuildTouchpoint(context.Background(), repo, orgID, staleCohortMember(t, accID, candID, mailbox), time.Now().UTC())
+	if err != nil {
+		t.Fatalf("stale cancelled row must not block: %v", err)
+	}
+	if !create {
+		t.Fatal("expected a fresh touchpoint, got reuse of the cancelled row")
+	}
+	if tp.State != models.TouchpointNeedsReview {
+		t.Fatalf("state = %s, want NEEDS_REVIEW", tp.State)
+	}
+}
+
+// An already-dispatched route must still block, so a frozen cohort cannot
+// produce a second send to the same mailbox.
+func TestSentTouchpointBlocksReauthorization(t *testing.T) {
+	accID, candID := uuid.New(), uuid.New()
+	orgID := uuid.New()
+	mailbox := "contato@empresa3.com.br"
+
+	for _, st := range []string{models.TouchpointSent, models.TouchpointQueued} {
+		repo := newMemRepo()
+		seedTouchpoint(t, repo, &models.OutreachTouchpoint{
+			ID: uuid.New(), OrganizationID: orgID, AccountID: accID, Ordinal: 1,
+			Purpose: models.TouchpointPurposeInitial, Recipient: mailbox, State: st,
+		})
+		_, _, err := locateOrBuildTouchpoint(context.Background(), repo, orgID, staleCohortMember(t, accID, candID, mailbox), time.Now().UTC())
+		if err == nil || !strings.Contains(err.Error(), "route_already_dispatched") {
+			t.Fatalf("state %s: err = %v, want route_already_dispatched", st, err)
+		}
+	}
+}
+
+// A recipient-level stop still blocks regardless of stop-reason text.
+func TestSuppressedTouchpointBlocksReauthorization(t *testing.T) {
+	accID, candID := uuid.New(), uuid.New()
+	orgID := uuid.New()
+	mailbox := "contato@empresa3.com.br"
+
+	for _, st := range []string{models.TouchpointDNC, models.TouchpointBounced, models.TouchpointRejected} {
+		repo := newMemRepo()
+		seedTouchpoint(t, repo, &models.OutreachTouchpoint{
+			ID: uuid.New(), OrganizationID: orgID, AccountID: accID, Ordinal: 1,
+			Purpose: models.TouchpointPurposeInitial, Recipient: mailbox, State: st,
+		})
+		_, _, err := locateOrBuildTouchpoint(context.Background(), repo, orgID, staleCohortMember(t, accID, candID, mailbox), time.Now().UTC())
+		if err == nil || !strings.Contains(err.Error(), "route_suppressed") {
+			t.Fatalf("state %s: err = %v, want route_suppressed", st, err)
+		}
+	}
+}
+
+// A live pre-send draft is still reused rather than duplicated.
+func TestPreSendTouchpointIsReused(t *testing.T) {
+	accID, candID := uuid.New(), uuid.New()
+	orgID := uuid.New()
+	mailbox := "contato@empresa3.com.br"
+	want := uuid.New()
+
+	repo := newMemRepo()
+	seedTouchpoint(t, repo, &models.OutreachTouchpoint{
+		ID: want, OrganizationID: orgID, AccountID: accID, Ordinal: 1,
+		Purpose: models.TouchpointPurposeInitial, Recipient: mailbox,
+		State: models.TouchpointDrafted,
+	})
+	tp, create, err := locateOrBuildTouchpoint(context.Background(), repo, orgID, staleCohortMember(t, accID, candID, mailbox), time.Now().UTC())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if create || tp.ID != want {
+		t.Fatalf("expected reuse of %s, got create=%v id=%s", want, create, tp.ID)
+	}
+}
+
+func seedTouchpoint(t *testing.T, repo *memRepo, tp *models.OutreachTouchpoint) {
+	t.Helper()
+	if err := repo.InsertTouchpoint(context.Background(), tp); err != nil {
+		t.Fatalf("seed touchpoint: %v", err)
+	}
+}


### PR DESCRIPTION
`AuthorizeFrozenCohort` refuses partial apply, so one unusable member blocks the whole cohort. `locateOrBuildTouchpoint` returned the first initial touchpoint for an account **regardless of state**, so a `CANCELLED` row left by an older composer version made authorization fail with `cannot cohort-authorize from state CANCELLED` and took all 50 members down with it.

Observed in production: 26 of the fresh cohort's touchpoints were `CANCELLED` with `composer_version_stale` / `TARGET_FIT_STALE` from Aug 13-14. None were suppression, opt-out, DNC, or bounce.

Now the scan classifies what it finds:

- pre-send (`DRAFTED`, `NEEDS_REVIEW`, `APPROVED`, `PLANNED`, `DUE`) is reused, as before
- `QUEUED` / `SENT` / `REPLIED` blocks with `route_already_dispatched`, so a frozen cohort can never mint a second initial touch for a route that already reached transport
- `DNC` / `BOUNCED` / `REJECTED` blocks with `route_suppressed`, independent of stop-reason text
- anything else stale is superseded by a fresh initial touch rather than reused

The two blocking cases are new guards: previously a `SENT` initial touchpoint would have been handed back and rejected only by the generic state check, and the duplicate risk was never named.