### PR TITLE
feat: allow BOUNDED_COHORT_AUTHORIZATION in the touchpoint authorization_mode check constraint

### DIFF
--- a/internal/app/confenge/cohort_auth_mode_migration_test.go
+++ b/internal/app/confenge/cohort_auth_mode_migration_test.go
@@ -1,0 +1,53 @@
+package confenge
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// Every authorization mode the cohort operator can persist must be permitted by
+// the newest outreach_touchpoints_auth_mode_check. Migration 000092 pinned the
+// column to three values; the bounded cohort added a fourth in Go only, so every
+// frozen-cohort touchpoint write failed with SQLSTATE 23514.
+func TestBoundedCohortAuthModeIsAllowedByLatestCheckConstraint(t *testing.T) {
+	dir := filepath.Join("..", "..", "infrastructure", "db", "migrations")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("read migrations: %v", err)
+	}
+	var ups []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".up.sql") {
+			ups = append(ups, e.Name())
+		}
+	}
+	sort.Strings(ups)
+
+	// The last migration that redefines the constraint wins.
+	var latest string
+	for _, name := range ups {
+		b, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		body := string(b)
+		if strings.Contains(body, "outreach_touchpoints_auth_mode_check") && strings.Contains(body, "ADD CONSTRAINT") {
+			latest = body
+		}
+	}
+	if latest == "" {
+		t.Fatal("no migration defines outreach_touchpoints_auth_mode_check")
+	}
+	for _, mode := range []string{
+		AuthorizationModeHumanTouchpoint,
+		AuthorizationModeCampaignPolicy,
+		AuthorizationModeBoundedCohort,
+	} {
+		if !strings.Contains(latest, "'"+mode+"'") {
+			t.Fatalf("authorization mode %q is written by Go but rejected by the check constraint", mode)
+		}
+	}
+}

--- a/internal/infrastructure/db/migrations/000109_confenge_bounded_cohort_auth_mode.down.sql
+++ b/internal/infrastructure/db/migrations/000109_confenge_bounded_cohort_auth_mode.down.sql
@@ -1,0 +1,14 @@
+-- Revert to the pre-bounded-cohort set. Rows already carrying the bounded mode
+-- are reset to '' so the narrower constraint can be re-applied.
+UPDATE outreach_touchpoints
+   SET authorization_mode = ''
+ WHERE authorization_mode = 'BOUNDED_COHORT_AUTHORIZATION';
+
+ALTER TABLE outreach_touchpoints
+    DROP CONSTRAINT IF EXISTS outreach_touchpoints_auth_mode_check;
+
+ALTER TABLE outreach_touchpoints
+    ADD CONSTRAINT outreach_touchpoints_auth_mode_check
+        CHECK (authorization_mode IN (
+            '', 'HUMAN_TOUCHPOINT_APPROVAL', 'CAMPAIGN_POLICY'
+        ));

--- a/internal/infrastructure/db/migrations/000109_confenge_bounded_cohort_auth_mode.up.sql
+++ b/internal/infrastructure/db/migrations/000109_confenge_bounded_cohort_auth_mode.up.sql
@@ -1,0 +1,14 @@
+-- Migration 000092 pinned authorization_mode to '', HUMAN_TOUCHPOINT_APPROVAL and
+-- CAMPAIGN_POLICY. The bounded cohort operator writes BOUNDED_COHORT_AUTHORIZATION,
+-- so every frozen-cohort touchpoint insert/update failed the check constraint.
+ALTER TABLE outreach_touchpoints
+    DROP CONSTRAINT IF EXISTS outreach_touchpoints_auth_mode_check;
+
+ALTER TABLE outreach_touchpoints
+    ADD CONSTRAINT outreach_touchpoints_auth_mode_check
+        CHECK (authorization_mode IN (
+            '', 'HUMAN_TOUCHPOINT_APPROVAL', 'CAMPAIGN_POLICY', 'BOUNDED_COHORT_AUTHORIZATION'
+        ));
+
+COMMENT ON COLUMN outreach_touchpoints.authorization_mode IS
+'HUMAN_TOUCHPOINT_APPROVAL requires approved_by; CAMPAIGN_POLICY uses a policy grant and must leave approved_by null; BOUNDED_COHORT_AUTHORIZATION is a frozen founder-authorized cohort grant.';


### PR DESCRIPTION
Migration 000092 pinned `outreach_touchpoints.authorization_mode` to `''`, `HUMAN_TOUCHPOINT_APPROVAL`, `CAMPAIGN_POLICY`. The bounded cohort operator writes `BOUNDED_COHORT_AUTHORIZATION`, which no migration ever added, so every frozen-cohort touchpoint insert or update failed:

```
new row for relation "outreach_touchpoints" violates check constraint
"outreach_touchpoints_auth_mode_check" (SQLSTATE 23514)
```

The bounded-cohort authorize path could therefore never persist against a real database, on any SHA since #104. It was not caught earlier because the in-memory repository used by the unit tests has no check constraints.

Migration 000109 re-adds the constraint with the fourth value. The down migration resets rows carrying the bounded mode before narrowing the constraint again, so the rollback is applicable rather than failing on existing data.

The guard test reads the newest migration that defines the constraint and asserts every authorization mode constant the Go code can write is accepted, so a future mode cannot repeat this.