### PR TITLE
feat: enforce touchpoint authorization-grant integrity with a mode-aware trigger

### DIFF
--- a/internal/infrastructure/db/migrations/000110_confenge_polymorphic_authorization_grant_fk.down.sql
+++ b/internal/infrastructure/db/migrations/000110_confenge_polymorphic_authorization_grant_fk.down.sql
@@ -1,0 +1,15 @@
+DROP TRIGGER IF EXISTS confenge_touchpoint_authorization_grant_check ON outreach_touchpoints;
+DROP FUNCTION IF EXISTS confenge_check_touchpoint_authorization_grant();
+
+-- Clear references the narrower single-table FK cannot satisfy before restoring it.
+UPDATE outreach_touchpoints
+   SET campaign_policy_authorization_id = NULL
+ WHERE campaign_policy_authorization_id IS NOT NULL
+   AND campaign_policy_authorization_id NOT IN (
+       SELECT id FROM confenge_campaign_policy_authorizations
+   );
+
+ALTER TABLE outreach_touchpoints
+    ADD CONSTRAINT outreach_touchpoints_cpa_fk
+        FOREIGN KEY (campaign_policy_authorization_id)
+        REFERENCES confenge_campaign_policy_authorizations(id) ON DELETE SET NULL;

--- a/internal/infrastructure/db/migrations/000110_confenge_polymorphic_authorization_grant_fk.up.sql
+++ b/internal/infrastructure/db/migrations/000110_confenge_polymorphic_authorization_grant_fk.up.sql
@@ -1,0 +1,52 @@
+-- outreach_touchpoints.campaign_policy_authorization_id is a polymorphic grant
+-- reference discriminated by authorization_mode. The single-table foreign key
+-- was only correct while CAMPAIGN_POLICY was the sole non-empty mode; a
+-- BOUNDED_COHORT_AUTHORIZATION grant lives in a different table and always
+-- failed outreach_touchpoints_cpa_fk. Replace the FK with a mode-aware trigger
+-- so both grant types keep referential integrity.
+ALTER TABLE outreach_touchpoints
+    DROP CONSTRAINT IF EXISTS outreach_touchpoints_cpa_fk;
+
+CREATE OR REPLACE FUNCTION confenge_check_touchpoint_authorization_grant()
+RETURNS trigger AS $$
+BEGIN
+    IF NEW.campaign_policy_authorization_id IS NULL THEN
+        RETURN NEW;
+    END IF;
+
+    IF NEW.authorization_mode = 'BOUNDED_COHORT_AUTHORIZATION' THEN
+        IF NOT EXISTS (
+            SELECT 1 FROM confenge_bounded_cohort_authorizations
+             WHERE id = NEW.campaign_policy_authorization_id
+        ) THEN
+            RAISE EXCEPTION
+                'bounded cohort grant % not found for touchpoint %',
+                NEW.campaign_policy_authorization_id, NEW.id
+                USING ERRCODE = 'foreign_key_violation';
+        END IF;
+        RETURN NEW;
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM confenge_campaign_policy_authorizations
+         WHERE id = NEW.campaign_policy_authorization_id
+    ) THEN
+        RAISE EXCEPTION
+            'campaign policy grant % not found for touchpoint %',
+            NEW.campaign_policy_authorization_id, NEW.id
+            USING ERRCODE = 'foreign_key_violation';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS confenge_touchpoint_authorization_grant_check ON outreach_touchpoints;
+
+CREATE TRIGGER confenge_touchpoint_authorization_grant_check
+    BEFORE INSERT OR UPDATE OF campaign_policy_authorization_id, authorization_mode
+    ON outreach_touchpoints
+    FOR EACH ROW
+    EXECUTE FUNCTION confenge_check_touchpoint_authorization_grant();
+
+COMMENT ON COLUMN outreach_touchpoints.campaign_policy_authorization_id IS
+'Polymorphic grant reference. authorization_mode selects the table: CAMPAIGN_POLICY -> confenge_campaign_policy_authorizations, BOUNDED_COHORT_AUTHORIZATION -> confenge_bounded_cohort_authorizations. Enforced by confenge_touchpoint_authorization_grant_check.';


### PR DESCRIPTION
`outreach_touchpoints.campaign_policy_authorization_id` is a polymorphic grant reference discriminated by `authorization_mode`, but it carried a single-table foreign key to `confenge_campaign_policy_authorizations`. A bounded cohort grant lives in `confenge_bounded_cohort_authorizations`, so `ApplyBoundedCohortAuthorization` always failed:

```
insert or update on table "outreach_touchpoints" violates foreign key
constraint "outreach_touchpoints_cpa_fk" (SQLSTATE 23503)
```

This was the second schema blocker behind #43 (the first was the `authorization_mode` check constraint, #113).

Rather than drop integrity, the FK is replaced with a trigger that validates the reference against the table the mode selects, raising `foreign_key_violation`. Adding a second column was rejected: ~20 call sites already treat this column as the mode-discriminated grant id, and splitting it would risk the campaign-policy path for no behavioral gain.

Verified against a scratch Postgres with the full migration chain applied from empty:

- existing bounded grant, mode `BOUNDED_COHORT_AUTHORIZATION` -> accepted
- missing bounded grant -> rejected
- missing campaign-policy grant, mode `CAMPAIGN_POLICY` -> still rejected
- null grant -> accepted

The down migration nulls references the narrower FK cannot satisfy before restoring it, so rollback applies against data that already has bounded rows.