### PR TITLE
feat: record CONFENGE first bounded email cohort production evidence and dispatch runbook

### DIFF
--- a/docs/ops/campaigns/CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01/EVIDENCE.md
+++ b/docs/ops/campaigns/CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01/EVIDENCE.md
@@ -1,0 +1,171 @@
+# CONFENGE first bounded email cohort — production evidence
+
+Round: `CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01` (2026-08-22 UTC)
+
+## Verdict
+
+`PRODUCTION_BLOCKED_BY_EXTERNAL_GATE:SEND_WINDOW`
+
+`GO_FOR_CONTROLLED_EMAIL_PILOT` was emitted by the live evaluator on the deployed SHA with
+every required gate PASS. No message was dispatched: the authorized 24h TTL and the campaign
+send window do not intersect, so no real send was possible inside the authorization.
+
+## Release identity
+
+| Field | Value |
+| --- | --- |
+| PRODUCTION_SHA | `8fa1af2cff88900013a683528f22935d33a57764` |
+| MAIN_SHA | `8fa1af2cff88900013a683528f22935d33a57764` |
+| Migration version | `110` (not dirty) |
+| Feed schema | `confenge.outreach.v1` |
+| Feed identity | `fresh-cohort-20260822T030709Z` |
+| FEED_HASH (sha256 of feed document) | `d71ce315d94d3846e6d84e9b5dd075de14e034c95b6111fe138e67767f3c9dca` |
+| COHORT_ID | `controlled-f02294cb6a1f` |
+| COHORT_HASH | `f02294cb6a1f55a7c947d111128f0c683d0319ef9bd6fb24c997c6059165ebd0` |
+| RECIPIENT_SET_HASH | `f3f1095d4d9c525768fa8585d2d5eaf3020b4969b473d9e2e65d8a9a486a8e0b` |
+| AUTHORIZATION_ID | `a8bb9e08-8c60-45d1-8eae-8f00e502d275` |
+| FROZEN_HASH | `464bc6c684437d3e466e1dce06f45e3a0a61dfc47c1ac6e2ce35aa9d03a1bab7` |
+| POLICY_VERSION | `bounded-cohort-policy.v1` |
+| COMPOSER_VERSION | `confenge.composer.v3` |
+| EVIDENCE_VERSION | `controlled-email-policy.v1` |
+| MAX_DAILY | `50` |
+| TTL | `24h`, expires `2026-08-23T04:25:13Z` |
+| Human verdict | `READY_FOR_CONTROLLED_EMAIL_GO_REVIEW` |
+| Reason | `founder_authorized_final_production_round_2026-08-21` |
+
+## Cohort composition
+
+Counts only. The frozen manifest carries operational PII and stays on the host volume,
+never in git.
+
+| Metric | Value |
+| --- | --- |
+| accounts_considered | 50 |
+| accounts_eligible | 50 |
+| recipients_final | 50 |
+| unique mailboxes | 50 |
+| unique accounts | 50 (exactly one initial route per account) |
+| GENERIC_COMPANY | 38 |
+| ROLE_OR_DEPARTMENT | 12 |
+| PROBABILISTIC_OR_RISKY | 0 (excluded by policy) |
+| suppressed / opt_out / hard_bounce | 0 / 0 / 0 |
+| duplicates / missing_provenance / stale | 0 / 0 / 0 |
+| copy_qa_failures | 0 |
+| person_unknown | 50/50 (no invented person, role, or title) |
+
+## Live GO review — every required gate
+
+| Check | State |
+| --- | --- |
+| repository_sha | PASS (expected == live) |
+| schema | PASS |
+| feed_hash | PASS |
+| cohort_hash | PASS |
+| recipient_set_hash | PASS |
+| policy_version | PASS |
+| composer_version | PASS |
+| evidence_version | PASS |
+| route_classes | PASS |
+| volume_cap | PASS (50) |
+| smtp_ready | PASS |
+| reply_ingest_ready | PASS |
+| observability_ready | PASS |
+| dispatch_wiring | PASS |
+| sender_provider_config | PASS |
+| db_cohort_authority | PASS |
+| suppression_clear | PASS |
+| ttl_valid | PASS |
+| kill_switch_available | PASS |
+| sending_paused | false |
+| auto_send | false |
+| green_autorun | false |
+
+`release_verdict=GO_FOR_CONTROLLED_EMAIL_PILOT`
+
+## Reply ingest — resolved
+
+IMAP is the real mechanism, not an assumption. Replies arrive worker IMAP sync ->
+consumer `ProcessIncomingReply` -> `OnClassifiedReply`. Proven live read-only:
+TCP reachability to the campaign IMAP host from both the VPS host and the worker
+container, plus an active `smtp_imap` mailbox row with a non-empty `imap_host`.
+No mailbox content was fetched and no credential was logged or read.
+
+## Transport reachability
+
+Outbound submission and IMAP are open from the host and from inside the worker
+container (587, 465, 993). The Netcup outbound-SMTP unlock is in place.
+
+## The blocker
+
+The CONFENGE campaign shell sends Mon-Fri 09:00-18:00 `America/Sao_Paulo`
+(`days` bitmask 31). `ListCampaignScheduleCandidates` additionally requires
+`campaigns.status = 'active'`; the shell is `draft`.
+
+| Moment | Value |
+| --- | --- |
+| Review executed | Sat 2026-08-22 01:26 (-03) |
+| Grant TTL expiry | Sun 2026-08-23 01:25 (-03) |
+| Next send window opens | Mon 2026-08-24 09:00 (-03) |
+| Gap | window opens **31.6 h after the grant expires** |
+
+The 24h TTL cannot reach a send window, so no dispatch inside this authorization
+could have produced a real email.
+
+Dispatching anyway was rejected deliberately: it would have enrolled 50 contacts into a
+campaign that never runs, consumed all 50 daily-cap slots, and moved 50 touchpoints to
+`QUEUED` — which the `route_already_dispatched` guard would then block from
+re-authorization. That is strictly worse than not dispatching.
+
+## Post-state (verified)
+
+| Metric | Value |
+| --- | --- |
+| REAL_EMAIL_SENT | false |
+| N_ATTEMPTED | 0 |
+| N_PROVIDER_ACCEPTED | 0 |
+| campaign_leads | 0 |
+| contacts | 0 |
+| touchpoints QUEUED/SENT | 0 |
+| cohort slots consumed | 0 |
+| touchpoints APPROVED under the grant | 50 |
+| grant revoked | no (valid until TTL) |
+| AUTO_SEND_ENABLED | false |
+| GREEN_AUTORUN_ENABLED | false |
+| KILL_SWITCH_AVAILABLE | true (engaged, fail-closed) |
+
+## Defects found and fixed this round
+
+Three shipped defects made a live GO structurally unreachable before this round.
+
+1. **#111** — a cohort frozen from the feed had no `account_id`/`candidate_id` (cannot
+   dispatch); one frozen from Postgres had no `feed_identity` (live review reports
+   `feed_identity_missing`). Neither shape could both pass review and dispatch.
+2. **#112** — one stale `CANCELLED` touchpoint from an older composer version blocked the
+   whole 50-member cohort, because authorization refuses partial apply.
+3. **#113 / #114** — two schema blockers: `authorization_mode` had no
+   `BOUNDED_COHORT_AUTHORIZATION` value, and the grant column carried a foreign key to the
+   campaign-policy table only. Every bounded-cohort touchpoint write failed against a real
+   database, on every SHA since #104. Unit tests missed both because the in-memory
+   repository has no constraints.
+
+## Smallest human action to complete the round
+
+Either is one decision, not new engineering:
+
+**A. Run inside the window (recommended).** On Mon 2026-08-24 between 09:00 and 18:00
+`America/Sao_Paulo`, activate the campaign shell and re-run the sequence in `RUNBOOK.md`.
+A fresh 24h grant is required because this one expires Sunday.
+
+**B. Authorize sending outside business days.** Widen the campaign `days`/window. This
+sends cold B2B mail outside business hours and is worse for deliverability, especially
+with `auth_dkim = false` on the sending mailbox.
+
+## Deliverability note (unrelated to the blocker)
+
+The sending mailbox reports `auth_spf = true`, `auth_dmarc = true`, `auth_dkim = false`.
+DKIM should be fixed before the first real cold cohort. Tracked separately by #138.
+
+Copy QA passes every policy gate, but three cosmetic defects are worth fixing before real
+recipients see them: subjects truncate mid-word, the body embeds a raw record dump
+(`objeto: ...; órgão: ...; UF ...; R$ ...`), and the English service code `portfolio review`
+leaks into Portuguese copy.

--- a/docs/ops/campaigns/CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01/RUNBOOK.md
+++ b/docs/ops/campaigns/CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01/RUNBOOK.md
@@ -1,0 +1,154 @@
+# Runbook: dispatch the first bounded email cohort
+
+Authorized host: Netcup `v2202607385716487230` `/opt/warmbly-confenge`.
+Run inside the campaign send window: Mon-Fri 09:00-18:00 `America/Sao_Paulo`.
+Outside it nothing transmits, and a grant that expires before the next window
+cannot produce a real send.
+
+All commands run the `confenge` binary shipped inside the backend image.
+
+## 0. Preconditions
+
+```bash
+cd /opt/warmbly-confenge
+cat .deployed_sha                       # must equal origin/main
+docker exec warmbly-confenge-backend-1 env | grep CONFENGE_REPOSITORY_SHA
+```
+
+The campaign shell must be `active`; it ships as `draft` and the scheduler only
+selects `status = 'active'`.
+
+```bash
+docker exec -i warmbly-confenge-postgres-1 psql -U warmbly -d warmbly_dev \
+  -c "SELECT id, status, days, start_time, end_time, timezone FROM campaigns;"
+```
+
+## 1. Pull and import the fresh feed
+
+`file://` feeds are refused in production. Use the feed plane over HTTPS.
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge import \
+  --feed https://confenge-feed:8443/controlled-email-cohort-fresh.json \
+  --org-id 22222222-0000-0000-0000-000000000001 --dry-run
+
+docker exec warmbly-confenge-backend-1 /app/confenge import \
+  --feed https://confenge-feed:8443/controlled-email-cohort-fresh.json \
+  --org-id 22222222-0000-0000-0000-000000000001
+```
+
+## 2. Freeze the cohort
+
+Pass `--feed` and `--org-id` together. The feed gives identity and scope; Postgres
+gives the account and candidate ids the dispatch path needs. Either flag alone
+produces a manifest that cannot both pass review and dispatch.
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort prepare \
+  --feed /data/confenge-ops/confenge.outreach.v1.json \
+  --org-id 22222222-0000-0000-0000-000000000001 \
+  --out /data/confenge-ops/first-cohort-bound.json \
+  --limit 50 --max-daily 50 --ttl 24h
+```
+
+Hashes are derived. Never copy one by hand. The manifest holds operational PII:
+it stays on the host volume and is never committed.
+
+## 3. Authorize
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort authorize \
+  --manifest /data/confenge-ops/first-cohort-bound.json \
+  --actor <FOUNDER_UUID> \
+  --org-id 22222222-0000-0000-0000-000000000001          # dry run first
+
+docker exec warmbly-confenge-backend-1 /app/confenge cohort authorize \
+  --manifest /data/confenge-ops/first-cohort-bound.json \
+  --actor <FOUNDER_UUID> \
+  --org-id 22222222-0000-0000-0000-000000000001 --confirm
+```
+
+Authorization is all-or-nothing. `authorized_touchpoints` must equal
+`selected_accounts` and `failed_authorization` must be 0.
+
+## 4. Release the kill switch
+
+Every deploy writes a paused kill switch, so the review reports
+`sending_paused=true` until this runs.
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge resume-sending
+```
+
+## 5. Live GO review
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort review \
+  --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID>
+```
+
+Proceed only on `release_verdict=GO_FOR_CONTROLLED_EMAIL_PILOT` with every check
+PASS. UNKNOWN is not PASS. Then persist the human verdict:
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort review \
+  --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID> \
+  --verdict READY_FOR_CONTROLLED_EMAIL_GO_REVIEW \
+  --reason "<founder reason>" --confirm
+```
+
+## 6. Dispatch
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort dispatch \
+  --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID> --limit 50    # preview
+
+docker exec warmbly-confenge-backend-1 /app/confenge cohort dispatch \
+  --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID> --limit 50 --confirm
+```
+
+Enrollment queues campaign execution. Provider acceptance is reported by the
+consumer after the worker reports transport success, so
+`N_PROVIDER_ACCEPTED` lags `N_ATTEMPTED`. Do not infer delivery.
+
+## 7. Kill switch
+
+Stops enroll and send paths immediately, including anything already queued,
+because the worker reads the same file switch at the SMTP boundary.
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge stop-sending
+```
+
+## 8. Observe
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort report --events <PATH>
+```
+
+Record attempted, provider-accepted, bounce, reply, opt-out per route class.
+Anything not yet observable stays UNKNOWN.
+
+## Rollback
+
+Images are tagged by SHA on every deploy.
+
+```bash
+cd /opt/warmbly-confenge
+git reset --hard <PREVIOUS_SHA>
+sed -i "s|^CONFENGE_REPOSITORY_SHA=.*|CONFENGE_REPOSITORY_SHA=<PREVIOUS_SHA>|" deploy/confenge-vps/.env
+export COMPOSE_PROJECT_NAME=warmbly-confenge
+for s in backend consumer worker; do
+  docker tag warmbly-confenge-$s:<PREVIOUS_SHA> warmbly-confenge-$s:latest
+done
+bash deploy/confenge-vps/up.sh
+```
+
+Migrations 109 and 110 are additive and idempotent. Both have applicable down
+migrations that clear rows the narrower constraints cannot satisfy before
+restoring them. Revoke a grant instead of rolling back code when the concern is
+the cohort rather than the release:
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort-auth revoke --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID>
+```


### PR DESCRIPTION
Evidence and runbook for round `CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01`.

`GO_FOR_CONTROLLED_EMAIL_PILOT` was emitted by the live evaluator on the deployed SHA with all 22 required gates PASS, and the human verdict is persisted against grant `a8bb9e08`. No message was dispatched.

The blocker is the campaign send window. The shell sends Mon-Fri 09:00-18:00 `America/Sao_Paulo` and the scheduler only selects `status = 'active'`; the review ran Saturday 01:26 (-03). The authorized 24h TTL expires Sunday 01:25, which is 31.6 hours **before** the next window opens on Monday. The TTL and the window do not intersect, so no dispatch inside this authorization could have produced a real email.

Dispatching anyway was rejected on purpose: it would have enrolled 50 contacts into a campaign that never runs, consumed all 50 daily-cap slots, and moved 50 touchpoints to `QUEUED`, which the `route_already_dispatched` guard would then block from re-authorization. Production is left fail-closed with the kill switch engaged, zero slots consumed, and the grant intact.

Only hashes, counts and redacted state are committed. The frozen manifest holds operational PII and stays on the host volume.