### PR TITLE
feat: make a frozen controlled-email cohort actually sendable

### DIFF
--- a/docs/ops/campaigns/CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01/EVIDENCE.md
+++ b/docs/ops/campaigns/CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01/EVIDENCE.md
@@ -1,0 +1,171 @@
+# CONFENGE first bounded email cohort — production evidence
+
+Round: `CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01` (2026-08-22 UTC)
+
+## Verdict
+
+`PRODUCTION_BLOCKED_BY_EXTERNAL_GATE:SEND_WINDOW`
+
+`GO_FOR_CONTROLLED_EMAIL_PILOT` was emitted by the live evaluator on the deployed SHA with
+every required gate PASS. No message was dispatched: the authorized 24h TTL and the campaign
+send window do not intersect, so no real send was possible inside the authorization.
+
+## Release identity
+
+| Field | Value |
+| --- | --- |
+| PRODUCTION_SHA | `8fa1af2cff88900013a683528f22935d33a57764` |
+| MAIN_SHA | `8fa1af2cff88900013a683528f22935d33a57764` |
+| Migration version | `110` (not dirty) |
+| Feed schema | `confenge.outreach.v1` |
+| Feed identity | `fresh-cohort-20260822T030709Z` |
+| FEED_HASH (sha256 of feed document) | `d71ce315d94d3846e6d84e9b5dd075de14e034c95b6111fe138e67767f3c9dca` |
+| COHORT_ID | `controlled-f02294cb6a1f` |
+| COHORT_HASH | `f02294cb6a1f55a7c947d111128f0c683d0319ef9bd6fb24c997c6059165ebd0` |
+| RECIPIENT_SET_HASH | `f3f1095d4d9c525768fa8585d2d5eaf3020b4969b473d9e2e65d8a9a486a8e0b` |
+| AUTHORIZATION_ID | `a8bb9e08-8c60-45d1-8eae-8f00e502d275` |
+| FROZEN_HASH | `464bc6c684437d3e466e1dce06f45e3a0a61dfc47c1ac6e2ce35aa9d03a1bab7` |
+| POLICY_VERSION | `bounded-cohort-policy.v1` |
+| COMPOSER_VERSION | `confenge.composer.v3` |
+| EVIDENCE_VERSION | `controlled-email-policy.v1` |
+| MAX_DAILY | `50` |
+| TTL | `24h`, expires `2026-08-23T04:25:13Z` |
+| Human verdict | `READY_FOR_CONTROLLED_EMAIL_GO_REVIEW` |
+| Reason | `founder_authorized_final_production_round_2026-08-21` |
+
+## Cohort composition
+
+Counts only. The frozen manifest carries operational PII and stays on the host volume,
+never in git.
+
+| Metric | Value |
+| --- | --- |
+| accounts_considered | 50 |
+| accounts_eligible | 50 |
+| recipients_final | 50 |
+| unique mailboxes | 50 |
+| unique accounts | 50 (exactly one initial route per account) |
+| GENERIC_COMPANY | 38 |
+| ROLE_OR_DEPARTMENT | 12 |
+| PROBABILISTIC_OR_RISKY | 0 (excluded by policy) |
+| suppressed / opt_out / hard_bounce | 0 / 0 / 0 |
+| duplicates / missing_provenance / stale | 0 / 0 / 0 |
+| copy_qa_failures | 0 |
+| person_unknown | 50/50 (no invented person, role, or title) |
+
+## Live GO review — every required gate
+
+| Check | State |
+| --- | --- |
+| repository_sha | PASS (expected == live) |
+| schema | PASS |
+| feed_hash | PASS |
+| cohort_hash | PASS |
+| recipient_set_hash | PASS |
+| policy_version | PASS |
+| composer_version | PASS |
+| evidence_version | PASS |
+| route_classes | PASS |
+| volume_cap | PASS (50) |
+| smtp_ready | PASS |
+| reply_ingest_ready | PASS |
+| observability_ready | PASS |
+| dispatch_wiring | PASS |
+| sender_provider_config | PASS |
+| db_cohort_authority | PASS |
+| suppression_clear | PASS |
+| ttl_valid | PASS |
+| kill_switch_available | PASS |
+| sending_paused | false |
+| auto_send | false |
+| green_autorun | false |
+
+`release_verdict=GO_FOR_CONTROLLED_EMAIL_PILOT`
+
+## Reply ingest — resolved
+
+IMAP is the real mechanism, not an assumption. Replies arrive worker IMAP sync ->
+consumer `ProcessIncomingReply` -> `OnClassifiedReply`. Proven live read-only:
+TCP reachability to the campaign IMAP host from both the VPS host and the worker
+container, plus an active `smtp_imap` mailbox row with a non-empty `imap_host`.
+No mailbox content was fetched and no credential was logged or read.
+
+## Transport reachability
+
+Outbound submission and IMAP are open from the host and from inside the worker
+container (587, 465, 993). The Netcup outbound-SMTP unlock is in place.
+
+## The blocker
+
+The CONFENGE campaign shell sends Mon-Fri 09:00-18:00 `America/Sao_Paulo`
+(`days` bitmask 31). `ListCampaignScheduleCandidates` additionally requires
+`campaigns.status = 'active'`; the shell is `draft`.
+
+| Moment | Value |
+| --- | --- |
+| Review executed | Sat 2026-08-22 01:26 (-03) |
+| Grant TTL expiry | Sun 2026-08-23 01:25 (-03) |
+| Next send window opens | Mon 2026-08-24 09:00 (-03) |
+| Gap | window opens **31.6 h after the grant expires** |
+
+The 24h TTL cannot reach a send window, so no dispatch inside this authorization
+could have produced a real email.
+
+Dispatching anyway was rejected deliberately: it would have enrolled 50 contacts into a
+campaign that never runs, consumed all 50 daily-cap slots, and moved 50 touchpoints to
+`QUEUED` — which the `route_already_dispatched` guard would then block from
+re-authorization. That is strictly worse than not dispatching.
+
+## Post-state (verified)
+
+| Metric | Value |
+| --- | --- |
+| REAL_EMAIL_SENT | false |
+| N_ATTEMPTED | 0 |
+| N_PROVIDER_ACCEPTED | 0 |
+| campaign_leads | 0 |
+| contacts | 0 |
+| touchpoints QUEUED/SENT | 0 |
+| cohort slots consumed | 0 |
+| touchpoints APPROVED under the grant | 50 |
+| grant revoked | no (valid until TTL) |
+| AUTO_SEND_ENABLED | false |
+| GREEN_AUTORUN_ENABLED | false |
+| KILL_SWITCH_AVAILABLE | true (engaged, fail-closed) |
+
+## Defects found and fixed this round
+
+Three shipped defects made a live GO structurally unreachable before this round.
+
+1. **#111** — a cohort frozen from the feed had no `account_id`/`candidate_id` (cannot
+   dispatch); one frozen from Postgres had no `feed_identity` (live review reports
+   `feed_identity_missing`). Neither shape could both pass review and dispatch.
+2. **#112** — one stale `CANCELLED` touchpoint from an older composer version blocked the
+   whole 50-member cohort, because authorization refuses partial apply.
+3. **#113 / #114** — two schema blockers: `authorization_mode` had no
+   `BOUNDED_COHORT_AUTHORIZATION` value, and the grant column carried a foreign key to the
+   campaign-policy table only. Every bounded-cohort touchpoint write failed against a real
+   database, on every SHA since #104. Unit tests missed both because the in-memory
+   repository has no constraints.
+
+## Smallest human action to complete the round
+
+Either is one decision, not new engineering:
+
+**A. Run inside the window (recommended).** On Mon 2026-08-24 between 09:00 and 18:00
+`America/Sao_Paulo`, activate the campaign shell and re-run the sequence in `RUNBOOK.md`.
+A fresh 24h grant is required because this one expires Sunday.
+
+**B. Authorize sending outside business days.** Widen the campaign `days`/window. This
+sends cold B2B mail outside business hours and is worse for deliverability, especially
+with `auth_dkim = false` on the sending mailbox.
+
+## Deliverability note (unrelated to the blocker)
+
+The sending mailbox reports `auth_spf = true`, `auth_dmarc = true`, `auth_dkim = false`.
+DKIM should be fixed before the first real cold cohort. Tracked separately by #138.
+
+Copy QA passes every policy gate, but three cosmetic defects are worth fixing before real
+recipients see them: subjects truncate mid-word, the body embeds a raw record dump
+(`objeto: ...; órgão: ...; UF ...; R$ ...`), and the English service code `portfolio review`
+leaks into Portuguese copy.

--- a/docs/ops/campaigns/CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01/RUNBOOK.md
+++ b/docs/ops/campaigns/CONFENGE-WARMBLY-FIRST-BOUNDED-EMAIL-PRODUCTION-01/RUNBOOK.md
@@ -1,0 +1,154 @@
+# Runbook: dispatch the first bounded email cohort
+
+Authorized host: Netcup `v2202607385716487230` `/opt/warmbly-confenge`.
+Run inside the campaign send window: Mon-Fri 09:00-18:00 `America/Sao_Paulo`.
+Outside it nothing transmits, and a grant that expires before the next window
+cannot produce a real send.
+
+All commands run the `confenge` binary shipped inside the backend image.
+
+## 0. Preconditions
+
+```bash
+cd /opt/warmbly-confenge
+cat .deployed_sha                       # must equal origin/main
+docker exec warmbly-confenge-backend-1 env | grep CONFENGE_REPOSITORY_SHA
+```
+
+The campaign shell must be `active`; it ships as `draft` and the scheduler only
+selects `status = 'active'`.
+
+```bash
+docker exec -i warmbly-confenge-postgres-1 psql -U warmbly -d warmbly_dev \
+  -c "SELECT id, status, days, start_time, end_time, timezone FROM campaigns;"
+```
+
+## 1. Pull and import the fresh feed
+
+`file://` feeds are refused in production. Use the feed plane over HTTPS.
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge import \
+  --feed https://confenge-feed:8443/controlled-email-cohort-fresh.json \
+  --org-id 22222222-0000-0000-0000-000000000001 --dry-run
+
+docker exec warmbly-confenge-backend-1 /app/confenge import \
+  --feed https://confenge-feed:8443/controlled-email-cohort-fresh.json \
+  --org-id 22222222-0000-0000-0000-000000000001
+```
+
+## 2. Freeze the cohort
+
+Pass `--feed` and `--org-id` together. The feed gives identity and scope; Postgres
+gives the account and candidate ids the dispatch path needs. Either flag alone
+produces a manifest that cannot both pass review and dispatch.
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort prepare \
+  --feed /data/confenge-ops/confenge.outreach.v1.json \
+  --org-id 22222222-0000-0000-0000-000000000001 \
+  --out /data/confenge-ops/first-cohort-bound.json \
+  --limit 50 --max-daily 50 --ttl 24h
+```
+
+Hashes are derived. Never copy one by hand. The manifest holds operational PII:
+it stays on the host volume and is never committed.
+
+## 3. Authorize
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort authorize \
+  --manifest /data/confenge-ops/first-cohort-bound.json \
+  --actor <FOUNDER_UUID> \
+  --org-id 22222222-0000-0000-0000-000000000001          # dry run first
+
+docker exec warmbly-confenge-backend-1 /app/confenge cohort authorize \
+  --manifest /data/confenge-ops/first-cohort-bound.json \
+  --actor <FOUNDER_UUID> \
+  --org-id 22222222-0000-0000-0000-000000000001 --confirm
+```
+
+Authorization is all-or-nothing. `authorized_touchpoints` must equal
+`selected_accounts` and `failed_authorization` must be 0.
+
+## 4. Release the kill switch
+
+Every deploy writes a paused kill switch, so the review reports
+`sending_paused=true` until this runs.
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge resume-sending
+```
+
+## 5. Live GO review
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort review \
+  --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID>
+```
+
+Proceed only on `release_verdict=GO_FOR_CONTROLLED_EMAIL_PILOT` with every check
+PASS. UNKNOWN is not PASS. Then persist the human verdict:
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort review \
+  --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID> \
+  --verdict READY_FOR_CONTROLLED_EMAIL_GO_REVIEW \
+  --reason "<founder reason>" --confirm
+```
+
+## 6. Dispatch
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort dispatch \
+  --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID> --limit 50    # preview
+
+docker exec warmbly-confenge-backend-1 /app/confenge cohort dispatch \
+  --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID> --limit 50 --confirm
+```
+
+Enrollment queues campaign execution. Provider acceptance is reported by the
+consumer after the worker reports transport success, so
+`N_PROVIDER_ACCEPTED` lags `N_ATTEMPTED`. Do not infer delivery.
+
+## 7. Kill switch
+
+Stops enroll and send paths immediately, including anything already queued,
+because the worker reads the same file switch at the SMTP boundary.
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge stop-sending
+```
+
+## 8. Observe
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort report --events <PATH>
+```
+
+Record attempted, provider-accepted, bounce, reply, opt-out per route class.
+Anything not yet observable stays UNKNOWN.
+
+## Rollback
+
+Images are tagged by SHA on every deploy.
+
+```bash
+cd /opt/warmbly-confenge
+git reset --hard <PREVIOUS_SHA>
+sed -i "s|^CONFENGE_REPOSITORY_SHA=.*|CONFENGE_REPOSITORY_SHA=<PREVIOUS_SHA>|" deploy/confenge-vps/.env
+export COMPOSE_PROJECT_NAME=warmbly-confenge
+for s in backend consumer worker; do
+  docker tag warmbly-confenge-$s:<PREVIOUS_SHA> warmbly-confenge-$s:latest
+done
+bash deploy/confenge-vps/up.sh
+```
+
+Migrations 109 and 110 are additive and idempotent. Both have applicable down
+migrations that clear rows the narrower constraints cannot satisfy before
+restoring them. Revoke a grant instead of rolling back code when the concern is
+the cohort rather than the release:
+
+```bash
+docker exec warmbly-confenge-backend-1 /app/confenge cohort-auth revoke --id <AUTHORIZATION_ID> --actor <FOUNDER_UUID>
+```

--- a/internal/app/confenge/campaign.go
+++ b/internal/app/confenge/campaign.go
@@ -171,7 +171,7 @@ func (s *service) EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.U
 			return nil, errx.New(errx.NotFound, "contact candidate not found")
 		}
 	}
-	if cand == nil || !cand.CanEnroll() {
+	if cand == nil || !CandidateEnrollable(cand) {
 		// Re-resolve by draft recipient email (human may have edited recipient
 		// after plan bound a phone-only or unverified candidate).
 		email := strings.TrimSpace(strings.ToLower(d.RecipientEmail))
@@ -179,7 +179,7 @@ func (s *service) EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.U
 			if list, lerr := s.repo.ListCandidates(ctx, orgID, d.AccountID); lerr == nil {
 				for i := range list {
 					c := &list[i]
-					if strings.EqualFold(strings.TrimSpace(c.Email), email) && c.CanEnroll() {
+					if strings.EqualFold(strings.TrimSpace(c.Email), email) && CandidateEnrollable(c) {
 						cand = c
 						id := c.ID
 						d.ContactCandidateID = &id
@@ -191,7 +191,7 @@ func (s *service) EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.U
 			// production (Mailpit/sink/dev/tests). Production fail-closed:
 			// never silently promote a draft address without a legitimate
 			// enrollable candidate. Explicit audited manual confirm is separate.
-			if (cand == nil || !cand.CanEnroll()) && strings.Contains(email, "@") && s.cfg.AllowSilentEnrollMint() {
+			if (cand == nil || !CandidateEnrollable(cand)) && strings.Contains(email, "@") && s.cfg.AllowSilentEnrollMint() {
 				mint := &models.OutreachContactCandidate{
 					OrganizationID:     orgID,
 					AccountID:          d.AccountID,
@@ -212,7 +212,7 @@ func (s *service) EnrollDraft(ctx context.Context, orgID, userID, draftID uuid.U
 	if err := RequireEmailOutbound(acc, cand); err != nil {
 		return nil, errx.New(errx.BadRequest, err.Error())
 	}
-	if cand == nil || !cand.CanEnroll() {
+	if cand == nil || !CandidateEnrollable(cand) {
 		return nil, errx.New(errx.BadRequest, "contact is not enrollable")
 	}
 

--- a/internal/app/confenge/cohort_apply.go
+++ b/internal/app/confenge/cohort_apply.go
@@ -230,15 +230,18 @@ func locateOrBuildTouchpoint(ctx context.Context, repo repository.OutreachReposi
 			}
 		}
 		if reusable != nil {
+			stampAccountContext(ctx, repo, orgID, reusable)
 			return reusable, false, nil
 		}
 		// Only stale non-terminal artifacts remain (e.g. a CANCELLED row from an
 		// older composer version). Supersede them with a fresh initial touch
 		// rather than blocking the whole frozen cohort on one stale row.
 		tp := newFrozenTouchpoint(orgID, m, now)
+		stampAccountContext(ctx, repo, orgID, tp)
 		return tp, true, nil
 	}
 	tp := newFrozenTouchpoint(orgID, m, now)
+	stampAccountContext(ctx, repo, orgID, tp)
 	return tp, true, nil
 }
 
@@ -259,6 +262,21 @@ func resolveAccountForMember(ctx context.Context, repo repository.OutreachReposi
 		}
 	}
 	return nil, fmt.Errorf("account_not_found")
+}
+
+// stampAccountContext binds the frozen touchpoint to the account snapshot the
+// transport gate re-checks. Without it AssertMessageContextFresh reports a
+// missing generated context hash and every cohort member fails to queue.
+func stampAccountContext(ctx context.Context, repo repository.OutreachRepository, orgID uuid.UUID, tp *models.OutreachTouchpoint) {
+	if repo == nil || tp == nil || tp.AccountID == uuid.Nil || tp.GeneratedContextHash != "" {
+		return
+	}
+	acc, err := repo.GetAccount(ctx, orgID, tp.AccountID)
+	if err != nil || acc == nil {
+		return
+	}
+	tp.GeneratedContextHash = acc.MessageContextHash
+	RecomputeContentHash(tp)
 }
 
 func newFrozenTouchpoint(orgID uuid.UUID, m FrozenCohortMember, now time.Time) *models.OutreachTouchpoint {

--- a/internal/app/confenge/cohort_compose.go
+++ b/internal/app/confenge/cohort_compose.go
@@ -65,6 +65,40 @@ func routingCTA(theme string) string {
 	return "Queria falar com quem acompanha " + ensureLowerStart(theme) + " por aí. Você consegue me indicar a pessoa responsável?"
 }
 
+// ensureClosingAsk keeps the mail ending in a real question. Portuguese
+// declaratives do not become questions by swapping the final period for "?",
+// so a short ask is appended instead of coercing the punctuation.
+func ensureClosingAsk(cta string) string {
+	cta = strings.TrimSpace(cta)
+	if cta == "" || strings.Contains(cta, "?") {
+		return cta
+	}
+	if !strings.HasSuffix(cta, ".") {
+		cta += "."
+	}
+	return cta + " Faz sentido para você?"
+}
+
+// referralAsk keeps a departmental pitch honest when no person is proven: the
+// offer still stands, but the reader is not assumed to own the subject.
+const referralAsk = "Se não for com você, pode me indicar a pessoa certa?"
+
+func appendReferralAsk(cta string) string {
+	cta = strings.TrimSpace(cta)
+	if cta == "" {
+		return referralAsk
+	}
+	blob := foldASCII(cta)
+	if strings.Contains(blob, "indicar a pessoa") || strings.Contains(blob, "pessoa certa") ||
+		strings.Contains(blob, "encaminhar") || strings.Contains(blob, "pessoa responsavel") {
+		return cta
+	}
+	if !strings.HasSuffix(cta, "?") && !strings.HasSuffix(cta, ".") {
+		cta += "."
+	}
+	return cta + " " + referralAsk
+}
+
 // ComposeControlledInitial is the freeze-time composer. It never invents a
 // person. GENERIC/FREEMAIL copy is institutional and may ask for a route.
 func ComposeControlledInitial(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, class string) (subject, body, greeting string) {
@@ -75,17 +109,27 @@ func ComposeControlledInitial(acc *models.OutreachAccount, cand *models.Outreach
 	if acc != nil {
 		obs = firstNonEmpty(strings.TrimSpace(acc.FactToMention), strings.TrimSpace(acc.MomentSummary))
 		if strings.TrimSpace(acc.CTA) != "" {
-			cta = strings.TrimSpace(acc.CTA)
-			if !strings.Contains(cta, "?") {
-				cta = strings.TrimRight(cta, ". ") + "?"
-			}
+			cta = ensureClosingAsk(strings.TrimSpace(acc.CTA))
 		}
 		theme = firstNonEmpty(humanizeMoment(acc.MomentCode), acc.ServiceName, theme)
 	}
 	obs = ApplyCopyHygiene(obs)
+	// A serialized feed record is not prose. Condense it, and drop it entirely
+	// rather than pasting a database row into a cold email.
+	if looksLikeMetadataDump(obs) || containsDumpLabel(obs) {
+		obs = condenseMetadataFact(obs)
+		if looksLikeMetadataDump(obs) || containsDumpLabel(obs) {
+			obs = ""
+		}
+	}
 	switch class {
 	case RouteClassGenericCompany, RouteClassPublicCompanyFreemail:
 		cta = routingCTA(theme)
+	case RouteClassRoleOrDepartment:
+		// A department mailbox is the right door, not proof of the right person.
+		if CandidatePersonUnknown(cand) {
+			cta = appendReferralAsk(cta)
+		}
 	}
 	var b strings.Builder
 	b.WriteString(greeting)
@@ -112,8 +156,8 @@ func controlledSubject(acc *models.OutreachAccount, obs, theme string) string {
 			raw = firstNonEmpty(theme, "Uma leitura objetiva")
 		}
 	}
-	if subjectHasLegalForm(raw) {
-		return "Uma leitura objetiva"
+	if subjectHasLegalForm(raw) || containsDumpLabel(raw) {
+		return firstNonEmpty(theme, "Uma leitura objetiva")
 	}
 	return strings.TrimSpace(raw)
 }
@@ -126,10 +170,9 @@ func trimSubjectFact(obs string) string {
 	if i := strings.IndexAny(obs, ".!?"); i > 12 && i < 80 {
 		return obs[:i]
 	}
-	if len(obs) > 80 {
-		return strings.TrimSpace(obs[:80])
-	}
-	return obs
+	// Rune-safe and on a word boundary: a byte slice can split a multi-byte
+	// rune into an invalid MIME Subject header, and cuts mid-word read broken.
+	return cutAtWordBoundary(obs, 64)
 }
 
 func humanizeMoment(code string) string {
@@ -141,11 +184,18 @@ func humanizeMoment(code string) string {
 		return "licitações"
 	case "REAJUSTE", "REAJUSTE_14133":
 		return "reajuste contratual"
+	case "PORTFOLIO_REVIEW":
+		return "a carteira de contratos públicos"
+	case "ADDENDUM":
+		return "aditivos"
+	case "GLOSA_MEDICAO":
+		return "glosas de medição"
+	case "REEQUILIBRIO":
+		return "reequilíbrio econômico-financeiro"
 	default:
-		if c == "" {
-			return ""
-		}
-		return strings.ToLower(strings.ReplaceAll(c, "_", " "))
+		// Closed on purpose: an unmapped code must fall through to ServiceName
+		// or the default theme, never reach copy as a raw enum.
+		return ""
 	}
 }
 

--- a/internal/app/confenge/cohort_compose_referral_test.go
+++ b/internal/app/confenge/cohort_compose_referral_test.go
@@ -1,0 +1,69 @@
+package confenge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func roleCandidate(t *testing.T, mailbox, purpose string) *models.OutreachContactCandidate {
+	t.Helper()
+	unk := true
+	return &models.OutreachContactCandidate{
+		Email:           mailbox,
+		MailboxPurpose:  purpose,
+		OwnershipStatus: "COMPANY_OWNED",
+		DiscoveryJSON:   eligibleDisc(t, RouteClassRoleOrDepartment, true, controlledDiscovery{PersonUnknown: &unk}),
+	}
+}
+
+// A department mailbox proves the door, not the person. When no person is
+// proven the initial touch must still ask to be routed, instead of assuming
+// the reader owns the subject.
+func TestRoleRouteWithUnknownPersonAsksForReferral(t *testing.T) {
+	acc := cohortAccount("acc-role", "22222222000192", "Edital publicado")
+	acc.CTA = "Disponibilizo apoio de pico em análise de edital/proposta sob NDA?"
+	cand := roleCandidate(t, "comercial@empresa.com.br", "COMERCIAL")
+
+	_, body, greeting := ComposeControlledInitial(&acc, cand, RouteClassRoleOrDepartment)
+
+	if !strings.Contains(body, referralAsk) {
+		t.Fatalf("role body must carry the referral ask, got:\n%s", body)
+	}
+	if !strings.Contains(body, "apoio de pico") {
+		t.Fatalf("referral ask must not replace the offer, got:\n%s", body)
+	}
+	if !strings.HasPrefix(greeting, "Olá, equipe") {
+		t.Fatalf("greeting = %q, want a team greeting", greeting)
+	}
+}
+
+// The ask is appended once, never stacked on copy that already routes.
+func TestReferralAskIsNotDuplicated(t *testing.T) {
+	acc := cohortAccount("acc-role2", "22222222000193", "Contrato vigente")
+	acc.CTA = "Pode me indicar a pessoa certa de contratos?"
+	cand := roleCandidate(t, "licitacoes@empresa.com.br", "LICITACOES")
+
+	_, body, _ := ComposeControlledInitial(&acc, cand, RouteClassRoleOrDepartment)
+
+	if n := strings.Count(body, "indicar a pessoa"); n != 1 {
+		t.Fatalf("referral ask appears %d times, want 1:\n%s", n, body)
+	}
+}
+
+// Generic and freemail routes keep their existing routing CTA.
+func TestGenericRouteStillUsesRoutingCTA(t *testing.T) {
+	unk := true
+	acc := cohortAccount("acc-generic", "33333333000193", "Contrato vigente")
+	cand := &models.OutreachContactCandidate{
+		Email:           "contato@empresa.com.br",
+		MailboxPurpose:  "GENERIC_CONTACT",
+		OwnershipStatus: "COMPANY_OWNED",
+		DiscoveryJSON:   eligibleDisc(t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unk}),
+	}
+	_, body, _ := ComposeControlledInitial(&acc, cand, RouteClassGenericCompany)
+	if !strings.Contains(body, "me indicar a pessoa responsável") {
+		t.Fatalf("generic body lost its routing CTA:\n%s", body)
+	}
+}

--- a/internal/app/confenge/cohort_dispatch.go
+++ b/internal/app/confenge/cohort_dispatch.go
@@ -262,6 +262,22 @@ func loadDispatchTouchpoint(ctx context.Context, repo repository.OutreachReposit
 	return tp, nil
 }
 
+// controlledDraftFact is the evidence the cohort message actually rests on,
+// condensed the same way the composer condenses it so a serialized feed record
+// never reaches the draft as prose.
+func controlledDraftFact(acc *models.OutreachAccount) string {
+	raw := firstNonEmpty(strings.TrimSpace(acc.FactToMention), strings.TrimSpace(acc.MomentSummary))
+	raw = ApplyCopyHygiene(raw)
+	if looksLikeMetadataDump(raw) || containsDumpLabel(raw) {
+		condensed := condenseMetadataFact(raw)
+		if condensed != "" && !looksLikeMetadataDump(condensed) && !containsDumpLabel(condensed) {
+			return condensed
+		}
+		return strings.TrimSpace(acc.MomentSummary)
+	}
+	return raw
+}
+
 func FormatCohortDispatch(res *CohortDispatchResult) string {
 	if res == nil {
 		return "dispatch_missing=true\n"
@@ -359,6 +375,12 @@ func (s *service) ensureCohortDraft(ctx context.Context, orgID, actor uuid.UUID,
 		ApprovedAt:     tp.ApprovedAt,
 		CreatedAt:      now,
 		UpdatedAt:      now,
+	}
+	// ValidateDraft requires a fact or a claim. Carry the account's observed
+	// fact so a cohort draft is not rejected as evidence-free at enroll.
+	if acc, err := s.repo.GetAccount(ctx, orgID, tp.AccountID); err == nil && acc != nil {
+		d.FactUsed = controlledDraftFact(acc)
+		d.ServiceCode = acc.ServiceCode
 	}
 	if d.ApprovedBy == nil && actor != uuid.Nil {
 		d.ApprovedBy = &actor

--- a/internal/app/confenge/cohort_freeze_send_qa_parity_test.go
+++ b/internal/app/confenge/cohort_freeze_send_qa_parity_test.go
@@ -1,0 +1,119 @@
+package confenge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Freeze-time QA must reject what the send-time hard QA rejects. When they
+// disagree a cohort freezes clean and then fails for every member at dispatch.
+func TestFreezeQARejectsWhatSendQARejects(t *testing.T) {
+	dump := "objeto: Obra de pavimentação asfáltica.; órgão: Prefeitura Municipal DE Brochier; UF RS; R$ 1.398.000."
+	body := "Olá, equipe,\n\nSou da CONFENGE.\n\n" + dump + "\n\nVocê consegue me indicar a pessoa responsável?"
+
+	errs := ValidateCopyForRouteClass(RouteClassGenericCompany, body, "objeto: Obra de pavimentação asfáltica", nil)
+	if len(errs) == 0 {
+		t.Fatal("freeze QA accepted a serialized feed record that send-time QA rejects")
+	}
+	joined := strings.Join(errs, ",")
+	for _, want := range []string{"metadata_dump", "subject_dump_label"} {
+		if !strings.Contains(joined, want) {
+			t.Fatalf("errs = %q, want %s", joined, want)
+		}
+	}
+}
+
+// The composer must not ship a serialized record as prose.
+func TestComposerDropsMetadataDumpFromBody(t *testing.T) {
+	unk := true
+	acc := cohortAccount("acc-dump", "33333333000193", "objeto: Obra de pavimentação asfáltica.; órgão: Prefeitura Municipal DE Brochier; UF RS; R$ 1.398.000.")
+	acc.MomentCode = "PORTFOLIO_REVIEW"
+	cand := &models.OutreachContactCandidate{
+		Email:           "contato@empresa.com.br",
+		MailboxPurpose:  "GENERIC_CONTACT",
+		OwnershipStatus: "COMPANY_OWNED",
+		DiscoveryJSON:   eligibleDisc(t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unk}),
+	}
+
+	subject, body, _ := ComposeControlledInitial(&acc, cand, RouteClassGenericCompany)
+
+	if containsDumpLabel(body) || looksLikeMetadataDump(body) {
+		t.Fatalf("body still carries a record dump:\n%s", body)
+	}
+	if containsDumpLabel(subject) {
+		t.Fatalf("subject still carries a dump label: %q", subject)
+	}
+	if strings.Contains(strings.ToLower(body), "portfolio review") {
+		t.Fatalf("English moment enum leaked into pt-BR copy:\n%s", body)
+	}
+	if errs := ValidateCopyForRouteClass(RouteClassGenericCompany, body, subject, cand); len(errs) != 0 {
+		t.Fatalf("composed copy fails its own freeze QA: %v\n%s", errs, body)
+	}
+}
+
+// An unmapped moment code must never reach copy as a lowercased enum.
+func TestUnmappedMomentCodeDoesNotReachCopy(t *testing.T) {
+	if got := humanizeMoment("SOME_NEW_UNMAPPED_CODE"); got != "" {
+		t.Fatalf("humanizeMoment = %q, want empty so it falls through", got)
+	}
+	if got := humanizeMoment("PORTFOLIO_REVIEW"); got == "portfolio review" || got == "" {
+		t.Fatalf("PORTFOLIO_REVIEW = %q, want a pt-BR label", got)
+	}
+}
+
+// A declarative CTA must not be turned into a pseudo-question by punctuation.
+func TestDeclarativeCTAGetsARealQuestion(t *testing.T) {
+	got := ensureClosingAsk("Disponibilizo apoio de pico em análise de edital/proposta sob NDA.")
+	if strings.HasSuffix(got, "NDA?") {
+		t.Fatalf("declarative was coerced into a question: %q", got)
+	}
+	if !strings.HasSuffix(got, "?") {
+		t.Fatalf("copy must still end in an ask: %q", got)
+	}
+}
+
+// A classified institutional route enrolls without nominal verification, but
+// suppression and provenance guards still reject.
+func TestControlledRouteEnrollableWithoutNominalVerification(t *testing.T) {
+	unk := true
+	base := func() *models.OutreachContactCandidate {
+		return &models.OutreachContactCandidate{
+			ID:                 uuid.New(),
+			Email:              "contato@empresa.com.br",
+			VerificationStatus: models.OutreachVerifyCandidateUnverified,
+			MailboxPurpose:     "GENERIC_CONTACT",
+			OwnershipStatus:    "COMPANY_OWNED",
+			DiscoveryJSON:      eligibleDisc(t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unk}),
+		}
+	}
+
+	c := base()
+	if c.CanEnroll() {
+		t.Fatal("CANDIDATE_UNVERIFIED must still fail the legacy nominal rule")
+	}
+	if !CandidateEnrollable(c) {
+		t.Fatal("a classified institutional route must be enrollable")
+	}
+
+	sup := base()
+	sup.DoNotContact = true
+	if CandidateEnrollable(sup) {
+		t.Fatal("suppression must still block a controlled route")
+	}
+
+	taint := base()
+	taint.BlockReason = "provenance_taint:fixture"
+	if CandidateEnrollable(taint) {
+		t.Fatal("provenance taint must still block a controlled route")
+	}
+
+	plain := base()
+	plain.DiscoveryJSON = nil
+	if CandidateEnrollable(plain) {
+		t.Fatal("without a classified route the strict verification rule must hold")
+	}
+}

--- a/internal/app/confenge/controlled_route.go
+++ b/internal/app/confenge/controlled_route.go
@@ -97,6 +97,20 @@ func CandidateControlledEligible(c *models.OutreachContactCandidate) bool {
 	return defaultPilotRouteClasses[class]
 }
 
+// CandidateEnrollable is the controlled-route enrollability rule: a classified
+// institutional route is contactable without nominal-person verification, while
+// suppression, provenance and fixture guards still apply. Legacy nominal paths
+// keep using CanEnroll directly.
+func CandidateEnrollable(c *models.OutreachContactCandidate) bool {
+	if c.CanEnroll() {
+		return true
+	}
+	if !CandidateControlledEligible(c) || !ControlledRouteAllowed(c, nil) {
+		return false
+	}
+	return c.EnrollableIgnoringVerification()
+}
+
 func CandidatePreferredInitial(c *models.OutreachContactCandidate) bool {
 	d := parseControlledDiscovery(c)
 	return d.PreferredInitial != nil && *d.PreferredInitial
@@ -194,6 +208,17 @@ func ValidateCopyForRouteClass(class, body, subject string, cand *models.Outreac
 	add := func(code string) { errs = append(errs, code) }
 	if strings.Contains(blob, "decision_unit") || strings.Contains(blob, "email_discovery_class") || strings.Contains(blob, "reachability_class") {
 		add("internal_dump")
+	}
+	// Freeze-time QA must reject what the send-time hard QA rejects, otherwise a
+	// cohort freezes clean and then fails for every member at dispatch.
+	if looksLikeMetadataDump(body) || containsDumpLabel(body) {
+		add("metadata_dump")
+	}
+	if containsDumpLabel(subject) {
+		add("subject_dump_label")
+	}
+	if looksMidTokenTruncation(subject) || looksMidTokenTruncation(body) {
+		add("mid_token_truncation")
 	}
 	switch class {
 	case RouteClassDirectPerson:

--- a/internal/app/confenge/outbound_gate.go
+++ b/internal/app/confenge/outbound_gate.go
@@ -409,7 +409,10 @@ func (s *service) AssertTransportable(ctx context.Context, orgID uuid.UUID, tp *
 	} else if FileKillSwitchActive() {
 		return fmt.Errorf("kill switch engaged")
 	}
-	if s.cfg.OperatorMode {
+	// A frozen bounded cohort carries its own membership (the grant manifest,
+	// re-validated by CanTransportCohort). The legacy confenge-pilot-v1
+	// membership table is not written for it and must not gate it.
+	if s.cfg.OperatorMode && mode != AuthorizationModeBoundedCohort {
 		if err := s.requirePilotMembershipForTouchpoint(ctx, orgID, tp); err != nil {
 			return fmt.Errorf("controlled pilot membership: %w", err)
 		}

--- a/internal/app/confenge/signature.go
+++ b/internal/app/confenge/signature.go
@@ -18,7 +18,7 @@ const (
 	// Env path override; prefer a pre-optimized JPEG under data/confenge/.
 	EnvSignatureImagePath = "CONFENGE_SIGNATURE_IMAGE_PATH"
 	// SignatureVersion bumps when the close text or CID decoration semantics change.
-	SignatureVersion = "confenge.signature.v2"
+	SignatureVersion = "confenge.signature.v3"
 )
 
 // First-touch close: plain text only (no image). Cold outreach should not look
@@ -26,10 +26,13 @@ const (
 const SignaturePlainBlock = `Abraço,
 Eng. Tiago Sasaki
 Consultor B2G | Confenge
-(48)9 8834-4559`
+(48)9 8834-4559
+
+Se preferir não receber mais contato meu, é só responder "sair" que removo seu e-mail.`
 
 // Legacy text blocks stripped before re-applying the current first-touch close.
 var legacyPlainSignatureTails = []string{
+	"\n\nAbraço,\nEng. Tiago Sasaki\nConsultor B2G | Confenge\n(48)9 8834-4559",
 	"\n\n" + SignaturePlainBlock,
 	"\n\nAtenciosamente,\n\nEng. Tiago Sasaki\nCONFENGE\ntiago.sasaki@confenge.com.br",
 	"\n\nAtenciosamente,\nEng. Tiago Sasaki\nCONFENGE\ntiago.sasaki@confenge.com.br",

--- a/internal/app/confenge/target_fit.go
+++ b/internal/app/confenge/target_fit.go
@@ -78,7 +78,7 @@ func RequireEmailOutbound(acc *models.OutreachAccount, cand *models.OutreachCont
 	if cand == nil {
 		return fmt.Errorf("contact candidate is missing")
 	}
-	if !cand.CanEnroll() {
+	if !CandidateEnrollable(cand) {
 		return fmt.Errorf("contact is not enrollable")
 	}
 	if CandidateControlledEligible(cand) && ControlledRouteAllowed(cand, nil) {

--- a/internal/app/confenge/validators.go
+++ b/internal/app/confenge/validators.go
@@ -128,7 +128,7 @@ func ValidateDraft(out *DraftOutput, acc *models.OutreachAccount, cand *models.O
 
 	if cand != nil {
 		if !skipEmail {
-			if !cand.CanEnroll() {
+			if !CandidateEnrollable(cand) {
 				res.OK = false
 				res.Errors = append(res.Errors, "contact is not enrollable (verification, DNC, bounce, or missing email)")
 			}

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -283,6 +283,17 @@ type OutreachContactCandidate struct {
 
 // CanEnroll reports whether this candidate may be put into a campaign.
 func (c *OutreachContactCandidate) CanEnroll() bool {
+	if !c.EnrollableIgnoringVerification() {
+		return false
+	}
+	return !OutreachUnenrollableVerification[c.VerificationStatus]
+}
+
+// EnrollableIgnoringVerification holds every enrollability guard except the
+// nominal-person verification map. Classified institutional routes use it so a
+// route extra-cli deliberately marked contactable is not rejected for lacking a
+// verified person, while suppression, provenance and fixture guards still apply.
+func (c *OutreachContactCandidate) EnrollableIgnoringVerification() bool {
 	if c == nil {
 		return false
 	}
@@ -290,9 +301,6 @@ func (c *OutreachContactCandidate) CanEnroll() bool {
 		return false
 	}
 	if c.Email == "" {
-		return false
-	}
-	if OutreachUnenrollableVerification[c.VerificationStatus] {
 		return false
 	}
 	// Defense-in-depth: known synthetic demo00Xobra channels never enroll

--- a/internal/pkg/dnsauth/dnsauth.go
+++ b/internal/pkg/dnsauth/dnsauth.go
@@ -56,7 +56,7 @@ func (r Result) State() string {
 // defaultSelectors are common DKIM selectors to probe when the caller doesn't
 // know the domain's selector. DKIM selectors aren't discoverable from DNS, so a
 // "not found" only means none of these matched, not that DKIM is absent.
-var defaultSelectors = []string{"google", "default", "selector1", "selector2", "k1", "mail", "dkim", "s1", "s2"}
+var defaultSelectors = []string{"google", "default", "selector1", "selector2", "k1", "mail", "dkim", "s1", "s2", "hostingermail1", "hostingermail2", "hostingermail3", "zoho", "titan"}
 
 const lookupTimeout = 5 * time.Second
 


### PR DESCRIPTION
A cohort could freeze clean, pass the live GO review, and then fail for **every** member at dispatch. Six independent defects, found by walking the real 50-member production cohort through the transport path.

### Transport gates

1. **Pilot membership** (`outbound_gate.go`) — `requirePilotMembershipForTouchpoint` demanded a `confenge-pilot-v1` membership row whenever operator mode is on. The frozen-cohort path never writes one, so every member failed with `touchpoint is not a member of the controlled pilot cohort`. A bounded cohort carries its own membership in the grant manifest, re-validated by `CanTransportCohort`; the legacy table no longer gates it.
2. **Missing context hash** (`cohort_apply.go`) — `newFrozenTouchpoint` never set `GeneratedContextHash`, so `AssertMessageContextFresh` rejected every member whose account had a `message_context_hash`. Frozen touchpoints are now stamped from the account snapshot.
3. **Evidence-free draft** (`cohort_dispatch.go`) — `ensureCohortDraft` set only subject and body, so `ValidateDraft` failed all 50 with `fact_used is required`. The draft now carries the account's fact and service code, condensed the same way the composer condenses it.
4. **Nominal verification on institutional routes** (`models/outreach.go`, `controlled_route.go`) — `CanEnroll` rejects `CANDIDATE_UNVERIFIED`, which is every classified institutional route. `CanEnroll` is split so `EnrollableIgnoringVerification` holds the suppression, provenance, and fixture guards, and a new `CandidateEnrollable` relaxes **only** the verification map, and only for a route extra-cli marked `controlled_email_eligible` in an allowed class. Swapped at the controlled call sites only; the legacy nominal path, `CanBatchApprove`, and all three SQL filters keep the strict rule.

### Copy

5. **Serialized feed records shipped as prose.** Bodies read `objeto: …; órgão: …; UF …; R$ …`. `condenseMetadataFact` already existed and was never called from this composer. It is now, and the observation is dropped entirely rather than pasting a database row into a cold email. Subjects went through a raw byte slice with no word boundary, producing `…(Parac` and risking invalid UTF-8 in a MIME header; they now use `cutAtWordBoundary` on runes and reject label-prefixed subjects.
6. **`humanizeMoment` was open.** Its default branch lowercased the raw enum, so `PORTFOLIO_REVIEW` — 93% of the feed — reached Portuguese copy as "portfolio review". It is now closed: unmapped codes return empty and fall through to the service name, with pt-BR labels added for the four codes the feed actually emits.

Also: a declarative CTA was turned into a pseudo-question by swapping its period for `?`; it now gets a real appended ask. `ROLE_OR_DEPARTMENT` routes with no proven person now carry the referral ask instead of assuming the reader owns the subject — a department mailbox is the right door, not proof of the right person. A visible reply-based opt-out joins the RFC 8058 header, since these are plain-text sends to an audience whose clients often render no unsubscribe affordance.

**Freeze-time QA now rejects what send-time QA rejects** (`ValidateCopyForRouteClass`), so this class of divergence surfaces at freeze instead of at dispatch.

Unrelated but found on the way: `dnsauth` probed no Hostinger DKIM selector, so a correctly configured Hostinger domain would still report `auth_dkim=false`. Added `hostingermail1/2/3` (plus zoho/titan).

Not addressed here, and still blocking: `target_fit_fresh=false` on 46 of the 50 accounts makes `RequireTargetFit` fail closed with `TARGET_FIT_STALE`. That is producer data, and relaxing a fail-closed target-fit gate is a policy decision, not a code fix.