### PR TITLE
fix(confenge): scope the cohort freeze to its feed run so a 402k-account org stops reading page one

### DIFF
--- a/internal/app/confenge/activation_test.go
+++ b/internal/app/confenge/activation_test.go
@@ -13,6 +13,20 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
+// The activation window has to move with the clock. It used to be frozen at
+// 2026-08-08 → 2026-08-22T10:00:00Z, and at exactly that instant every test
+// resting on this fixture began failing: the account fell out of the "agora"
+// lane because its activation had expired, and the failure pointed at
+// target-fit rather than at a lapsed fixture. Relative timestamps keep the same
+// fourteen-day span without a date that rots.
+func activationFixtureEvaluatedAt() string {
+	return time.Now().UTC().Add(-24 * time.Hour).Format(time.RFC3339)
+}
+
+func activationFixtureExpiresAt() string {
+	return time.Now().UTC().Add(13 * 24 * time.Hour).Format(time.RFC3339)
+}
+
 func sampleLeadWithActivation(score float64, state string) FeedLead {
 	ready := true
 	return FeedLead{
@@ -49,9 +63,9 @@ func sampleLeadWithActivation(score float64, state string) FeedLead {
 			State: state, Score: score,
 			ReasonCodes:      []string{"NEW_RELEVANT_CONTRACT"},
 			PolicyVersion:    "confenge-activation-v1",
-			EvaluatedAt:      "2026-08-08T10:00:00Z",
-			NextBestActionAt: "2026-08-08T10:00:00Z",
-			ExpiresAt:        "2026-08-22T10:00:00Z",
+			EvaluatedAt:      activationFixtureEvaluatedAt(),
+			NextBestActionAt: activationFixtureEvaluatedAt(),
+			ExpiresAt:        activationFixtureExpiresAt(),
 			SourceHash:       "src-hash-1",
 			ScoreComponents: map[string]float64{
 				"trigger_strength": 34, "freshness": 21, "evidence_quality": 14, "commercial_relevance": 13.4,

--- a/internal/app/confenge/cohort_apply.go
+++ b/internal/app/confenge/cohort_apply.go
@@ -197,9 +197,15 @@ func locateOrBuildTouchpoint(ctx context.Context, repo repository.OutreachReposi
 		return tp, false, nil
 	}
 	if m.AccountID == uuid.Nil {
-		if acc, err := resolveAccountForMember(ctx, repo, orgID, m); err == nil && acc != nil {
-			m.AccountID = acc.ID
+		// An unbound member must fail here, not reach the touchpoint FK as uuid.Nil.
+		acc, err := resolveAccountForMember(ctx, repo, orgID, m)
+		if err != nil {
+			return nil, false, fmt.Errorf("resolve account for member %q: %w", m.AccountRef, err)
 		}
+		if acc == nil || acc.ID == uuid.Nil {
+			return nil, false, fmt.Errorf("resolve account for member %q: account_not_found", m.AccountRef)
+		}
+		m.AccountID = acc.ID
 	}
 	if m.AccountID != uuid.Nil {
 		list, err := repo.ListTouchpoints(ctx, orgID, m.AccountID, "", 50, 0)
@@ -249,16 +255,32 @@ func resolveAccountForMember(ctx context.Context, repo repository.OutreachReposi
 	if repo == nil {
 		return nil, fmt.Errorf("repository required")
 	}
-	if cnpj := NormalizeCNPJ14(m.AccountRef); len(cnpj) == 14 {
-		return repo.GetAccountByCNPJ(ctx, orgID, cnpj)
+	ref := strings.TrimSpace(m.AccountRef)
+	if ref == "" {
+		return nil, fmt.Errorf("account_ref_missing")
 	}
-	accs, err := repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{})
-	if err != nil {
+	// accountRef prefers source_lead_id, so try that index before anything else.
+	if acc, err := repo.GetAccountBySourceLeadID(ctx, orgID, ref); err != nil {
 		return nil, err
+	} else if acc != nil {
+		return acc, nil
 	}
-	for i := range accs {
-		if accs[i].SourceLeadID == m.AccountRef || accs[i].ID.String() == m.AccountRef {
-			return &accs[i], nil
+	if cnpj := NormalizeCNPJ14(ref); len(cnpj) == 14 {
+		acc, err := repo.GetAccountByCNPJ(ctx, orgID, cnpj)
+		if err != nil {
+			return nil, err
+		}
+		if acc != nil {
+			return acc, nil
+		}
+	}
+	if id, err := uuid.Parse(ref); err == nil {
+		acc, err := repo.GetAccount(ctx, orgID, id)
+		if err != nil {
+			return nil, err
+		}
+		if acc != nil {
+			return acc, nil
 		}
 	}
 	return nil, fmt.Errorf("account_not_found")

--- a/internal/app/confenge/cohort_feed.go
+++ b/internal/app/confenge/cohort_feed.go
@@ -73,13 +73,45 @@ func accountsFromFeed(feed *Feed, source string) []CohortAccountInput {
 	return out
 }
 
+// orgAccountPageSize is the per-query page for org-bound account scans. An empty
+// filter silently means 50 rows in the repository, which is never what a freeze wants.
+const orgAccountPageSize = 1000
+
+// maxOrgFreezeAccounts bounds an org-bound freeze. Beyond it the operator must
+// scope by feed run: truncating would freeze a different cohort than the one asked for.
+const maxOrgFreezeAccounts = 5000
+
 func AccountsFromOrg(ctx context.Context, repo repository.OutreachRepository, orgID uuid.UUID, source string) ([]CohortAccountInput, error) {
+	return accountsFromOrgScoped(ctx, repo, orgID, source, "")
+}
+
+// accountsFromOrgScoped pages through outreach_accounts with an explicit limit,
+// pushing the run scope into the query so the freeze never depends on page one.
+func accountsFromOrgScoped(ctx context.Context, repo repository.OutreachRepository, orgID uuid.UUID, source, runID string) ([]CohortAccountInput, error) {
 	if repo == nil {
 		return nil, fmt.Errorf("repository required")
 	}
-	accs, err := repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{})
-	if err != nil {
-		return nil, err
+	var accs []models.OutreachAccount
+	for offset := 0; ; offset += orgAccountPageSize {
+		batch, err := repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{
+			Limit:       orgAccountPageSize,
+			Offset:      offset,
+			StableOrder: true,
+			SourceRunID: runID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		accs = append(accs, batch...)
+		if len(accs) > maxOrgFreezeAccounts {
+			if runID == "" {
+				return nil, fmt.Errorf("organization has more than %d accounts; scope the freeze to one feed run (--feed) instead of the whole org", maxOrgFreezeAccounts)
+			}
+			return nil, fmt.Errorf("feed run %q has more than %d accounts; split the import before freezing", runID, maxOrgFreezeAccounts)
+		}
+		if len(batch) < orgAccountPageSize {
+			break
+		}
 	}
 	out := make([]CohortAccountInput, 0, len(accs))
 	for i := range accs {
@@ -87,7 +119,7 @@ func AccountsFromOrg(ctx context.Context, repo repository.OutreachRepository, or
 		if err != nil {
 			return nil, err
 		}
-		out = append(out, CohortAccountInput{Account: accs[i], Candidates: cands, Source: source})
+		out = append(out, CohortAccountInput{Account: accs[i], Candidates: cands, Source: source, Persisted: true})
 	}
 	return out, nil
 }
@@ -171,19 +203,13 @@ func routeSuppressionActive(v string) bool {
 // run. Freezing from Postgres keeps real account/candidate ids for dispatch;
 // scoping by run id keeps the frozen set tied to the imported feed.
 func AccountsFromOrgForRun(ctx context.Context, repo repository.OutreachRepository, orgID uuid.UUID, source, runID string) ([]CohortAccountInput, error) {
-	all, err := AccountsFromOrg(ctx, repo, orgID, source)
-	if err != nil {
-		return nil, err
-	}
 	runID = strings.TrimSpace(runID)
 	if runID == "" {
-		return all, nil
+		return AccountsFromOrg(ctx, repo, orgID, source)
 	}
-	out := make([]CohortAccountInput, 0, len(all))
-	for i := range all {
-		if strings.TrimSpace(all[i].Account.SourceRunID) == runID {
-			out = append(out, all[i])
-		}
+	out, err := accountsFromOrgScoped(ctx, repo, orgID, source, runID)
+	if err != nil {
+		return nil, err
 	}
 	if len(out) == 0 {
 		return nil, fmt.Errorf("no imported accounts for feed run %q; import the feed first", runID)

--- a/internal/app/confenge/cohort_feed_page_scope_test.go
+++ b/internal/app/confenge/cohort_feed_page_scope_test.go
@@ -1,0 +1,163 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// seedRunAccount stages one account plus one controlled-eligible generic route.
+func seedRunAccount(t *testing.T, repo *memRepo, orgID uuid.UUID, ref, cnpj, runID string) uuid.UUID {
+	t.Helper()
+	unk := true
+	acc := cohortAccount(ref, cnpj, "Contrato vigente")
+	acc.OrganizationID = orgID
+	acc.SourceRunID = runID
+	if _, err := repo.UpsertAccount(context.Background(), &acc); err != nil {
+		t.Fatalf("upsert account %s: %v", ref, err)
+	}
+	if acc.ID == uuid.Nil {
+		t.Fatalf("account %s got no id from upsert", ref)
+	}
+	cand := models.OutreachContactCandidate{
+		OrganizationID:  orgID,
+		AccountID:       acc.ID,
+		Email:           "contato@" + ref + ".com.br",
+		MailboxPurpose:  "GENERIC_CONTACT",
+		OwnershipStatus: "COMPANY_OWNED",
+		DiscoveryJSON:   eligibleDisc(t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unk}),
+	}
+	if _, err := repo.UpsertCandidate(context.Background(), &cand); err != nil {
+		t.Fatalf("upsert candidate %s: %v", ref, err)
+	}
+	return acc.ID
+}
+
+// An org far past one page must still freeze the imported run. Before the run
+// scope was pushed into the query, an empty filter returned 50 rows ordered by
+// priority and the client-side run filter found nothing.
+func TestAccountsFromOrgForRunFindsMembersBeyondFirstPage(t *testing.T) {
+	repo := newMemRepo()
+	orgID := uuid.New()
+	ctx := context.Background()
+
+	const noise = 1200
+	for i := 0; i < noise; i++ {
+		// cnpj14 sorts low, so this run fills every page before the target run.
+		seedRunAccount(t, repo, orgID, fmt.Sprintf("noise-%04d", i), fmt.Sprintf("1%013d", i), "run-old")
+	}
+
+	const wanted = 12
+	targetIDs := map[uuid.UUID]bool{}
+	for i := 0; i < wanted; i++ {
+		id := seedRunAccount(t, repo, orgID, fmt.Sprintf("target-%02d", i), fmt.Sprintf("9%013d", i), "run-target")
+		targetIDs[id] = true
+	}
+
+	// Guard the premise: the target run really is beyond the first page.
+	page1, err := repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{})
+	if err != nil {
+		t.Fatalf("list page 1: %v", err)
+	}
+	for i := range page1 {
+		if page1[i].SourceRunID == "run-target" {
+			t.Fatal("premise broken: target run appears on page 1, the regression cannot be observed")
+		}
+	}
+
+	accounts, err := AccountsFromOrgForRun(ctx, repo, orgID, "extra-cli", "run-target")
+	if err != nil {
+		t.Fatalf("accounts from org for run: %v", err)
+	}
+	if len(accounts) != wanted {
+		t.Fatalf("scoped accounts = %d, want %d", len(accounts), wanted)
+	}
+	for i := range accounts {
+		if accounts[i].Account.SourceRunID != "run-target" {
+			t.Fatalf("account %s leaked from run %q", accounts[i].Account.SourceLeadID, accounts[i].Account.SourceRunID)
+		}
+		if !accounts[i].Persisted {
+			t.Fatalf("account %s must be marked persisted", accounts[i].Account.SourceLeadID)
+		}
+		if len(accounts[i].Candidates) != 1 {
+			t.Fatalf("account %s candidates = %d, want 1", accounts[i].Account.SourceLeadID, len(accounts[i].Candidates))
+		}
+	}
+
+	snap, err := PrepareControlledCohort(accounts, CohortPrepareOptions{
+		RepositorySHA:  "sha-1",
+		FeedIdentity:   "run-target",
+		Limit:          50,
+		MaxDailyVolume: 50,
+	})
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+	if len(snap.Members) != wanted {
+		t.Fatalf("members = %d, want %d", len(snap.Members), wanted)
+	}
+	for i := range snap.Members {
+		m := &snap.Members[i]
+		if m.AccountID == uuid.Nil {
+			t.Fatalf("member %q frozen with a nil account id", m.AccountRef)
+		}
+		if !targetIDs[m.AccountID] {
+			t.Fatalf("member %q bound to account %s outside the target run", m.AccountRef, m.AccountID)
+		}
+		if m.CandidateID == uuid.Nil {
+			t.Fatalf("member %q frozen with a nil candidate id", m.AccountRef)
+		}
+	}
+}
+
+// An unscoped org freeze must refuse rather than truncate to whatever fits.
+func TestAccountsFromOrgRefusesUnscopedOversizedOrg(t *testing.T) {
+	repo := newMemRepo()
+	orgID := uuid.New()
+
+	for i := 0; i < maxOrgFreezeAccounts+10; i++ {
+		seedRunAccount(t, repo, orgID, fmt.Sprintf("bulk-%05d", i), fmt.Sprintf("1%013d", i), "run-old")
+	}
+
+	_, err := AccountsFromOrg(context.Background(), repo, orgID, "extra-cli")
+	if err == nil {
+		t.Fatal("oversized unscoped org must not silently truncate")
+	}
+	if !strings.Contains(err.Error(), "scope the freeze to one feed run") {
+		t.Fatalf("error = %v, want operator guidance to scope by feed run", err)
+	}
+}
+
+// A Postgres-bound account with no canonical id must fail at freeze time, not
+// at authorize time as an opaque touchpoint foreign key violation.
+func TestPrepareRefusesPersistedAccountWithoutCanonicalID(t *testing.T) {
+	unk := true
+	acc := cohortAccount("acc-unbound", "77777777000177", "Contrato vigente")
+	accounts := []CohortAccountInput{{
+		Account:   acc,
+		Persisted: true,
+		Candidates: []models.OutreachContactCandidate{{
+			Email:           "contato@empresa7.com.br",
+			MailboxPurpose:  "GENERIC_CONTACT",
+			OwnershipStatus: "COMPANY_OWNED",
+			DiscoveryJSON:   eligibleDisc(t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unk}),
+		}},
+		Source: "extra-cli",
+	}}
+
+	_, err := PrepareControlledCohort(accounts, CohortPrepareOptions{
+		RepositorySHA: "sha-1", FeedIdentity: "run-1", Limit: 50, MaxDailyVolume: 50,
+	})
+	if err == nil {
+		t.Fatal("freezing a persisted account without a canonical id must fail")
+	}
+	if !strings.Contains(err.Error(), "no canonical id") {
+		t.Fatalf("error = %v, want a canonical-id refusal", err)
+	}
+}

--- a/internal/app/confenge/cohort_prepare.go
+++ b/internal/app/confenge/cohort_prepare.go
@@ -29,14 +29,16 @@ type CohortAccountInput struct {
 	Account    models.OutreachAccount
 	Candidates []models.OutreachContactCandidate
 	Source     string
+	// Persisted marks a row read back from Postgres, so its canonical ids must be real.
+	Persisted bool
 }
 
 // FrozenCohortMember is the exact authorization composition for one account.
 // One member = one initial route. Membership is frozen at preview time.
 type FrozenCohortMember struct {
-	AccountID        uuid.UUID `json:"account_id,omitempty"`
+	AccountID        uuid.UUID `json:"account_id"`
 	AccountRef       string    `json:"account_ref"`
-	CandidateID      uuid.UUID `json:"candidate_id,omitempty"`
+	CandidateID      uuid.UUID `json:"candidate_id"`
 	CandidateRef     string    `json:"candidate_ref"`
 	Mailbox          string    `json:"mailbox"`
 	RouteClass       string    `json:"route_class"`
@@ -240,6 +242,11 @@ func PrepareControlledCohort(accounts []CohortAccountInput, opts CohortPrepareOp
 		if in.Account.Blocked {
 			exclude(ref, "account_blocked", "", "")
 			continue
+		}
+		// A Postgres-bound account without its canonical id would freeze uuid.Nil
+		// and only surface at authorize time as an opaque touchpoint FK violation.
+		if in.Persisted && in.Account.ID == uuid.Nil {
+			return nil, fmt.Errorf("account %q loaded from postgres has no canonical id; refusing to freeze an unbound member", ref)
 		}
 
 		cand, reason := SelectInitialRoute(in.Candidates, allowed, opts.Now)

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -3,6 +3,7 @@ package confenge
 import (
 	"context"
 	"fmt"
+	"sort"
 	"strings"
 	"sync"
 	"testing"
@@ -127,6 +128,22 @@ func (m *memRepo) GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 
 	return &cp, nil
 }
 
+func (m *memRepo) GetAccountBySourceLeadID(ctx context.Context, orgID uuid.UUID, sourceLeadID string) (*models.OutreachAccount, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	sourceLeadID = strings.TrimSpace(sourceLeadID)
+	if sourceLeadID == "" {
+		return nil, nil
+	}
+	for _, a := range m.byID {
+		if a.OrganizationID == orgID && a.SourceLeadID == sourceLeadID {
+			cp := *a
+			return &cp, nil
+		}
+	}
+	return nil, nil
+}
+
 func (m *memRepo) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -191,6 +208,9 @@ func (m *memRepo) ListAccounts(ctx context.Context, orgID uuid.UUID, filter repo
 		if filter.CNPJ14 != "" && a.CNPJ14 != filter.CNPJ14 {
 			continue
 		}
+		if filter.SourceRunID != "" && a.SourceRunID != filter.SourceRunID {
+			continue
+		}
 		if filter.ActivationState != "" && a.ActivationState != filter.ActivationState {
 			continue
 		}
@@ -247,10 +267,19 @@ func (m *memRepo) ListAccounts(ctx context.Context, orgID uuid.UUID, filter repo
 		cp := *a
 		out = append(out, cp)
 	}
-	// stable-ish order by CNPJ
+	// Mirror the repository: deterministic page order, and an empty filter is 50 rows, not everything.
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].CNPJ14 != out[j].CNPJ14 {
+			return out[i].CNPJ14 < out[j].CNPJ14
+		}
+		return out[i].ID.String() < out[j].ID.String()
+	})
 	limit := filter.Limit
 	if limit <= 0 {
-		limit = len(out)
+		limit = 50
+	}
+	if limit > 1000 {
+		limit = 1000
 	}
 	offset := filter.Offset
 	if offset < 0 {

--- a/internal/infrastructure/db/migrations/000113_confenge_outreach_accounts_source_run_idx.down.sql
+++ b/internal/infrastructure/db/migrations/000113_confenge_outreach_accounts_source_run_idx.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS outreach_accounts_org_source_run_idx;

--- a/internal/infrastructure/db/migrations/000113_confenge_outreach_accounts_source_run_idx.up.sql
+++ b/internal/infrastructure/db/migrations/000113_confenge_outreach_accounts_source_run_idx.up.sql
@@ -1,0 +1,5 @@
+-- Scoped cohort freeze reads outreach_accounts by (organization_id, source_run_id).
+-- Without this index the run predicate degrades to a full org scan.
+CREATE INDEX IF NOT EXISTS outreach_accounts_org_source_run_idx
+    ON outreach_accounts (organization_id, source_run_id)
+    WHERE source_run_id <> '';

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -29,6 +30,8 @@ type OutreachRepository interface {
 
 	// Accounts
 	GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error)
+	// GetAccountBySourceLeadID resolves the extra-cli lead id via the org+source_lead_id index.
+	GetAccountBySourceLeadID(ctx context.Context, orgID uuid.UUID, sourceLeadID string) (*models.OutreachAccount, error)
 	GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachAccount, error)
 	UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (created bool, err error)
 	ListAccounts(ctx context.Context, orgID uuid.UUID, filter OutreachAccountFilter) ([]models.OutreachAccount, error)
@@ -113,6 +116,8 @@ type OutreachAccountFilter struct {
 	RequireTargetFitEligible bool
 	RequireOperational       bool
 	StableOrder              bool
+	// SourceRunID scopes the page to one extra-cli import run. Indexed; implies StableOrder.
+	SourceRunID string
 }
 
 // OutreachActivationCounts is aggregate activation_state distribution for an org.
@@ -337,6 +342,21 @@ func scanImportRun(row scannable) (*models.OutreachImportRun, error) {
 func (r *outreachRepository) GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error) {
 	row := r.db.QueryRow(ctx, outreachAccountSelect+`
 		FROM outreach_accounts WHERE organization_id=$1 AND cnpj14=$2`, orgID, cnpj14)
+	acc, err := scanAccount(row)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	return acc, err
+}
+
+func (r *outreachRepository) GetAccountBySourceLeadID(ctx context.Context, orgID uuid.UUID, sourceLeadID string) (*models.OutreachAccount, error) {
+	sourceLeadID = strings.TrimSpace(sourceLeadID)
+	if sourceLeadID == "" {
+		return nil, nil
+	}
+	row := r.db.QueryRow(ctx, outreachAccountSelect+`
+		FROM outreach_accounts WHERE organization_id=$1 AND source_lead_id=$2
+		ORDER BY updated_at DESC LIMIT 1`, orgID, sourceLeadID)
 	acc, err := scanAccount(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
@@ -675,6 +695,11 @@ func (r *outreachRepository) ListAccounts(ctx context.Context, orgID uuid.UUID, 
 		args = append(args, filter.CNPJ14)
 		n++
 	}
+	if filter.SourceRunID != "" {
+		q += fmt.Sprintf(` AND source_run_id=$%d`, n)
+		args = append(args, filter.SourceRunID)
+		n++
+	}
 	if filter.Search != "" {
 		q += fmt.Sprintf(` AND (razao_social ILIKE $%d OR nome_fantasia ILIKE $%d OR cnpj14 LIKE $%d)`, n, n, n)
 		args = append(args, "%"+filter.Search+"%")
@@ -703,8 +728,9 @@ func (r *outreachRepository) ListAccounts(ctx context.Context, orgID uuid.UUID, 
 		q += ` AND email_send_ready = true`
 		q += ` AND EXISTS (SELECT 1 FROM outreach_contact_candidates occ WHERE occ.organization_id=outreach_accounts.organization_id AND occ.account_id=outreach_accounts.id AND occ.email_send_ready=true AND occ.email<>'' AND occ.blocked=false AND occ.do_not_contact=false AND occ.bounced=false AND occ.mailbox_purpose_send_blocked=false AND occ.verification_status NOT IN ('CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT'))`
 	}
-	if filter.StableOrder {
-		q += fmt.Sprintf(` ORDER BY cnpj14 ASC LIMIT $%d OFFSET $%d`, n, n+1)
+	// A run-scoped page must paginate deterministically; priority_rank ordering is not stable.
+	if filter.StableOrder || filter.SourceRunID != "" {
+		q += fmt.Sprintf(` ORDER BY cnpj14 ASC, id ASC LIMIT $%d OFFSET $%d`, n, n+1)
 	} else if filter.DynamicPriority {
 		q += fmt.Sprintf(` ORDER BY next_best_action_at ASC NULLS LAST, activation_score DESC, priority_rank ASC NULLS LAST, moment_observed_at DESC NULLS LAST, cnpj14 ASC LIMIT $%d OFFSET $%d`, n, n+1)
 	} else {


### PR DESCRIPTION
`cohort prepare --feed --org-id` could not find the accounts it had just imported. It reported `no imported accounts for feed run "..."; import the feed first` about a run that was imported, complete, and eligible.

## What actually happened

`AccountsFromOrg` passed an empty `OutreachAccountFilter{}`. `pg_outreach.go` reads that as `limit <= 0 → 50`. So the query was:

```sql
SELECT ... FROM outreach_accounts WHERE organization_id = $1
ORDER BY priority_rank ASC NULLS LAST, updated_at DESC
LIMIT 50 OFFSET 0
```

No `source_run_id` predicate at all — the run scope was applied in Go, over those 50 rows. With ~402k accounts in the org, a freshly imported run is essentially never in the top 50 by `priority_rank`, so the scope matched nothing and the error blamed the import.

The workaround was `--feed` alone. That path builds accounts and candidates with no `ID`, so `PrepareControlledCohort` froze `uuid.Nil` into every member — and `json:"account_id,omitempty"` hid it, so the snapshot looked fine. At authorize time `cohort_apply.go` did:

```go
if acc, err := resolveAccountForMember(...); err == nil && acc != nil {
```

discarding the error, then built the touchpoint anyway. The zero UUID hit `outreach_touchpoints.account_id uuid NOT NULL REFERENCES outreach_accounts(id)` and surfaced as `persist touchpoint: ...` — a foreign-key error nowhere near the cause.

`resolveAccountForMember` repeated the same 50-row scan, and because `accountRef` prefers `source_lead_id` over CNPJ, the indexed `GetAccountByCNPJ` fast path was never taken.

## The fix

Push the scope into SQL. `OutreachAccountFilter.SourceRunID` adds `AND source_run_id=$n`, backed by a new partial index, with `ORDER BY cnpj14 ASC, id ASC` so offset pagination is deterministic:

```sql
CREATE INDEX IF NOT EXISTS outreach_accounts_org_source_run_idx
    ON outreach_accounts (organization_id, source_run_id)
    WHERE source_run_id <> '';
```

`AccountsFromOrg` now paginates explicitly (1000/page) instead of relying on the silent 50, and refuses an oversized unscoped org rather than truncating it — no silent wrong answer.

`GetAccountBySourceLeadID` uses the index that already existed (`outreach_accounts_org_source_lead_idx`) and `resolveAccountForMember` tries it first, matching what `accountRef` actually emits. The 50-row scan is gone.

The resolver error is propagated, `omitempty` is dropped from `account_id`/`candidate_id` so a zero id is visible rather than absent, and a Postgres-bound account without a canonical id is refused at freeze time instead of at the FK.

## Why no test caught it

`memRepo.ListAccounts` did `if limit <= 0 { limit = len(out) }` — the fake treated an empty filter as unbounded while production capped it at 50. The fake now mirrors production, which is what makes the regression observable at all.

`TestAccountsFromOrgForRunFindsMembersBeyondFirstPage` seeds 1200 accounts on one run plus 12 targets on another, asserts the premise that page one holds no target, then requires all 12 frozen with non-nil in-run `AccountID` and `CandidateID`. Reverting `cohort_feed.go` to the client-side filter fails it with the production symptom verbatim:

```
cohort_feed_page_scope_test.go:76: accounts from org for run: no imported accounts for feed run "run-target"; import the feed first
```

## Migration numbering

`origin/main` ends at 000110, and 000111/000112 are already used on unmerged branches. This uses 000113 to avoid a golang-migrate duplicate-version collision on merge.

## Verification

`gofmt -l ./cmd ./internal` silent, `go build ./...` clean, `go vet ./internal/... ./cmd/...` clean.

`TestProductAcceptanceMultichannelSum` (needs Mailpit) and `TestTargetFitConfirmedFreshRemainsOperational` fail identically on clean `origin/main` — pre-existing, not caused here. The second looks like a genuine product defect and deserves its own issue.

## Residual

- Candidates are still loaded N+1, bounded now by the run scope.
- `maxOrgFreezeAccounts = 5000` also caps the run-scoped path; a legitimately huge import run hard-fails with `split the import before freezing` rather than silently freezing a subset.
- `source_lead_id` has no uniqueness constraint, so `GetAccountBySourceLeadID` takes the most recently updated row on a collision.
- Other empty-filter `ListAccounts` callers were not audited; the silent 50 default remains a repo-wide footgun.

🤖 Generated with [Claude Code](https://claude.com/claude-code)