### PR TITLE
feat(confenge): make the cohort preview something a founder can actually review

### DIFF
--- a/cmd/confenge/cohort.go
+++ b/cmd/confenge/cohort.go
@@ -55,6 +55,7 @@ func cmdCohortPrepare(args []string) int {
 	volume := fs.Int("max-daily", confenge.DefaultCohortDailyVolume, "max daily volume bound into the grant")
 	ttl := fs.String("ttl", "24h", "authorization TTL")
 	sha := fs.String("repository-sha", "", "deployed SHA (defaults to CONFENGE_REPOSITORY_SHA)")
+	previewOpts := registerPreviewFlags(fs)
 	_ = fs.Parse(args)
 
 	dur, err := time.ParseDuration(*ttl)
@@ -162,7 +163,7 @@ func cmdCohortPrepare(args []string) int {
 		return 2
 	}
 
-	fmt.Print(confenge.FormatCohortPreview(snap))
+	fmt.Print(confenge.FormatCohortPreviewWithOptions(snap, previewOpts()))
 	enc, err := confenge.MarshalFrozenCohort(snap)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "BLOCKED: marshal: %v\n", err)
@@ -180,10 +181,26 @@ func cmdCohortPrepare(args []string) int {
 	return 0
 }
 
+// registerPreviewFlags binds the founder review knobs. They tune what the
+// operator reads before authorizing; none of them can change what was admitted.
+func registerPreviewFlags(fs *flag.FlagSet) func() confenge.CohortPreviewOptions {
+	samples := fs.Int("samples", confenge.DefaultPreviewSamplesPerClass, "sampled recipients rendered per route class")
+	bodies := fs.Int("bodies", confenge.DefaultPreviewFullBodies, "sampled recipients whose full composed body is printed")
+	showMailbox := fs.Bool("show-mailbox", false, "print the real destination address instead of the redacted one")
+	return func() confenge.CohortPreviewOptions {
+		return confenge.CohortPreviewOptions{
+			SamplesPerClass: *samples,
+			FullBodies:      *bodies,
+			ShowMailbox:     *showMailbox,
+		}
+	}
+}
+
 func cmdCohortPreview(args []string) int {
 	fs := flag.NewFlagSet("cohort preview", flag.ExitOnError)
 	manifest := fs.String("manifest", "", "frozen snapshot JSON from cohort prepare --out")
 	asJSON := fs.Bool("json", false, "print the snapshot JSON")
+	previewOpts := registerPreviewFlags(fs)
 	_ = fs.Parse(args)
 	snap, err := readFrozenManifest(*manifest)
 	if err != nil {
@@ -195,7 +212,7 @@ func cmdCohortPreview(args []string) int {
 		fmt.Println(string(enc))
 		return 0
 	}
-	fmt.Print(confenge.FormatCohortPreview(snap))
+	fmt.Print(confenge.FormatCohortPreviewWithOptions(snap, previewOpts()))
 	return 0
 }
 
@@ -205,6 +222,7 @@ func cmdCohortAuthorize(args []string) int {
 	actor := fs.String("actor", "", "human actor UUID (required)")
 	orgStr := fs.String("org-id", seed.DevOrgID.String(), "organization UUID")
 	confirm := fs.Bool("confirm", false, "persist the grant and apply to touchpoints")
+	previewOpts := registerPreviewFlags(fs)
 	_ = fs.Parse(args)
 	if strings.TrimSpace(*actor) == "" {
 		fmt.Fprintln(os.Stderr, "BLOCKED: --actor (human UUID) is required")
@@ -230,7 +248,7 @@ func cmdCohortAuthorize(args []string) int {
 		}
 		enc, _ := json.MarshalIndent(auth.Summary(), "", "  ")
 		fmt.Println(string(enc))
-		fmt.Print(confenge.FormatCohortPreview(snap))
+		fmt.Print(confenge.FormatCohortPreviewWithOptions(snap, previewOpts()))
 		fmt.Fprintln(os.Stderr, "not persisted. Re-run with --confirm after reviewing the summary.")
 		return 0
 	}

--- a/internal/app/confenge/cohort_compose.go
+++ b/internal/app/confenge/cohort_compose.go
@@ -99,20 +99,73 @@ func appendReferralAsk(cta string) string {
 	return cta + " " + referralAsk
 }
 
+// ComposedInitial is what the composer decided, not only what it printed. The
+// founder review has to judge the observed fact and the ask on their own, and
+// neither survives inside BodyText in a form that can be read back without
+// re-parsing prose.
+type ComposedInitial struct {
+	Subject  string
+	Body     string
+	Greeting string
+	// ObservedFact is empty whenever the composer printed no fact. FactSource
+	// says which kind of empty it is, so "the feed carried nothing" is never
+	// silently shown as "the composer refused what the feed carried".
+	ObservedFact string
+	FactSource   string
+	CTA          string
+	CTASource    string
+	Theme        string
+}
+
+// Closed set of fact provenances. A fact the composer refused to print is a
+// different founder signal from a fact that was never in the feed.
+const (
+	FactSourceFactToMention = "fact_to_mention"
+	FactSourceMomentSummary = "moment_summary"
+	FactSourceDropped       = "dropped_unusable"
+	FactSourceNone          = "none"
+)
+
+// Closed set of ask provenances. A routing ask is the composer's own words for
+// a mailbox with no owner; an account CTA came from the feed.
+const (
+	CTASourceAccount = "account_cta"
+	CTASourceRouting = "routing_ask"
+	CTASourceDefault = "composer_default"
+)
+
 // ComposeControlledInitial is the freeze-time composer. It never invents a
 // person. GENERIC/FREEMAIL copy is institutional and may ask for a route.
 func ComposeControlledInitial(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, class string) (subject, body, greeting string) {
-	greeting = greetingForRouteClass(class, cand)
+	c := ComposeControlledInitialDetailed(acc, cand, class)
+	return c.Subject, c.Body, c.Greeting
+}
+
+// ComposeControlledInitialDetailed composes exactly what ComposeControlledInitial
+// composes and additionally reports the inputs the copy was built from, so the
+// preview can show the fact and the ask without guessing them back out of prose.
+func ComposeControlledInitialDetailed(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, class string) ComposedInitial {
+	out := ComposedInitial{
+		Greeting:   greetingForRouteClass(class, cand),
+		FactSource: FactSourceNone,
+		CTASource:  CTASourceDefault,
+	}
 	obs := ""
 	cta := "Posso te mandar o recorte objetivo que eu conferiria?"
 	theme := "contratos públicos"
 	if acc != nil {
-		obs = firstNonEmpty(strings.TrimSpace(acc.FactToMention), strings.TrimSpace(acc.MomentSummary))
+		if s := strings.TrimSpace(acc.FactToMention); s != "" {
+			obs, out.FactSource = s, FactSourceFactToMention
+		} else if s := strings.TrimSpace(acc.MomentSummary); s != "" {
+			obs, out.FactSource = s, FactSourceMomentSummary
+		}
 		if strings.TrimSpace(acc.CTA) != "" {
 			cta = ensureClosingAsk(strings.TrimSpace(acc.CTA))
+			out.CTASource = CTASourceAccount
 		}
 		theme = firstNonEmpty(humanizeMoment(acc.MomentCode), acc.ServiceName, theme)
 	}
+	fedAFact := out.FactSource != FactSourceNone
 	obs = ApplyCopyHygiene(obs)
 	// A serialized feed record is not prose. Condense it, and drop it entirely
 	// rather than pasting a database row into a cold email.
@@ -122,9 +175,15 @@ func ComposeControlledInitial(acc *models.OutreachAccount, cand *models.Outreach
 			obs = ""
 		}
 	}
+	// Hygiene can also empty a fact that arrived non-empty. Reporting that as
+	// "none" would tell the founder the feed carried no fact, which is false.
+	if obs == "" && fedAFact {
+		out.FactSource = FactSourceDropped
+	}
 	switch class {
 	case RouteClassGenericCompany, RouteClassPublicCompanyFreemail:
 		cta = routingCTA(theme)
+		out.CTASource = CTASourceRouting
 	case RouteClassRoleOrDepartment:
 		// A department mailbox is the right door, not proof of the right person.
 		if CandidatePersonUnknown(cand) {
@@ -132,7 +191,7 @@ func ComposeControlledInitial(acc *models.OutreachAccount, cand *models.Outreach
 		}
 	}
 	var b strings.Builder
-	b.WriteString(greeting)
+	b.WriteString(out.Greeting)
 	b.WriteString(",\n\nSou da CONFENGE.\n\n")
 	if obs != "" {
 		b.WriteString(obs)
@@ -142,9 +201,12 @@ func ComposeControlledInitial(acc *models.OutreachAccount, cand *models.Outreach
 		b.WriteString("\n\n")
 	}
 	b.WriteString(cta)
-	body = b.String()
-	subject = controlledSubject(acc, obs, theme)
-	return subject, body, greeting
+	out.ObservedFact = obs
+	out.CTA = cta
+	out.Theme = theme
+	out.Body = b.String()
+	out.Subject = controlledSubject(acc, obs, theme)
+	return out
 }
 
 func controlledSubject(acc *models.OutreachAccount, obs, theme string) string {

--- a/internal/app/confenge/cohort_feed.go
+++ b/internal/app/confenge/cohort_feed.go
@@ -59,6 +59,30 @@ func accountsFromFeed(feed *Feed, source string) []CohortAccountInput {
 			QuestionToAsk: lead.MessagingContext.QuestionToAsk,
 			CTA:           lead.MessagingContext.CTA,
 			SourceRunID:   feed.Source.RunID,
+
+			// Carried for the founder preview's admission evidence. Nothing in
+			// the prepare ladder reads these: the ladder admits on controlled
+			// route eligibility and copy QA, and dropping them here only hid
+			// from the reviewer what the feed had actually asserted.
+			PriorityRank:             lead.Priority.Rank,
+			PriorityScore:            lead.Priority.Score,
+			PriorityTier:             lead.Priority.Tier,
+			PriorityConfidence:       lead.Priority.Confidence,
+			MomentConfidence:         lead.Moment.Confidence,
+			MomentObservedAt:         parseFeedDate(lead.Moment.ObservedAt),
+			MomentEvidenceIDs:        append([]string(nil), lead.Moment.EvidenceIDs...),
+			TargetFitSendTier:        lead.TargetFitSendTier,
+			TargetFitReasons:         append([]string(nil), lead.TargetFitReasons...),
+			TargetFitClass:           lead.TargetFitClass,
+			TargetFitConfidence:      lead.TargetFitConfidence,
+			TargetFitVersion:         lead.TargetFitVersion,
+			TargetFitComputedAt:      parseFeedDate(lead.TargetFitComputedAt),
+			TargetFitSourceWatermark: lead.TargetFitSourceWatermark,
+			TargetFitEvidenceIDs:     append([]string(nil), lead.TargetFitEvidenceIDs...),
+			TargetFitFreshnessReason: lead.TargetFitFreshnessReason,
+		}
+		if lead.TargetFitFresh != nil {
+			acc.TargetFitFresh = *lead.TargetFitFresh
 		}
 		if lead.Activation != nil && strings.EqualFold(lead.Activation.State, ActivationSuppressed) {
 			acc.Blocked = true
@@ -187,6 +211,22 @@ func candidateFromFeedContact(fc FeedContact) models.OutreachContactCandidate {
 	}
 	c.DiscoveryJSON = mergeControlledDiscovery(fc.DiscoveryJSON, fc)
 	return c
+}
+
+// parseFeedDate accepts both shapes extra-cli emits. An unparseable date stays
+// nil so the preview reports it absent instead of inventing an epoch.
+func parseFeedDate(s string) *time.Time {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil
+	}
+	for _, layout := range []string{"2006-01-02", time.RFC3339} {
+		if ts, err := time.Parse(layout, s); err == nil {
+			ts = ts.UTC()
+			return &ts
+		}
+	}
+	return nil
 }
 
 // routeSuppressionActive is extra-cli's suppression enum. NONE/CLEAR/empty are not suppressed.

--- a/internal/app/confenge/cohort_founder_preview_test.go
+++ b/internal/app/confenge/cohort_founder_preview_test.go
@@ -1,0 +1,198 @@
+package confenge
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// reviewCohort is the fixture the founder review is judged on: one departmental
+// route with a fact, a company name and a mailbox purpose, plus a second
+// eligible mailbox on the same account so "why this route" has something to
+// compare against.
+func reviewCohort(t *testing.T) *FrozenCohortSnapshot {
+	t.Helper()
+	unk := true
+	acc := models.OutreachAccount{
+		SourceLeadID: "acc-review", CNPJ14: "11111111000191",
+		RazaoSocial: "CONSTRUTORA ALFA LTDA", NomeFantasia: "Construtora Alfa",
+		MomentCode: "REAJUSTE_14133", MomentConfidence: "HIGH",
+		FactToMention:     "Contrato 12/2023 com reajuste previsto para maio",
+		CTA:               "Posso enviar o recorte?",
+		TargetFitSendTier: "B_EVIDENCE_SUPPORTED", TargetFitClass: "ICP_CORE",
+		TargetFitReasons:  []string{"contrato_ativo", "obra_publica"},
+		TargetFitEligible: true, TargetFitFresh: true,
+		PriorityTier: "A", PriorityRank: 3, PriorityConfidence: "HIGH",
+	}
+	snap, err := PrepareControlledCohort([]CohortAccountInput{{
+		Account: acc,
+		Candidates: []models.OutreachContactCandidate{
+			{
+				Email: "licitacoes@alfa.com.br", MailboxPurpose: "LICITACOES", OwnershipStatus: "COMPANY_OWNED",
+				DiscoveryJSON: eligibleDisc(t, RouteClassRoleOrDepartment, true, controlledDiscovery{PersonUnknown: &unk}),
+			},
+			{
+				Email: "contato@alfa.com.br", MailboxPurpose: "GENERIC_CONTACT", OwnershipStatus: "COMPANY_OWNED",
+				DiscoveryJSON: eligibleDisc(t, RouteClassGenericCompany, false, controlledDiscovery{PersonUnknown: &unk}),
+			},
+		},
+		Source: "pncp",
+	}}, CohortPrepareOptions{Now: time.Now().UTC(), RepositorySHA: "sha-test", SnapshotHash: "snap-review"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.Members) != 1 {
+		t.Fatalf("fixture must freeze exactly one route, got %d", len(snap.Members))
+	}
+	return snap
+}
+
+// The founder authorizes a real cold-email cohort from this text. Counts and
+// hashes cannot show the wrong company, false personalization or bad copy, so
+// every judgeable dimension has to be on the page.
+func TestPreviewShowsCopyRouteAndAdmissionForSampledMember(t *testing.T) {
+	snap := reviewCohort(t)
+	m := snap.Members[0]
+	out := FormatCohortPreview(snap)
+
+	for _, want := range []string{
+		"Construtora Alfa",              // wrong company is the first thing to catch
+		m.Subject,                       // subject verbatim
+		"Olá, pessoal de licitações",    // greeting verbatim
+		"Contrato 12/2023 com reajuste", // the observed fact the copy is built on
+		"source=" + FactSourceFactToMention,
+		"Posso enviar o recorte?", // the CTA
+		RouteClassRoleOrDepartment,
+		"mailbox_purpose=LICITACOES",
+		"why_admitted:",
+		"admitted_by=controlled_route_eligible",
+		"feed_target_fit_tier=B_EVIDENCE_SUPPORTED class=ICP_CORE eligible=true fresh=true",
+		"why_this_route:",
+		"chosen_route_class=" + RouteClassRoleOrDepartment,
+		"preferred_initial=true",
+		// The alternative mailbox on the same account, and why it lost.
+		"not_chosen=c***@alfa.com.br",
+		"reason=lower_selection_score",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("preview missing %q\n---\n%s", want, out)
+		}
+	}
+
+	// A pasted database row or a raw enum in prose is usually only visible in
+	// the whole message, so at least one full body must be rendered.
+	if !strings.Contains(out, "full composed body") || !strings.Contains(out, "| Sou da CONFENGE.") {
+		t.Fatalf("preview must render whole bodies for a few samples\n---\n%s", out)
+	}
+}
+
+// Absence has to look like absence. An empty string reads as "no fact was
+// needed here", which is exactly the judgement the founder must not be nudged
+// into making by the renderer.
+func TestPreviewRendersMissingFieldsAsExplicitAbsence(t *testing.T) {
+	unk := true
+	snap, err := PrepareControlledCohort([]CohortAccountInput{{
+		// No company name, no fact, no moment, no target-fit, no CTA.
+		Account: models.OutreachAccount{SourceLeadID: "acc-bare", CNPJ14: "22222222000192"},
+		Candidates: []models.OutreachContactCandidate{{
+			Email: "contato@bare.com.br", OwnershipStatus: "COMPANY_OWNED",
+			DiscoveryJSON: eligibleDisc(t, RouteClassGenericCompany, false, controlledDiscovery{PersonUnknown: &unk}),
+		}},
+	}}, CohortPrepareOptions{Now: time.Now().UTC(), RepositorySHA: "sha-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.Members) != 1 {
+		t.Fatalf("fixture must freeze one route, got %d", len(snap.Members))
+	}
+	if snap.Members[0].ObservedFact != "" || snap.Members[0].FactSource != FactSourceNone {
+		t.Fatalf("fixture is supposed to carry no fact: %+v", snap.Members[0])
+	}
+	out := FormatCohortPreview(snap)
+	for _, want := range []string{
+		"company=" + previewAbsent,
+		"fact=" + previewAbsent,
+		"source=" + FactSourceNone,
+		"mailbox_purpose=" + previewAbsent,
+		"feed_target_fit=" + previewAbsent,
+		"feed_moment=" + previewAbsent,
+		"feed_priority=" + previewAbsent,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("absent field must render as %q\n---\n%s", want, out)
+		}
+	}
+	// Never a blank that reads as deliberate copy, and never a stand-in that
+	// could be mistaken for a real value.
+	for _, forbidden := range []string{`fact=""`, "fact=\n", "fact=N/A", "fact=-", "fact=TBD", "fact=example"} {
+		if strings.Contains(out, forbidden) {
+			t.Fatalf("absence rendered as %q instead of a marker\n---\n%s", forbidden, out)
+		}
+	}
+}
+
+// The rendered preview is the text that ends up pasted into aggregated logs, so
+// it stays redacted until the founder explicitly asks for the real destination.
+func TestPreviewRedactsMailboxUntilExplicitlyRevealed(t *testing.T) {
+	snap := reviewCohort(t)
+	full := snap.Members[0].Mailbox
+	if full != "licitacoes@alfa.com.br" {
+		t.Fatalf("fixture mailbox drifted: %q", full)
+	}
+	redacted := RedactMailbox(full)
+
+	def := FormatCohortPreview(snap)
+	if strings.Contains(def, full) {
+		t.Fatalf("default preview leaked the real address\n---\n%s", def)
+	}
+	if !strings.Contains(def, redacted) {
+		t.Fatalf("default preview must show the redacted address\n---\n%s", def)
+	}
+
+	shown := FormatCohortPreviewWithOptions(snap, CohortPreviewOptions{ShowMailbox: true})
+	if !strings.Contains(shown, full) {
+		t.Fatalf("--show-mailbox must reveal the real destination\n---\n%s", shown)
+	}
+	// The alternative mailboxes are never sent to, so revealing the chosen one
+	// must not widen exposure of the ones that lost.
+	if strings.Contains(shown, "contato@alfa.com.br") {
+		t.Fatalf("rejected routes must stay redacted even when revealing\n---\n%s", shown)
+	}
+}
+
+// The sample is a judgement aid, not a per-message approval queue: it must stay
+// bounded and spread across route classes rather than dumping the whole cohort.
+func TestPreviewSampleIsBoundedPerRouteClass(t *testing.T) {
+	unk := true
+	var in []CohortAccountInput
+	for i := 0; i < 6; i++ {
+		ref := string(rune('a' + i))
+		in = append(in, CohortAccountInput{
+			Account: cohortAccount("acc-"+ref, "1111111100019"+ref, "Aditivo publicado no PNCP"),
+			Candidates: []models.OutreachContactCandidate{{
+				Email: "contato@" + ref + ".com.br", MailboxPurpose: "GENERIC_CONTACT", OwnershipStatus: "COMPANY_OWNED",
+				DiscoveryJSON: eligibleDisc(t, RouteClassGenericCompany, false, controlledDiscovery{PersonUnknown: &unk}),
+			}},
+		})
+	}
+	snap, err := PrepareControlledCohort(in, CohortPrepareOptions{Now: time.Now().UTC(), RepositorySHA: "sha-test"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snap.Members) != 6 {
+		t.Fatalf("fixture must freeze six routes, got %d", len(snap.Members))
+	}
+	def := FormatCohortPreview(snap)
+	if n := strings.Count(def, "why_this_route:"); n != DefaultPreviewSamplesPerClass {
+		t.Fatalf("default sample must stay at %d per class, got %d\n---\n%s", DefaultPreviewSamplesPerClass, n, def)
+	}
+	wide := FormatCohortPreviewWithOptions(snap, CohortPreviewOptions{SamplesPerClass: 4, FullBodies: 1})
+	if n := strings.Count(wide, "why_this_route:"); n != 4 {
+		t.Fatalf("--samples must widen the sample, got %d\n---\n%s", n, wide)
+	}
+	if n := strings.Count(wide, "--- end ["); n != 1 {
+		t.Fatalf("--bodies must bound whole-body rendering, got %d\n---\n%s", n, wide)
+	}
+}

--- a/internal/app/confenge/cohort_prepare.go
+++ b/internal/app/confenge/cohort_prepare.go
@@ -52,6 +52,18 @@ type FrozenCohortMember struct {
 	PersonUnknown    bool      `json:"person_unknown"`
 	PreferredInitial bool      `json:"preferred_initial"`
 	TouchpointID     uuid.UUID `json:"touchpoint_id,omitempty"`
+
+	// Founder-review projection. These carry no omitempty on purpose: a missing
+	// fact or an unclassified mailbox purpose has to stay visible as a missing
+	// field in the JSON too, not vanish into a key that was never written.
+	Company          string   `json:"company"`
+	MailboxPurpose   string   `json:"mailbox_purpose"`
+	ObservedFact     string   `json:"observed_fact"`
+	FactSource       string   `json:"fact_source"`
+	CTA              string   `json:"cta"`
+	CTASource        string   `json:"cta_source"`
+	AdmissionReasons []string `json:"admission_reasons"`
+	RouteReasons     []string `json:"route_reasons"`
 }
 
 // CohortExclusion is one account left out of the frozen set.
@@ -62,14 +74,31 @@ type CohortExclusion struct {
 	RouteClass string `json:"route_class,omitempty"`
 }
 
-// CohortClassSample is a founder-reviewable excerpt. Aggregated logs should
-// use RedactedMailbox, not the full address.
+// CohortClassSample is a founder-reviewable excerpt: enough of the composed
+// message to spot the wrong company, strange copy, a raw enum in prose, a pasted
+// database row or personalization nobody observed.
+//
+// Aggregated logs should use RedactedMailbox, not Mailbox. Mailbox is carried
+// because the founder deciding whether to authorize a real send needs the real
+// destination, and the frozen manifest already holds it on the member; renderers
+// must gate it behind an explicit reveal rather than printing it by default.
 type CohortClassSample struct {
-	AccountRef      string `json:"account_ref"`
-	RouteClass      string `json:"route_class"`
-	RedactedMailbox string `json:"redacted_mailbox"`
-	Greeting        string `json:"greeting"`
-	PersonUnknown   bool   `json:"person_unknown"`
+	AccountRef       string   `json:"account_ref"`
+	Company          string   `json:"company"`
+	RouteClass       string   `json:"route_class"`
+	RedactedMailbox  string   `json:"redacted_mailbox"`
+	Mailbox          string   `json:"mailbox"`
+	MailboxPurpose   string   `json:"mailbox_purpose"`
+	Greeting         string   `json:"greeting"`
+	PersonUnknown    bool     `json:"person_unknown"`
+	Subject          string   `json:"subject"`
+	ObservedFact     string   `json:"observed_fact"`
+	FactSource       string   `json:"fact_source"`
+	CTA              string   `json:"cta"`
+	CTASource        string   `json:"cta_source"`
+	BodyText         string   `json:"body_text"`
+	AdmissionReasons []string `json:"admission_reasons"`
+	RouteReasons     []string `json:"route_reasons"`
 }
 
 // CohortPreviewReport is the deterministic operator preview. Totals reconcile.
@@ -249,7 +278,7 @@ func PrepareControlledCohort(accounts []CohortAccountInput, opts CohortPrepareOp
 			return nil, fmt.Errorf("account %q loaded from postgres has no canonical id; refusing to freeze an unbound member", ref)
 		}
 
-		cand, reason := SelectInitialRoute(in.Candidates, allowed, opts.Now)
+		cand, reason, routeReasons := selectInitialRouteRationale(in.Candidates, allowed, opts.Now)
 		if cand == nil {
 			if reason == "" {
 				reason = "no_controlled_eligible_route"
@@ -265,8 +294,8 @@ func PrepareControlledCohort(accounts []CohortAccountInput, opts CohortPrepareOp
 			continue
 		}
 
-		subject, body, greeting := ComposeControlledInitial(&in.Account, cand, class)
-		if qa := ValidateCopyForRouteClass(class, body, subject, cand); len(qa) > 0 {
+		comp := ComposeControlledInitialDetailed(&in.Account, cand, class)
+		if qa := ValidateCopyForRouteClass(class, comp.Body, comp.Subject, cand); len(qa) > 0 {
 			exclude(ref, "copy_qa_failure", mailbox, class)
 			continue
 		}
@@ -285,14 +314,24 @@ func PrepareControlledCohort(accounts []CohortAccountInput, opts CohortPrepareOp
 			Mailbox:          mailbox,
 			RouteClass:       class,
 			Source:           src,
-			ContentHash:      hashControlledContent(mailbox, class, subject, body),
+			ContentHash:      hashControlledContent(mailbox, class, comp.Subject, comp.Body),
 			EvidenceHash:     hashControlledEvidence(cand),
 			ComposerVersion:  opts.ComposerVersion,
-			Subject:          subject,
-			BodyText:         body,
-			Greeting:         greeting,
+			Subject:          comp.Subject,
+			BodyText:         comp.Body,
+			Greeting:         comp.Greeting,
 			PersonUnknown:    CandidatePersonUnknown(cand),
 			PreferredInitial: CandidatePreferredInitial(cand),
+			// accountCompany, not accountRef: nobody spots the wrong company
+			// from fourteen digits of CNPJ.
+			Company:          accountCompany(&in.Account),
+			MailboxPurpose:   strings.TrimSpace(cand.MailboxPurpose),
+			ObservedFact:     comp.ObservedFact,
+			FactSource:       comp.FactSource,
+			CTA:              comp.CTA,
+			CTASource:        comp.CTASource,
+			AdmissionReasons: admissionEvidence(&in.Account, class),
+			RouteReasons:     routeReasons,
 		}
 		members = append(members, member)
 		preview.ByRouteClass[class]++
@@ -300,16 +339,6 @@ func PrepareControlledCohort(accounts []CohortAccountInput, opts CohortPrepareOp
 			src = "UNKNOWN"
 		}
 		preview.BySource[src]++
-		samples := preview.SamplesByClass[class]
-		if len(samples) < previewSamplePerClass {
-			preview.SamplesByClass[class] = append(samples, CohortClassSample{
-				AccountRef:      ref,
-				RouteClass:      class,
-				RedactedMailbox: RedactMailbox(mailbox),
-				Greeting:        greeting,
-				PersonUnknown:   member.PersonUnknown,
-			})
-		}
 	}
 
 	preview.AccountsEligible = len(members)
@@ -327,6 +356,7 @@ func PrepareControlledCohort(accounts []CohortAccountInput, opts CohortPrepareOp
 		}
 		return members[i].AccountRef < members[j].AccountRef
 	})
+	preview.SamplesByClass = selectPreviewSamples(members, previewSamplePerClass)
 
 	var warnings []string
 	if strings.TrimSpace(opts.RepositorySHA) == "" {
@@ -389,34 +419,10 @@ func reconcileCohortPreview(p CohortPreviewReport, considered int) (bool, string
 
 // SelectInitialRoute picks at most one controlled-eligible mailbox.
 // DIRECT_PERSON wins when proven; otherwise preferred_initial; else class rank.
+// The rationale variant carries why, for the founder preview.
 func SelectInitialRoute(cands []models.OutreachContactCandidate, allowed map[string]bool, now time.Time) (*models.OutreachContactCandidate, string) {
-	if allowed == nil {
-		allowed = defaultPilotRouteClasses
-	}
-	var eligible []models.OutreachContactCandidate
-	lastReason := "no_controlled_eligible_route"
-	for i := range cands {
-		c := cands[i]
-		if reason := controlledPrepareBlock(&c, allowed, now); reason != "" {
-			lastReason = reason
-			continue
-		}
-		eligible = append(eligible, c)
-	}
-	if len(eligible) == 0 {
-		return nil, lastReason
-	}
-	var best *models.OutreachContactCandidate
-	bestScore := -1
-	for i := range eligible {
-		c := &eligible[i]
-		score := routeSelectionScore(c)
-		if score > bestScore {
-			bestScore = score
-			best = c
-		}
-	}
-	return best, ""
+	cand, reason, _ := selectInitialRouteRationale(cands, allowed, now)
+	return cand, reason
 }
 
 func routeSelectionScore(c *models.OutreachContactCandidate) int {
@@ -595,8 +601,18 @@ func RedactMailbox(email string) string {
 	return string([]rune(local)[0]) + "***@" + parts[1]
 }
 
-// FormatCohortPreview is the founder-readable report. JSON is separate.
+// FormatCohortPreview is the founder-readable report with review defaults:
+// mailboxes redacted, a small sample per route class. JSON is separate.
 func FormatCohortPreview(snap *FrozenCohortSnapshot) string {
+	return FormatCohortPreviewWithOptions(snap, CohortPreviewOptions{
+		SamplesPerClass: DefaultPreviewSamplesPerClass,
+		FullBodies:      DefaultPreviewFullBodies,
+	})
+}
+
+// FormatCohortPreviewWithOptions is the same report with the review knobs the
+// founder controls. Options change what is rendered, never what was admitted.
+func FormatCohortPreviewWithOptions(snap *FrozenCohortSnapshot, opts CohortPreviewOptions) string {
 	if snap == nil {
 		return "no cohort snapshot\n"
 	}
@@ -636,20 +652,7 @@ func FormatCohortPreview(snap *FrozenCohortSnapshot) string {
 			fmt.Fprintf(&b, "  %s=%d\n", k, p.ByExclusionReason[k])
 		}
 	}
-	classKeys := make([]string, 0, len(p.SamplesByClass))
-	for k := range p.SamplesByClass {
-		classKeys = append(classKeys, k)
-	}
-	sort.Strings(classKeys)
-	if len(classKeys) > 0 {
-		fmt.Fprintf(&b, "\nsamples (redacted mailbox):\n")
-		for _, k := range classKeys {
-			for _, s := range p.SamplesByClass[k] {
-				fmt.Fprintf(&b, "  %s %s %s greeting=%q person_unknown=%v\n",
-					s.RouteClass, s.AccountRef, s.RedactedMailbox, s.Greeting, s.PersonUnknown)
-			}
-		}
-	}
+	writeFounderSamples(&b, snap, opts)
 	for _, w := range snap.Warnings {
 		fmt.Fprintf(&b, "\nWARNING: %s\n", w)
 	}

--- a/internal/app/confenge/cohort_preview_review.go
+++ b/internal/app/confenge/cohort_preview_review.go
@@ -1,0 +1,310 @@
+package confenge
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// previewAbsent is printed wherever a field the founder is asked to judge has
+// no value. An empty string reads as "nothing was needed here"; the founder has
+// to be able to see the difference between that and "nothing was recorded".
+const previewAbsent = "<none recorded>"
+
+const (
+	// DefaultPreviewSamplesPerClass keeps the review a representative sample.
+	// The authorization stays cohort-bounded, so this is a judgement aid, not a
+	// per-message approval queue.
+	DefaultPreviewSamplesPerClass = 2
+	// DefaultPreviewFullBodies is small on purpose: a raw enum or a pasted
+	// database row is usually only visible in the whole message, and two or
+	// three whole messages are still readable in one sitting.
+	DefaultPreviewFullBodies = 2
+)
+
+// CohortPreviewOptions tunes the founder-facing render only. It cannot change
+// what was admitted; the frozen snapshot is already decided by the time it runs.
+type CohortPreviewOptions struct {
+	SamplesPerClass int
+	FullBodies      int
+	// ShowMailbox reveals the real destination address. Default off, because the
+	// same rendered text ends up in aggregated logs; a founder deciding whether
+	// to authorize a send legitimately needs the real address and asks for it.
+	ShowMailbox bool
+}
+
+func (o CohortPreviewOptions) normalized() CohortPreviewOptions {
+	if o.SamplesPerClass <= 0 {
+		o.SamplesPerClass = DefaultPreviewSamplesPerClass
+	}
+	if o.FullBodies < 0 {
+		o.FullBodies = 0
+	}
+	return o
+}
+
+func orAbsent(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return previewAbsent
+	}
+	return strings.TrimSpace(s)
+}
+
+// assertedBool renders a stored boolean the way a reviewer can trust. These
+// columns default to false, and the direct-feed path has no field to set some of
+// them at all, so a printed "false" would read as an upstream denial that never
+// happened. "not_asserted" is true in both cases.
+func assertedBool(b bool) string {
+	if b {
+		return "true"
+	}
+	return "not_asserted"
+}
+
+func absentDate(t *time.Time) string {
+	if t == nil || t.IsZero() {
+		return previewAbsent
+	}
+	return t.UTC().Format("2006-01-02")
+}
+
+// admissionEvidence answers "why was this company admitted", in the ladder's own
+// terms. PrepareControlledCohort admits on controlled-route eligibility and copy
+// QA alone; the target-fit, moment and priority values below are evidence the
+// feed carried, not gates this path applied, so they are labelled feed_* and are
+// never presented as the reason the account got in.
+func admissionEvidence(acc *models.OutreachAccount, class string) []string {
+	out := []string{
+		"admitted_by=controlled_route_eligible",
+		"route_class=" + orAbsent(class),
+		"copy_qa=passed",
+	}
+	if acc == nil {
+		return append(out, "feed_target_fit="+previewAbsent, "feed_moment="+previewAbsent, "feed_priority="+previewAbsent)
+	}
+	tier := strings.TrimSpace(acc.TargetFitSendTier)
+	fitClass := strings.TrimSpace(acc.TargetFitClass)
+	if tier == "" && fitClass == "" && len(acc.TargetFitReasons) == 0 {
+		out = append(out, "feed_target_fit="+previewAbsent)
+	} else {
+		out = append(out,
+			fmt.Sprintf("feed_target_fit_tier=%s class=%s eligible=%s fresh=%s",
+				orAbsent(tier), orAbsent(fitClass), assertedBool(acc.TargetFitEligible), assertedBool(acc.TargetFitFresh)),
+			"feed_target_fit_reasons="+orAbsent(strings.Join(acc.TargetFitReasons, ",")),
+		)
+	}
+	if strings.TrimSpace(acc.MomentCode) == "" && strings.TrimSpace(acc.MomentSummary) == "" {
+		out = append(out, "feed_moment="+previewAbsent)
+	} else {
+		out = append(out, fmt.Sprintf("feed_moment_code=%s confidence=%s observed_at=%s",
+			orAbsent(acc.MomentCode), orAbsent(acc.MomentConfidence), absentDate(acc.MomentObservedAt)))
+	}
+	if strings.TrimSpace(acc.PriorityTier) == "" && acc.PriorityRank == 0 {
+		out = append(out, "feed_priority="+previewAbsent)
+	} else {
+		out = append(out, fmt.Sprintf("feed_priority_tier=%s rank=%d confidence=%s",
+			orAbsent(acc.PriorityTier), acc.PriorityRank, orAbsent(acc.PriorityConfidence)))
+	}
+	return out
+}
+
+// selectInitialRouteRationale is SelectInitialRoute plus the record of why the
+// winner won. "Why this mailbox and not the other one for the same company" is
+// not answerable from the chosen route alone.
+//
+// Rejected mailboxes are redacted here and stay redacted: nothing is ever sent
+// to them, so the preview has no reason to widen their exposure the way
+// --show-mailbox legitimately does for the one destination under review.
+func selectInitialRouteRationale(cands []models.OutreachContactCandidate, allowed map[string]bool, now time.Time) (*models.OutreachContactCandidate, string, []string) {
+	if allowed == nil {
+		allowed = defaultPilotRouteClasses
+	}
+	var eligible []models.OutreachContactCandidate
+	var rejected []string
+	lastReason := "no_controlled_eligible_route"
+	for i := range cands {
+		c := cands[i]
+		if reason := controlledPrepareBlock(&c, allowed, now); reason != "" {
+			lastReason = reason
+			rejected = append(rejected, fmt.Sprintf("not_chosen=%s reason=%s", RedactMailbox(c.Email), reason))
+			continue
+		}
+		eligible = append(eligible, c)
+	}
+	if len(eligible) == 0 {
+		return nil, lastReason, rejected
+	}
+	var best *models.OutreachContactCandidate
+	bestScore := -1
+	for i := range eligible {
+		c := &eligible[i]
+		if score := routeSelectionScore(c); score > bestScore {
+			bestScore = score
+			best = c
+		}
+	}
+	reasons := []string{
+		"chosen_route_class=" + orAbsent(CandidateRouteClass(best)),
+		fmt.Sprintf("chosen_selection_score=%d", bestScore),
+		fmt.Sprintf("preferred_initial=%v", CandidatePreferredInitial(best)),
+		fmt.Sprintf("proven_person_name=%v", provenPersonName(best)),
+		fmt.Sprintf("eligible_routes=%d rejected_routes=%d", len(eligible), len(rejected)),
+	}
+	for i := range eligible {
+		c := &eligible[i]
+		if c == best {
+			continue
+		}
+		score := routeSelectionScore(c)
+		why := "lower_selection_score"
+		if score == bestScore {
+			// A tie is broken by input order, not by merit. Saying "lower score"
+			// here would tell the founder a comparison happened that did not.
+			why = "tied_selection_score_first_seen_wins"
+		}
+		reasons = append(reasons, fmt.Sprintf("not_chosen=%s route_class=%s score=%d reason=%s",
+			RedactMailbox(c.Email), orAbsent(CandidateRouteClass(c)), score, why))
+	}
+	return best, "", append(reasons, rejected...)
+}
+
+// selectPreviewSamples spreads the sample across route classes so no class is
+// judged by another class's copy. Members arrive sorted, so the pick is stable
+// between the frozen snapshot and any later render of it.
+func selectPreviewSamples(members []FrozenCohortMember, perClass int) map[string][]CohortClassSample {
+	if perClass <= 0 {
+		perClass = DefaultPreviewSamplesPerClass
+	}
+	out := map[string][]CohortClassSample{}
+	for i := range members {
+		m := members[i]
+		if len(out[m.RouteClass]) >= perClass {
+			continue
+		}
+		out[m.RouteClass] = append(out[m.RouteClass], sampleFromMember(&m))
+	}
+	return out
+}
+
+// sampleFromMember is the single projection from frozen member to reviewable
+// excerpt. Keeping it in one place is what stops the sample and the member from
+// disagreeing about what was composed.
+func sampleFromMember(m *FrozenCohortMember) CohortClassSample {
+	return CohortClassSample{
+		AccountRef:       m.AccountRef,
+		Company:          m.Company,
+		RouteClass:       m.RouteClass,
+		RedactedMailbox:  RedactMailbox(m.Mailbox),
+		Mailbox:          m.Mailbox,
+		MailboxPurpose:   m.MailboxPurpose,
+		Greeting:         m.Greeting,
+		PersonUnknown:    m.PersonUnknown,
+		Subject:          m.Subject,
+		ObservedFact:     m.ObservedFact,
+		FactSource:       m.FactSource,
+		CTA:              m.CTA,
+		CTASource:        m.CTASource,
+		BodyText:         m.BodyText,
+		AdmissionReasons: append([]string(nil), m.AdmissionReasons...),
+		RouteReasons:     append([]string(nil), m.RouteReasons...),
+	}
+}
+
+func sampleMailbox(s CohortClassSample, show bool) string {
+	if show {
+		return orAbsent(s.Mailbox)
+	}
+	return orAbsent(s.RedactedMailbox)
+}
+
+// writeFounderSamples renders what the founder is actually being asked to judge:
+// the wrong company, strange copy, a raw enum in prose, a pasted database row, a
+// personalization that was never observed, a fact that should not be said out
+// loud. Counts and hashes cannot show any of that.
+func writeFounderSamples(b *strings.Builder, snap *FrozenCohortSnapshot, opts CohortPreviewOptions) {
+	opts = opts.normalized()
+	samples := selectPreviewSamples(snap.Members, opts.SamplesPerClass)
+	if len(samples) == 0 {
+		// Fall back to whatever the frozen report carried: a snapshot read back
+		// without members is still worth previewing, and printing nothing would
+		// look like an empty cohort rather than a narrower render.
+		samples = snap.Preview.SamplesByClass
+	}
+	classes := make([]string, 0, len(samples))
+	for k := range samples {
+		classes = append(classes, k)
+	}
+	sort.Strings(classes)
+	if len(classes) == 0 {
+		return
+	}
+
+	mailboxNote := "mailbox redacted; pass --show-mailbox to reveal the real destination"
+	if opts.ShowMailbox {
+		mailboxNote = "REAL DESTINATION ADDRESSES SHOWN"
+	}
+	fmt.Fprintf(b, "\nreview sample (up to %d per route class; %s):\n", opts.SamplesPerClass, mailboxNote)
+
+	n := 0
+	var ordered []CohortClassSample
+	for _, class := range classes {
+		for _, s := range samples[class] {
+			n++
+			ordered = append(ordered, s)
+			fmt.Fprintf(b, "\n  [%d] %s account_ref=%s\n", n, orAbsent(s.RouteClass), orAbsent(s.AccountRef))
+			fmt.Fprintf(b, "      company=%s\n", orAbsent(s.Company))
+			fmt.Fprintf(b, "      mailbox=%s mailbox_purpose=%s\n", sampleMailbox(s, opts.ShowMailbox), orAbsent(s.MailboxPurpose))
+			fmt.Fprintf(b, "      subject=%s\n", quoteOrAbsent(s.Subject))
+			fmt.Fprintf(b, "      greeting=%s person_unknown=%v\n", quoteOrAbsent(s.Greeting), s.PersonUnknown)
+			fmt.Fprintf(b, "      fact=%s (source=%s)\n", quoteOrAbsent(s.ObservedFact), orAbsent(s.FactSource))
+			fmt.Fprintf(b, "      cta=%s (source=%s)\n", quoteOrAbsent(s.CTA), orAbsent(s.CTASource))
+			writeReasonList(b, "why_admitted", s.AdmissionReasons)
+			writeReasonList(b, "why_this_route", s.RouteReasons)
+		}
+	}
+
+	if opts.FullBodies <= 0 || len(ordered) == 0 {
+		return
+	}
+	shown := opts.FullBodies
+	if shown > len(ordered) {
+		shown = len(ordered)
+	}
+	fmt.Fprintf(b, "\nfull composed body (%d of %d sampled; read for raw enums, pasted records and unearned personalization):\n", shown, len(ordered))
+	for i := 0; i < shown; i++ {
+		s := ordered[i]
+		fmt.Fprintf(b, "\n  --- [%d] %s %s %s\n", i+1, orAbsent(s.RouteClass), orAbsent(s.AccountRef), sampleMailbox(s, opts.ShowMailbox))
+		if strings.TrimSpace(s.BodyText) == "" {
+			fmt.Fprintf(b, "  body=%s\n", previewAbsent)
+		} else {
+			for _, line := range strings.Split(s.BodyText, "\n") {
+				fmt.Fprintf(b, "  | %s\n", line)
+			}
+		}
+		fmt.Fprintf(b, "  --- end [%d]\n", i+1)
+	}
+}
+
+func writeReasonList(b *strings.Builder, label string, reasons []string) {
+	if len(reasons) == 0 {
+		fmt.Fprintf(b, "      %s: %s\n", label, previewAbsent)
+		return
+	}
+	fmt.Fprintf(b, "      %s:\n", label)
+	for _, r := range reasons {
+		fmt.Fprintf(b, "        - %s\n", r)
+	}
+}
+
+// quoteOrAbsent keeps quoted copy quoted so trailing spaces and stray newlines
+// are visible, while an absent value stays an unquoted marker: "" would read as
+// deliberate empty copy rather than a missing field.
+func quoteOrAbsent(s string) string {
+	if strings.TrimSpace(s) == "" {
+		return previewAbsent
+	}
+	return fmt.Sprintf("%q", s)
+}


### PR DESCRIPTION
Before authorizing cold email to real companies, the founder has to be able to spot the wrong company, strange copy, a raw enum in prose, a pasted database record, unearned personalization, and a fact that is commercially or legally inappropriate.

The old preview could not support any of that. Per recipient it printed:

```
GENERIC_COMPANY lead-beta c***@exemplo.com.br greeting="Olá, equipe" person_unknown=true
```

A CNPJ, a redacted mailbox, a greeting. Everything else was hashes and counts.

## What it shows now

Per sampled recipient: company, mailbox purpose, subject, greeting, the observed fact **with its source**, the CTA **with its source**, why the account was admitted, and why that route was chosen over the alternatives — plus the full composed body for two or three of them, because a pasted record is often only visible in the whole message.

`FactSource` is a closed set (`fact_to_mention` / `moment_summary` / `dropped_unusable` / `none`) because "the feed carried nothing" and "the composer refused what the feed carried" are different signals to a reviewer.

Absence renders as `<none recorded>`, never as an empty string that reads as "nothing needed here".

`why_admitted` is deliberately thin — `admitted_by=controlled_route_eligible` — because that is genuinely all the ladder checks. Target-fit fields are shown as `feed_*` observations rather than as the admission reason, since presenting them as the gate would claim a check that does not run.

## Not a per-message approval queue

Authorization stays cohort/policy bounded. This samples up to N per route class (`--samples`, default 2), renders a couple of full bodies (`--bodies`), and keeps mailboxes redacted unless `--show-mailbox` is passed. Rejected alternative routes stay redacted even then — nothing is ever sent to them.

## It found something on its first run

Fed a `fact_to_mention` shaped like a pipe-delimited record (`cnpj14=… | razao_social=… | priority_score=…`), the composer passed it verbatim into both the subject and the body. `looksLikeMetadataDump` matches colon-labelled fields and semicolon-delimited fields; it does not match `key=value | key=value`.

**This does not block the current cohort.** The canonical extra-cli producer builds the fact as `objeto: …; órgão: …; UF …; R$ …` (`message_spine.py:94-104`) — semicolon-delimited with `objeto:`/`órgão:` labels, which is exactly what the detector is built to catch. The blind spot is a hardening gap in the guard, reachable only from a feed shape the real producer does not emit. Filed as a residual rather than fixed here, because widening the detector changes what gets rejected.

Second observation, also not fixed: `PrepareControlledCohort` does not consult target fit at all. It admits on DoNotContact / Blocked / controlled-route eligibility / copy QA. If target fit is *meant* to gate the freeze, that is a real hole — but closing it changes what gets admitted, so it does not belong in a presentation change.

## Also

`accountsFromFeed` was dropping `Priority*`, `MomentConfidence`, `MomentObservedAt` and `TargetFit*`. Nothing in the prepare ladder reads them, so admission is unchanged — dropping them just left the admission evidence blank on the `--feed`-only path.

## Verification

`gofmt` clean, `go build ./...` clean, `go vet` clean. Four new tests pass. `TestProductAcceptanceMultichannelSum` (needs Mailpit) fails locally and passes in CI; verified pre-existing by stashing onto the base commit.

## Residual

- The rendered example in the commit is real output from the real binary, but over a synthetic feed: none of the four feeds shipped in the repo admits a single member, and the Postgres path needs a live DSN.
- `target_fit_eligible` has no field on `FeedLead` (extra-cli publishes it only through the Postgres projection), so it renders `not_asserted` on the feed-only path rather than a `false` that would read as an upstream denial.

🤖 Generated with [Claude Code](https://claude.com/claude-code)