### PR TITLE
fix(dnsauth): probe Hostinger's real DKIM selectors

### DIFF
--- a/internal/pkg/dnsauth/dnsauth.go
+++ b/internal/pkg/dnsauth/dnsauth.go
@@ -56,7 +56,12 @@ func (r Result) State() string {
 // defaultSelectors are common DKIM selectors to probe when the caller doesn't
 // know the domain's selector. DKIM selectors aren't discoverable from DNS, so a
 // "not found" only means none of these matched, not that DKIM is absent.
-var defaultSelectors = []string{"google", "default", "selector1", "selector2", "k1", "mail", "dkim", "s1", "s2", "hostingermail1", "hostingermail2", "hostingermail3", "zoho", "titan"}
+// Hostinger publishes hostingermail-a/-b/-c (hyphen, letter), not
+// hostingermail1/2/3. The numeric spellings match nothing, so every
+// Hostinger-hosted domain probed as "no DKIM" — including confenge.com.br,
+// whose selector hostingermail-a has been live and signing all along. The
+// numeric forms are kept: they cost one lookup and removing them cannot help.
+var defaultSelectors = []string{"google", "default", "selector1", "selector2", "k1", "mail", "dkim", "s1", "s2", "hostingermail-a", "hostingermail-b", "hostingermail-c", "hostingermail1", "hostingermail2", "hostingermail3", "zoho", "titan"}
 
 const lookupTimeout = 5 * time.Second
 

--- a/internal/pkg/dnsauth/dnsauth_selectors_test.go
+++ b/internal/pkg/dnsauth/dnsauth_selectors_test.go
@@ -1,0 +1,28 @@
+package dnsauth
+
+import (
+	"slices"
+	"testing"
+)
+
+// Hostinger's real selectors are hostingermail-a/-b/-c. The numeric spellings
+// that used to stand in for them match nothing, so a Hostinger-hosted domain
+// probed as "no DKIM" while it was signing correctly the whole time —
+// confenge.com.br being the case that surfaced it.
+func TestDefaultSelectorsCoverHostingerRealFormat(t *testing.T) {
+	for _, want := range []string{"hostingermail-a", "hostingermail-b", "hostingermail-c"} {
+		if !slices.Contains(defaultSelectors, want) {
+			t.Fatalf("defaultSelectors is missing %q; a Hostinger domain would probe as having no DKIM", want)
+		}
+	}
+}
+
+func TestDefaultSelectorsHaveNoDuplicates(t *testing.T) {
+	seen := map[string]bool{}
+	for _, s := range defaultSelectors {
+		if seen[s] {
+			t.Fatalf("duplicate selector %q costs a DNS lookup per check for nothing", s)
+		}
+		seen[s] = true
+	}
+}


### PR DESCRIPTION
`defaultSelectors` listed `hostingermail1/2/3`. Hostinger publishes
`hostingermail-a/-b/-c` — hyphen, letter. The numeric spellings match nothing,
so every Hostinger-hosted domain came back as having no DKIM.

Including our own. `confenge.com.br` probed clean across all fourteen selectors
while `hostingermail-a` had been live and signing the whole time:

    dkim-signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
                    d=confenge.com.br; s=hostingermail-a
    DKIM check: pass (matches From: tiago.sasaki@confenge.com.br)

verified end to end against verifier.port25.com.

The comment above the list already says a miss "only means none of these
matched, not that DKIM is absent" — which is exactly right, and exactly why a
wrong entry is expensive: the honest caveat makes the false negative look like
the documented limitation instead of a typo.

The numeric forms stay. They cost one lookup each and removing them cannot
help anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)