### PR TITLE
fix(confenge): keep empty outcome report contract

### DIFF
--- a/internal/app/confenge/intel/controlled_email_outcomes.go
+++ b/internal/app/confenge/intel/controlled_email_outcomes.go
@@ -56,7 +56,7 @@ func normalizeControlledProvider(value string) string {
 
 func SliceControlledEmailOutcomes(events []CommercialEvent) []ControlledEmailOutcomeSlice {
 	idx := map[string]int{}
-	var out []ControlledEmailOutcomeSlice
+	out := make([]ControlledEmailOutcomeSlice, 0)
 	keyOf := func(ev CommercialEvent) string {
 		return strings.Join([]string{
 			orUnknown(ev.EmailRouteClass),

--- a/internal/app/confenge/intel/controlled_email_outcomes_truth_test.go
+++ b/internal/app/confenge/intel/controlled_email_outcomes_truth_test.go
@@ -1,10 +1,22 @@
 package intel
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 	"time"
 )
+
+func TestControlledEmailReportPublishesStableEmptyArray(t *testing.T) {
+	report := BuildObservabilityReport(NewMemoryStore(), "11111111-2222-4333-8444-555555555555", "2026-08", false)
+	raw, err := json.Marshal(report)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(raw), `"controlled_email":[]`) {
+		t.Fatalf("empty real report must keep the controlled-email contract: %s", raw)
+	}
+}
 
 func TestControlledEmailReportPreservesUnknownAndDeduplicatesReplay(t *testing.T) {
 	attempt := CommercialEvent{

--- a/internal/app/confenge/intel/report.go
+++ b/internal/app/confenge/intel/report.go
@@ -37,6 +37,7 @@ func BuildObservabilityReport(store Store, orgID, month string, includeSynthetic
 		RevenueStatus:      Unknown,
 		LearningCandidates: []LearningSummary{},
 		Blockers:           []string{},
+		ControlledEmail:    []ControlledEmailOutcomeSlice{},
 	}
 	if store == nil {
 		rep.RealEmpty = true

--- a/internal/app/confenge/intel/types.go
+++ b/internal/app/confenge/intel/types.go
@@ -858,7 +858,7 @@ type ObservabilityReport struct {
 	RealEmpty                bool                          `json:"real_empty"`
 	AutoSend                 bool                          `json:"auto_send"`
 	EmailSideEffects         bool                          `json:"email_side_effects"`
-	ControlledEmail          []ControlledEmailOutcomeSlice `json:"controlled_email,omitempty"`
+	ControlledEmail          []ControlledEmailOutcomeSlice `json:"controlled_email"`
 }
 
 // LearningSummary is the PII-free learning row on the report.


### PR DESCRIPTION
## Outcome

Keeps `controlled_email` as an explicit JSON array even before the first real event. Production currently returned HTTP 200 but omitted this key, so the Control Center correctly rejected the report as contract drift and could only show UNKNOWN.

## Truth semantics

- empty remains `[]`, not a fabricated metric zero
- every per-outcome counter remains nullable/UNKNOWN
- `SMTP accepted` is still not delivery
- synthetic filtering is unchanged

## Evidence

- focused controlled-email report/read-model tests PASS
- production probe reproduced the omitted-key contract drift before this patch

No authorization, dispatch, or email send is performed.