### PR TITLE
feat(confenge): make a bounded Warmbly cohort reviewable, correctable and provable in production

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1483,10 +1483,22 @@ func main() {
 		// contacts each tick so hard-bouncing addresses are dropped before any
 		// worker sends. CONTROL-PLANE ONLY — the SMTP RCPT probe dials remote MX
 		// on :25 from this backend host (a non-sending IP), never a worker.
-		emailVerifier := emailverify.New(emailverify.Config{
-			HeloHost: os.Getenv("EMAIL_VERIFY_HELO_HOST"), // e.g. verify.warmbly.com
-			MailFrom: os.Getenv("EMAIL_VERIFY_MAIL_FROM"), // e.g. verify@warmbly.com
-		})
+		emailVerifyCfg := emailverify.Config{
+			HeloHost: os.Getenv(emailverify.EnvHeloHost), // e.g. verify.warmbly.com
+			MailFrom: os.Getenv(emailverify.EnvMailFrom), // e.g. verify@warmbly.com
+		}
+		// Fail closed on a production outreach plane with no usable prober
+		// identity. Verify() alone would degrade every probe to UNKNOWN, which
+		// is correct but silent — and the deploy that shipped without
+		// EMAIL_VERIFY_HELO_HOST announced "localhost", collected 5xx replies
+		// that named our own HELO, and stored them as if the RECIPIENT were
+		// bad. A refusal to boot is the only version of that nobody misses.
+		// Dev / self-host / outreach-off keep booting with the verifier idle.
+		if err := emailVerifyCfg.ValidateStartup(os.Getenv("APP_ENV"), confengeCfg.Enabled); err != nil {
+			sentry.CaptureException(err)
+			log.Fatalf("email verifier identity: %v", err)
+		}
+		emailVerifier := emailverify.New(emailVerifyCfg)
 		emailVerifyService = emailverifyapp.NewService(contactRepostory, emailVerifier)
 		emailVerificationJob := jobs.NewEmailVerificationJob(emailVerifyService, 100)
 		emailVerificationScheduler := jobs.NewEmailVerificationScheduler(emailVerificationJob, 15*time.Minute)

--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -39,6 +39,11 @@ x-confenge-env: &confenge-env
   CONFENGE_IMAP_HOST: ${CONFENGE_IMAP_HOST:-imap.hostinger.com}
   CONFENGE_IMAP_PORT: ${CONFENGE_IMAP_PORT:-993}
   CONFENGE_MAILBOX_EMAIL: ${CONFENGE_MAILBOX_EMAIL:-}
+  # Identity the pre-send verifier announces in EHLO/MAIL FROM. Without it the
+  # prober has no usable identity and every probe stays UNKNOWN by design: a
+  # remote MTA refusing our HELO must never be recorded against the recipient.
+  EMAIL_VERIFY_HELO_HOST: ${EMAIL_VERIFY_HELO_HOST:-}
+  EMAIL_VERIFY_MAIL_FROM: ${EMAIL_VERIFY_MAIL_FROM:-}
   IMAP_HOST: ${CONFENGE_IMAP_HOST:-imap.hostinger.com}
   IMAP_PORT: ${CONFENGE_IMAP_PORT:-993}
   CONFENGE_SENDING_PAUSED: ${CONFENGE_SENDING_PAUSED:-false}

--- a/deploy/confenge-vps/env.example
+++ b/deploy/confenge-vps/env.example
@@ -132,3 +132,11 @@ MAIL_TLS_INSECURE=false
 # Stable worker UUID (must match email_accounts.worker_id / assignment)
 WORKER_ID=10c8f5e4-1c39-5b2a-9c8b-3d2f0a8b1a01
 WORKER_TIER=shared
+
+# Pre-send email verifier identity. Both must be real and attributable to the
+# verifying host: RFC 5321 4.1.1.1 requires a fully-qualified EHLO name, and a
+# server that refuses our identity answers with a 5xx that names *us*, not the
+# recipient. Leave empty and every probe stays UNKNOWN instead of producing a
+# false INVALID that would suppress a live company.
+EMAIL_VERIFY_HELO_HOST=
+EMAIL_VERIFY_MAIL_FROM=

--- a/deploy/config/env.example
+++ b/deploy/config/env.example
@@ -166,6 +166,24 @@ TRACKING_DOMAIN=localhost:3000
 # SMTP_EHLO_NAME=                    # defaults to the sender domain
 # SMTP_TLS_INSECURE_SKIP_VERIFY=false  # only for a relay with a private CA
 
+# === Pre-send email verification (backend / control plane only) ===
+#
+# The verifier opens an SMTP RCPT probe to the recipient's MX to drop
+# hard-bouncing addresses before a worker ever sends. It announces these two
+# values as its own identity: EHLO name and envelope sender.
+#
+# Both are unset by default and nothing invents a fallback. RFC 5321 4.1.1.1
+# requires a fully-qualified EHLO name; a server that refuses ours answers with
+# a 5xx naming *us*, and mis-reading that as a recipient failure suppresses live
+# contacts. Unset, every probe stays "unknown" and no address is ever dropped —
+# and a production outreach plane (APP_ENV=production with
+# CONFENGE_OUTREACH_ENABLED=true) refuses to start rather than probe blind.
+#
+# Set both to real, attributable values for the *verifying* host, which must be
+# a non-sending IP. "localhost" and any dotless name are rejected.
+# EMAIL_VERIFY_HELO_HOST=verify.example.com
+# EMAIL_VERIFY_MAIL_FROM=verify@example.com
+
 # === Auth policy ===
 #
 # AUTH_LOGIN_CODE: always | new_device | off. Self-host defaults to off, so a

--- a/deploy/verify-release.sh
+++ b/deploy/verify-release.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+# Reconcile repository SHA -> image label -> running container for the Warmbly
+# backend. HTTP 200 on a health endpoint proves a process answered, not which
+# code answered, so this is the acceptance gate for a release.
+#
+# Usage: verify-release.sh <expected-sha> [container]
+set -euo pipefail
+
+EXPECTED="${1:?usage: verify-release.sh <expected-sha> [container]}"
+CONTAINER="${2:-warmbly-confenge-backend-1}"
+
+if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
+  echo "FAIL: container ${CONTAINER} not found"
+  exit 1
+fi
+
+image_id=$(docker inspect "$CONTAINER" --format '{{.Image}}')
+running=$(docker inspect "$CONTAINER" --format '{{.State.Running}}')
+label=$(docker inspect "$image_id" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || echo "")
+envsha=$(docker inspect "$CONTAINER" --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^WARMBLY_RELEASE_SHA=//p' | head -1)
+
+echo "container   : ${CONTAINER} (running=${running})"
+echo "image id    : ${image_id}"
+echo "image label : ${label:-<none>}"
+echo "runtime env : ${envsha:-<none>}"
+
+if [ "$running" != "true" ]; then
+  echo "-> FAIL: container is not running"
+  exit 1
+fi
+if [ -z "$label" ] || [ "$label" = "local" ]; then
+  echo "-> FAIL: image carries no release revision label; the running code cannot be proven"
+  exit 1
+fi
+case "$EXPECTED" in
+  "$label"*) ;;
+  *) echo "-> FAIL: image label ${label} does not match expected ${EXPECTED}"; exit 1 ;;
+esac
+if [ -n "$envsha" ]; then
+  case "$EXPECTED" in
+    "$envsha"*) ;;
+    *) echo "-> FAIL: runtime WARMBLY_RELEASE_SHA ${envsha} does not match expected ${EXPECTED}"; exit 1 ;;
+  esac
+fi
+echo "-> OK: repo ${EXPECTED} reconciles with image label and runtime"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -272,9 +272,23 @@ services:
     build:
       context: .
       dockerfile: deploy/docker/backend.Dockerfile
+      # Stamp the release onto the image. Compose derives an untagged image name
+      # for this service, so without a label there is nothing that distinguishes
+      # one build from the next and "healthz 200" can never prove which code is
+      # running. Default stays "local" because compose interpolates this file on
+      # every command, including an emergency restart; the release is enforced by
+      # deploy/verify-release.sh, not by making routine ops fail.
+      labels:
+        org.opencontainers.image.revision: "${WARMBLY_RELEASE_SHA:-local}"
+        org.opencontainers.image.version: "${WARMBLY_RELEASE_SHA:-local}"
+        org.opencontainers.image.source: "https://github.com/tjsasakifln/warmbly"
+        br.com.confenge.service: "warmbly-backend"
     ports: ["8080:8080"]
     environment:
       <<: *selfhost-env
+      # Readable from the running container so repo -> image -> runtime can be
+      # reconciled without re-resolving the image.
+      WARMBLY_RELEASE_SHA: "${WARMBLY_RELEASE_SHA:-local}"
       API_HOST: "0.0.0.0:8080"
       GIN_MODE: release
       # To reach Warmbly from another machine, set PUBLIC_HOST=<ip-or-domain> in

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -286,6 +286,21 @@ services:
       CORS_ALLOW_ORIGINS: ${CORS_ALLOW_ORIGINS:-http://${PUBLIC_HOST:-localhost}:5173,http://${PUBLIC_HOST:-localhost}:5174}
       WEBSOCKET_URL: ${WEBSOCKET_URL:-ws://${PUBLIC_HOST:-localhost}:4000/socket/websocket}
       ENCRYPTED_KEYS_PROVIDER: postgres
+      # Identity the pre-send email verifier announces in EHLO / MAIL FROM
+      # (internal/pkg/emailverify). Backend-only on purpose: the RCPT probe is
+      # CONTROL-PLANE ONLY and must never run from a worker (sending IP), and
+      # only cmd/backend constructs emailverify.New — so consumer/worker
+      # deliberately do NOT get these.
+      #
+      # Empty default, never a literal: RFC 5321 4.1.1.1 requires a
+      # fully-qualified EHLO name, and a server that refuses our identity
+      # answers with a 5xx naming *us*, not the recipient. Unset leaves every
+      # probe UNKNOWN (dev/self-host) and fails the backend closed at boot when
+      # APP_ENV=production and CONFENGE_OUTREACH_ENABLED=true. Inventing a
+      # default here would resurrect exactly the "localhost" HELO that got real
+      # recipients recorded as INVALID.
+      EMAIL_VERIFY_HELO_HOST: ${EMAIL_VERIFY_HELO_HOST:-}
+      EMAIL_VERIFY_MAIL_FROM: ${EMAIL_VERIFY_MAIL_FROM:-}
       # Mail and auth policy live in the shared anchor above, so the consumer
       # gets them too. It previously received neither, which silently disabled
       # every notification and digest email in this stack.

--- a/docs/confenge/human-gate-api.md
+++ b/docs/confenge/human-gate-api.md
@@ -13,6 +13,9 @@ send operation.
   canonical import run.
 - `POST /v1/confenge/cohorts/{version_id}/reproduce` copies the exact immutable
   snapshot into the next version.
+- `POST /v1/confenge/cohorts/{version_id}/candidates/{candidate_id}/adjust`
+  forks the version into N+1 carrying a human copy edit for exactly that one
+  candidate. See "Adjust" below.
 - `GET /v1/confenge/cohorts/{version_id}` returns the exact candidate/message
   preview, validations, reviews, invalidations and GO/NO-GO receipt.
 - `GET /v1/confenge/cohorts/{version_id}/candidates/{candidate_id}` returns one
@@ -31,7 +34,7 @@ correlation id and receipt. List responses use `data` plus `pagination`.
 The acknowledgement and typed version are included in the idempotent intent
 hash, so an ambiguous retry cannot silently change the human confirmation.
 
-Reads require read-contacts. Cohort/validation/review writes require
+Reads require read-contacts. Cohort/validation/review/adjust writes require
 manage-contacts. GO/NO-GO requires manage-campaigns, not send-campaigns. The
 authenticated API principal is audited by Warmbly; the edge separately audits
 the Authelia human identity and never accepts a browser actor header.
@@ -56,3 +59,138 @@ The authorization TTL is narrowed to the earliest of the frozen snapshot TTL,
 canonical source-freshness expiry and every candidate-validation expiry. A
 failed NO_GO revocation fails closed and does not record a misleading NO_GO
 receipt.
+
+## Derivation taxonomy
+
+Every version row records how it came to exist. "There is a version N+1" cannot,
+by itself, tell an auditor whether the bytes are identical, machine-recomposed
+or human-edited, so the distinction is durable in Postgres
+(`confenge_cohort_versions.derivation`, migration 000117) and is projected on
+every read as `derivation` plus `parent_version`.
+
+| derivation  | meaning                                                              |
+| ----------- | -------------------------------------------------------------------- |
+| `CREATE`    | first freeze of a cohort from a completed canonical source run.       |
+| `REPRODUCE` | `frozen_manifest` copied byte for byte from `parent_version`.         |
+| `RECOMPOSE` | **reserved.** Re-run the composer against the current source, policy and composer version. No endpoint implements it yet; the taxonomy is durable first so today's rows never have to be reinterpreted later. |
+| `ADJUST`    | a human edited `subject`/`body_text` for exactly one candidate.       |
+
+`parent_version` is `null` only for `CREATE`. Rows that predate 000117 are
+backfilled: `reproduced_from_version IS NOT NULL` becomes `REPRODUCE`, all
+others become `CREATE`.
+
+## Adjust
+
+`POST /v1/confenge/cohorts/{version_id}/candidates/{candidate_id}/adjust`
+
+Adjust is an **operator** action. It requires manage-contacts + write-contacts,
+exactly like review; it is deliberately *not* an admin action, and GO stays
+manage-campaigns. Like every other write it requires `Idempotency-Key` and
+carries the same correlation id header as the other human-gate writes.
+
+**Adjust neither queues, dispatches, sends nor resumes anything.** It creates an
+immutable draft version and nothing else. The new version is not authorized, not
+approved and not queue-ready; reaching a real send still requires validation,
+per-candidate APPROVE and a fresh GO on the new version, and the bounded
+transport authority still revalidates everything at the last mile.
+
+Request body — subject and body_text are the only mutable facts:
+
+```json
+{
+  "subject": "…",
+  "body_text": "…",
+  "reason": "…",
+  "confirmation": "v1",
+  "expected_frozen_hash": "…"
+}
+```
+
+`reason` must be at least 8 characters after trimming. `confirmation` must be
+exactly `"v"` + the current version number. `expected_frozen_hash` must equal
+the current version's `frozen_hash`; together they make an adjustment
+impossible to apply to a version the operator was not actually looking at.
+
+Success is `201` with:
+
+```json
+{
+  "contract_version": "confenge.human-gate.v1",
+  "cohort": { "…": "the full cohort payload of the NEW version" },
+  "adjustment": {
+    "id": "…", "cohort_id": "…", "from_version": 1, "to_version": 2,
+    "candidate_id": "…",
+    "before_content_hash": "…", "after_content_hash": "…",
+    "before_frozen_hash": "…", "after_frozen_hash": "…",
+    "diff": [{"field": "subject", "before": "…", "after": "…"},
+             {"field": "body_text", "before": "…", "after": "…"}],
+    "revoked_authorization_id": null,
+    "actor_id": "…", "correlation_id": "…", "receipt": "…", "created_at": "…"
+  }
+}
+```
+
+### What adjust guarantees
+
+- The prior version is **never** updated. Its `frozen_manifest` stays byte
+  identical and readable forever; adjust only ever inserts.
+- Version N+1 lives under the same `cohort_id`, carries the adjusted copy for
+  exactly the addressed candidate, and copies every other member unchanged.
+- The member `content_hash`, the manifest `cohort_hash`/`frozen_hash`, the
+  recipient-set hash and the preview samples are recomputed with the same
+  helpers the freeze path uses. There is no second hashing implementation.
+- The adjusted copy is re-run through the freeze-time copy QA
+  (`ValidateCopyForRouteClass`) and is refused if it fails.
+- The new version is born with **no validation, no review and no GO**. Nothing
+  is inherited: nothing that was approved about the old copy is evidence about
+  the new copy.
+- Replaying the same `Idempotency-Key` returns the same adjustment and does not
+  create another version. A different key against a now-superseded version fails
+  `version_superseded` rather than silently forking the cohort.
+- Two simultaneous adjusts of the same version cannot both create N+1. The
+  parent row is locked `FOR UPDATE` and `UNIQUE (organization_id, cohort_id,
+  version)` is the backstop.
+- If the prior version carries a live bounded authority, it is revoked inside
+  the same transaction that creates N+1, and `revoked_authorization_id` names
+  it. If that revocation cannot be proven inside the transaction, the whole
+  adjustment is refused with `authority_active`. There is never a moment with
+  two valid authorities.
+
+### Immutable fields
+
+`mailbox`, `recipient*`, `evidence*`, `source*`, `policy_version`,
+`route_class` and `composer_version` are canonical-source evidence or
+machine-derived bindings. Sending any of them in the body is a hard `422`
+`immutable_field` naming the offending key, checked against the raw request body
+so a protected key can never be silently dropped by a typed struct. These are
+correctable only at the canonical source, followed by a fresh composition — not
+by typing over them here.
+
+### Error codes
+
+| status | code                          | when                                                        |
+| ------ | ----------------------------- | ----------------------------------------------------------- |
+| 400    | `idempotency_key_required`    | no `Idempotency-Key`.                                        |
+| 400    | `adjust_copy_required`        | empty `subject` or `body_text`.                              |
+| 400    | `adjust_reason_required`      | `reason` shorter than 8 characters after trimming.           |
+| 400    | `adjust_confirmation_required`| `confirmation` missing.                                      |
+| 400    | `adjust_expected_frozen_hash_required` | `expected_frozen_hash` missing.                     |
+| 404    | `candidate_not_found`         | the candidate is not in this immutable version.              |
+| 404    | `cohort_version_not_found`    | the version does not exist for this organization.            |
+| 409    | `frozen_hash_mismatch`        | `expected_frozen_hash` != the current `frozen_hash`.         |
+| 409    | `confirmation_mismatch`       | `confirmation` != `"v"` + current version.                   |
+| 409    | `version_superseded`          | the addressed version is not the latest for its cohort, including when a concurrent adjust won the race. |
+| 409    | `authority_active`            | the prior version carries a GO authority that could not be atomically revoked. |
+| 409    | `source_stale`                | the version's canonical source evidence expired. Adjust cannot refresh evidence. |
+| 409    | `composer_drift`              | the version was composed by another composer version; recomposing a content hash onto a composer that did not produce the manifest would invent a second source of truth. |
+| 409    | `idempotency_payload_conflict`| the key was already used with another payload.               |
+| 422    | `immutable_field`             | the body tried to set a protected field. The message names it. |
+| 422    | `copy_qa_failed`              | the adjusted copy fails copy QA. The message lists the reason codes. |
+| 422    | `cohort_bounds_violation`     | the cohort size or daily cap is outside the bounded-cohort limits. |
+
+Live recipient state (late suppression, opt-out, hard bounce, removal) is not an
+adjust gate: it is read on every detail view and re-enforced at GO and at
+dispatch. Adjust edits a draft; it cannot make anything sendable. The live
+candidate is read only to give copy QA the same recipient context the freeze
+path had, and an unreadable live source degrades that context rather than
+blocking the edit.

--- a/internal/api/handler/confenge_human_gate.go
+++ b/internal/api/handler/confenge_human_gate.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"encoding/json"
 	"net/http"
 	"strconv"
 	"strings"
@@ -280,4 +281,55 @@ func (h *Handler) DecideConfengeHumanGateCohort(c *gin.Context) {
 		receipt = v.Decision.Receipt
 	}
 	c.JSON(http.StatusOK, gin.H{"data": v, "meta": humanGateMeta(c, v, v.Reason), "receipt": receipt})
+}
+
+// AdjustConfengeHumanGateCandidate forks the addressed immutable version into
+// N+1 with human-edited copy for exactly one candidate. It is an operator
+// action (manage-contacts), not an admin one: GO stays manage-campaigns.
+//
+// It neither queues, dispatches, sends nor resumes anything.
+func (h *Handler) AdjustConfengeHumanGateCandidate(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	actor, ok := humanGateActor(c)
+	if !ok {
+		return
+	}
+	versionID, candidateID, ok := humanGateIDs(c)
+	if !ok {
+		return
+	}
+	if candidateID == uuid.Nil {
+		errx.JSON(c, errx.NewWithIdentifier(errx.BadRequest, "invalid_resource_id", "cohort or candidate id is invalid"))
+		return
+	}
+	// The raw body is read first and kept: the server has to be able to see a
+	// key the typed struct would silently drop, such as "mailbox".
+	raw, err := c.GetRawData()
+	if err != nil {
+		errx.JSON(c, errx.NewWithIdentifier(errx.BadRequest, "invalid_payload", "JSON body is invalid"))
+		return
+	}
+	var in confenge.HumanGateAdjustInput
+	if json.Unmarshal(raw, &in) != nil {
+		errx.JSON(c, errx.NewWithIdentifier(errx.BadRequest, "invalid_payload", "JSON body is invalid"))
+		return
+	}
+	in.RawBody = raw
+	in.IdempotencyKey = strings.TrimSpace(c.GetHeader("Idempotency-Key"))
+	in.CorrelationID = c.GetString("request_id")
+	result, x := h.ConfengeService.AdjustHumanGateCandidate(c.Request.Context(), orgID, actor, versionID, candidateID, in)
+	if x != nil {
+		errx.JSON(c, x)
+		return
+	}
+	c.JSON(http.StatusCreated, gin.H{
+		"contract_version": result.ContractVersion,
+		"cohort":           result.Cohort,
+		"adjustment":       result.Adjustment,
+		"meta":             humanGateMeta(c, result.Cohort, result.Cohort.Reason),
+		"receipt":          result.Adjustment.Receipt,
+	})
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -571,6 +571,10 @@ func Run(
 					confengeWrite.POST("/cohorts/:id/reproduce", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReproduceConfengeHumanGateCohort)
 					confengeWrite.POST("/cohorts/:id/candidates/:candidateId/validation", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ValidateConfengeHumanGateCandidate)
 					confengeWrite.POST("/cohorts/:id/candidates/:candidateId/review", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.ReviewConfengeHumanGateCandidate)
+					// Adjust is an operator action, deliberately the same
+					// permission as review. It forks the immutable version into
+					// N+1 with human-edited copy; it never queues or sends.
+					confengeWrite.POST("/cohorts/:id/candidates/:candidateId/adjust", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.AdjustConfengeHumanGateCandidate)
 					confengeWrite.POST("/cohorts/:id/decision", m.RequireAccess(models.PermManageCampaigns, models.APIPermWriteCampaigns), h.DecideConfengeHumanGateCohort)
 					confengeWrite.POST("/accounts/:id/cancel-touchpoints", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.CancelConfengeAccountTouchpoints)
 					confengeWrite.POST("/accounts/:id/generate", m.RequireAccess(models.PermManageContacts, models.APIPermWriteContacts), h.GenerateConfengeDraft)

--- a/internal/app/confenge/cohort_apply.go
+++ b/internal/app/confenge/cohort_apply.go
@@ -193,6 +193,19 @@ func planCohortApply(ctx context.Context, repo repository.OutreachRepository, or
 		tp.Subject = m.Subject
 		tp.BodyText = m.BodyText
 		RecomputeContentHash(tp)
+		// An approval authorizes the exact copy a human read. The drift check
+		// above only fires when the row already carries both a ContentHash and
+		// a BodyText, so a legacy APPROVED row with neither kept its approval
+		// while this loop stamped different copy onto it — an approval of old
+		// copy authorizing new copy. Re-verify against the content we just
+		// stamped and, when it cannot be proven to be the approved content, run
+		// the canonical invalidation. ClearApproval demotes APPROVED/QUEUED to
+		// NEEDS_REVIEW and drops the approver identity, so the history is
+		// preserved and the founder re-reviews rather than the cohort silently
+		// inheriting authority.
+		if tp.ApprovedContentHash != tp.ContentHash {
+			ClearApproval(tp)
+		}
 		works = append(works, cohortApplyWork{member: m, tp: tp, create: create})
 	}
 	return works, fails

--- a/internal/app/confenge/cohort_apply_stale_approval_test.go
+++ b/internal/app/confenge/cohort_apply_stale_approval_test.go
@@ -1,0 +1,144 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+
+// cleanCohortMember carries copy that passes admission QA, so a test that means
+// to exercise the approval gate is not silently short-circuited by copy QA.
+func cleanCohortMember(accID, candID uuid.UUID, mailbox string) FrozenCohortMember {
+	return FrozenCohortMember{
+		AccountID:   accID,
+		AccountRef:  "cnpj:33333333000193",
+		CandidateID: candID,
+		Mailbox:     mailbox,
+		RouteClass:  RouteClassGenericCompany,
+		Subject:     "recuperação estrutural da ponte",
+		BodyText:    "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: recuperação estrutural da ponte sobre o Rio Sapucaí.\n\nQueria falar com quem acompanha a carteira de contratos públicos por aí. Você consegue me indicar a pessoa responsável?",
+	}
+}
+
+// An APPROVED touchpoint carries an authorization for the exact copy a human
+// read. When a frozen cohort stamps different copy onto that row, the approval
+// must not survive: otherwise an approval of old copy silently authorizes new
+// copy. The existing drift guard only fires when the row already carries both a
+// ContentHash and a BodyText, so a legacy APPROVED row with neither slipped
+// through and kept its approval.
+func TestApprovedTouchpointCannotCarryApprovalOntoNewCopy(t *testing.T) {
+	orgID, accID, candID := uuid.New(), uuid.New(), uuid.New()
+	mailbox := "contato@empresa-stale.com.br"
+	approver := uuid.New()
+	approvedAt := time.Now().UTC().Add(-72 * time.Hour)
+
+	cases := []struct {
+		name string
+		seed func(tp *models.OutreachTouchpoint)
+	}{
+		{
+			// The legacy hole: approved, but nothing recorded to compare against.
+			name: "approved_without_recorded_content",
+			seed: func(tp *models.OutreachTouchpoint) {
+				tp.BodyText = ""
+				tp.Subject = ""
+				tp.ContentHash = ""
+				tp.ApprovedContentHash = ""
+			},
+		},
+		{
+			// Approved for materially different copy.
+			name: "approved_for_different_copy",
+			seed: func(tp *models.OutreachTouchpoint) {
+				tp.Subject = "assunto antigo"
+				tp.BodyText = "Olá, equipe,\n\nSou da CONFENGE.\n\ncopy antiga aprovada.\n\nVocê consegue me indicar a pessoa responsável?"
+				RecomputeContentHash(tp)
+				tp.ApprovedContentHash = tp.ContentHash
+			},
+		},
+		{
+			// Approved under a superseded composer: the hash embeds the composer
+			// version, so the stored approval cannot match current output.
+			name: "approved_under_previous_composer",
+			seed: func(tp *models.OutreachTouchpoint) {
+				tp.Subject = "assunto"
+				tp.BodyText = "Olá, equipe,\n\nSou da CONFENGE.\n\nfato.\n\nVocê consegue me indicar a pessoa responsável?"
+				tp.ContentHash = "hash-computed-by-confenge.composer.v3"
+				tp.ApprovedContentHash = "hash-computed-by-confenge.composer.v3"
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			repo := newMemRepo()
+			tp := &models.OutreachTouchpoint{
+				ID: uuid.New(), OrganizationID: orgID, AccountID: accID, Ordinal: 1,
+				Purpose: models.TouchpointPurposeInitial, Recipient: mailbox,
+				State: models.TouchpointApproved,
+				ApprovedBy: &approver, ApprovedAt: &approvedAt,
+				AuthorizationMode: AuthorizationModeHumanTouchpoint,
+			}
+			tc.seed(tp)
+			seedTouchpoint(t, repo, tp)
+
+			member := cleanCohortMember(accID, candID, mailbox)
+			snap := &FrozenCohortSnapshot{Members: []FrozenCohortMember{member}}
+			works, fails := planCohortApply(context.Background(), repo, orgID, snap, time.Now().UTC())
+
+			// Either outcome is acceptable governance: refuse the member, or
+			// demote it for re-review. What must never happen is that the row
+			// stays APPROVED while carrying the newly stamped copy.
+			for _, w := range works {
+				if w.tp.State == models.TouchpointApproved {
+					t.Fatalf("approval survived onto new copy: state=%s approved_hash=%q content_hash=%q",
+						w.tp.State, w.tp.ApprovedContentHash, w.tp.ContentHash)
+				}
+				if w.tp.ApprovedContentHash != "" && w.tp.ApprovedContentHash != w.tp.ContentHash {
+					t.Fatalf("stale approved_content_hash %q retained against content %q",
+						w.tp.ApprovedContentHash, w.tp.ContentHash)
+				}
+				if w.tp.ApprovedBy != nil || w.tp.ApprovedAt != nil {
+					t.Fatalf("approver identity survived a content change: by=%v at=%v", w.tp.ApprovedBy, w.tp.ApprovedAt)
+				}
+			}
+			t.Logf("works=%d fails=%d", len(works), len(fails))
+		})
+	}
+}
+
+// A touchpoint approved for exactly this copy keeps its approval: the gate must
+// not force the founder to re-approve identical text.
+func TestApprovalSurvivesWhenContentIsIdentical(t *testing.T) {
+	orgID, accID, candID := uuid.New(), uuid.New(), uuid.New()
+	mailbox := "contato@empresa-igual.com.br"
+	approver := uuid.New()
+	approvedAt := time.Now().UTC().Add(-time.Hour)
+	member := cleanCohortMember(accID, candID, mailbox)
+
+	repo := newMemRepo()
+	tp := &models.OutreachTouchpoint{
+		ID: uuid.New(), OrganizationID: orgID, AccountID: accID, Ordinal: 1,
+		Purpose: models.TouchpointPurposeInitial, Recipient: mailbox,
+		State: models.TouchpointApproved, Subject: member.Subject, BodyText: member.BodyText,
+		ApprovedBy: &approver, ApprovedAt: &approvedAt,
+		AuthorizationMode: AuthorizationModeHumanTouchpoint,
+	}
+	RecomputeContentHash(tp)
+	tp.ApprovedContentHash = tp.ContentHash
+	seedTouchpoint(t, repo, tp)
+
+	snap := &FrozenCohortSnapshot{Members: []FrozenCohortMember{member}}
+	works, fails := planCohortApply(context.Background(), repo, orgID, snap, time.Now().UTC())
+	if len(works) != 1 {
+		t.Fatalf("identical copy must still plan: works=%d fails=%v", len(works), fails)
+	}
+	if works[0].tp.State != models.TouchpointApproved {
+		t.Fatalf("approval for identical copy must survive, got state=%s", works[0].tp.State)
+	}
+}

--- a/internal/app/confenge/cohort_apply_stale_approval_test.go
+++ b/internal/app/confenge/cohort_apply_stale_approval_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
-
 // cleanCohortMember carries copy that passes admission QA, so a test that means
 // to exercise the approval gate is not silently short-circuited by copy QA.
 func cleanCohortMember(accID, candID uuid.UUID, mailbox string) FrozenCohortMember {
@@ -80,7 +79,7 @@ func TestApprovedTouchpointCannotCarryApprovalOntoNewCopy(t *testing.T) {
 			tp := &models.OutreachTouchpoint{
 				ID: uuid.New(), OrganizationID: orgID, AccountID: accID, Ordinal: 1,
 				Purpose: models.TouchpointPurposeInitial, Recipient: mailbox,
-				State: models.TouchpointApproved,
+				State:      models.TouchpointApproved,
 				ApprovedBy: &approver, ApprovedAt: &approvedAt,
 				AuthorizationMode: AuthorizationModeHumanTouchpoint,
 			}

--- a/internal/app/confenge/cohort_compose.go
+++ b/internal/app/confenge/cohort_compose.go
@@ -194,10 +194,9 @@ func ComposeControlledInitialDetailed(acc *models.OutreachAccount, cand *models.
 	b.WriteString(out.Greeting)
 	b.WriteString(",\n\nSou da CONFENGE.\n\n")
 	if obs != "" {
+		// A fact cut at a comma used to gain a period and read "Sapucaí,.".
+		obs = terminateFactSentence(obs)
 		b.WriteString(obs)
-		if !strings.HasSuffix(strings.TrimSpace(obs), ".") {
-			b.WriteByte('.')
-		}
 		b.WriteString("\n\n")
 	}
 	b.WriteString(cta)

--- a/internal/app/confenge/controlled_route.go
+++ b/internal/app/confenge/controlled_route.go
@@ -220,6 +220,13 @@ func ValidateCopyForRouteClass(class, body, subject string, cand *models.Outreac
 	if looksMidTokenTruncation(subject) || looksMidTokenTruncation(body) {
 		add("mid_token_truncation")
 	}
+	// Cohort v1 froze five members with admission_reasons saying
+	// "copy_qa=passed" while two messages carried ",." and one repeated a
+	// three-word run. The composer now prevents all three, and these gates make
+	// a regression refuse admission instead of freezing quietly.
+	for _, code := range copyProjectionDefects(subject, body) {
+		add(code)
+	}
 	switch class {
 	case RouteClassDirectPerson:
 		if cand != nil && provenPersonName(cand) {

--- a/internal/app/confenge/copy_defect_projection_test.go
+++ b/internal/app/confenge/copy_defect_projection_test.go
@@ -1,0 +1,92 @@
+package confenge
+
+import (
+	"strings"
+	"testing"
+)
+
+// The live v1 body read:
+//   "contratação pública: contratação DE Empresa Especializada Para Execução
+//    DOS Serviços Necessários DOS Serviços Necessários À Recuperação
+//    Estrutural DA Ponte SOB O RIO Sapucaí,."
+// Three separate defects, all owned by this repository's outreach projection.
+func TestLiveV1FactProjectionHasNoCopyDefects(t *testing.T) {
+	got := condenseMetadataFact(liveV1RawFact)
+	got = ApplyCopyHygiene(got)
+	if got == "" {
+		t.Fatal("the projection must still produce a usable fact")
+	}
+
+	if ng, ok := hasRepeatedNGram(got, 3); ok {
+		t.Errorf("repeated 3-gram %q survived the projection: %q", ng, got)
+	}
+	if ng, ok := hasRepeatedNGram(got, 1); ok && ng == "contratação" {
+		t.Errorf("the label repeats the object's own first word: %q", got)
+	}
+	for _, bad := range []string{",.", ",,", " ,", "..", ";."} {
+		if strings.Contains(got, bad) {
+			t.Errorf("defective punctuation %q in projection: %q", bad, got)
+		}
+	}
+	// Short Portuguese function words must not survive as shouted residue of an
+	// all-caps edital. "DOS Serviços" is the tell the founder actually saw.
+	for _, w := range strings.Fields(got) {
+		trimmed := strings.Trim(w, ".,;:!?()")
+		if trimmed == "" {
+			continue
+		}
+		upper := strings.ToUpper(trimmed)
+		lower := strings.ToLower(trimmed)
+		if trimmed == upper && upper != lower && len([]rune(trimmed)) <= 3 {
+			t.Errorf("all-caps residue %q in projection: %q", trimmed, got)
+		}
+	}
+	t.Logf("projection = %q", got)
+}
+
+// Whatever the projection produces must be terminated as a sentence by the
+// composer without ever creating ",." — the exact defect in two live messages.
+func TestComposerTerminatesFactWithoutDoublePunctuation(t *testing.T) {
+	for _, fact := range []string{
+		"contratação pública: recuperação estrutural da ponte sobre o Rio Sapucaí,",
+		"contratação pública: pavimentação asfáltica em vias urbanas;",
+		"contratação pública: reforma da escola municipal",
+		"contratação pública: obra concluída.",
+	} {
+		got := terminateFactSentence(fact)
+		if strings.HasSuffix(got, ",.") || strings.HasSuffix(got, ";.") || strings.HasSuffix(got, "..") {
+			t.Errorf("terminated %q into %q", fact, got)
+		}
+		if !strings.HasSuffix(got, ".") {
+			t.Errorf("fact %q must end as a sentence, got %q", fact, got)
+		}
+	}
+}
+
+// Defence in depth: even if a future composer change reintroduces a defect, the
+// admission gate must refuse the member instead of freezing it as eligible.
+// The live v1 froze with admission_reasons carrying "copy_qa=passed".
+func TestCopyQARefusesDefectiveCopy(t *testing.T) {
+	cases := map[string]string{
+		"repeated_ngram":       "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: execução dos serviços necessários dos serviços necessários à recuperação.\n\nQueria falar com quem acompanha a carteira.",
+		"defective_punctuation": "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: recuperação estrutural da ponte,.\n\nQueria falar com quem acompanha a carteira.",
+		"shouted_residue":      "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: execução DOS Serviços Necessários DA Ponte.\n\nQueria falar com quem acompanha a carteira.",
+	}
+	for name, body := range cases {
+		t.Run(name, func(t *testing.T) {
+			errs := ValidateCopyForRouteClass(RouteClassGenericCompany, body, "contratação pública", nil)
+			if len(errs) == 0 {
+				t.Fatalf("copy QA passed defective copy (%s): %q", name, body)
+			}
+			t.Logf("%s -> %v", name, errs)
+		})
+	}
+}
+
+// Clean copy must still pass; a gate that refuses everything blocks the pilot.
+func TestCopyQAAcceptsCleanCopy(t *testing.T) {
+	body := "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: recuperação estrutural da ponte sobre o Rio Sapucaí.\n\nQueria falar com quem acompanha a carteira de contratos públicos por aí. Você consegue me indicar a pessoa responsável?"
+	if errs := ValidateCopyForRouteClass(RouteClassGenericCompany, body, "recuperação estrutural da ponte", nil); len(errs) > 0 {
+		t.Fatalf("clean copy must pass, got %v", errs)
+	}
+}

--- a/internal/app/confenge/copy_defect_projection_test.go
+++ b/internal/app/confenge/copy_defect_projection_test.go
@@ -6,9 +6,11 @@ import (
 )
 
 // The live v1 body read:
-//   "contratação pública: contratação DE Empresa Especializada Para Execução
-//    DOS Serviços Necessários DOS Serviços Necessários À Recuperação
-//    Estrutural DA Ponte SOB O RIO Sapucaí,."
+//
+//	"contratação pública: contratação DE Empresa Especializada Para Execução
+//	 DOS Serviços Necessários DOS Serviços Necessários À Recuperação
+//	 Estrutural DA Ponte SOB O RIO Sapucaí,."
+//
 // Three separate defects, all owned by this repository's outreach projection.
 func TestLiveV1FactProjectionHasNoCopyDefects(t *testing.T) {
 	got := condenseMetadataFact(liveV1RawFact)
@@ -68,9 +70,9 @@ func TestComposerTerminatesFactWithoutDoublePunctuation(t *testing.T) {
 // The live v1 froze with admission_reasons carrying "copy_qa=passed".
 func TestCopyQARefusesDefectiveCopy(t *testing.T) {
 	cases := map[string]string{
-		"repeated_ngram":       "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: execução dos serviços necessários dos serviços necessários à recuperação.\n\nQueria falar com quem acompanha a carteira.",
+		"repeated_ngram":        "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: execução dos serviços necessários dos serviços necessários à recuperação.\n\nQueria falar com quem acompanha a carteira.",
 		"defective_punctuation": "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: recuperação estrutural da ponte,.\n\nQueria falar com quem acompanha a carteira.",
-		"shouted_residue":      "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: execução DOS Serviços Necessários DA Ponte.\n\nQueria falar com quem acompanha a carteira.",
+		"shouted_residue":       "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: execução DOS Serviços Necessários DA Ponte.\n\nQueria falar com quem acompanha a carteira.",
 	}
 	for name, body := range cases {
 		t.Run(name, func(t *testing.T) {

--- a/internal/app/confenge/copy_defect_regression_test.go
+++ b/internal/app/confenge/copy_defect_regression_test.go
@@ -1,0 +1,22 @@
+package confenge
+
+import "strings"
+
+// liveV1RawFact is the fact_to_mention that produced cohort v1 in production on
+// 2026-08-23. It is stored verbatim as the raw provenance and must stay that
+// way; only the outreach projection may normalize it. The doubled
+// "DOS SERVIÇOS NECESSÁRIOS" is genuinely in the PNCP object text, so the feed
+// is faithful and the collapse belongs here, not upstream.
+const liveV1RawFact = "objeto: CONTRATAÇÃO DE EMPRESA ESPECIALIZADA PARA EXECUÇÃO DOS SERVIÇOS NECESSÁRIOS DOS SERVIÇOS NECESSÁRIOS À RECUPERAÇÃO ESTRUTURAL DA PONTE SOB O RIO SAPUCAÍ, SITUADA DA RODOVIA FEDERAL; órgão: SUPERINTENDÊNCIA REGIONAL DO DNIT - MG; UF MG; R$ 8,763,672"
+
+func hasRepeatedNGram(s string, n int) (string, bool) {
+	words := strings.Fields(strings.ToLower(s))
+	for i := 0; i+2*n <= len(words); i++ {
+		a := strings.Join(words[i:i+n], " ")
+		b := strings.Join(words[i+n:i+2*n], " ")
+		if a == b {
+			return a, true
+		}
+	}
+	return "", false
+}

--- a/internal/app/confenge/copy_hygiene.go
+++ b/internal/app/confenge/copy_hygiene.go
@@ -35,7 +35,17 @@ func ApplyCopyHygiene(s string) string {
 	s = ocrLoneSRe.ReplaceAllString(s, "$1 $2")
 	s = normalizePtBRAmount(s)
 	s = normalizeBareUSAmount(s)
+	// De-shout before collapseEditalCaps, not after: collapseEditalCaps only
+	// touches wholly-uppercase words of four letters or more, and once it has
+	// title-cased those, the remaining "DOS"/"DA"/"SOB" are a minority and no
+	// longer look like a shouted line. Reading the still-shouted original is
+	// what lets the short prepositions and proper nouns be fixed at all.
+	s = deshoutEditalProse(s)
 	s = collapseEditalCaps(s)
+	// Source object text repeats itself verbatim often enough that a recipient
+	// would read it as a broken merge. Collapse after casing so the comparison
+	// sees one consistent form.
+	s = collapseRepeatedNGrams(s)
 	s = stripLegalVocative(s)
 	s = orphanCommaRe.ReplaceAllString(s, ",")
 	s = doubleDotRe.ReplaceAllString(s, ".")

--- a/internal/app/confenge/copy_projection.go
+++ b/internal/app/confenge/copy_projection.go
@@ -1,0 +1,325 @@
+package confenge
+
+import (
+	"strings"
+	"unicode"
+)
+
+// This file owns the outreach *projection* of a raw source fact. The raw fact
+// and its provenance are never modified: PNCP object text is frequently shouted,
+// truncated and self-repeating, and that is faithful data. What must not reach a
+// recipient is the shouting, the repetition and the broken terminal punctuation.
+
+// ptFunctionWords are Portuguese articles, prepositions and contractions. In an
+// all-caps edital they carry no emphasis, so they are lowercased rather than
+// title-cased: "PONTE SOB O RIO" must read "Ponte sob o Rio", not "Ponte Sob O Rio".
+var ptFunctionWords = map[string]bool{
+	"a": true, "as": true, "o": true, "os": true, "e": true, "ou": true,
+	"de": true, "do": true, "da": true, "dos": true, "das": true,
+	"em": true, "no": true, "na": true, "nos": true, "nas": true, "num": true, "numa": true,
+	"ao": true, "aos": true, "as_": true, "à": true, "às": true, "àa": true,
+	"por": true, "pelo": true, "pela": true, "pelos": true, "pelas": true,
+	"para": true, "com": true, "sem": true, "sob": true, "sobre": true,
+	"entre": true, "ate": true, "até": true, "que": true, "se": true, "ser": true,
+}
+
+// knownAcronyms stay uppercase when the rest of a shouted line is de-shouted.
+// Anything absent from this set and longer than two letters is treated as an
+// ordinary shouted word, which is the safe direction: a mis-title-cased acronym
+// is readable, a shouted sentence is not.
+var knownAcronyms = map[string]bool{
+	"pncp": true, "cnpj": true, "cpf": true, "uf": true, "crea": true, "cau": true,
+	"art": true, "rrt": true, "dnit": true, "dner": true, "der": true, "ans": true,
+	"epp": true, "mei": true, "sa": true, "ltda": true, "eireli": true,
+	"cbuq": true, "epi": true, "abnt": true, "nbr": true, "iss": true, "inss": true,
+	"srp": true, "ata": true, "tce": true, "tcu": true, "cgu": true, "ufmg": true,
+}
+
+// shoutedRatio reports the share of alphabetic words written entirely in caps.
+func shoutedRatio(s string) float64 {
+	words, shouted := 0, 0
+	for _, w := range strings.Fields(s) {
+		t := strings.Trim(w, ".,;:!?()[]\"'")
+		letters, upper := 0, 0
+		for _, r := range t {
+			if unicode.IsLetter(r) {
+				letters++
+				if unicode.IsUpper(r) {
+					upper++
+				}
+			}
+		}
+		if letters < 2 {
+			continue
+		}
+		words++
+		if upper == letters {
+			shouted++
+		}
+	}
+	if words == 0 {
+		return 0
+	}
+	return float64(shouted) / float64(words)
+}
+
+// deshoutEditalProse converts an all-caps edital line into ordinary prose. It
+// runs only when the line really is shouted, so a normal sentence that happens
+// to contain an acronym is left alone.
+func deshoutEditalProse(s string) string {
+	if shoutedRatio(s) < 0.5 {
+		return s
+	}
+	fields := strings.Fields(s)
+	for i, w := range fields {
+		prefix, core, suffix := splitAffixes(w)
+		if core == "" {
+			continue
+		}
+		letters, upper, digits := 0, 0, 0
+		for _, r := range core {
+			if unicode.IsLetter(r) {
+				letters++
+				if unicode.IsUpper(r) {
+					upper++
+				}
+			}
+			if unicode.IsDigit(r) {
+				digits++
+			}
+		}
+		if letters == 0 || upper != letters || digits > 0 {
+			continue
+		}
+		key := foldASCII(strings.ToLower(core))
+		switch {
+		case ptFunctionWords[key] && i > 0:
+			// Never lowercase the first word of the projection.
+			fields[i] = prefix + strings.ToLower(core) + suffix
+		case knownAcronyms[key], letters <= 2:
+			// Acronyms and two-letter tokens (state codes) keep their case.
+			continue
+		default:
+			fields[i] = prefix + titleWordPT(core) + suffix
+		}
+	}
+	return strings.Join(fields, " ")
+}
+
+// splitAffixes separates leading/trailing punctuation from a token so casing
+// rules operate on letters only and never eat a comma.
+func splitAffixes(w string) (prefix, core, suffix string) {
+	runes := []rune(w)
+	i := 0
+	for i < len(runes) && !unicode.IsLetter(runes[i]) && !unicode.IsDigit(runes[i]) {
+		i++
+	}
+	j := len(runes)
+	for j > i && !unicode.IsLetter(runes[j-1]) && !unicode.IsDigit(runes[j-1]) {
+		j--
+	}
+	return string(runes[:i]), string(runes[i:j]), string(runes[j:])
+}
+
+// collapseRepeatedNGrams removes an n-gram immediately repeated verbatim. PNCP
+// object text does this often ("DOS SERVIÇOS NECESSÁRIOS DOS SERVIÇOS
+// NECESSÁRIOS"); repeating it to a recipient reads as a broken mail merge.
+// Comparison folds case and accents so a de-shouted copy is still caught.
+func collapseRepeatedNGrams(s string) string {
+	for n := 6; n >= 2; n-- {
+		for {
+			collapsed, changed := collapseOnce(s, n)
+			s = collapsed
+			if !changed {
+				break
+			}
+		}
+	}
+	return s
+}
+
+func collapseOnce(s string, n int) (string, bool) {
+	words := strings.Fields(s)
+	if len(words) < 2*n {
+		return s, false
+	}
+	norm := make([]string, len(words))
+	for i, w := range words {
+		norm[i] = foldASCII(strings.ToLower(strings.Trim(w, ".,;:!?()[]\"'")))
+	}
+	for i := 0; i+2*n <= len(words); i++ {
+		match := true
+		for k := 0; k < n; k++ {
+			if norm[i+k] == "" || norm[i+k] != norm[i+n+k] {
+				match = false
+				break
+			}
+		}
+		if !match {
+			continue
+		}
+		// Keep the first occurrence, drop the second, and keep whatever
+		// punctuation the dropped run carried at its end.
+		tail := words[i+2*n-1]
+		_, _, suffix := splitAffixes(tail)
+		out := append([]string{}, words[:i+n]...)
+		if suffix != "" {
+			last := len(out) - 1
+			_, core, existing := splitAffixes(out[last])
+			pre, _, _ := splitAffixes(out[last])
+			if existing == "" {
+				out[last] = pre + core + suffix
+			}
+		}
+		out = append(out, words[i+2*n:]...)
+		return strings.Join(out, " "), true
+	}
+	return s, false
+}
+
+// terminateFactSentence ends a projected fact as one sentence. The composer used
+// to append "." unconditionally, so a fact truncated at a comma became ",." —
+// which reached two live messages in cohort v1.
+func terminateFactSentence(fact string) string {
+	fact = strings.TrimSpace(fact)
+	if fact == "" {
+		return ""
+	}
+	fact = strings.TrimRight(fact, " \t,;:-–—")
+	if fact == "" {
+		return ""
+	}
+	if strings.HasSuffix(fact, ".") || strings.HasSuffix(fact, "!") || strings.HasSuffix(fact, "?") {
+		return fact
+	}
+	return fact + "."
+}
+
+// dropRedundantLeadingLabel removes a label whose first content word repeats the
+// label's own head noun. condenseMetadataFact prefixes "contratação pública: "
+// and the PNCP object then opens with "CONTRATAÇÃO DE EMPRESA...", which read
+// "contratação pública: contratação DE Empresa" in production.
+func dropRedundantLeadingLabel(label, body string) string {
+	label = strings.TrimSpace(label)
+	body = strings.TrimSpace(body)
+	if label == "" {
+		return body
+	}
+	if body == "" {
+		return label
+	}
+	head := foldASCII(strings.ToLower(strings.Fields(label)[0]))
+	first := strings.Fields(body)
+	if len(first) > 0 && foldASCII(strings.ToLower(strings.Trim(first[0], ".,;:"))) == head {
+		rest := first[1:]
+		// Dropping the head noun strands the preposition that governed it:
+		// "contratação DE EMPRESA" would read "contratação pública: de Empresa".
+		// Dropping that too yields "contratação pública: Empresa ...".
+		if len(rest) > 1 {
+			lead := foldASCII(strings.ToLower(strings.Trim(rest[0], ".,;:")))
+			switch lead {
+			case "de", "da", "do", "dos", "das", "para", "em":
+				rest = rest[1:]
+			}
+		}
+		body = ensureLowerStart(strings.TrimSpace(strings.Join(rest, " ")))
+	}
+	return strings.TrimSpace(label + ": " + body)
+}
+
+// defectivePunctuation lists sequences that only ever result from mechanical
+// assembly, never from prose a human would write.
+var defectivePunctuation = []string{",.", ",,", ";.", "..", " ,", " ;", ":.", "!.", "?."}
+
+// copyProjectionDefects returns machine-readable reason codes for copy that a
+// recipient would read as broken. It inspects the composed subject and body,
+// so it catches a defect regardless of which upstream stage introduced it.
+func copyProjectionDefects(subject, body string) []string {
+	var codes []string
+	seen := map[string]bool{}
+	add := func(c string) {
+		if !seen[c] {
+			seen[c] = true
+			codes = append(codes, c)
+		}
+	}
+	for _, text := range []string{subject, body} {
+		t := strings.TrimSpace(text)
+		if t == "" {
+			continue
+		}
+		for _, bad := range defectivePunctuation {
+			if strings.Contains(t, bad) {
+				add("defective_punctuation")
+				break
+			}
+		}
+		if repeatedNGramIn(t) {
+			add("repeated_ngram")
+		}
+		if shoutedResidueIn(t) {
+			add("shouted_residue")
+		}
+	}
+	return codes
+}
+
+// repeatedNGramIn reports a verbatim immediately-repeated run of two or more
+// words. Comparison folds case and accents, matching the collapse rule.
+func repeatedNGramIn(s string) bool {
+	words := strings.Fields(s)
+	norm := make([]string, 0, len(words))
+	for _, w := range words {
+		t := foldASCII(strings.ToLower(strings.Trim(w, ".,;:!?()[]\"'")))
+		if t != "" {
+			norm = append(norm, t)
+		}
+	}
+	for n := 2; n <= 6; n++ {
+		for i := 0; i+2*n <= len(norm); i++ {
+			match := true
+			for k := 0; k < n; k++ {
+				if norm[i+k] != norm[i+n+k] {
+					match = false
+					break
+				}
+			}
+			if match {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// shoutedResidueIn reports a short all-caps Portuguese function word left over
+// from an edital, e.g. "execução DOS Serviços". A genuine acronym is exempt,
+// and a wholly shouted line is a different defect handled by the dump checks.
+func shoutedResidueIn(s string) bool {
+	for _, w := range strings.Fields(s) {
+		_, core, _ := splitAffixes(w)
+		if core == "" {
+			continue
+		}
+		letters, upper := 0, 0
+		for _, r := range core {
+			if unicode.IsLetter(r) {
+				letters++
+				if unicode.IsUpper(r) {
+					upper++
+				}
+			}
+		}
+		if letters < 2 || upper != letters {
+			continue
+		}
+		key := foldASCII(strings.ToLower(core))
+		if knownAcronyms[key] {
+			continue
+		}
+		if ptFunctionWords[key] {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/confenge/dispatch/governor.go
+++ b/internal/app/confenge/dispatch/governor.go
@@ -233,7 +233,10 @@ func (g *Governor) Status(ctx context.Context, orgID *uuid.UUID) (Status, error)
 	inWin, _ := InSendWindowBusiness(now, g.cfg.Timezone, g.cfg.WindowStart, g.cfg.WindowEnd, g.cfg.BusinessDaysOnly)
 	st.InSendWindow = inWin
 	if st.Paused {
-		t := now.Add(g.cfg.MinGap)
+		// A pause gap is plain arithmetic and lands wherever it lands, so on a
+		// Sunday it used to advertise a Sunday slot beside in_send_window=false.
+		// Normalizing it keeps the two fields telling the founder one story.
+		t := NextEligibleSlot(now.Add(g.cfg.MinGap), g.cfg.Timezone, g.cfg.WindowStart, g.cfg.WindowEnd, g.cfg.BusinessDaysOnly)
 		st.NextSlotAt = &t
 	} else if !inWin {
 		t := NextWindowOpenBusiness(now, g.cfg.Timezone, g.cfg.WindowStart, g.cfg.WindowEnd, g.cfg.BusinessDaysOnly)
@@ -249,6 +252,9 @@ func (g *Governor) Status(ctx context.Context, orgID *uuid.UUID) (Status, error)
 		}
 		ok, _, next := snap.CanGrant()
 		if !ok {
+			// A rolling-cap expiry or min-gap can cross the window close or a
+			// Friday evening; it is a lower bound on the slot, not the slot.
+			next = NextEligibleSlot(next, g.cfg.Timezone, g.cfg.WindowStart, g.cfg.WindowEnd, g.cfg.BusinessDaysOnly)
 			st.NextSlotAt = &next
 		}
 	}

--- a/internal/app/confenge/dispatch/send_neutrality_test.go
+++ b/internal/app/confenge/dispatch/send_neutrality_test.go
@@ -1,0 +1,93 @@
+package dispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The window fix touches the dispatch package, which the repository guards as
+// the last-mile send path. The file-level guard only compares the working tree
+// to HEAD, so it cannot say whether a committed change altered behaviour. This
+// test states the property that actually matters: correcting the *reported*
+// next slot must not change any decision about whether something is sent.
+func TestNextSlotReportingDoesNotChangeSendDecisions(t *testing.T) {
+	sp, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	org := uuid.New()
+	instants := []time.Time{
+		time.Date(2026, 8, 23, 14, 9, 0, 0, sp),  // Sunday, the observed case
+		time.Date(2026, 8, 22, 11, 0, 0, 0, sp),  // Saturday
+		time.Date(2026, 8, 24, 10, 0, 0, 0, sp),  // Monday inside window
+		time.Date(2026, 8, 24, 8, 0, 0, 0, sp),   // Monday before open
+		time.Date(2026, 8, 24, 19, 0, 0, 0, sp),  // Monday after close
+	}
+	for _, inst := range instants {
+		for _, paused := range []bool{false, true} {
+			cfg := DefaultConfig()
+			cfg.BusinessDaysOnly = true
+			cfg.EnvPaused = paused
+			g := NewGovernor(cfg, NewMemoryStore(), &FixedClock{T: inst.UTC()})
+
+			res, err := g.TryReserve(context.Background(), ReserveRequest{
+				OrganizationID: org,
+				Channel:        ChannelEmail,
+				MessageKey:     "email:draft:" + inst.Format(time.RFC3339) + "-neutrality",
+			})
+			if err != nil {
+				t.Fatalf("%s paused=%v: %v", inst, paused, err)
+			}
+			// A weekend, an out-of-hours instant, or a pause must never allow a
+			// reservation. This is the send decision; the fix must not move it.
+			inWindow, werr := InSendWindowBusiness(inst.UTC(), cfg.Timezone, cfg.WindowStart, cfg.WindowEnd, true)
+			if werr != nil {
+				t.Fatal(werr)
+			}
+			wantAllowed := inWindow && !paused
+			if res.Allowed != wantAllowed {
+				t.Fatalf("%s paused=%v: allowed=%v want %v (reason=%s)",
+					inst.In(sp), paused, res.Allowed, wantAllowed, res.Reason)
+			}
+		}
+	}
+}
+
+// Whatever next_slot_at reports, a paused governor must refuse to reserve. The
+// advertised slot is information for the founder, never an authorization.
+func TestReportedNextSlotIsNotAnAuthorization(t *testing.T) {
+	sp, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	// Monday inside the window, but paused: the reported slot is "now-ish" and
+	// must still not permit a send.
+	monday := time.Date(2026, 8, 24, 10, 0, 0, 0, sp)
+	cfg := DefaultConfig()
+	cfg.BusinessDaysOnly = true
+	cfg.EnvPaused = true
+	g := NewGovernor(cfg, NewMemoryStore(), &FixedClock{T: monday.UTC()})
+
+	st, err := g.Status(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Paused {
+		t.Fatal("fixture must be paused")
+	}
+	if st.NextSlotAt == nil {
+		t.Fatal("expected a reported next slot")
+	}
+	res, err := g.TryReserve(context.Background(), ReserveRequest{
+		OrganizationID: uuid.New(), Channel: ChannelEmail, MessageKey: "email:draft:paused-authz",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.Allowed {
+		t.Fatal("a paused governor reserved a slot: next_slot_at must never authorize a send")
+	}
+}

--- a/internal/app/confenge/dispatch/send_neutrality_test.go
+++ b/internal/app/confenge/dispatch/send_neutrality_test.go
@@ -20,11 +20,11 @@ func TestNextSlotReportingDoesNotChangeSendDecisions(t *testing.T) {
 	}
 	org := uuid.New()
 	instants := []time.Time{
-		time.Date(2026, 8, 23, 14, 9, 0, 0, sp),  // Sunday, the observed case
-		time.Date(2026, 8, 22, 11, 0, 0, 0, sp),  // Saturday
-		time.Date(2026, 8, 24, 10, 0, 0, 0, sp),  // Monday inside window
-		time.Date(2026, 8, 24, 8, 0, 0, 0, sp),   // Monday before open
-		time.Date(2026, 8, 24, 19, 0, 0, 0, sp),  // Monday after close
+		time.Date(2026, 8, 23, 14, 9, 0, 0, sp), // Sunday, the observed case
+		time.Date(2026, 8, 22, 11, 0, 0, 0, sp), // Saturday
+		time.Date(2026, 8, 24, 10, 0, 0, 0, sp), // Monday inside window
+		time.Date(2026, 8, 24, 8, 0, 0, 0, sp),  // Monday before open
+		time.Date(2026, 8, 24, 19, 0, 0, 0, sp), // Monday after close
 	}
 	for _, inst := range instants {
 		for _, paused := range []bool{false, true} {

--- a/internal/app/confenge/dispatch/window.go
+++ b/internal/app/confenge/dispatch/window.go
@@ -196,3 +196,21 @@ func NextWindowOpenBusiness(now time.Time, tzName, startHHMM, endHHMM string, bu
 	}
 	return NextWindowOpen(now, tzName, startHHMM, endHHMM)
 }
+
+// NextEligibleSlot normalizes any candidate instant to a time the send window
+// would actually admit. Callers derive candidates from a pause gap, a min-gap
+// or a rolling-cap expiry, and none of those arithmetic results know about
+// business days: 09:00 Monday plus a cap window is 10:00 Monday, but Sunday
+// plus a min-gap is still Sunday. Offering such an instant as "next slot"
+// contradicts an in_send_window=false computed by the business-day rule.
+//
+// The returned instant is always either inside the window or the next window
+// open, in the configured location, so daylight-saving shifts are resolved by
+// the tzdata rules for that zone rather than a hardcoded offset.
+func NextEligibleSlot(candidate time.Time, tzName, startHHMM, endHHMM string, businessDaysOnly bool) time.Time {
+	in, err := InSendWindowBusiness(candidate, tzName, startHHMM, endHHMM, businessDaysOnly)
+	if err == nil && in {
+		return candidate.UTC()
+	}
+	return NextWindowOpenBusiness(candidate, tzName, startHHMM, endHHMM, businessDaysOnly)
+}

--- a/internal/app/confenge/dispatch/window_business_regression_test.go
+++ b/internal/app/confenge/dispatch/window_business_regression_test.go
@@ -42,10 +42,10 @@ func TestNextEligibleSlotNormalizesEveryOutOfWindowInstant(t *testing.T) {
 		t.Skipf("tzdata unavailable: %v", err)
 	}
 	cases := []time.Time{
-		time.Date(2026, 8, 22, 11, 0, 0, 0, sp), // Saturday inside hours
-		time.Date(2026, 8, 23, 14, 9, 0, 0, sp), // Sunday inside hours
+		time.Date(2026, 8, 22, 11, 0, 0, 0, sp),  // Saturday inside hours
+		time.Date(2026, 8, 23, 14, 9, 0, 0, sp),  // Sunday inside hours
 		time.Date(2026, 8, 21, 19, 30, 0, 0, sp), // Friday after close
-		time.Date(2026, 8, 24, 6, 0, 0, 0, sp),  // Monday before open
+		time.Date(2026, 8, 24, 6, 0, 0, 0, sp),   // Monday before open
 		time.Date(2026, 8, 24, 23, 59, 0, 0, sp), // Monday after close
 	}
 	for _, c := range cases {

--- a/internal/app/confenge/dispatch/window_business_regression_test.go
+++ b/internal/app/confenge/dispatch/window_business_regression_test.go
@@ -1,0 +1,153 @@
+package dispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The founder saw "fora da janela" on Sunday 2026-08-23 while the same panel
+// offered next_slot_at on that same Sunday. Outbound was paused, and the paused
+// branch derived the slot from now+MinGap, which never consults the business-day
+// rule that produced in_send_window=false.
+func TestNextSlotNeverLandsOnAWeekend(t *testing.T) {
+	sp, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	// 2026-08-23 14:09 America/Sao_Paulo is the Sunday the founder observed.
+	sunday := time.Date(2026, 8, 23, 14, 9, 0, 0, sp)
+	if sunday.Weekday() != time.Sunday {
+		t.Fatalf("fixture is not a Sunday: %s", sunday.Weekday())
+	}
+
+	got := NextEligibleSlot(sunday.Add(30*time.Second), "America/Sao_Paulo", "09:00", "18:00", true)
+	local := got.In(sp)
+	if local.Weekday() != time.Monday {
+		t.Fatalf("next slot after a Sunday must be Monday, got %s (%s)", local, local.Weekday())
+	}
+	if local.Hour() < 9 || local.Hour() >= 18 {
+		t.Fatalf("next slot must fall inside 09:00-18:00, got %s", local)
+	}
+	if !got.After(sunday) {
+		t.Fatalf("next slot %s must be after now %s", got, sunday)
+	}
+}
+
+// Every weekend instant and every out-of-hours instant must normalize forward
+// into a business-day window; none may be handed back unchanged.
+func TestNextEligibleSlotNormalizesEveryOutOfWindowInstant(t *testing.T) {
+	sp, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	cases := []time.Time{
+		time.Date(2026, 8, 22, 11, 0, 0, 0, sp), // Saturday inside hours
+		time.Date(2026, 8, 23, 14, 9, 0, 0, sp), // Sunday inside hours
+		time.Date(2026, 8, 21, 19, 30, 0, 0, sp), // Friday after close
+		time.Date(2026, 8, 24, 6, 0, 0, 0, sp),  // Monday before open
+		time.Date(2026, 8, 24, 23, 59, 0, 0, sp), // Monday after close
+	}
+	for _, c := range cases {
+		got := NextEligibleSlot(c, "America/Sao_Paulo", "09:00", "18:00", true)
+		in, err := InSendWindowBusiness(got, "America/Sao_Paulo", "09:00", "18:00", true)
+		if err != nil {
+			t.Fatalf("%s: %v", c, err)
+		}
+		if !in {
+			t.Fatalf("normalized slot for %s is still outside the window: %s", c, got.In(sp))
+		}
+		if got.Before(c) {
+			t.Fatalf("normalized slot for %s went backwards: %s", c, got.In(sp))
+		}
+	}
+}
+
+// An instant already inside a business window is its own next slot.
+func TestNextEligibleSlotKeepsAnInWindowInstant(t *testing.T) {
+	sp, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	monday := time.Date(2026, 8, 24, 10, 0, 0, 0, sp)
+	got := NextEligibleSlot(monday, "America/Sao_Paulo", "09:00", "18:00", true)
+	if !got.Equal(monday.UTC()) {
+		t.Fatalf("in-window instant must be returned unchanged, got %s want %s", got, monday.UTC())
+	}
+}
+
+// The window must be resolved by the zone's own rules. Brazil has no DST in
+// 2026, but the São Paulo offset is still a zone property and must never be
+// read from a hardcoded -03:00: asserting the boundary through the location
+// catches any future reintroduction of a fixed offset in the window path.
+func TestWindowBoundaryUsesZoneRulesNotAFixedOffset(t *testing.T) {
+	for _, tz := range []string{"America/Sao_Paulo", "Europe/Lisbon", "America/New_York"} {
+		loc, err := time.LoadLocation(tz)
+		if err != nil {
+			t.Skipf("tzdata unavailable for %s: %v", tz, err)
+		}
+		// A zone that does observe DST proves the boundary follows the zone.
+		for _, month := range []time.Month{time.January, time.July} {
+			// Monday nearest the 12th of that month, at 08:59 and 09:01 local.
+			d := time.Date(2026, month, 12, 0, 0, 0, 0, loc)
+			for d.Weekday() != time.Monday {
+				d = d.AddDate(0, 0, 1)
+			}
+			before := time.Date(d.Year(), d.Month(), d.Day(), 8, 59, 0, 0, loc)
+			after := time.Date(d.Year(), d.Month(), d.Day(), 9, 1, 0, 0, loc)
+			inBefore, err := InSendWindowBusiness(before, tz, "09:00", "18:00", true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			inAfter, err := InSendWindowBusiness(after, tz, "09:00", "18:00", true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if inBefore {
+				t.Fatalf("%s %s: 08:59 local must be outside the window", tz, month)
+			}
+			if !inAfter {
+				t.Fatalf("%s %s: 09:01 local must be inside the window", tz, month)
+			}
+		}
+	}
+}
+
+// End-to-end over the exact production shape the founder hit: outbound paused
+// by the kill switch, on a Sunday. Status must not report an out-of-window
+// state and a Sunday next slot in the same payload. Reverting the paused branch
+// of Governor.Status to now+MinGap fails this test.
+func TestPausedStatusOnSundayOffersABusinessDaySlot(t *testing.T) {
+	sp, err := time.LoadLocation("America/Sao_Paulo")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+	sunday := time.Date(2026, 8, 23, 14, 9, 0, 0, sp)
+	clock := &FixedClock{T: sunday.UTC()}
+	cfg := DefaultConfig()
+	cfg.BusinessDaysOnly = true
+	cfg.EnvPaused = true
+	cfg.EnvPauseReason = "kill_switch"
+	g := NewGovernor(cfg, NewMemoryStore(), clock)
+
+	st, err := g.Status(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !st.Paused {
+		t.Fatal("fixture must be paused")
+	}
+	if st.InSendWindow {
+		t.Fatal("Sunday must not be reported as inside the send window")
+	}
+	if st.NextSlotAt == nil {
+		t.Fatal("a paused, out-of-window status still owes the founder a next slot")
+	}
+	local := st.NextSlotAt.In(sp)
+	if local.Weekday() == time.Saturday || local.Weekday() == time.Sunday {
+		t.Fatalf("next_slot_at contradicts in_send_window=false: %s (%s)", local, local.Weekday())
+	}
+	if local.Hour() < 9 || local.Hour() >= 18 {
+		t.Fatalf("next_slot_at must be inside 09:00-18:00, got %s", local)
+	}
+}

--- a/internal/app/confenge/generate_test.go
+++ b/internal/app/confenge/generate_test.go
@@ -386,7 +386,12 @@ func TestPromptVersionV5(t *testing.T) {
 	if OutreachDoctrineVersion != "confenge-outreach-v2" {
 		t.Fatalf("doctrine=%s", OutreachDoctrineVersion)
 	}
-	if ComposerVersion != "confenge.composer.v3" {
+	// v4 (2026-08-23) de-shouts edital prose, collapses verbatim repeated
+	// n-grams, removes the "contratação pública: contratação" label stutter and
+	// terminates a fact without producing ",.". The bump is deliberate: copy
+	// composed by v3 is materially different text, so a v3 grant must not
+	// authorize v4 output. Bump this pin only together with that reasoning.
+	if ComposerVersion != "confenge.composer.v4" {
 		t.Fatalf("composer=%s", ComposerVersion)
 	}
 }

--- a/internal/app/confenge/human_gate.go
+++ b/internal/app/confenge/human_gate.go
@@ -79,10 +79,15 @@ type HumanGateDecision struct {
 }
 
 type HumanGateCohort struct {
-	ContractVersion  string               `json:"contract_version"`
-	ID               uuid.UUID            `json:"id"`
-	CohortID         uuid.UUID            `json:"cohort_id"`
-	Version          int                  `json:"version"`
+	ContractVersion string    `json:"contract_version"`
+	ID              uuid.UUID `json:"id"`
+	CohortID        uuid.UUID `json:"cohort_id"`
+	Version         int       `json:"version"`
+	// Derivation says how this version came to exist: CREATE, REPRODUCE,
+	// RECOMPOSE (reserved) or ADJUST. ParentVersion is the version it was
+	// derived from, nil only for CREATE.
+	Derivation       string               `json:"derivation"`
+	ParentVersion    *int                 `json:"parent_version"`
 	Source           string               `json:"source"`
 	SourceRunID      string               `json:"source_run_id"`
 	AsOf             time.Time            `json:"as_of"`
@@ -289,8 +294,8 @@ func (s *service) ReproduceHumanGateCohort(ctx context.Context, orgID, actorID, 
 	b, _ := json.Marshal(old.Manifest)
 	var version int
 	err := s.humanGateDB.QueryRow(ctx, `INSERT INTO confenge_cohort_versions
-		(id,organization_id,cohort_id,version,source_run_id,source_system,source_as_of,freshness_expires_at,policy_version,frozen_hash,frozen_manifest,reproduced_from_version,created_by,correlation_id,idempotency_key,request_hash)
-		SELECT $1,organization_id,cohort_id,(SELECT max(version)+1 FROM confenge_cohort_versions WHERE organization_id=$2 AND cohort_id=$3),source_run_id,source_system,source_as_of,freshness_expires_at,policy_version,frozen_hash,$4,version,$5,$6,$7,$8
+		(id,organization_id,cohort_id,version,source_run_id,source_system,source_as_of,freshness_expires_at,policy_version,frozen_hash,frozen_manifest,reproduced_from_version,derivation,parent_version,created_by,correlation_id,idempotency_key,request_hash)
+		SELECT $1,organization_id,cohort_id,(SELECT max(version)+1 FROM confenge_cohort_versions WHERE organization_id=$2 AND cohort_id=$3),source_run_id,source_system,source_as_of,freshness_expires_at,policy_version,frozen_hash,$4,version,'REPRODUCE',version,$5,$6,$7,$8
 		FROM confenge_cohort_versions WHERE id=$9 AND organization_id=$2 RETURNING version`, newID, orgID, old.CohortID, b, actorID, in.CorrelationID, in.IdempotencyKey, reqHash, id).Scan(&version)
 	if err != nil {
 		if existing, idemErr := s.humanGateByIdempotency(ctx, orgID, in.IdempotencyKey, reqHash); existing != nil || idemErr != nil {
@@ -338,7 +343,7 @@ func (s *service) GetHumanGateCohort(ctx context.Context, orgID, id uuid.UUID, n
 	}
 	v := &HumanGateCohort{ContractVersion: HumanGateContractV1, ID: id, Source: HumanGateSource, CorrelationID: uuid.NewString(), Receipt: humanGateReceipt("cohort", id)}
 	var raw []byte
-	err := s.humanGateDB.QueryRow(ctx, `SELECT cohort_id,version,source_run_id,source_system,source_as_of,freshness_expires_at,policy_version,frozen_hash,frozen_manifest,correlation_id,created_at FROM confenge_cohort_versions WHERE id=$1 AND organization_id=$2`, id, orgID).Scan(&v.CohortID, &v.Version, &v.SourceRunID, &v.Source, &v.AsOf, &v.FreshUntil, &v.PolicyVersion, &v.FrozenHash, &raw, &v.CorrelationID, &v.CreatedAt)
+	err := s.humanGateDB.QueryRow(ctx, `SELECT cohort_id,version,derivation,parent_version,source_run_id,source_system,source_as_of,freshness_expires_at,policy_version,frozen_hash,frozen_manifest,correlation_id,created_at FROM confenge_cohort_versions WHERE id=$1 AND organization_id=$2`, id, orgID).Scan(&v.CohortID, &v.Version, &v.Derivation, &v.ParentVersion, &v.SourceRunID, &v.Source, &v.AsOf, &v.FreshUntil, &v.PolicyVersion, &v.FrozenHash, &raw, &v.CorrelationID, &v.CreatedAt)
 	if err == pgx.ErrNoRows {
 		return nil, humanGateError(errx.NotFound, "cohort_version_not_found", "cohort version was not found")
 	}

--- a/internal/app/confenge/human_gate_adjust.go
+++ b/internal/app/confenge/human_gate_adjust.go
@@ -1,0 +1,530 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Derivation taxonomy for confenge_cohort_versions. It is durable in Postgres
+// (000117) because "there is a version N+1" cannot, by itself, tell an auditor
+// whether the bytes are identical, recomposed by machine, or edited by a human.
+const (
+	// DerivationCreate is the first freeze of a cohort from a canonical run.
+	DerivationCreate = "CREATE"
+	// DerivationReproduce copies frozen_manifest byte-for-byte.
+	DerivationReproduce = "REPRODUCE"
+	// DerivationRecompose is reserved: re-run the composer against the current
+	// source, policy and composer version. Not implemented by this contract.
+	DerivationRecompose = "RECOMPOSE"
+	// DerivationAdjust is a human copy edit on exactly one candidate.
+	DerivationAdjust = "ADJUST"
+)
+
+// HumanGateAdjustMinReason is the shortest reason that can justify overriding
+// composed copy. A one-word reason is not an audit trail.
+const HumanGateAdjustMinReason = 8
+
+// humanGateImmutableFields are the facts an operator may never "fix" by typing.
+// Each one is either canonical-source evidence or a machine-derived binding;
+// changing it in a copy edit would produce a manifest that claims provenance it
+// does not have. Correction is a source correction plus a fresh composition.
+var humanGateImmutableFields = []string{
+	"mailbox",
+	"recipient",
+	"evidence",
+	"source",
+	"policy_version",
+	"route_class",
+	"composer_version",
+}
+
+// HumanGateAdjustInput is one human copy edit on one candidate of one
+// immutable version. Subject and body are the only mutable facts.
+type HumanGateAdjustInput struct {
+	Subject            string `json:"subject"`
+	BodyText           string `json:"body_text"`
+	Reason             string `json:"reason"`
+	Confirmation       string `json:"confirmation"`
+	ExpectedFrozenHash string `json:"expected_frozen_hash"`
+
+	// RawBody is the exact request body. It is how the server detects an
+	// attempt to set an immutable field: a typed struct silently drops
+	// unknown keys, and silently dropping "mailbox" is how a caller comes to
+	// believe it changed the recipient.
+	RawBody        []byte `json:"-"`
+	IdempotencyKey string `json:"-"`
+	CorrelationID  string `json:"-"`
+}
+
+// HumanGateAdjustmentDiffEntry is one field the human changed.
+type HumanGateAdjustmentDiffEntry struct {
+	Field  string `json:"field"`
+	Before string `json:"before"`
+	After  string `json:"after"`
+}
+
+// HumanGateAdjustment is the durable per-candidate audit of a copy edit.
+type HumanGateAdjustment struct {
+	ID                     uuid.UUID                      `json:"id"`
+	CohortID               uuid.UUID                      `json:"cohort_id"`
+	FromVersion            int                            `json:"from_version"`
+	ToVersion              int                            `json:"to_version"`
+	CandidateID            uuid.UUID                      `json:"candidate_id"`
+	BeforeContentHash      string                         `json:"before_content_hash"`
+	AfterContentHash       string                         `json:"after_content_hash"`
+	BeforeFrozenHash       string                         `json:"before_frozen_hash"`
+	AfterFrozenHash        string                         `json:"after_frozen_hash"`
+	Diff                   []HumanGateAdjustmentDiffEntry `json:"diff"`
+	RevokedAuthorizationID *uuid.UUID                     `json:"revoked_authorization_id"`
+	ActorID                uuid.UUID                      `json:"actor_id"`
+	CorrelationID          string                         `json:"correlation_id"`
+	Receipt                string                         `json:"receipt"`
+	CreatedAt              time.Time                      `json:"created_at"`
+
+	// reason is durable in confenge_cohort_adjustments but deliberately not in
+	// the v1 response body; the contract's adjustment envelope is fixed.
+	reason string
+}
+
+// HumanGateAdjustResult is the 201 body: the whole new version plus the receipt
+// that explains how it differs from its parent.
+type HumanGateAdjustResult struct {
+	ContractVersion string              `json:"contract_version"`
+	Cohort          *HumanGateCohort    `json:"cohort"`
+	Adjustment      HumanGateAdjustment `json:"adjustment"`
+}
+
+// humanGateImmutableField reports the first protected key present in the raw
+// body, or "". Keys are inspected in sorted order so the same body always
+// names the same field.
+func humanGateImmutableField(raw []byte) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var body map[string]json.RawMessage
+	if json.Unmarshal(raw, &body) != nil {
+		return ""
+	}
+	keys := make([]string, 0, len(body))
+	for k := range body {
+		keys = append(keys, strings.ToLower(strings.TrimSpace(k)))
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		for _, protected := range humanGateImmutableFields {
+			if k == protected || strings.HasPrefix(k, protected+"_") {
+				return k
+			}
+		}
+	}
+	return ""
+}
+
+func humanGateImmutableFieldError(field string) *errx.Error {
+	return humanGateError(errx.Unprocessable, "immutable_field", fmt.Sprintf(
+		"%q is not correctable here: recipient, evidence, source, policy, route class and composer version are bound to the canonical source and to the composition that produced this version. Correct the canonical source, then compose a fresh cohort. Adjust may only change subject and body_text.",
+		field))
+}
+
+// AdjustHumanGateCandidate creates version N+1 of the same cohort carrying a
+// human copy edit for exactly one candidate.
+//
+// It never updates the parent row: the prior frozen_manifest stays byte
+// identical and readable forever. The new version is born with no validation,
+// no review and no GO, because nothing that was approved about the old copy is
+// evidence about the new copy. It queues nothing, dispatches nothing, sends
+// nothing and resumes nothing.
+func (s *service) AdjustHumanGateCandidate(ctx context.Context, orgID, actorID, versionID, candidateID uuid.UUID, in HumanGateAdjustInput) (*HumanGateAdjustResult, *errx.Error) {
+	if s.humanGateDB == nil {
+		return nil, humanGateError(errx.ServiceUnavailable, "human_gate_store_unavailable", "human gate store is not configured")
+	}
+	if actorID == uuid.Nil {
+		return nil, errx.ErrUnauthorized
+	}
+	// The immutable-field refusal runs before any other validation: a caller
+	// that tried to retype a mailbox must be told that, not that its reason
+	// was too short.
+	if field := humanGateImmutableField(in.RawBody); field != "" {
+		return nil, humanGateImmutableFieldError(field)
+	}
+
+	subject := strings.TrimSpace(in.Subject)
+	body := strings.TrimSpace(in.BodyText)
+	reason := strings.TrimSpace(in.Reason)
+	confirmation := strings.ToLower(strings.TrimSpace(in.Confirmation))
+	expected := strings.TrimSpace(in.ExpectedFrozenHash)
+	key := strings.TrimSpace(in.IdempotencyKey)
+
+	if key == "" {
+		return nil, humanGateError(errx.BadRequest, "idempotency_key_required", "Idempotency-Key is required")
+	}
+	if subject == "" || body == "" {
+		return nil, humanGateError(errx.BadRequest, "adjust_copy_required", "subject and body_text are required and cannot be empty")
+	}
+	if len([]rune(reason)) < HumanGateAdjustMinReason {
+		return nil, humanGateError(errx.BadRequest, "adjust_reason_required", fmt.Sprintf("reason is required and must be at least %d characters", HumanGateAdjustMinReason))
+	}
+	if confirmation == "" {
+		return nil, humanGateError(errx.BadRequest, "adjust_confirmation_required", "confirmation must name the immutable version being adjusted, for example \"v1\"")
+	}
+	if expected == "" {
+		return nil, humanGateError(errx.BadRequest, "adjust_expected_frozen_hash_required", "expected_frozen_hash is required")
+	}
+
+	unlock, lockErr := s.lockHumanGateIntent(ctx, orgID, key)
+	if lockErr != nil {
+		return nil, lockErr
+	}
+	defer unlock()
+
+	reqHash := humanGateRequestHash(struct {
+		V, C           uuid.UUID
+		S, B, R, F, Cf string
+	}{versionID, candidateID, subject, body, reason, expected, confirmation})
+
+	if replay, x := s.humanGateAdjustmentByIdempotency(ctx, orgID, key, reqHash); replay != nil || x != nil {
+		return replay, x
+	}
+
+	now := time.Now().UTC()
+	parent, x := s.GetHumanGateCohort(ctx, orgID, versionID, now)
+	if x != nil {
+		return nil, x
+	}
+	if expected != parent.FrozenHash {
+		return nil, humanGateError(errx.Conflict, "frozen_hash_mismatch", "expected_frozen_hash does not match the frozen hash of this version; re-read the version before adjusting it")
+	}
+	if !humanGateVersionConfirmed(confirmation, parent.Version) {
+		return nil, humanGateError(errx.Conflict, "confirmation_mismatch", fmt.Sprintf("confirmation must be exactly \"v%d\"", parent.Version))
+	}
+	if parent.Freshness != "FRESH" {
+		return nil, humanGateError(errx.Conflict, "source_stale", "canonical source evidence for this version is stale; adjust cannot refresh evidence")
+	}
+	// Recomputing ContentHash uses the same freeze-path helper, which binds the
+	// current ComposerVersion. Rebasing a hash onto a composer that did not
+	// produce the manifest would silently invent a second source of truth.
+	if strings.TrimSpace(parent.Manifest.ComposerVersion) != ComposerVersion {
+		return nil, humanGateError(errx.Conflict, "composer_drift", "this version was composed by another composer version; recompose before adjusting")
+	}
+	if n := len(parent.Manifest.Members); n < 1 || n > HumanGateMaxCohort {
+		return nil, humanGateError(errx.Unprocessable, "cohort_bounds_violation", fmt.Sprintf("cohort holds %d members; the bounded cohort is 1..%d", n, HumanGateMaxCohort))
+	}
+	if parent.Manifest.MaxDailyVolume < 1 || parent.Manifest.MaxDailyVolume > DefaultCohortDispatchCap {
+		return nil, humanGateError(errx.Unprocessable, "cohort_bounds_violation", fmt.Sprintf("max_daily_volume %d is outside the bounded cohort cap 1..%d", parent.Manifest.MaxDailyVolume, DefaultCohortDispatchCap))
+	}
+
+	// Deep-copy the parent manifest. The parent row is never written again;
+	// this is a new artifact that happens to start from the old bytes.
+	next, err := humanGateCloneManifest(&parent.Manifest)
+	if err != nil {
+		return nil, humanGateError(errx.Internal, "cohort_read_failed", "cohort version could not be read")
+	}
+	idx := -1
+	for i := range next.Members {
+		if next.Members[i].CandidateID == candidateID {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return nil, humanGateError(errx.NotFound, "candidate_not_found", "candidate is not in this immutable version")
+	}
+	member := &next.Members[idx]
+	beforeSubject, beforeBody, beforeContentHash := member.Subject, member.BodyText, member.ContentHash
+
+	// Live candidate is best effort: it only gives copy QA the same recipient
+	// context the freeze path had. Live suppression/opt-out/bounce are gates on
+	// GO and on dispatch, not on editing a draft, and are re-read on every GET.
+	live := s.humanGateLiveCandidate(ctx, orgID, parent, member.AccountID, candidateID)
+	if qa := ValidateCopyForRouteClass(member.RouteClass, body, subject, live); len(qa) > 0 {
+		sort.Strings(qa)
+		return nil, humanGateError(errx.Unprocessable, "copy_qa_failed", "adjusted copy failed copy QA: "+strings.Join(qa, ","))
+	}
+
+	member.Subject = subject
+	member.BodyText = body
+	member.ContentHash = hashControlledContent(member.Mailbox, member.RouteClass, subject, body)
+
+	// Every derived value is recomputed with the freeze path's own helpers. A
+	// second hashing implementation is a second source of truth.
+	mailboxes := make([]string, 0, len(next.Members))
+	for i := range next.Members {
+		mailboxes = append(mailboxes, next.Members[i].Mailbox)
+	}
+	next.RecipientSetHash = HashRecipientSet(mailboxes)
+	next.Preview.SamplesByClass = selectPreviewSamples(next.Members, previewSamplePerClass)
+	// N+1 is born with no authority. Carrying the parent's authorization id
+	// into a manifest that nobody authorized is exactly the two-live-authority
+	// bug this operation exists to avoid.
+	next.AuthorizationID = uuid.Nil
+	next.RealEmailSent = false
+	next.AutoSendEnabled = false
+	next.GreenAutorunEnabled = false
+	next.Warnings = humanGateAppendWarning(next.Warnings, "human_adjusted_copy:"+candidateID.String())
+	next.CohortHash = HashFrozenCohort(next)
+	next.CohortID = deriveCohortID(next.SnapshotHash, next.FeedIdentity, next.CohortHash)
+
+	adjustment := HumanGateAdjustment{
+		ID:                uuid.New(),
+		CohortID:          parent.CohortID,
+		FromVersion:       parent.Version,
+		CandidateID:       candidateID,
+		BeforeContentHash: beforeContentHash,
+		AfterContentHash:  member.ContentHash,
+		BeforeFrozenHash:  parent.FrozenHash,
+		AfterFrozenHash:   next.CohortHash,
+		Diff: []HumanGateAdjustmentDiffEntry{
+			{Field: "subject", Before: beforeSubject, After: subject},
+			{Field: "body_text", Before: beforeBody, After: body},
+		},
+		ActorID:       actorID,
+		CorrelationID: strings.TrimSpace(in.CorrelationID),
+		CreatedAt:     now,
+		reason:        reason,
+	}
+	adjustment.Receipt = humanGateReceipt("adjustment", adjustment.ID)
+
+	newVersionID, toVersion, revoked, x := s.humanGateCommitAdjust(ctx, orgID, actorID, versionID, parent, next, &adjustment, key, reqHash)
+	if x != nil {
+		if replay, rx := s.humanGateAdjustmentByIdempotency(ctx, orgID, key, reqHash); replay != nil || rx != nil {
+			return replay, rx
+		}
+		return nil, x
+	}
+	adjustment.ToVersion = toVersion
+	adjustment.RevokedAuthorizationID = revoked
+
+	s.auditHumanGate(ctx, orgID, actorID, "cohort_candidate_copy_adjusted", newVersionID,
+		map[string]string{"version": fmt.Sprint(parent.Version), "frozen_hash": parent.FrozenHash, "content_hash": beforeContentHash},
+		map[string]string{"version": fmt.Sprint(toVersion), "frozen_hash": next.CohortHash, "content_hash": member.ContentHash, "derivation": DerivationAdjust})
+
+	cohort, x := s.GetHumanGateCohort(ctx, orgID, newVersionID, time.Now().UTC())
+	if x != nil {
+		return nil, x
+	}
+	cohort.OperationReceipt = adjustment.Receipt
+	return &HumanGateAdjustResult{ContractVersion: HumanGateContractV1, Cohort: cohort, Adjustment: adjustment}, nil
+}
+
+func humanGateAppendWarning(warnings []string, w string) []string {
+	for _, existing := range warnings {
+		if existing == w {
+			return warnings
+		}
+	}
+	return append(append([]string{}, warnings...), w)
+}
+
+// humanGateCloneManifest round-trips through JSON so the new manifest shares no
+// slice or map backing array with the parent's in-memory copy.
+func humanGateCloneManifest(in *FrozenCohortSnapshot) (*FrozenCohortSnapshot, error) {
+	raw, err := json.Marshal(in)
+	if err != nil {
+		return nil, err
+	}
+	var out FrozenCohortSnapshot
+	if err = json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+func (s *service) humanGateLiveCandidate(ctx context.Context, orgID uuid.UUID, v *HumanGateCohort, accountID, candidateID uuid.UUID) *models.OutreachContactCandidate {
+	if s.repo == nil || v == nil {
+		return nil
+	}
+	accounts, err := AccountsFromOrgForRun(ctx, s.repo, orgID, v.Source, v.SourceRunID)
+	if err != nil {
+		return nil
+	}
+	for i := range accounts {
+		if accounts[i].Account.ID != accountID {
+			continue
+		}
+		for j := range accounts[i].Candidates {
+			if accounts[i].Candidates[j].ID == candidateID {
+				return &accounts[i].Candidates[j]
+			}
+		}
+	}
+	return nil
+}
+
+// humanGateCommitAdjust is the whole side effect, in one transaction:
+// lock the parent, prove it is still the latest version, revoke any live
+// authority it carries, insert N+1, insert the audit row. Nothing here updates
+// the parent's frozen_manifest.
+func (s *service) humanGateCommitAdjust(ctx context.Context, orgID, actorID, versionID uuid.UUID, parent *HumanGateCohort, next *FrozenCohortSnapshot, adjustment *HumanGateAdjustment, key, reqHash string) (uuid.UUID, int, *uuid.UUID, *errx.Error) {
+	tx, err := s.humanGateDB.Begin(ctx)
+	if err != nil {
+		return uuid.Nil, 0, nil, humanGateError(errx.ServiceUnavailable, "human_gate_store_unavailable", "human gate store is not available")
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	var lockedVersion int
+	var lockedHash string
+	err = tx.QueryRow(ctx, `SELECT version,frozen_hash FROM confenge_cohort_versions WHERE id=$1 AND organization_id=$2 FOR UPDATE`, versionID, orgID).Scan(&lockedVersion, &lockedHash)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return uuid.Nil, 0, nil, humanGateError(errx.NotFound, "cohort_version_not_found", "cohort version was not found")
+	}
+	if err != nil {
+		return uuid.Nil, 0, nil, humanGateError(errx.ServiceUnavailable, "human_gate_read_failed", "cohort version could not be locked")
+	}
+	if lockedHash != parent.FrozenHash || lockedVersion != parent.Version {
+		return uuid.Nil, 0, nil, humanGateError(errx.Conflict, "frozen_hash_mismatch", "this version changed while the adjustment was being prepared; re-read it")
+	}
+
+	var maxVersion int
+	if err = tx.QueryRow(ctx, `SELECT COALESCE(max(version),0) FROM confenge_cohort_versions WHERE organization_id=$1 AND cohort_id=$2`, orgID, parent.CohortID).Scan(&maxVersion); err != nil {
+		return uuid.Nil, 0, nil, humanGateError(errx.ServiceUnavailable, "human_gate_read_failed", "cohort versions could not be read")
+	}
+	if maxVersion != lockedVersion {
+		return uuid.Nil, 0, nil, humanGateError(errx.Conflict, "version_superseded", fmt.Sprintf("version %d is no longer the latest version of this cohort (latest is %d); re-read it before adjusting", lockedVersion, maxVersion))
+	}
+
+	revoked, x := humanGateRevokePriorAuthority(ctx, tx, orgID, actorID, versionID, adjustment.reason)
+	if x != nil {
+		return uuid.Nil, 0, nil, x
+	}
+
+	toVersion := lockedVersion + 1
+	manifest, err := json.Marshal(next)
+	if err != nil {
+		return uuid.Nil, 0, nil, humanGateError(errx.Internal, "cohort_store_failed", "adjusted manifest could not be encoded")
+	}
+	newVersionID := uuid.New()
+	_, err = tx.Exec(ctx, `INSERT INTO confenge_cohort_versions
+		(id,organization_id,cohort_id,version,source_run_id,source_system,source_as_of,freshness_expires_at,policy_version,frozen_hash,frozen_manifest,derivation,parent_version,created_by,correlation_id,idempotency_key,request_hash)
+		VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17)`,
+		newVersionID, orgID, parent.CohortID, toVersion, parent.SourceRunID, parent.Source, parent.AsOf, parent.FreshUntil,
+		parent.PolicyVersion, next.CohortHash, manifest, DerivationAdjust, lockedVersion, actorID,
+		adjustment.CorrelationID, key, reqHash)
+	if err != nil {
+		return uuid.Nil, 0, nil, humanGateAdjustWriteError(err, "cohort_store_failed", "adjusted cohort version could not be stored")
+	}
+
+	diff, err := json.Marshal(adjustment.Diff)
+	if err != nil {
+		return uuid.Nil, 0, nil, humanGateError(errx.Internal, "cohort_store_failed", "adjustment diff could not be encoded")
+	}
+	_, err = tx.Exec(ctx, `INSERT INTO confenge_cohort_adjustments
+		(id,organization_id,cohort_id,from_version_id,to_version_id,from_version,to_version,candidate_id,before_content_hash,after_content_hash,before_frozen_hash,after_frozen_hash,diff,reason,revoked_authorization_id,actor_id,correlation_id,receipt,idempotency_key,request_hash,created_at)
+		VALUES($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21)`,
+		adjustment.ID, orgID, parent.CohortID, versionID, newVersionID, lockedVersion, toVersion, adjustment.CandidateID,
+		adjustment.BeforeContentHash, adjustment.AfterContentHash, adjustment.BeforeFrozenHash, adjustment.AfterFrozenHash,
+		diff, adjustment.reason, revoked, actorID, adjustment.CorrelationID, adjustment.Receipt, key, reqHash, adjustment.CreatedAt)
+	if err != nil {
+		return uuid.Nil, 0, nil, humanGateAdjustWriteError(err, "adjustment_store_failed", "adjustment receipt could not be stored")
+	}
+
+	if err = tx.Commit(ctx); err != nil {
+		return uuid.Nil, 0, nil, humanGateAdjustWriteError(err, "adjustment_store_failed", "adjustment could not be committed")
+	}
+	return newVersionID, toVersion, revoked, nil
+}
+
+func humanGateAdjustWriteError(err error, id, message string) *errx.Error {
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+		switch pgErr.ConstraintName {
+		case "confenge_cohort_versions_identity", "confenge_cohort_adjustments_target":
+			return humanGateError(errx.Conflict, "version_superseded", "another adjustment created the next version first; re-read the cohort")
+		case "confenge_cohort_versions_idempotency", "confenge_cohort_adjustments_idempotency":
+			return humanGateError(errx.Conflict, "idempotency_payload_conflict", "Idempotency-Key was already used with another payload")
+		}
+		return humanGateError(errx.Conflict, "version_superseded", "the cohort changed concurrently; re-read it")
+	}
+	return humanGateError(errx.Internal, id, message)
+}
+
+// humanGateRevokePriorAuthority revokes, inside the caller's transaction, any
+// live bounded authority the parent version carries. There must never be two
+// valid authorities over the same cohort. If the authority cannot be proven
+// revoked inside this transaction, the adjustment is refused instead.
+func humanGateRevokePriorAuthority(ctx context.Context, tx pgx.Tx, orgID, actorID, versionID uuid.UUID, reason string) (*uuid.UUID, *errx.Error) {
+	var decision string
+	var authorizationID *uuid.UUID
+	err := tx.QueryRow(ctx, `SELECT decision,authorization_id FROM confenge_cohort_go_decisions
+		WHERE organization_id=$1 AND cohort_version_id=$2 ORDER BY created_at DESC,id DESC LIMIT 1`, orgID, versionID).Scan(&decision, &authorizationID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, humanGateError(errx.Conflict, "authority_active", "the prior version's authorization state could not be read; adjust refuses rather than risk two live authorities")
+	}
+	if decision != "GO" || authorizationID == nil || *authorizationID == uuid.Nil {
+		return nil, nil
+	}
+
+	var reg *string
+	if err = tx.QueryRow(ctx, `SELECT to_regclass('confenge_bounded_cohort_authorizations')::text`).Scan(&reg); err != nil || reg == nil {
+		return nil, humanGateError(errx.Conflict, "authority_active", "version carries a GO authorization that cannot be revoked in this transaction; revoke it explicitly before adjusting")
+	}
+
+	now := time.Now().UTC()
+	var revokedAt *time.Time
+	var expiresAt time.Time
+	err = tx.QueryRow(ctx, `SELECT revoked_at,expires_at FROM confenge_bounded_cohort_authorizations
+		WHERE id=$1 AND organization_id=$2 FOR UPDATE`, *authorizationID, orgID).Scan(&revokedAt, &expiresAt)
+	if errors.Is(err, pgx.ErrNoRows) {
+		// The GO receipt names an authority that no longer exists. Nothing can
+		// dispatch through it, so there is nothing to revoke.
+		return nil, nil
+	}
+	if err != nil {
+		return nil, humanGateError(errx.Conflict, "authority_active", "the prior version's authorization could not be locked; adjust refuses rather than risk two live authorities")
+	}
+	if revokedAt != nil || !now.Before(expiresAt.UTC()) {
+		return nil, nil
+	}
+	tag, err := tx.Exec(ctx, `UPDATE confenge_bounded_cohort_authorizations
+		SET revoked_at=$2, revoke_actor=$3, revoke_reason=$4, updated_at=$2
+		WHERE id=$1 AND organization_id=$5 AND revoked_at IS NULL`, *authorizationID, now, actorID, "human_gate_adjust:"+reason, orgID)
+	if err != nil || tag.RowsAffected() != 1 {
+		return nil, humanGateError(errx.Conflict, "authority_active", "the prior version's authorization could not be atomically revoked; revoke it explicitly, then adjust")
+	}
+	return authorizationID, nil
+}
+
+// humanGateAdjustmentByIdempotency replays a stored adjustment. A replay must
+// return the same adjustment and must not create a second version.
+func (s *service) humanGateAdjustmentByIdempotency(ctx context.Context, orgID uuid.UUID, key, reqHash string) (*HumanGateAdjustResult, *errx.Error) {
+	var stored string
+	var toVersionID uuid.UUID
+	var a HumanGateAdjustment
+	var diff []byte
+	err := s.humanGateDB.QueryRow(ctx, `SELECT id,cohort_id,to_version_id,from_version,to_version,candidate_id,before_content_hash,after_content_hash,before_frozen_hash,after_frozen_hash,diff,reason,revoked_authorization_id,actor_id,correlation_id,receipt,created_at,request_hash
+		FROM confenge_cohort_adjustments WHERE organization_id=$1 AND idempotency_key=$2`, orgID, key).
+		Scan(&a.ID, &a.CohortID, &toVersionID, &a.FromVersion, &a.ToVersion, &a.CandidateID, &a.BeforeContentHash, &a.AfterContentHash,
+			&a.BeforeFrozenHash, &a.AfterFrozenHash, &diff, &a.reason, &a.RevokedAuthorizationID, &a.ActorID, &a.CorrelationID, &a.Receipt, &a.CreatedAt, &stored)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, humanGateError(errx.Internal, "idempotency_read_failed", "idempotency receipt could not be read")
+	}
+	if stored != reqHash {
+		return nil, humanGateError(errx.Conflict, "idempotency_payload_conflict", "Idempotency-Key was already used with another payload")
+	}
+	if json.Unmarshal(diff, &a.Diff) != nil {
+		a.Diff = []HumanGateAdjustmentDiffEntry{}
+	}
+	cohort, x := s.GetHumanGateCohort(ctx, orgID, toVersionID, time.Now().UTC())
+	if x != nil {
+		return nil, x
+	}
+	cohort.OperationReceipt = a.Receipt
+	return &HumanGateAdjustResult{ContractVersion: HumanGateContractV1, Cohort: cohort, Adjustment: a}, nil
+}

--- a/internal/app/confenge/human_gate_adjust_pg_test.go
+++ b/internal/app/confenge/human_gate_adjust_pg_test.go
@@ -1,0 +1,694 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// adjustFixture is one organization with one frozen human-gate version over a
+// real Postgres, plus the in-memory canonical source that version was frozen
+// from. Every test gets a fresh organization id, so tests never observe each
+// other's rows even though they share the schema.
+type adjustFixture struct {
+	t         *testing.T
+	ctx       context.Context
+	pool      *pgxpool.Pool
+	svc       *service
+	repo      *memRepo
+	org       uuid.UUID
+	actor     uuid.UUID
+	runID     string
+	source    string
+	cohortID  uuid.UUID
+	versionID uuid.UUID
+	version   *HumanGateCohort
+	candidate uuid.UUID
+}
+
+func newAdjustFixture(t *testing.T) *adjustFixture {
+	t.Helper()
+	dsn := testPostgresDSN(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	applyBoundedCohortSchema(t, ctx, pool)
+	applyHumanGateSchema(t, pool)
+
+	f := &adjustFixture{
+		t: t, ctx: ctx, pool: pool,
+		repo:   newMemRepo(),
+		org:    uuid.New(),
+		actor:  uuid.New(),
+		runID:  "run-adjust-" + uuid.NewString(),
+		source: "extra-cli",
+	}
+	f.svc = &service{
+		humanGateDB: pool,
+		repo:        f.repo,
+		cohortStore: NewPostgresCohortStore(pool),
+		cfg:         Config{Enabled: true, RepositorySHA: "sha-adjust", FeedMaxAge: 24 * time.Hour},
+	}
+	f.seedCanonicalSource()
+	f.freezeVersionOne()
+	return f
+}
+
+// seedCanonicalSource publishes two accounts with one controlled-eligible
+// generic-company mailbox each. Nothing here is a real mailbox: every domain is
+// .invalid, which can never resolve.
+func (f *adjustFixture) seedCanonicalSource() {
+	f.t.Helper()
+	unknown := true
+	for i, spec := range []struct{ ref, cnpj, mailbox string }{
+		{"acc-adjust-a", "11111111000191", "contato@empresa-a.invalid"},
+		{"acc-adjust-b", "22222222000192", "contato@empresa-b.invalid"},
+	} {
+		acc := cohortAccount(spec.ref, spec.cnpj, "Contrato vigente publicado")
+		acc.ID = uuid.New()
+		acc.OrganizationID = f.org
+		acc.SourceRunID = f.runID
+		cand := models.OutreachContactCandidate{
+			ID:              uuid.New(),
+			AccountID:       acc.ID,
+			Email:           spec.mailbox,
+			MailboxPurpose:  "GENERIC_CONTACT",
+			OwnershipStatus: "COMPANY_OWNED",
+			DiscoveryJSON:   eligibleDisc(f.t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unknown}),
+		}
+		f.repo.mu.Lock()
+		f.repo.byID[acc.ID] = &acc
+		f.repo.cands[acc.ID] = []models.OutreachContactCandidate{cand}
+		f.repo.mu.Unlock()
+		if i == 0 {
+			f.candidate = cand.ID
+		}
+	}
+}
+
+// freezeVersionOne runs the real freeze path and stores version 1 exactly the
+// way CreateHumanGateCohort does.
+func (f *adjustFixture) freezeVersionOne() {
+	f.t.Helper()
+	now := time.Now().UTC()
+	accounts, err := AccountsFromOrgForRun(f.ctx, f.repo, f.org, f.source, f.runID)
+	if err != nil {
+		f.t.Fatalf("load canonical source: %v", err)
+	}
+	freshness := &FeedSourceFreshness{
+		ContractVersion: AuthoritativeFreshnessContractV1,
+		Status:          "FRESH",
+		AsOf:            now.Add(-time.Hour).Format(time.RFC3339Nano),
+		ExpiresAt:       now.Add(23 * time.Hour).Format(time.RFC3339Nano),
+		RunID:           f.runID,
+	}
+	snap, err := PrepareControlledCohort(accounts, CohortPrepareOptions{
+		Now: now, Limit: 5, MaxDailyVolume: 5, TTL: DefaultCohortTTL,
+		RepositorySHA: "sha-adjust", FeedSchemaVersion: models.OutreachSchemaV1,
+		FeedIdentity: f.runID, PolicyVersion: BoundedCohortPolicyV1,
+		EvidenceVersion: DefaultEvidenceVersion, Source: f.source,
+		AuthoritativeSourceFreshness: freshness, RequireAuthoritativeFreshness: true,
+	})
+	if err != nil {
+		f.t.Fatalf("prepare: %v", err)
+	}
+	if len(snap.Members) != 2 {
+		f.t.Fatalf("members = %d, want 2", len(snap.Members))
+	}
+	// The fixture edits whichever member the manifest sorted first; the
+	// candidate id has to come from the frozen bytes, not from seeding order.
+	f.candidate = snap.Members[0].CandidateID
+
+	f.cohortID, f.versionID = uuid.New(), uuid.New()
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	_, err = f.pool.Exec(f.ctx, `INSERT INTO confenge_cohort_versions
+		(id,organization_id,cohort_id,version,source_run_id,source_system,source_as_of,freshness_expires_at,policy_version,frozen_hash,frozen_manifest,created_by,correlation_id,idempotency_key,request_hash)
+		VALUES($1,$2,$3,1,$4,$5,$6,$7,$8,$9,$10,$11,'corr-fixture',$12,'fixture-hash')`,
+		f.versionID, f.org, f.cohortID, f.runID, f.source, now.Add(-time.Hour), now.Add(23*time.Hour),
+		BoundedCohortPolicyV1, snap.CohortHash, raw, f.actor, "fixture-"+uuid.NewString())
+	if err != nil {
+		f.t.Fatalf("store version 1: %v", err)
+	}
+	v, x := f.svc.GetHumanGateCohort(f.ctx, f.org, f.versionID, time.Now().UTC())
+	if x != nil {
+		f.t.Fatalf("read version 1: %v", x)
+	}
+	if v.Freshness != "FRESH" {
+		f.t.Fatalf("fixture freshness = %s", v.Freshness)
+	}
+	if v.Derivation != DerivationCreate || v.ParentVersion != nil {
+		f.t.Fatalf("version 1 derivation = %q parent = %v, want CREATE/nil", v.Derivation, v.ParentVersion)
+	}
+	f.version = v
+}
+
+func (f *adjustFixture) input(key string) HumanGateAdjustInput {
+	return HumanGateAdjustInput{
+		Subject:            "Reajuste contratual: posso enviar o recorte?",
+		BodyText:           "Bom dia. Vi o contrato vigente publicado e preparei um recorte do reajuste. Posso enviar?",
+		Reason:             "assunto anterior estava truncado",
+		Confirmation:       fmt.Sprintf("v%d", f.version.Version),
+		ExpectedFrozenHash: f.version.FrozenHash,
+		IdempotencyKey:     key,
+		CorrelationID:      "corr-" + key,
+	}
+}
+
+func (f *adjustFixture) versionCount() int {
+	f.t.Helper()
+	var n int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM confenge_cohort_versions WHERE organization_id=$1 AND cohort_id=$2`, f.org, f.cohortID).Scan(&n); err != nil {
+		f.t.Fatal(err)
+	}
+	return n
+}
+
+func (f *adjustFixture) rawManifest(versionID uuid.UUID) []byte {
+	f.t.Helper()
+	var raw []byte
+	if err := f.pool.QueryRow(f.ctx, `SELECT frozen_manifest FROM confenge_cohort_versions WHERE id=$1`, versionID).Scan(&raw); err != nil {
+		f.t.Fatal(err)
+	}
+	return raw
+}
+
+func (f *adjustFixture) memberOf(v *HumanGateCohort, candidateID uuid.UUID) *FrozenCohortMember {
+	f.t.Helper()
+	for i := range v.Manifest.Members {
+		if v.Manifest.Members[i].CandidateID == candidateID {
+			return &v.Manifest.Members[i]
+		}
+	}
+	f.t.Fatalf("candidate %s missing from version %d", candidateID, v.Version)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+
+func TestHumanGateAdjustCreatesNextVersionAndLeavesTheParentByteIdentical(t *testing.T) {
+	f := newAdjustFixture(t)
+	before := f.rawManifest(f.versionID)
+	beforeMember := *f.memberOf(f.version, f.candidate)
+
+	in := f.input("adjust-happy-" + uuid.NewString())
+	got, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, in)
+	if x != nil {
+		t.Fatalf("adjust: %v", x)
+	}
+	if got.ContractVersion != HumanGateContractV1 {
+		t.Fatalf("contract = %q", got.ContractVersion)
+	}
+	if got.Cohort.Version != 2 || got.Cohort.CohortID != f.cohortID {
+		t.Fatalf("new version = %d cohort = %s", got.Cohort.Version, got.Cohort.CohortID)
+	}
+	if got.Cohort.Derivation != DerivationAdjust {
+		t.Fatalf("derivation = %q, want ADJUST", got.Cohort.Derivation)
+	}
+	if got.Cohort.ParentVersion == nil || *got.Cohort.ParentVersion != 1 {
+		t.Fatalf("parent_version = %v, want 1", got.Cohort.ParentVersion)
+	}
+	if got.Adjustment.FromVersion != 1 || got.Adjustment.ToVersion != 2 {
+		t.Fatalf("adjustment %d -> %d", got.Adjustment.FromVersion, got.Adjustment.ToVersion)
+	}
+	if got.Adjustment.RevokedAuthorizationID != nil {
+		t.Fatalf("nothing was authorized; revoked = %v", got.Adjustment.RevokedAuthorizationID)
+	}
+	if len(got.Adjustment.Diff) != 2 || got.Adjustment.Diff[0].Field != "subject" || got.Adjustment.Diff[1].Field != "body_text" {
+		t.Fatalf("diff = %+v", got.Adjustment.Diff)
+	}
+
+	// 1. The prior version is byte identical and still readable.
+	if after := f.rawManifest(f.versionID); string(after) != string(before) {
+		t.Fatal("the parent frozen_manifest was rewritten; prior versions must stay byte identical")
+	}
+	parent, x := f.svc.GetHumanGateCohort(f.ctx, f.org, f.versionID, time.Now().UTC())
+	if x != nil {
+		t.Fatalf("re-read parent: %v", x)
+	}
+	if got, want := *f.memberOf(parent, f.candidate), beforeMember; got.Subject != want.Subject || got.BodyText != want.BodyText || got.ContentHash != want.ContentHash {
+		t.Fatal("the parent's copy changed")
+	}
+	if parent.FrozenHash != f.version.FrozenHash {
+		t.Fatal("the parent's frozen hash changed")
+	}
+
+	// 2. Exactly the addressed member changed; every other member is copied.
+	next := got.Cohort
+	edited := f.memberOf(next, f.candidate)
+	if edited.Subject != in.Subject || edited.BodyText != in.BodyText {
+		t.Fatalf("edited copy not applied: %q / %q", edited.Subject, edited.BodyText)
+	}
+	if edited.ContentHash != hashControlledContent(edited.Mailbox, edited.RouteClass, in.Subject, in.BodyText) {
+		t.Fatal("content hash was not recomputed with the freeze path helper")
+	}
+	if edited.Mailbox != beforeMember.Mailbox || edited.RouteClass != beforeMember.RouteClass || edited.EvidenceHash != beforeMember.EvidenceHash {
+		t.Fatal("adjust must not touch recipient, route class or evidence")
+	}
+	for i := range next.Manifest.Members {
+		m := next.Manifest.Members[i]
+		if m.CandidateID == f.candidate {
+			continue
+		}
+		old := f.memberOf(f.version, m.CandidateID)
+		if m.Subject != old.Subject || m.BodyText != old.BodyText || m.ContentHash != old.ContentHash {
+			t.Fatalf("member %s was not copied unchanged", m.CandidateID)
+		}
+	}
+
+	// 3. Hashes were recomputed with the freeze path's own helpers.
+	if next.FrozenHash != HashFrozenCohort(&next.Manifest) {
+		t.Fatal("frozen hash does not match the recomputed manifest hash")
+	}
+	if next.FrozenHash == parent.FrozenHash {
+		t.Fatal("an edited manifest must not keep the parent frozen hash")
+	}
+	if next.Manifest.CohortHash != next.FrozenHash {
+		t.Fatal("manifest cohort_hash and the stored frozen_hash disagree")
+	}
+	if next.Manifest.RecipientSetHash != parent.Manifest.RecipientSetHash {
+		t.Fatal("recipients did not change; the recipient set hash must not change")
+	}
+	if got.Adjustment.BeforeFrozenHash != parent.FrozenHash || got.Adjustment.AfterFrozenHash != next.FrozenHash {
+		t.Fatal("the adjustment receipt does not name both frozen hashes")
+	}
+	if got.Adjustment.BeforeContentHash != beforeMember.ContentHash || got.Adjustment.AfterContentHash != edited.ContentHash {
+		t.Fatal("the adjustment receipt does not name both content hashes")
+	}
+
+	// 4. Preview was recomputed deterministically from the new members.
+	wantSamples := selectPreviewSamples(next.Manifest.Members, previewSamplePerClass)
+	gotSamples, _ := json.Marshal(next.Manifest.Preview.SamplesByClass)
+	expected, _ := json.Marshal(wantSamples)
+	if string(gotSamples) != string(expected) {
+		t.Fatal("preview samples were not recomputed from the adjusted members")
+	}
+
+	// 5. The new version carries no authority of its own.
+	if next.Manifest.AuthorizationID != uuid.Nil {
+		t.Fatal("a freshly adjusted version must not carry an authorization id")
+	}
+	if f.versionCount() != 2 {
+		t.Fatalf("version rows = %d, want 2", f.versionCount())
+	}
+}
+
+// The same intent replayed must return the same adjustment and must not fork
+// the cohort. This is the browser retry after an ambiguous timeout.
+func TestHumanGateAdjustReplayReturnsTheSameAdjustment(t *testing.T) {
+	f := newAdjustFixture(t)
+	key := "adjust-replay-" + uuid.NewString()
+
+	first, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input(key))
+	if x != nil {
+		t.Fatalf("first adjust: %v", x)
+	}
+	second, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input(key))
+	if x != nil {
+		t.Fatalf("replay: %v", x)
+	}
+	if second.Adjustment.ID != first.Adjustment.ID || second.Adjustment.Receipt != first.Adjustment.Receipt {
+		t.Fatalf("replay produced another adjustment: %s vs %s", second.Adjustment.ID, first.Adjustment.ID)
+	}
+	if second.Cohort.ID != first.Cohort.ID || second.Cohort.Version != 2 {
+		t.Fatalf("replay produced another version: %s v%d", second.Cohort.ID, second.Cohort.Version)
+	}
+	if second.Adjustment.AfterFrozenHash != first.Adjustment.AfterFrozenHash {
+		t.Fatal("replay returned a different frozen hash")
+	}
+	if f.versionCount() != 2 {
+		t.Fatalf("version rows = %d, want 2 after a replay", f.versionCount())
+	}
+
+	// The same key with a different payload is a different intent, not a replay.
+	conflicting := f.input(key)
+	conflicting.Subject = "Outro assunto"
+	if _, x = f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, conflicting); x == nil || x.Identifier != "idempotency_payload_conflict" {
+		t.Fatalf("got %#v, want idempotency_payload_conflict", x)
+	}
+
+	// A different key with an identical payload addresses a version that is now
+	// superseded: it must fail loudly rather than silently fork the cohort.
+	forked := f.input("adjust-fork-" + uuid.NewString())
+	if _, x = f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, forked); x == nil || x.Identifier != "version_superseded" {
+		t.Fatalf("got %#v, want version_superseded", x)
+	}
+	if f.versionCount() != 2 {
+		t.Fatalf("version rows = %d, want 2 after a rejected fork", f.versionCount())
+	}
+}
+
+// Two operators adjusting the same version at the same moment must not both
+// create version 2.
+func TestHumanGateAdjustConcurrentDoubleAdjustCreatesOneVersion(t *testing.T) {
+	f := newAdjustFixture(t)
+	const tabs = 4
+	results := make(chan *errx.Error, tabs)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < tabs; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input("adjust-race-"+uuid.NewString()))
+			results <- x
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	accepted, superseded, other := 0, 0, []string{}
+	for x := range results {
+		switch {
+		case x == nil:
+			accepted++
+		case x.Identifier == "version_superseded":
+			superseded++
+		default:
+			other = append(other, x.Identifier)
+		}
+	}
+	if accepted != 1 || superseded != tabs-1 || len(other) != 0 {
+		t.Fatalf("accepted=%d superseded=%d other=%v", accepted, superseded, other)
+	}
+	if n := f.versionCount(); n != 2 {
+		t.Fatalf("version rows = %d, want 2: concurrent adjusts forked the cohort", n)
+	}
+	var adjustments int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM confenge_cohort_adjustments WHERE organization_id=$1`, f.org).Scan(&adjustments); err != nil {
+		t.Fatal(err)
+	}
+	if adjustments != 1 {
+		t.Fatalf("adjustment rows = %d, want 1", adjustments)
+	}
+}
+
+// After a process restart the receipt must still be visible to a brand new
+// pool, and the retry must resolve to the original adjustment rather than
+// creating a second version.
+func TestHumanGateAdjustRetryAfterSimulatedCrashResolvesToTheSameVersion(t *testing.T) {
+	f := newAdjustFixture(t)
+	key := "adjust-crash-" + uuid.NewString()
+	first, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input(key))
+	if x != nil {
+		t.Fatalf("adjust: %v", x)
+	}
+
+	// Simulate the crash: drop every connection and rebuild the service the way
+	// a restarted process would.
+	f.pool.Close()
+	restarted, err := pgxpool.New(f.ctx, testPostgresDSN(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer restarted.Close()
+	f.pool = restarted
+	f.svc = &service{humanGateDB: restarted, repo: f.repo, cohortStore: NewPostgresCohortStore(restarted), cfg: f.svc.cfg}
+
+	replay, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input(key))
+	if x != nil {
+		t.Fatalf("retry after restart: %v", x)
+	}
+	if replay.Adjustment.ID != first.Adjustment.ID || replay.Cohort.ID != first.Cohort.ID {
+		t.Fatal("retry after restart created a second adjustment")
+	}
+	if n := f.versionCount(); n != 2 {
+		t.Fatalf("version rows = %d, want 2 after a restart retry", n)
+	}
+}
+
+// Nothing about the old copy is evidence about the new copy.
+func TestHumanGateAdjustNewVersionInheritsNoValidationReviewOrDecision(t *testing.T) {
+	f := newAdjustFixture(t)
+	now := time.Now().UTC()
+	validationID := uuid.New()
+	for _, m := range f.version.Manifest.Members {
+		id := uuid.New()
+		if _, err := f.pool.Exec(f.ctx, `INSERT INTO confenge_cohort_validations(id,organization_id,cohort_version_id,candidate_id,status,reason,provider,method,evidence_hash,checked_at,expires_at,actor_id,correlation_id,receipt,idempotency_key,request_hash)
+			VALUES($1,$2,$3,$4,'VALID','fixture','warmbly-emailverify','syntax-mx-smtp',$5,$6,$7,$8,'corr',$9,$10,'h')`,
+			id, f.org, f.versionID, m.CandidateID, m.EvidenceHash, now, now.Add(time.Hour), f.actor,
+			humanGateReceipt("validation", id), "val-"+uuid.NewString()); err != nil {
+			t.Fatal(err)
+		}
+		if m.CandidateID == f.candidate {
+			validationID = id
+		}
+		reviewID := uuid.New()
+		if _, err := f.pool.Exec(f.ctx, `INSERT INTO confenge_cohort_candidate_reviews(id,organization_id,cohort_version_id,candidate_id,decision,reason,recipient_hash,content_hash,policy_version,evidence_hash,validation_id,validation_expires_at,actor_id,correlation_id,receipt,idempotency_key,request_hash)
+			VALUES($1,$2,$3,$4,'APPROVE','fixture',$5,$6,$7,$8,$9,$10,$11,'corr',$12,$13,'h')`,
+			reviewID, f.org, f.versionID, m.CandidateID, HashRecipientSet([]string{m.Mailbox}), m.ContentHash,
+			BoundedCohortPolicyV1, m.EvidenceHash, id, now.Add(time.Hour), f.actor,
+			humanGateReceipt("review", reviewID), "rev-"+uuid.NewString()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	decisionID := uuid.New()
+	if _, err := f.pool.Exec(f.ctx, `INSERT INTO confenge_cohort_go_decisions(id,organization_id,cohort_version_id,decision,reason,readiness_hash,actor_id,correlation_id,receipt,idempotency_key,request_hash)
+		VALUES($1,$2,$3,'NO_GO','fixture','readiness',$4,'corr',$5,$6,'h')`,
+		decisionID, f.org, f.versionID, f.actor, humanGateReceipt("decision", decisionID), "dec-"+uuid.NewString()); err != nil {
+		t.Fatal(err)
+	}
+	_ = validationID
+
+	parent, x := f.svc.GetHumanGateCohort(f.ctx, f.org, f.versionID, time.Now().UTC())
+	if x != nil {
+		t.Fatal(x)
+	}
+	f.version = parent
+	for _, c := range parent.Candidates {
+		if c.Validation == nil || c.Review == nil {
+			t.Fatal("fixture did not attach validation and review to version 1")
+		}
+	}
+	if parent.Decision == nil {
+		t.Fatal("fixture did not attach a decision to version 1")
+	}
+
+	got, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input("adjust-inherit-"+uuid.NewString()))
+	if x != nil {
+		t.Fatalf("adjust: %v", x)
+	}
+	if got.Cohort.Decision != nil {
+		t.Fatalf("version 2 inherited a decision: %+v", got.Cohort.Decision)
+	}
+	for _, c := range got.Cohort.Candidates {
+		if c.Validation != nil {
+			t.Fatalf("candidate %s inherited a validation", c.CandidateID)
+		}
+		if c.Review != nil {
+			t.Fatalf("candidate %s inherited a review", c.CandidateID)
+		}
+		if !containsString(c.BlockedBy, "validation_missing") || !containsString(c.BlockedBy, "approval_missing_or_invalid") {
+			t.Fatalf("candidate %s must be blocked as unvalidated and unapproved: %v", c.CandidateID, c.BlockedBy)
+		}
+	}
+	if blockers := humanGateDecisionBlockers(got.Cohort); len(blockers) == 0 {
+		t.Fatal("a freshly adjusted version must not be GO-ready")
+	}
+	// The parent keeps its own receipts.
+	parent, x = f.svc.GetHumanGateCohort(f.ctx, f.org, f.versionID, time.Now().UTC())
+	if x != nil {
+		t.Fatal(x)
+	}
+	if parent.Decision == nil || parent.Candidates[0].Validation == nil || parent.Candidates[0].Review == nil {
+		t.Fatal("adjust must not remove the parent's receipts")
+	}
+}
+
+func TestHumanGateAdjustRefusesMismatchedHashConfirmationAndSupersededVersion(t *testing.T) {
+	f := newAdjustFixture(t)
+
+	badHash := f.input("adjust-badhash-" + uuid.NewString())
+	badHash.ExpectedFrozenHash = strings.Repeat("0", 64)
+	if _, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, badHash); x == nil || x.Identifier != "frozen_hash_mismatch" || x.Code != errx.Conflict {
+		t.Fatalf("got %#v, want 409 frozen_hash_mismatch", x)
+	}
+
+	badConfirm := f.input("adjust-badconfirm-" + uuid.NewString())
+	badConfirm.Confirmation = "v9"
+	if _, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, badConfirm); x == nil || x.Identifier != "confirmation_mismatch" || x.Code != errx.Conflict {
+		t.Fatalf("got %#v, want 409 confirmation_mismatch", x)
+	}
+
+	missing := f.input("adjust-missing-" + uuid.NewString())
+	if _, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, uuid.New(), missing); x == nil || x.Identifier != "candidate_not_found" || x.Code != errx.NotFound {
+		t.Fatalf("got %#v, want 404 candidate_not_found", x)
+	}
+	if n := f.versionCount(); n != 1 {
+		t.Fatalf("version rows = %d, want 1: a refused adjust must write nothing", n)
+	}
+
+	// Accept one adjust, then address the now-superseded version 1 again.
+	if _, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input("adjust-ok-"+uuid.NewString())); x != nil {
+		t.Fatalf("adjust: %v", x)
+	}
+	if _, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input("adjust-late-"+uuid.NewString())); x == nil || x.Identifier != "version_superseded" || x.Code != errx.Conflict {
+		t.Fatalf("got %#v, want 409 version_superseded", x)
+	}
+	if n := f.versionCount(); n != 2 {
+		t.Fatalf("version rows = %d, want 2", n)
+	}
+}
+
+func TestHumanGateAdjustRefusesCopyThatFailsCopyQA(t *testing.T) {
+	f := newAdjustFixture(t)
+	bad := f.input("adjust-qa-" + uuid.NewString())
+	bad.BodyText = "Segue o registro: decision_unit=COMERCIAL; email_discovery_class=GENERIC_COMPANY."
+	_, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, bad)
+	if x == nil || x.Identifier != "copy_qa_failed" || x.Code != errx.Unprocessable {
+		t.Fatalf("got %#v, want 422 copy_qa_failed", x)
+	}
+	if !strings.Contains(x.Message, "internal_dump") {
+		t.Fatalf("copy_qa_failed must name the reason codes: %q", x.Message)
+	}
+	if n := f.versionCount(); n != 1 {
+		t.Fatalf("version rows = %d, want 1: failed copy QA must write nothing", n)
+	}
+}
+
+func TestHumanGateAdjustRefusesImmutableFieldsOverTheRealStore(t *testing.T) {
+	f := newAdjustFixture(t)
+	for _, field := range humanGateImmutableFields {
+		in := f.input("adjust-immutable-" + uuid.NewString())
+		in.RawBody = []byte(`{"subject":"a","body_text":"b","` + field + `":"typed-by-hand"}`)
+		_, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, in)
+		if x == nil || x.Identifier != "immutable_field" || x.Code != errx.Unprocessable {
+			t.Fatalf("%s: got %#v, want 422 immutable_field", field, x)
+		}
+		if !strings.Contains(x.Message, field) {
+			t.Fatalf("%s: error must name the field: %q", field, x.Message)
+		}
+	}
+	if n := f.versionCount(); n != 1 {
+		t.Fatalf("version rows = %d, want 1", n)
+	}
+}
+
+// A live authority on the prior version is revoked in the same transaction that
+// creates N+1. There must never be two valid authorities.
+func TestHumanGateAdjustRevokesTheLiveAuthorityAtomically(t *testing.T) {
+	f := newAdjustFixture(t)
+	authID := f.authorizeVersionOne(t, time.Now().UTC().Add(6*time.Hour))
+
+	got, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input("adjust-revoke-"+uuid.NewString()))
+	if x != nil {
+		t.Fatalf("adjust: %v", x)
+	}
+	if got.Adjustment.RevokedAuthorizationID == nil || *got.Adjustment.RevokedAuthorizationID != authID {
+		t.Fatalf("revoked = %v, want %s", got.Adjustment.RevokedAuthorizationID, authID)
+	}
+	var live int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM confenge_bounded_cohort_authorizations WHERE organization_id=$1 AND revoked_at IS NULL AND expires_at > now()`, f.org).Scan(&live); err != nil {
+		t.Fatal(err)
+	}
+	if live != 0 {
+		t.Fatalf("live authorities = %d, want 0: adjust must never leave two valid authorities", live)
+	}
+	grant, err := f.svc.cohortStore.GetGrant(f.ctx, authID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grant.RevokedAt == nil || !strings.HasPrefix(grant.RevokeReason, "human_gate_adjust:") {
+		t.Fatalf("prior authority not revoked with an attributable reason: %+v", grant.Summary())
+	}
+	if got.Cohort.Manifest.AuthorizationID != uuid.Nil {
+		t.Fatal("the adjusted version must not be born with an authority")
+	}
+}
+
+// If the authority cannot be proven revoked inside the same transaction, the
+// adjustment is refused and nothing is written.
+func TestHumanGateAdjustRefusesWhenTheLiveAuthorityCannotBeRevoked(t *testing.T) {
+	f := newAdjustFixture(t)
+	// A GO receipt naming an authority row that this transaction cannot lock:
+	// the decision points at an id that is not in the authority table, but the
+	// GO receipt itself is durable, so adjust must fail closed rather than
+	// assume the authority is dead.
+	ghost := uuid.New()
+	f.recordGO(t, ghost)
+	if _, err := f.pool.Exec(f.ctx, `ALTER TABLE confenge_bounded_cohort_authorizations RENAME TO confenge_bounded_cohort_authorizations_hidden`); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		_, _ = f.pool.Exec(f.ctx, `ALTER TABLE confenge_bounded_cohort_authorizations_hidden RENAME TO confenge_bounded_cohort_authorizations`)
+	}()
+
+	_, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input("adjust-authority-"+uuid.NewString()))
+	if x == nil || x.Identifier != "authority_active" || x.Code != errx.Conflict {
+		t.Fatalf("got %#v, want 409 authority_active", x)
+	}
+	if n := f.versionCount(); n != 1 {
+		t.Fatalf("version rows = %d, want 1: a refused adjust must write nothing", n)
+	}
+}
+
+// A GO whose authority already expired is not a live authority.
+func TestHumanGateAdjustProceedsWhenThePriorAuthorityIsAlreadyDead(t *testing.T) {
+	f := newAdjustFixture(t)
+	authID := f.authorizeVersionOne(t, time.Now().UTC().Add(-time.Minute))
+
+	got, x := f.svc.AdjustHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidate, f.input("adjust-expired-"+uuid.NewString()))
+	if x != nil {
+		t.Fatalf("adjust: %v", x)
+	}
+	if got.Adjustment.RevokedAuthorizationID != nil {
+		t.Fatalf("an expired authority must not be reported as revoked by this adjust: %v", got.Adjustment.RevokedAuthorizationID)
+	}
+	grant, err := f.svc.cohortStore.GetGrant(f.ctx, authID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if grant.RevokedAt != nil {
+		t.Fatal("adjust must not rewrite the revocation history of a dead authority")
+	}
+}
+
+// authorizeVersionOne stores a real bounded authority bound to version 1's
+// frozen manifest and the GO receipt that points at it.
+func (f *adjustFixture) authorizeVersionOne(t *testing.T, expiresAt time.Time) uuid.UUID {
+	t.Helper()
+	snapshot := f.version.Manifest
+	snapshot.AuthorizationID = uuid.New()
+	auth, err := GrantFromFrozenSnapshot(&snapshot, f.org, f.actor, time.Now().UTC())
+	if err != nil {
+		t.Fatalf("grant: %v", err)
+	}
+	auth.ExpiresAt = expiresAt
+	auth.TTL = expiresAt.Sub(auth.AuthorizedAt)
+	if err = f.svc.cohortStore.PutGrant(f.ctx, auth); err != nil {
+		t.Fatalf("put grant: %v", err)
+	}
+	if err = f.svc.cohortStore.RecordGOReview(f.ctx, auth.ID, f.actor, HumanGateReadyVerdict, "fixture", time.Now().UTC()); err != nil {
+		t.Fatalf("record go review: %v", err)
+	}
+	f.recordGO(t, auth.ID)
+	return auth.ID
+}
+
+func (f *adjustFixture) recordGO(t *testing.T, authorizationID uuid.UUID) {
+	t.Helper()
+	id := uuid.New()
+	if _, err := f.pool.Exec(f.ctx, `INSERT INTO confenge_cohort_go_decisions(id,organization_id,cohort_version_id,decision,reason,readiness_hash,authorization_id,actor_id,correlation_id,receipt,idempotency_key,request_hash)
+		VALUES($1,$2,$3,'GO','fixture','readiness',$4,$5,'corr',$6,$7,'h')`,
+		id, f.org, f.versionID, authorizationID, f.actor, humanGateReceipt("decision", id), "go-"+uuid.NewString()); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/app/confenge/human_gate_adjust_test.go
+++ b/internal/app/confenge/human_gate_adjust_test.go
@@ -1,0 +1,126 @@
+package confenge
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+// Every protected field must be refused by name. A typed struct would silently
+// drop these keys, so the caller would believe the recipient changed.
+func TestHumanGateAdjustRefusesEveryImmutableFieldByName(t *testing.T) {
+	cases := map[string]string{
+		"mailbox":          `{"mailbox":"ops@company.invalid"}`,
+		"mailbox_purpose":  `{"mailbox_purpose":"PERSONAL_WORK"}`,
+		"recipient":        `{"recipient":"someone"}`,
+		"recipient_hash":   `{"recipient_hash":"deadbeef"}`,
+		"evidence":         `{"evidence":"fabricated"}`,
+		"evidence_hash":    `{"evidence_hash":"deadbeef"}`,
+		"source":           `{"source":"typed-by-hand"}`,
+		"source_run_id":    `{"source_run_id":"run-2"}`,
+		"policy_version":   `{"policy_version":"policy-v9"}`,
+		"route_class":      `{"route_class":"DIRECT_PERSON"}`,
+		"composer_version": `{"composer_version":"confenge.composer.v9"}`,
+	}
+	for want, body := range cases {
+		t.Run(want, func(t *testing.T) {
+			if got := humanGateImmutableField([]byte(body)); got != want {
+				t.Fatalf("immutable field = %q, want %q", got, want)
+			}
+			x := humanGateImmutableFieldError(want)
+			if x.Code != errx.Unprocessable || x.Identifier != "immutable_field" {
+				t.Fatalf("code=%d identifier=%q", x.Code, x.Identifier)
+			}
+		})
+	}
+}
+
+func TestHumanGateAdjustAcceptsOnlyCopyFields(t *testing.T) {
+	body := `{"subject":"Assunto","body_text":"Corpo","reason":"typo no assunto","confirmation":"v1","expected_frozen_hash":"abc"}`
+	if got := humanGateImmutableField([]byte(body)); got != "" {
+		t.Fatalf("copy-only body must be accepted, got %q", got)
+	}
+	if got := humanGateImmutableField(nil); got != "" {
+		t.Fatalf("absent raw body must not invent a violation, got %q", got)
+	}
+}
+
+// The immutable-field refusal must be reported before any other validation, so
+// a caller that tried to retype a mailbox is told that, not that its reason was
+// too short.
+func TestHumanGateAdjustImmutableFieldOutranksOtherValidation(t *testing.T) {
+	svc := &service{humanGateDB: new(pgxpool.Pool)}
+	_, x := svc.AdjustHumanGateCandidate(t.Context(), uuid.New(), uuid.New(), uuid.New(), uuid.New(), HumanGateAdjustInput{
+		RawBody: []byte(`{"mailbox":"ops@company.invalid","subject":"","reason":"x"}`),
+	})
+	if x == nil || x.Identifier != "immutable_field" {
+		t.Fatalf("got %#v, want immutable_field", x)
+	}
+}
+
+func TestHumanGateAdjustRequiresHumanActor(t *testing.T) {
+	svc := &service{humanGateDB: new(pgxpool.Pool)}
+	if _, x := svc.AdjustHumanGateCandidate(t.Context(), uuid.New(), uuid.Nil, uuid.New(), uuid.New(), HumanGateAdjustInput{}); x != errx.ErrUnauthorized {
+		t.Fatalf("got %#v, want unauthorized", x)
+	}
+}
+
+// Recomputing hashes must reuse the freeze path's own helpers, and must be a
+// pure function of the frozen bytes: the same edit applied twice produces the
+// same content hash and the same cohort hash.
+func TestHumanGateAdjustHashRecomputationIsDeterministic(t *testing.T) {
+	member := FrozenCohortMember{
+		AccountRef: "acc-1", CandidateRef: "cand-1", Mailbox: "contato@empresa.invalid",
+		RouteClass: RouteClassGenericCompany, EvidenceHash: "evidence-1",
+	}
+	subject, body := "Reajuste contratual", "Bom dia. Posso enviar o recorte do contrato?"
+	first := hashControlledContent(member.Mailbox, member.RouteClass, subject, body)
+	second := hashControlledContent(member.Mailbox, member.RouteClass, subject, body)
+	if first != second || first == "" {
+		t.Fatalf("content hash is not deterministic: %q vs %q", first, second)
+	}
+	if first == hashControlledContent(member.Mailbox, member.RouteClass, subject, body+" ok") {
+		t.Fatal("a different body must produce a different content hash")
+	}
+
+	snap := &FrozenCohortSnapshot{Members: []FrozenCohortMember{member}}
+	snap.Members[0].ContentHash = first
+	a := HashFrozenCohort(snap)
+	clone, err := humanGateCloneManifest(snap)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if b := HashFrozenCohort(clone); a != b {
+		t.Fatalf("cohort hash is not deterministic across a clone: %q vs %q", a, b)
+	}
+	clone.Members[0].ContentHash = "other"
+	if HashFrozenCohort(clone) == a {
+		t.Fatal("changed member content must change the cohort hash")
+	}
+	// The clone must not alias the parent's backing array.
+	if snap.Members[0].ContentHash != first {
+		t.Fatal("cloning a manifest must not mutate the parent")
+	}
+}
+
+func TestHumanGateAdjustDiffCarriesBothCopyFields(t *testing.T) {
+	diff := []HumanGateAdjustmentDiffEntry{
+		{Field: "subject", Before: "a", After: "b"},
+		{Field: "body_text", Before: "c", After: "d"},
+	}
+	raw, err := json.Marshal(diff)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var back []HumanGateAdjustmentDiffEntry
+	if err = json.Unmarshal(raw, &back); err != nil {
+		t.Fatal(err)
+	}
+	if len(back) != 2 || back[0].Field != "subject" || back[1].Field != "body_text" {
+		t.Fatalf("diff round trip = %+v", back)
+	}
+}

--- a/internal/app/confenge/human_gate_pg_test.go
+++ b/internal/app/confenge/human_gate_pg_test.go
@@ -17,13 +17,24 @@ import (
 func applyHumanGateSchema(t *testing.T, pool *pgxpool.Pool) {
 	t.Helper()
 	_, file, _, _ := runtime.Caller(0)
-	raw, err := os.ReadFile(filepath.Join(filepath.Dir(file), "..", "..", "infrastructure", "db", "migrations", "000116_confenge_human_gate.up.sql"))
-	if err != nil {
-		t.Fatal(err)
+	dir := filepath.Join(filepath.Dir(file), "..", "..", "infrastructure", "db", "migrations")
+	for _, name := range []string{
+		"000116_confenge_human_gate.up.sql",
+		"000117_confenge_cohort_derivation.up.sql",
+	} {
+		raw, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err = pool.Exec(context.Background(), string(raw)); err != nil {
+			t.Fatalf("apply %s: %v", name, err)
+		}
 	}
-	if _, err = pool.Exec(context.Background(), string(raw)); err != nil {
-		t.Fatal(err)
-	}
+}
+
+func dropHumanGateSchema(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	_, _ = pool.Exec(context.Background(), "DROP TABLE IF EXISTS confenge_cohort_adjustments,confenge_cohort_go_decisions,confenge_cohort_candidate_reviews,confenge_cohort_validations,confenge_cohort_versions")
 }
 
 func TestHumanGatePostgresIdempotencySurvivesConcurrencyAndRestart(t *testing.T) {
@@ -128,7 +139,7 @@ func TestHumanGatePostgresIdempotencySurvivesConcurrencyAndRestart(t *testing.T)
 	}
 	defer afterCrash.Close()
 	defer func() {
-		_, _ = afterCrash.Exec(ctx, "DROP TABLE IF EXISTS confenge_cohort_go_decisions,confenge_cohort_candidate_reviews,confenge_cohort_validations,confenge_cohort_versions")
+		_, _ = afterCrash.Exec(ctx, "DROP TABLE IF EXISTS confenge_cohort_adjustments,confenge_cohort_go_decisions,confenge_cohort_candidate_reviews,confenge_cohort_validations,confenge_cohort_versions")
 	}()
 	for table, key := range map[string]string{
 		"confenge_cohort_versions":          "same-two-tabs",

--- a/internal/app/confenge/messageability.go
+++ b/internal/app/confenge/messageability.go
@@ -25,7 +25,12 @@ const (
 
 // ComposerVersion stamps the outbound-safe composer. Prior-version unsent
 // drafts are identifiable and must be regenerated.
-const ComposerVersion = "confenge.composer.v3"
+// Bumped to v4 on 2026-08-23: the projection now de-shouts edital prose,
+// collapses verbatim repeated n-grams, stops the "contratação pública:
+// contratação" label stutter and terminates a fact without producing ",.".
+// Copy composed by v3 is materially different text, so a v3 grant must not
+// authorize v4 output — release_manifest.go already fails closed on drift.
+const ComposerVersion = "confenge.composer.v4"
 
 // Outbound hook classes from the service playbook.
 const (
@@ -400,7 +405,9 @@ func condenseMetadataFact(raw string) string {
 		obj = stripTruncation(obj)
 		obj = cutAtWordBoundary(strings.TrimSpace(obj), 160)
 		if obj != "" {
-			return "contratação pública: " + ensureLowerStart(obj)
+			// The label and the object both start with "contratação" often
+			// enough that the pair read as a stutter in live copy.
+			return dropRedundantLeadingLabel("contratação pública", obj)
 		}
 	}
 	// Fall back to a short natural clause without labels.

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -129,6 +129,10 @@ type Service interface {
 	GetHumanGateCohort(ctx context.Context, orgID, id uuid.UUID, now time.Time) (*HumanGateCohort, *errx.Error)
 	RecordHumanGateValidation(ctx context.Context, orgID, actorID, versionID, candidateID uuid.UUID, result emailverify.Result, key, correlation string) (*HumanGateCohort, *errx.Error)
 	ReviewHumanGateCandidate(ctx context.Context, orgID, actorID, versionID, candidateID uuid.UUID, in HumanGateReviewInput) (*HumanGateCohort, *errx.Error)
+	// AdjustHumanGateCandidate forks an immutable version into N+1 carrying a
+	// human copy edit for one candidate. It queues, dispatches, sends and
+	// resumes nothing.
+	AdjustHumanGateCandidate(ctx context.Context, orgID, actorID, versionID, candidateID uuid.UUID, in HumanGateAdjustInput) (*HumanGateAdjustResult, *errx.Error)
 	DecideHumanGateCohort(ctx context.Context, orgID, actorID, versionID uuid.UUID, in HumanGateDecisionInput) (*HumanGateCohort, *errx.Error)
 
 	// confenge-dossier/1.0 manifest references. Card metadata, never a send path.

--- a/internal/infrastructure/db/migrations/000117_confenge_cohort_derivation.down.sql
+++ b/internal/infrastructure/db/migrations/000117_confenge_cohort_derivation.down.sql
@@ -1,0 +1,15 @@
+DROP INDEX IF EXISTS confenge_cohort_adjustments_from_idx;
+DROP INDEX IF EXISTS confenge_cohort_adjustments_cohort_idx;
+DROP TABLE IF EXISTS confenge_cohort_adjustments;
+
+ALTER TABLE confenge_cohort_versions
+    DROP CONSTRAINT IF EXISTS confenge_cohort_versions_parent_check;
+
+ALTER TABLE confenge_cohort_versions
+    DROP CONSTRAINT IF EXISTS confenge_cohort_versions_derivation_check;
+
+ALTER TABLE confenge_cohort_versions
+    DROP COLUMN IF EXISTS parent_version;
+
+ALTER TABLE confenge_cohort_versions
+    DROP COLUMN IF EXISTS derivation;

--- a/internal/infrastructure/db/migrations/000117_confenge_cohort_derivation.up.sql
+++ b/internal/infrastructure/db/migrations/000117_confenge_cohort_derivation.up.sql
@@ -1,0 +1,99 @@
+-- Human-gate derivation taxonomy.
+--
+-- Every confenge_cohort_versions row is now explicit about HOW it came to
+-- exist, because "version N+1 exists" alone cannot answer the only question
+-- that matters at audit time: is this the same bytes, the same composer, or a
+-- human's edit?
+--
+--   CREATE    first freeze of a cohort from a canonical source run
+--   REPRODUCE frozen_manifest copied byte-for-byte from the parent version
+--   RECOMPOSE reserved: re-run the composer against current source/policy
+--             /composer. Not implemented yet; the taxonomy is durable first so
+--             existing rows never have to be reinterpreted later.
+--   ADJUST    a human edited subject/body for exactly one candidate; every
+--             other member is copied unchanged and hashes are recomputed.
+--
+-- parent_version names the version this row was derived from, within the same
+-- (organization_id, cohort_id). It is NULL only for CREATE.
+
+ALTER TABLE confenge_cohort_versions
+    ADD COLUMN IF NOT EXISTS derivation text NOT NULL DEFAULT 'CREATE';
+
+ALTER TABLE confenge_cohort_versions
+    ADD COLUMN IF NOT EXISTS parent_version integer;
+
+-- Backfill: rows written before this migration are either a byte-for-byte
+-- reproduction (they carry reproduced_from_version) or an original freeze.
+UPDATE confenge_cohort_versions
+   SET derivation = 'REPRODUCE'
+ WHERE reproduced_from_version IS NOT NULL
+   AND derivation = 'CREATE';
+
+UPDATE confenge_cohort_versions
+   SET parent_version = reproduced_from_version
+ WHERE reproduced_from_version IS NOT NULL
+   AND parent_version IS NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conname = 'confenge_cohort_versions_derivation_check'
+    ) THEN
+        ALTER TABLE confenge_cohort_versions
+            ADD CONSTRAINT confenge_cohort_versions_derivation_check
+            CHECK (derivation IN ('CREATE','REPRODUCE','RECOMPOSE','ADJUST'));
+    END IF;
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+         WHERE conname = 'confenge_cohort_versions_parent_check'
+    ) THEN
+        ALTER TABLE confenge_cohort_versions
+            ADD CONSTRAINT confenge_cohort_versions_parent_check
+            CHECK (
+                (derivation = 'CREATE' AND parent_version IS NULL)
+                OR (derivation <> 'CREATE' AND parent_version IS NOT NULL AND parent_version < version)
+            );
+    END IF;
+END
+$$;
+
+-- Per-candidate audit of every human copy adjustment. One row per accepted
+-- adjust; the immutable before/after hashes make the edit provable without
+-- re-reading either manifest.
+CREATE TABLE IF NOT EXISTS confenge_cohort_adjustments (
+    id uuid PRIMARY KEY,
+    organization_id uuid NOT NULL,
+    cohort_id uuid NOT NULL,
+    from_version_id uuid NOT NULL REFERENCES confenge_cohort_versions(id) ON DELETE RESTRICT,
+    to_version_id uuid NOT NULL REFERENCES confenge_cohort_versions(id) ON DELETE RESTRICT,
+    from_version integer NOT NULL CHECK (from_version > 0),
+    to_version integer NOT NULL CHECK (to_version > from_version),
+    candidate_id uuid NOT NULL,
+    before_content_hash text NOT NULL,
+    after_content_hash text NOT NULL,
+    before_frozen_hash text NOT NULL,
+    after_frozen_hash text NOT NULL,
+    diff jsonb NOT NULL DEFAULT '[]'::jsonb,
+    reason text NOT NULL,
+    revoked_authorization_id uuid,
+    actor_id uuid NOT NULL,
+    correlation_id text NOT NULL,
+    receipt text NOT NULL,
+    idempotency_key text NOT NULL,
+    request_hash text NOT NULL,
+    created_at timestamptz NOT NULL DEFAULT now(),
+    CONSTRAINT confenge_cohort_adjustments_idempotency UNIQUE (organization_id, idempotency_key),
+    CONSTRAINT confenge_cohort_adjustments_target UNIQUE (to_version_id, candidate_id)
+);
+
+CREATE INDEX IF NOT EXISTS confenge_cohort_adjustments_cohort_idx
+    ON confenge_cohort_adjustments (organization_id, cohort_id, created_at DESC, id DESC);
+
+CREATE INDEX IF NOT EXISTS confenge_cohort_adjustments_from_idx
+    ON confenge_cohort_adjustments (from_version_id, created_at DESC, id DESC);

--- a/internal/pkg/emailverify/compose_env_test.go
+++ b/internal/pkg/emailverify/compose_env_test.go
@@ -1,0 +1,281 @@
+package emailverify
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// This package's correctness depends on something outside Go: the backend
+// CONTAINER must actually receive EMAIL_VERIFY_HELO_HOST / EMAIL_VERIFY_MAIL_FROM.
+// The production incident was exactly that gap — the code read both variables,
+// the host .env defined both, and the compose file in between propagated
+// neither, so the running backend fell back to "localhost" and recorded its own
+// HELO refusals against real recipients.
+//
+// A grep for the literal string would pass on a var that is defined in a stanza
+// no service consumes. These tests parse the compose YAML, resolve anchors and
+// merge keys the way the compose engine does, and assert the value resolves ON
+// THE BACKEND SERVICE.
+
+// composeFiles are the two files that must agree: the canonical root compose
+// and the production overlay.
+var composeFiles = []struct {
+	path    string
+	service string
+}{
+	{"docker-compose.yml", "backend"},
+	{filepath.Join("deploy", "confenge-vps", "docker-compose.override.yml"), "backend"},
+}
+
+// requiredVerifierEnv must resolve on the backend service to a pure
+// interpolation of the same-named variable with an EMPTY default. An empty
+// default is load-bearing: a missing value must fail closed (boot refusal in
+// production, UNKNOWN elsewhere) rather than invent an identity, and a
+// hardcoded default would put a real hostname into a committed file.
+var requiredVerifierEnv = []string{EnvHeloHost, EnvMailFrom}
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			if _, err := os.Stat(filepath.Join(dir, "docker-compose.yml")); err == nil {
+				return dir
+			}
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate repo root above %s", dir)
+		}
+		dir = parent
+	}
+}
+
+// deref follows YAML aliases (*anchor) to the node they point at.
+func deref(n *yaml.Node) *yaml.Node {
+	for n != nil && n.Kind == yaml.AliasNode {
+		n = n.Alias
+	}
+	return n
+}
+
+// mergeSources returns the mapping nodes referenced by a "<<" merge key, which
+// may be a single alias or a sequence of them.
+func mergeSources(n *yaml.Node) []*yaml.Node {
+	n = deref(n)
+	if n == nil {
+		return nil
+	}
+	if n.Kind == yaml.SequenceNode {
+		out := make([]*yaml.Node, 0, len(n.Content))
+		for _, item := range n.Content {
+			if d := deref(item); d != nil && d.Kind == yaml.MappingNode {
+				out = append(out, d)
+			}
+		}
+		return out
+	}
+	if n.Kind == yaml.MappingNode {
+		return []*yaml.Node{n}
+	}
+	return nil
+}
+
+// mapValue looks a key up in a mapping, honouring merge keys with the same
+// precedence the YAML spec gives them: an explicit key wins over a merged one.
+func mapValue(n *yaml.Node, key string) *yaml.Node {
+	n = deref(n)
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil
+	}
+	var merged []*yaml.Node
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		k, v := n.Content[i], n.Content[i+1]
+		if k.Value == "<<" {
+			merged = append(merged, mergeSources(v)...)
+			continue
+		}
+		if k.Value == key {
+			return v
+		}
+	}
+	for _, m := range merged {
+		if got := mapValue(m, key); got != nil {
+			return got
+		}
+	}
+	return nil
+}
+
+// flattenEnv renders a compose `environment:` block as the engine would, in
+// either supported form (mapping or "KEY=value" list) and through merge keys.
+func flattenEnv(n *yaml.Node) map[string]string {
+	out := map[string]string{}
+	n = deref(n)
+	if n == nil {
+		return out
+	}
+	if n.Kind == yaml.SequenceNode {
+		for _, item := range n.Content {
+			if d := deref(item); d != nil && d.Kind == yaml.ScalarNode {
+				k, v, _ := strings.Cut(d.Value, "=")
+				out[strings.TrimSpace(k)] = v
+			}
+		}
+		return out
+	}
+	if n.Kind != yaml.MappingNode {
+		return out
+	}
+	var merged []*yaml.Node
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		k, v := n.Content[i], n.Content[i+1]
+		if k.Value == "<<" {
+			merged = append(merged, mergeSources(v)...)
+			continue
+		}
+		if d := deref(v); d != nil {
+			out[k.Value] = d.Value
+		}
+	}
+	for _, m := range merged {
+		for mk, mv := range flattenEnv(m) {
+			if _, ok := out[mk]; !ok {
+				out[mk] = mv
+			}
+		}
+	}
+	return out
+}
+
+func serviceEnv(t *testing.T, path, service string) map[string]string {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	if len(doc.Content) == 0 {
+		t.Fatalf("%s is empty", path)
+	}
+	svc := mapValue(mapValue(doc.Content[0], "services"), service)
+	if svc == nil {
+		t.Fatalf("%s has no service %q", path, service)
+	}
+	return flattenEnv(mapValue(svc, "environment"))
+}
+
+// TestVerifierIdentityReachesBackendService fails the build if either variable
+// stops reaching the backend service in either compose file.
+func TestVerifierIdentityReachesBackendService(t *testing.T) {
+	root := repoRoot(t)
+	for _, cf := range composeFiles {
+		env := serviceEnv(t, filepath.Join(root, cf.path), cf.service)
+		for _, key := range requiredVerifierEnv {
+			val, ok := env[key]
+			if !ok {
+				t.Fatalf("%s: service %q does not receive %s; the backend container "+
+					"would fall back to an unusable prober identity", cf.path, cf.service, key)
+			}
+			want := regexp.MustCompile(`^\$\{` + regexp.QuoteMeta(key) + `(:-)?\}$`)
+			if !want.MatchString(strings.TrimSpace(val)) {
+				t.Fatalf("%s: %s on service %q must be %q (empty default so a missing "+
+					"value fails closed instead of inventing an identity), got %q",
+					cf.path, key, cf.service, "${"+key+":-}", val)
+			}
+		}
+	}
+}
+
+// TestComposeFilesCarryNoHardcodedVerifierIdentity: the canonical values live in
+// the host .env, never in a committed file. A literal here would both leak an
+// operational identity into git and silently paper over a missing .env.
+func TestComposeFilesCarryNoHardcodedVerifierIdentity(t *testing.T) {
+	root := repoRoot(t)
+	for _, cf := range composeFiles {
+		raw, err := os.ReadFile(filepath.Join(root, cf.path))
+		if err != nil {
+			t.Fatalf("read %s: %v", cf.path, err)
+		}
+		for _, line := range strings.Split(string(raw), "\n") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "#") {
+				continue
+			}
+			for _, key := range requiredVerifierEnv {
+				if !strings.HasPrefix(trimmed, key+":") && !strings.HasPrefix(trimmed, "- "+key+"=") {
+					continue
+				}
+				if !strings.Contains(trimmed, "${"+key) {
+					t.Fatalf("%s: %s must be an interpolation, not a literal: %q", cf.path, key, trimmed)
+				}
+				// "${KEY:-something}" would reintroduce an invented identity.
+				if idx := strings.Index(trimmed, "${"+key+":-"); idx >= 0 {
+					rest := trimmed[idx+len("${"+key+":-"):]
+					if !strings.HasPrefix(rest, "}") {
+						t.Fatalf("%s: %s must have an EMPTY default so a missing value fails "+
+							"closed, got %q", cf.path, key, trimmed)
+					}
+				}
+			}
+		}
+	}
+}
+
+// TestDockerComposeConfigResolvesVerifierIdentity is the belt-and-braces check
+// against the real compose engine: it renders the merged root+overlay config and
+// asserts our probe value lands on the backend. YAML parsing above is the
+// load-bearing assertion; this only runs where docker exists.
+func TestDockerComposeConfigResolvesVerifierIdentity(t *testing.T) {
+	if _, err := exec.LookPath("docker"); err != nil {
+		t.Skip("docker not available; TestVerifierIdentityReachesBackendService is the primary assertion")
+	}
+	root := repoRoot(t)
+	const probeHelo = "compose-probe.example.invalid"
+	const probeFrom = "probe@compose-probe.example.invalid"
+
+	cmd := exec.Command("docker", "compose",
+		"-f", "docker-compose.yml",
+		"-f", filepath.Join("deploy", "confenge-vps", "docker-compose.override.yml"),
+		"config")
+	cmd.Dir = root
+	cmd.Env = append(os.Environ(),
+		EnvHeloHost+"="+probeHelo,
+		EnvMailFrom+"="+probeFrom,
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Skipf("docker compose config unavailable in this environment (%v); YAML assertions still apply:\n%s", err, out)
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(out, &doc); err != nil {
+		t.Fatalf("parse docker compose config output: %v", err)
+	}
+	if len(doc.Content) == 0 {
+		t.Fatal("docker compose config produced no document")
+	}
+	backend := mapValue(mapValue(doc.Content[0], "services"), "backend")
+	if backend == nil {
+		t.Fatal("rendered config has no backend service")
+	}
+	env := flattenEnv(mapValue(backend, "environment"))
+	if env[EnvHeloHost] != probeHelo {
+		t.Fatalf("rendered backend %s = %q, want %q", EnvHeloHost, env[EnvHeloHost], probeHelo)
+	}
+	if env[EnvMailFrom] != probeFrom {
+		t.Fatalf("rendered backend %s = %q, want %q", EnvMailFrom, env[EnvMailFrom], probeFrom)
+	}
+}

--- a/internal/pkg/emailverify/emailverify.go
+++ b/internal/pkg/emailverify/emailverify.go
@@ -104,12 +104,30 @@ type Config struct {
 	MXTimeout time.Duration
 }
 
-func (c Config) withDefaults() Config {
-	if c.HeloHost == "" {
-		c.HeloHost = "localhost"
+// usableHeloHost reports whether the announced name is a fully-qualified
+// hostname a remote MTA will accept. RFC 5321 4.1.1.1 requires a FQDN, and a
+// bare name such as "localhost" is rejected by any server that enforces it —
+// producing a 5xx that names *our* identity, not the recipient.
+func usableHeloHost(name string) bool {
+	name = strings.TrimSpace(strings.TrimSuffix(name, "."))
+	if name == "" || strings.EqualFold(name, "localhost") {
+		return false
 	}
-	if c.MailFrom == "" {
-		c.MailFrom = "verify@" + c.HeloHost
+	if strings.ContainsAny(name, " \t\r\n") || !strings.Contains(name, ".") {
+		return false
+	}
+	if strings.HasPrefix(name, ".") || strings.Contains(name, "..") {
+		return false
+	}
+	return true
+}
+
+func (c Config) withDefaults() Config {
+	// No fallback identity. An unset or unusable HeloHost must disable probing
+	// instead of silently announcing a name remote servers reject: a probe made
+	// with a broken identity can only produce false verdicts.
+	if c.MailFrom == "" && usableHeloHost(c.HeloHost) {
+		c.MailFrom = "verify@" + strings.TrimSuffix(strings.TrimSpace(c.HeloHost), ".")
 	}
 	if c.DialTimeout <= 0 {
 		c.DialTimeout = 5 * time.Second
@@ -182,6 +200,14 @@ func (v *SMTPVerifier) Verify(ctx context.Context, email string) Result {
 	res.HasMX = true
 
 	// 3. SMTP RCPT probe against the lowest-preference (highest priority) MX.
+	// Refuse to probe without a usable identity: an unset EMAIL_VERIFY_HELO_HOST
+	// would announce a name remote MTAs reject, and their refusal would be
+	// recorded against the recipient. Unknown is the only honest verdict here.
+	if !usableHeloHost(v.cfg.HeloHost) {
+		res.Status = StatusUnknown
+		res.Reason = "verifier identity not configured: EMAIL_VERIFY_HELO_HOST must be a fully-qualified hostname"
+		return res
+	}
 	probe := v.probe(ctx, hosts[0], localpart, domain)
 	switch probe.outcome {
 	case probeAccepted:
@@ -318,6 +344,23 @@ func (v *SMTPVerifier) probe(ctx context.Context, host, localpart, domain string
 	return probeResult{outcome: probeAccepted, catchAll: controlOutcome == probeAccepted}
 }
 
+// identityRejection reports whether a rejection text blames the connecting
+// client — its HELO/EHLO name, its reverse DNS or its envelope sender — rather
+// than the recipient address.
+func identityRejection(msg string) bool {
+	m := strings.ToLower(msg)
+	for _, marker := range []string{
+		"helo", "ehlo", "reverse", "rdns", "ptr",
+		"fully-qualified", "fully qualified", "sender address rejected",
+		"access denied",
+	} {
+		if strings.Contains(m, marker) {
+			return true
+		}
+	}
+	return false
+}
+
 // classifyRcpt maps the error from smtp.Client.Rcpt to a probe outcome. The
 // stdlib surfaces the SMTP reply code on *textproto.Error; 5xx is a hard
 // rejection, 4xx is transient (unknown), and a nil error is acceptance.
@@ -330,6 +373,12 @@ func classifyRcpt(err error) (probeOutcome, string) {
 		code := protoErr.Code
 		switch {
 		case code >= 500 && code < 600:
+			// A 5xx that names our own HELO/sender identity is a statement about
+			// the prober, not the mailbox. Postfix and others defer that refusal
+			// to RCPT, so trusting the code alone marks live addresses invalid.
+			if identityRejection(protoErr.Msg) {
+				return probeUnknown, "prober identity refused (" + strconv.Itoa(code) + "): " + protoErr.Msg
+			}
 			return probeRejected, "recipient rejected (" + strconv.Itoa(code) + "): " + protoErr.Msg
 		case code >= 400 && code < 500:
 			return probeUnknown, "transient/greylisted (" + strconv.Itoa(code) + "): " + protoErr.Msg

--- a/internal/pkg/emailverify/emailverify.go
+++ b/internal/pkg/emailverify/emailverify.go
@@ -65,16 +65,74 @@ const (
 	StatusUnknown Status = "unknown"
 )
 
+// ReasonCode is a machine-readable tag for *why* a verdict came out the way it
+// did. It exists so an operator can separate the failure modes that are about
+// the prober's own identity from anything about the recipient, without
+// pattern-matching remote-server prose that differs per MTA.
+//
+// Today only the identity family is emitted; every other verdict leaves Code
+// empty and keeps its human reason. Callers must treat an unrecognised code as
+// "no opinion" rather than switching exhaustively.
+type ReasonCode string
+
+const (
+	// ReasonIdentityNotConfigured means we never dialled: EMAIL_VERIFY_HELO_HOST
+	// is unset or not a FQDN, so any probe would announce a name remote MTAs
+	// reject. Says nothing at all about the address.
+	ReasonIdentityNotConfigured ReasonCode = "identity_not_configured"
+	// ReasonIdentityHeloRefused means the remote server refused our EHLO/HELO
+	// name ("need fully-qualified hostname", "Invalid HELO name"). Fix: set
+	// EMAIL_VERIFY_HELO_HOST to a real FQDN for the probing host.
+	ReasonIdentityHeloRefused ReasonCode = "identity_helo_refused"
+	// ReasonIdentityRDNSMissing means the remote server could not resolve a PTR
+	// for our egress IP ("cannot find your reverse hostname"). This is a
+	// DIFFERENT fix from the HELO name — it needs a PTR record from whoever owns
+	// the IP — so it must never be reported as a HELO problem.
+	ReasonIdentityRDNSMissing ReasonCode = "identity_rdns_missing"
+	// ReasonIdentitySenderRefused means the remote server refused our envelope
+	// sender ("Sender address rejected", MAIL FROM refusals). Fix:
+	// EMAIL_VERIFY_MAIL_FROM must be a real, resolvable address.
+	ReasonIdentitySenderRefused ReasonCode = "identity_sender_refused"
+)
+
+// IsIdentity reports whether the code blames our own probing identity rather
+// than the recipient. Every identity code yields StatusUnknown, never
+// StatusInvalid: a server refusing us proves nothing about the mailbox.
+func (c ReasonCode) IsIdentity() bool {
+	switch c {
+	case ReasonIdentityNotConfigured, ReasonIdentityHeloRefused,
+		ReasonIdentityRDNSMissing, ReasonIdentitySenderRefused:
+		return true
+	}
+	return false
+}
+
+// withCode prefixes the human reason with its machine code. Only Reason is
+// persisted (contacts.verification_reason has no companion column), so without
+// this prefix an operator reading stored evidence would be back to grepping
+// prose. The Result carries Code separately for in-process callers.
+func withCode(code ReasonCode, reason string) string {
+	if code == "" {
+		return reason
+	}
+	return string(code) + ": " + reason
+}
+
 // Result is the outcome of verifying one address. It round-trips into the
 // contacts table (verification_status / verification_reason / is_catch_all /
 // verification_checked_at).
 type Result struct {
-	Email      string    `json:"email"`
-	Status     Status    `json:"status"`
-	Reason     string    `json:"reason"`
-	IsCatchAll bool      `json:"is_catch_all"`
-	HasMX      bool      `json:"has_mx"`
-	CheckedAt  time.Time `json:"checked_at"`
+	Email  string `json:"email"`
+	Status Status `json:"status"`
+	Reason string `json:"reason"`
+	// Code is the machine-readable classification of Reason, empty when the
+	// verdict has no code. It is additive: Reason stays human-readable (and
+	// carries the code as a prefix when one is set) so stored evidence is
+	// self-describing.
+	Code       ReasonCode `json:"reason_code,omitempty"`
+	IsCatchAll bool       `json:"is_catch_all"`
+	HasMX      bool       `json:"has_mx"`
+	CheckedAt  time.Time  `json:"checked_at"`
 }
 
 // Verifier is the single contract the rest of the platform depends on. The
@@ -148,6 +206,18 @@ func (c Config) withDefaults() Config {
 type SMTPVerifier struct {
 	cfg      Config
 	resolver *net.Resolver
+
+	// Test seams. Both are package-private and nil/zero in every production
+	// path, so New() behaves exactly as before. They exist because the only
+	// honest proof that we announce the CONFIGURED FQDN is to read the EHLO line
+	// off the wire, and that requires pointing the prober at an in-process
+	// listener instead of a real MX on :25 — reaching the public network from a
+	// unit test is both flaky and, for an SMTP RCPT probe, rude.
+	//
+	// lookupHosts, when set, replaces the MX/implicit-MX resolution entirely
+	// (no DNS is performed). smtpPort, when set, replaces the fixed "25".
+	lookupHosts func(ctx context.Context, domain string) ([]string, error)
+	smtpPort    string
 }
 
 // New constructs the in-house SMTP verifier. The resolver mirrors dnsauth's
@@ -205,7 +275,8 @@ func (v *SMTPVerifier) Verify(ctx context.Context, email string) Result {
 	// recorded against the recipient. Unknown is the only honest verdict here.
 	if !usableHeloHost(v.cfg.HeloHost) {
 		res.Status = StatusUnknown
-		res.Reason = "verifier identity not configured: EMAIL_VERIFY_HELO_HOST must be a fully-qualified hostname"
+		res.Code = ReasonIdentityNotConfigured
+		res.Reason = withCode(res.Code, "verifier identity not configured: EMAIL_VERIFY_HELO_HOST must be a fully-qualified hostname")
 		return res
 	}
 	probe := v.probe(ctx, hosts[0], localpart, domain)
@@ -223,11 +294,14 @@ func (v *SMTPVerifier) Verify(ctx context.Context, email string) Result {
 		res.Reason = "recipient accepted"
 		return res
 	case probeRejected:
+		// An identity code can never reach this branch (probe() maps every one
+		// of them to probeUnknown), so a rejection is always about the mailbox.
 		res.Status = StatusInvalid
 		res.Reason = probe.reason
 		return res
 	default: // probeUnknown
 		res.Status = StatusUnknown
+		res.Code = probe.code
 		res.Reason = probe.reason
 		return res
 	}
@@ -238,6 +312,9 @@ func (v *SMTPVerifier) Verify(ctx context.Context, email string) Result {
 // to the A/AAAA record of the domain itself; we honour that so apex-only mail
 // domains aren't misjudged as invalid.
 func (v *SMTPVerifier) lookupMXHosts(ctx context.Context, domain string) ([]string, error) {
+	if v.lookupHosts != nil {
+		return v.lookupHosts(ctx, domain)
+	}
 	c, cancel := context.WithTimeout(ctx, v.cfg.MXTimeout)
 	defer cancel()
 
@@ -287,6 +364,7 @@ const (
 type probeResult struct {
 	outcome  probeOutcome
 	catchAll bool
+	code     ReasonCode
 	reason   string
 }
 
@@ -300,7 +378,11 @@ type probeResult struct {
 //	4xx / timeout/ dial error -> unknown (greylist, blocked :25, transient)
 func (v *SMTPVerifier) probe(ctx context.Context, host, localpart, domain string) probeResult {
 	dialer := net.Dialer{Timeout: v.cfg.DialTimeout}
-	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, "25"))
+	port := v.smtpPort
+	if port == "" {
+		port = "25"
+	}
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, port))
 	if err != nil {
 		// Most commonly: outbound :25 blocked by the cloud provider, or the MX is
 		// firewalled/tarpitting. Either way we cannot conclude invalid.
@@ -321,71 +403,123 @@ func (v *SMTPVerifier) probe(ctx context.Context, host, localpart, domain string
 	defer func() { _ = client.Close() }()
 
 	if err := client.Hello(v.cfg.HeloHost); err != nil {
-		return probeResult{outcome: probeUnknown, reason: "EHLO/HELO rejected: " + err.Error()}
+		// A hard refusal of the greeting itself is by construction about our
+		// name, not the mailbox; fall back to the HELO code only when the
+		// server's prose does not name a more specific dimension (e.g. it is
+		// really our missing rDNS that it objected to).
+		code := commandIdentityCode(err, ReasonIdentityHeloRefused)
+		return probeResult{outcome: probeUnknown, code: code, reason: withCode(code, "EHLO/HELO rejected: "+err.Error())}
 	}
 	if err := client.Mail(v.cfg.MailFrom); err != nil {
-		return probeResult{outcome: probeUnknown, reason: "MAIL FROM rejected: " + err.Error()}
+		code := commandIdentityCode(err, ReasonIdentitySenderRefused)
+		return probeResult{outcome: probeUnknown, code: code, reason: withCode(code, "MAIL FROM rejected: "+err.Error())}
 	}
 
-	realOutcome, realReason := classifyRcpt(client.Rcpt(localpart + "@" + domain))
+	realOutcome, realCode, realReason := classifyRcpt(client.Rcpt(localpart + "@" + domain))
 	switch realOutcome {
 	case probeRejected:
 		return probeResult{outcome: probeRejected, reason: realReason}
 	case probeUnknown:
-		return probeResult{outcome: probeUnknown, reason: realReason}
+		return probeResult{outcome: probeUnknown, code: realCode, reason: realReason}
 	}
 
 	// Real address accepted — probe a random control localpart to detect a
 	// catch-all. If that is also accepted, the domain accepts everything and the
 	// real 250 proves nothing.
 	control := randomLocalpart()
-	controlOutcome, _ := classifyRcpt(client.Rcpt(control + "@" + domain))
+	controlOutcome, _, _ := classifyRcpt(client.Rcpt(control + "@" + domain))
 
 	return probeResult{outcome: probeAccepted, catchAll: controlOutcome == probeAccepted}
 }
 
-// identityRejection reports whether a rejection text blames the connecting
-// client — its HELO/EHLO name, its reverse DNS or its envelope sender — rather
-// than the recipient address.
-func identityRejection(msg string) bool {
+// identityRejection classifies a rejection text that blames the connecting
+// client rather than the recipient address, and says WHICH part of our identity
+// was refused. The three dimensions have three different fixes — a HELO name in
+// config, a PTR record from whoever owns the egress IP, and a resolvable
+// envelope sender — so collapsing them into one string would leave an operator
+// guessing which knob to turn. Returns "" when nothing in the text blames us.
+//
+// rDNS is tested FIRST and deliberately: a server that says "cannot find your
+// reverse hostname" often also mentions "helo"/"host rejected" in the same
+// line, and reporting that as a HELO problem would hide a missing PTR behind a
+// hostname that is already correct.
+//
+// Note on "access denied": a bare "access denied" / "5.7.1 access denied" is
+// NOT listed. It is a policy verdict about this delivery, not a statement about
+// our identity, and Exchange returns it for genuine recipient/anti-spam blocks;
+// treating it as an identity refusal would silently convert real blocks into
+// UNKNOWN. The production case that motivated this list ("Access denied -
+// Invalid HELO name") is still caught, by the "invalid helo"/"helo" marker.
+// See TestAccessDeniedAloneIsNotIdentity.
+func identityRejection(msg string) ReasonCode {
 	m := strings.ToLower(msg)
-	for _, marker := range []string{
-		"helo", "ehlo", "reverse", "rdns", "ptr",
-		"fully-qualified", "fully qualified", "sender address rejected",
-		"access denied",
-	} {
-		if strings.Contains(m, marker) {
-			return true
+	contains := func(markers ...string) bool {
+		for _, marker := range markers {
+			if strings.Contains(m, marker) {
+				return true
+			}
 		}
+		return false
 	}
-	return false
+	switch {
+	case contains("reverse", "rdns", "ptr record", "ptr lookup", "cannot find your hostname"):
+		return ReasonIdentityRDNSMissing
+	case contains("helo", "ehlo", "fully-qualified", "fully qualified"):
+		return ReasonIdentityHeloRefused
+	case contains("sender address rejected", "sender rejected", "sender verify failed", "mail from"):
+		return ReasonIdentitySenderRefused
+	}
+	return ""
+}
+
+// commandIdentityCode classifies an error returned by an SMTP command that can
+// only fail on our own identity (EHLO, MAIL FROM). A 5xx gets fallback when the
+// server's prose is unspecific; a 4xx (greylist/tarpit) or a transport error
+// gets no identity code at all, because neither is a statement about us.
+func commandIdentityCode(err error, fallback ReasonCode) ReasonCode {
+	var protoErr *textproto.Error
+	if !errors.As(err, &protoErr) {
+		return ""
+	}
+	if code := identityRejection(protoErr.Msg); code != "" {
+		return code
+	}
+	if protoErr.Code >= 500 && protoErr.Code < 600 {
+		return fallback
+	}
+	return ""
 }
 
 // classifyRcpt maps the error from smtp.Client.Rcpt to a probe outcome. The
 // stdlib surfaces the SMTP reply code on *textproto.Error; 5xx is a hard
 // rejection, 4xx is transient (unknown), and a nil error is acceptance.
-func classifyRcpt(err error) (probeOutcome, string) {
+func classifyRcpt(err error) (probeOutcome, ReasonCode, string) {
 	if err == nil {
-		return probeAccepted, "recipient accepted"
+		return probeAccepted, "", "recipient accepted"
 	}
 	var protoErr *textproto.Error
 	if errors.As(err, &protoErr) {
 		code := protoErr.Code
 		switch {
 		case code >= 500 && code < 600:
-			// A 5xx that names our own HELO/sender identity is a statement about
-			// the prober, not the mailbox. Postfix and others defer that refusal
-			// to RCPT, so trusting the code alone marks live addresses invalid.
-			if identityRejection(protoErr.Msg) {
-				return probeUnknown, "prober identity refused (" + strconv.Itoa(code) + "): " + protoErr.Msg
+			// A 5xx that names our own HELO/rDNS/sender identity is a statement
+			// about the prober, not the mailbox. Postfix and others defer that
+			// refusal to RCPT, so trusting the code alone marks live addresses
+			// invalid. Never StatusInvalid, whichever dimension it names.
+			if idCode := identityRejection(protoErr.Msg); idCode != "" {
+				return probeUnknown, idCode, withCode(idCode, "prober identity refused ("+strconv.Itoa(code)+"): "+protoErr.Msg)
 			}
-			return probeRejected, "recipient rejected (" + strconv.Itoa(code) + "): " + protoErr.Msg
+			return probeRejected, "", "recipient rejected (" + strconv.Itoa(code) + "): " + protoErr.Msg
 		case code >= 400 && code < 500:
-			return probeUnknown, "transient/greylisted (" + strconv.Itoa(code) + "): " + protoErr.Msg
+			// 4xx is transient by definition. Still tag the dimension when the
+			// server named one, so a tarpit that is really our missing PTR is
+			// visible without waiting for it to harden into a 5xx.
+			idCode := identityRejection(protoErr.Msg)
+			return probeUnknown, idCode, withCode(idCode, "transient/greylisted ("+strconv.Itoa(code)+"): "+protoErr.Msg)
 		}
 	}
 	// Connection reset, timeout mid-command, or an unparseable reply.
-	return probeUnknown, "rcpt indeterminate: " + err.Error()
+	return probeUnknown, "", "rcpt indeterminate: " + err.Error()
 }
 
 func randomLocalpart() string {

--- a/internal/pkg/emailverify/identity_regression_test.go
+++ b/internal/pkg/emailverify/identity_regression_test.go
@@ -1,0 +1,61 @@
+package emailverify
+
+import (
+	"context"
+	"net/textproto"
+	"testing"
+)
+
+func TestUnusableHeloHostNeverProbes(t *testing.T) {
+	for _, name := range []string{"", "localhost", "LOCALHOST", "backend", "bad host.com", ".leading", "a..b"} {
+		if usableHeloHost(name) {
+			t.Fatalf("%q must not be accepted as an EHLO identity", name)
+		}
+	}
+	for _, name := range []string{"verify.warmbly.com", "api.confenge.com.br", "mx1.example.org."} {
+		if !usableHeloHost(name) {
+			t.Fatalf("%q is a fully-qualified hostname and must be accepted", name)
+		}
+	}
+}
+
+func TestVerifyRefusesToProbeWithoutIdentity(t *testing.T) {
+	v := New(Config{})
+	if v.cfg.HeloHost != "" {
+		t.Fatalf("no fallback identity may be invented, got %q", v.cfg.HeloHost)
+	}
+	if v.cfg.MailFrom != "" {
+		t.Fatalf("MailFrom must stay empty without a usable HeloHost, got %q", v.cfg.MailFrom)
+	}
+	res := v.Verify(context.Background(), "someone@gmail.com")
+	if res.Status != StatusUnknown {
+		t.Fatalf("unconfigured verifier must yield UNKNOWN, got %s (%s)", res.Status, res.Reason)
+	}
+	if res.Reason == "" || res.Status == StatusInvalid {
+		t.Fatalf("unconfigured verifier must never mark an address invalid: %+v", res)
+	}
+}
+
+func TestIdentityRejectionIsNotRecipientRejection(t *testing.T) {
+	// Postfix defers a HELO refusal to RCPT with a 5xx that names our identity.
+	identity := []string{
+		`5.5.2 <localhost>: Helo command rejected: need fully-qualified hostname`,
+		`Access denied - Invalid HELO name (See RFC2821 4.1.1.1)`,
+		`Client host rejected: cannot find your reverse hostname`,
+		`Sender address rejected: Domain not found`,
+	}
+	for _, msg := range identity {
+		out, reason := classifyRcpt(&textproto.Error{Code: 504, Msg: msg})
+		if out != probeUnknown {
+			t.Fatalf("identity refusal must be UNKNOWN, got %v for %q", out, msg)
+		}
+		if reason == "" {
+			t.Fatalf("identity refusal must carry a reason for %q", msg)
+		}
+	}
+	// A genuine recipient rejection stays a hard rejection.
+	out, _ := classifyRcpt(&textproto.Error{Code: 550, Msg: "5.1.1 User unknown in virtual mailbox table"})
+	if out != probeRejected {
+		t.Fatalf("real unknown-user rejection must stay REJECTED, got %v", out)
+	}
+}

--- a/internal/pkg/emailverify/identity_regression_test.go
+++ b/internal/pkg/emailverify/identity_regression_test.go
@@ -3,6 +3,7 @@ package emailverify
 import (
 	"context"
 	"net/textproto"
+	"strings"
 	"testing"
 )
 
@@ -34,6 +35,12 @@ func TestVerifyRefusesToProbeWithoutIdentity(t *testing.T) {
 	if res.Reason == "" || res.Status == StatusInvalid {
 		t.Fatalf("unconfigured verifier must never mark an address invalid: %+v", res)
 	}
+	if res.Code != ReasonIdentityNotConfigured {
+		t.Fatalf("want code %s, got %q", ReasonIdentityNotConfigured, res.Code)
+	}
+	if !strings.HasPrefix(res.Reason, string(ReasonIdentityNotConfigured)+": ") {
+		t.Fatalf("persisted reason must carry its code as a prefix, got %q", res.Reason)
+	}
 }
 
 func TestIdentityRejectionIsNotRecipientRejection(t *testing.T) {
@@ -45,17 +52,95 @@ func TestIdentityRejectionIsNotRecipientRejection(t *testing.T) {
 		`Sender address rejected: Domain not found`,
 	}
 	for _, msg := range identity {
-		out, reason := classifyRcpt(&textproto.Error{Code: 504, Msg: msg})
+		out, code, reason := classifyRcpt(&textproto.Error{Code: 504, Msg: msg})
 		if out != probeUnknown {
 			t.Fatalf("identity refusal must be UNKNOWN, got %v for %q", out, msg)
 		}
 		if reason == "" {
 			t.Fatalf("identity refusal must carry a reason for %q", msg)
 		}
+		if !code.IsIdentity() {
+			t.Fatalf("identity refusal must carry an identity code, got %q for %q", code, msg)
+		}
 	}
 	// A genuine recipient rejection stays a hard rejection.
-	out, _ := classifyRcpt(&textproto.Error{Code: 550, Msg: "5.1.1 User unknown in virtual mailbox table"})
+	out, code, _ := classifyRcpt(&textproto.Error{Code: 550, Msg: "5.1.1 User unknown in virtual mailbox table"})
 	if out != probeRejected {
 		t.Fatalf("real unknown-user rejection must stay REJECTED, got %v", out)
+	}
+	if code != "" {
+		t.Fatalf("recipient rejection must carry no identity code, got %q", code)
+	}
+}
+
+// TestIdentityDimensionsAreDistinguishable is the point of the reason codes:
+// three refusals with three different fixes must not collapse into one string.
+func TestIdentityDimensionsAreDistinguishable(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want ReasonCode
+	}{
+		{`5.5.2 <localhost>: Helo command rejected: need fully-qualified hostname`, ReasonIdentityHeloRefused},
+		{`Access denied - Invalid HELO name (See RFC2821 4.1.1.1)`, ReasonIdentityHeloRefused},
+		{`504 5.5.2 EHLO requires a fully qualified domain name`, ReasonIdentityHeloRefused},
+		{`Client host rejected: cannot find your reverse hostname`, ReasonIdentityRDNSMissing},
+		{`5.7.25 Reverse DNS lookup for your IP failed`, ReasonIdentityRDNSMissing},
+		{`no PTR record for the connecting address`, ReasonIdentityRDNSMissing},
+		{`5.7.1 Sender address rejected: Domain not found`, ReasonIdentitySenderRefused},
+		{`MAIL FROM command rejected: unverified address`, ReasonIdentitySenderRefused},
+		{`5.1.1 User unknown in virtual mailbox table`, ""},
+		{`5.2.2 Mailbox full`, ""},
+	}
+	for _, tc := range cases {
+		if got := identityRejection(tc.msg); got != tc.want {
+			t.Fatalf("identityRejection(%q) = %q, want %q", tc.msg, got, tc.want)
+		}
+	}
+}
+
+// TestAbsentRDNSIsNotMaskedAsHelo guards the ordering in identityRejection: a
+// server that names BOTH our reverse hostname and the HELO command is telling
+// us the PTR is missing. Reporting that as a HELO problem sends the operator to
+// edit a hostname that is already correct.
+func TestAbsentRDNSIsNotMaskedAsHelo(t *testing.T) {
+	msg := `450 4.7.1 <unknown[203.0.113.7]>: Helo command rejected: cannot find your reverse hostname`
+	if got := identityRejection(msg); got != ReasonIdentityRDNSMissing {
+		t.Fatalf("mixed rDNS/HELO refusal must report rDNS, got %q", got)
+	}
+	out, code, reason := classifyRcpt(&textproto.Error{Code: 550, Msg: msg})
+	if out != probeUnknown || code != ReasonIdentityRDNSMissing {
+		t.Fatalf("want UNKNOWN/%s, got %v/%q", ReasonIdentityRDNSMissing, out, code)
+	}
+	if !strings.HasPrefix(reason, string(ReasonIdentityRDNSMissing)+": ") {
+		t.Fatalf("stored reason must be code-prefixed, got %q", reason)
+	}
+}
+
+// TestAccessDeniedAloneIsNotIdentity pins the narrowing of the marker list. A
+// bare "access denied" is a policy verdict about this delivery (Exchange
+// returns it for genuine recipient/anti-spam blocks); only the variant that
+// actually names our HELO is an identity refusal.
+func TestAccessDeniedAloneIsNotIdentity(t *testing.T) {
+	if got := identityRejection("5.7.1 Access denied"); got != "" {
+		t.Fatalf("bare access denied must not be treated as an identity refusal, got %q", got)
+	}
+	if out, _, _ := classifyRcpt(&textproto.Error{Code: 550, Msg: "5.7.1 Access denied"}); out != probeRejected {
+		t.Fatalf("bare access denied must stay a recipient verdict, got %v", out)
+	}
+	if got := identityRejection("Access denied - Invalid HELO name"); got != ReasonIdentityHeloRefused {
+		t.Fatalf("the production message must still be caught, got %q", got)
+	}
+}
+
+// TestTransientKeepsDimensionWithoutRejecting: a 4xx tarpit that names our PTR
+// is still UNKNOWN, but must not lose which dimension the server complained
+// about.
+func TestTransientKeepsDimensionWithoutRejecting(t *testing.T) {
+	out, code, _ := classifyRcpt(&textproto.Error{Code: 450, Msg: "4.7.1 cannot find your reverse hostname"})
+	if out != probeUnknown {
+		t.Fatalf("4xx must stay UNKNOWN, got %v", out)
+	}
+	if code != ReasonIdentityRDNSMissing {
+		t.Fatalf("want %s, got %q", ReasonIdentityRDNSMissing, code)
 	}
 }

--- a/internal/pkg/emailverify/startup.go
+++ b/internal/pkg/emailverify/startup.go
@@ -1,0 +1,67 @@
+package emailverify
+
+import (
+	"fmt"
+	"net/mail"
+	"strings"
+)
+
+// Environment variables that carry the prober's identity. Named here so the
+// error text an operator reads matches the key they have to set.
+const (
+	EnvHeloHost = "EMAIL_VERIFY_HELO_HOST"
+	EnvMailFrom = "EMAIL_VERIFY_MAIL_FROM"
+)
+
+// IsProductionEnv reports a production-like APP_ENV, matching the convention
+// the rest of the platform uses ("prod" or "production", case-insensitive).
+func IsProductionEnv(appEnv string) bool {
+	e := strings.ToLower(strings.TrimSpace(appEnv))
+	return e == "prod" || e == "production"
+}
+
+// ValidateStartup fails the process closed when a production outreach plane is
+// configured to verify addresses with an unusable identity.
+//
+// Why this exists as a *boot* gate and not only a per-probe guard: Verify()
+// already degrades to StatusUnknown when the identity is unusable, which is the
+// right per-address behaviour but is silent. In production that silence is the
+// whole defect — a backend deployed without EMAIL_VERIFY_HELO_HOST announced
+// "localhost", collected 5xx replies that named *our* HELO, and those verdicts
+// were stored as if the RECIPIENT were the problem. Nobody notices a column
+// full of "unknown" either; they notice a container that will not start.
+//
+// Scope is deliberately narrow. Outside production, or with outreach disabled,
+// the old behaviour stands (UNKNOWN per probe) so a dev stack, a test, and a
+// self-hosted install with no verifier configured all still boot.
+//
+// This can never make an address INVALID: it runs before any probe and its only
+// outcome is a refusal to start.
+func (c Config) ValidateStartup(appEnv string, outreachEnabled bool) error {
+	if from := strings.TrimSpace(c.MailFrom); from != "" {
+		if _, err := mail.ParseAddress(from); err != nil {
+			return fmt.Errorf("%s is not a valid email address: %w", EnvMailFrom, err)
+		}
+	}
+	if !IsProductionEnv(appEnv) || !outreachEnabled {
+		return nil
+	}
+	host := strings.TrimSpace(c.HeloHost)
+	if host == "" {
+		return fmt.Errorf(
+			"%s is required when APP_ENV=%s and CONFENGE_OUTREACH_ENABLED=true: "+
+				"without it the SMTP prober announces no usable EHLO name, remote servers "+
+				"refuse the connection, and their refusal is recorded against the recipient",
+			EnvHeloHost, strings.TrimSpace(appEnv))
+	}
+	if !usableHeloHost(host) {
+		// Do not echo the value: it is operator-supplied config that lands in
+		// logs. Naming the key and the rule is enough to fix it.
+		return fmt.Errorf(
+			"%s must be a fully-qualified hostname (RFC 5321 4.1.1.1) when APP_ENV=%s and "+
+				"CONFENGE_OUTREACH_ENABLED=true; %q and any dotless or whitespace-bearing name "+
+				"are refused by remote MTAs",
+			EnvHeloHost, strings.TrimSpace(appEnv), "localhost")
+	}
+	return nil
+}

--- a/internal/pkg/emailverify/startup_test.go
+++ b/internal/pkg/emailverify/startup_test.go
@@ -1,0 +1,88 @@
+package emailverify
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestProductionOutreachRefusesUnusableIdentity is the boot gate. The
+// production defect was a backend that started happily with no
+// EMAIL_VERIFY_HELO_HOST and then attributed its own HELO refusals to
+// recipients; in a production outreach plane that must be a startup failure.
+func TestProductionOutreachRefusesUnusableIdentity(t *testing.T) {
+	for _, host := range []string{"", "   ", "localhost", "LocalHost", "backend", "api", "bad host.com", ".x.com", "a..b.com"} {
+		cfg := Config{HeloHost: host}
+		err := cfg.ValidateStartup("production", true)
+		if err == nil {
+			t.Fatalf("APP_ENV=production + outreach must refuse HeloHost %q", host)
+		}
+		if !strings.Contains(err.Error(), EnvHeloHost) {
+			t.Fatalf("error must name %s so an operator knows the knob: %v", EnvHeloHost, err)
+		}
+	}
+	if err := (Config{HeloHost: "api.confenge.example"}).ValidateStartup("production", true); err != nil {
+		t.Fatalf("a fully-qualified identity must boot in production: %v", err)
+	}
+	if err := (Config{HeloHost: "verify.example.org"}).ValidateStartup("prod", true); err != nil {
+		t.Fatalf("APP_ENV=prod is production-like and must accept a FQDN: %v", err)
+	}
+}
+
+// TestNonProductionKeepsPerProbeUnknown: dev, test, and self-host installs with
+// no verifier configured must still boot. Their per-probe behaviour is UNKNOWN,
+// which is already covered by TestVerifyRefusesToProbeWithoutIdentity.
+func TestNonProductionKeepsPerProbeUnknown(t *testing.T) {
+	for _, env := range []string{"", "dev", "development", "test", "staging"} {
+		if err := (Config{}).ValidateStartup(env, true); err != nil {
+			t.Fatalf("APP_ENV=%q must not fail boot on an empty identity: %v", env, err)
+		}
+	}
+	// Production with outreach OFF is not an outreach plane; nothing probes.
+	if err := (Config{}).ValidateStartup("production", false); err != nil {
+		t.Fatalf("outreach-disabled production must still boot: %v", err)
+	}
+}
+
+// TestValidateStartupNeverLeaksConfiguredIdentity: the error text goes to logs
+// and to Sentry. It may name the KEY, never the operator's value.
+func TestValidateStartupNeverLeaksConfiguredIdentity(t *testing.T) {
+	// Dotless, so it is unusable — and distinctive, so a leak is unmistakable.
+	const secretish = "internal-relay-7"
+	err := Config{HeloHost: secretish}.ValidateStartup("production", true)
+	if err == nil {
+		t.Fatalf("%q is not fully qualified and must be refused", secretish)
+	}
+	if strings.Contains(err.Error(), secretish) {
+		t.Fatalf("startup error must not echo the configured hostname: %v", err)
+	}
+}
+
+func TestValidateStartupRejectsMalformedMailFrom(t *testing.T) {
+	// Bad sender syntax is a config error in every environment: it can only ever
+	// produce MAIL FROM refusals, never a useful verdict.
+	for _, env := range []string{"dev", "production"} {
+		err := Config{HeloHost: "verify.example.org", MailFrom: "not an address"}.ValidateStartup(env, true)
+		if err == nil {
+			t.Fatalf("APP_ENV=%s must reject a malformed %s", env, EnvMailFrom)
+		}
+		if !strings.Contains(err.Error(), EnvMailFrom) {
+			t.Fatalf("error must name %s: %v", EnvMailFrom, err)
+		}
+	}
+	if err := (Config{HeloHost: "verify.example.org", MailFrom: "probe@verify.example.org"}).ValidateStartup("production", true); err != nil {
+		t.Fatalf("a well-formed sender must pass: %v", err)
+	}
+}
+
+func TestIsProductionEnv(t *testing.T) {
+	for _, e := range []string{"prod", "production", "PRODUCTION", " Prod "} {
+		if !IsProductionEnv(e) {
+			t.Fatalf("%q must be production-like", e)
+		}
+	}
+	for _, e := range []string{"", "dev", "staging", "preprod", "production-like"} {
+		if IsProductionEnv(e) {
+			t.Fatalf("%q must not be production-like", e)
+		}
+	}
+}

--- a/internal/pkg/emailverify/wire_identity_test.go
+++ b/internal/pkg/emailverify/wire_identity_test.go
@@ -1,0 +1,244 @@
+package emailverify
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+// fakeMTA is a minimal in-process SMTP server. It is NOT a real MTA: it speaks
+// just enough of RFC 5321 for smtp.Client to complete EHLO / MAIL / RCPT, and
+// it records every command line it received so a test can assert what we put on
+// the wire. It never accepts mail (no DATA), so nothing can be sent.
+type fakeMTA struct {
+	ln net.Listener
+
+	mu    sync.Mutex
+	lines []string
+	// rcptReplies are consumed in order, one per RCPT TO. Anything past the end
+	// of the slice gets the last entry.
+	rcptReplies []string
+}
+
+func newFakeMTA(t *testing.T, rcptReplies ...string) *fakeMTA {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	f := &fakeMTA{ln: ln, rcptReplies: rcptReplies}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		conn, aerr := ln.Accept()
+		if aerr != nil {
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_ = conn.SetDeadline(time.Now().Add(10 * time.Second))
+		f.serve(conn)
+	}()
+	t.Cleanup(func() {
+		_ = ln.Close()
+		select {
+		case <-done:
+		case <-time.After(5 * time.Second):
+		}
+	})
+	return f
+}
+
+func (f *fakeMTA) serve(conn net.Conn) {
+	w := bufio.NewWriter(conn)
+	r := bufio.NewReader(conn)
+	write := func(s string) bool {
+		if _, err := w.WriteString(s + "\r\n"); err != nil {
+			return false
+		}
+		return w.Flush() == nil
+	}
+	if !write("220 mta.test ESMTP fake") {
+		return
+	}
+	rcpts := 0
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return
+		}
+		line = strings.TrimRight(line, "\r\n")
+		f.mu.Lock()
+		f.lines = append(f.lines, line)
+		f.mu.Unlock()
+
+		upper := strings.ToUpper(line)
+		switch {
+		case strings.HasPrefix(upper, "EHLO"):
+			// Deliberately advertise no STARTTLS and no AUTH: the prober must
+			// never negotiate either, and a missing extension proves it.
+			if !write("250-mta.test") || !write("250 SIZE 10240000") {
+				return
+			}
+		case strings.HasPrefix(upper, "HELO"):
+			if !write("250 mta.test") {
+				return
+			}
+		case strings.HasPrefix(upper, "MAIL FROM"):
+			if !write("250 2.1.0 Ok") {
+				return
+			}
+		case strings.HasPrefix(upper, "RCPT TO"):
+			reply := "250 2.1.5 Ok"
+			if len(f.rcptReplies) > 0 {
+				idx := rcpts
+				if idx >= len(f.rcptReplies) {
+					idx = len(f.rcptReplies) - 1
+				}
+				reply = f.rcptReplies[idx]
+			}
+			rcpts++
+			if !write(reply) {
+				return
+			}
+		case strings.HasPrefix(upper, "QUIT"):
+			_ = write("221 2.0.0 Bye")
+			return
+		default:
+			if !write("502 5.5.2 Command not implemented") {
+				return
+			}
+		}
+	}
+}
+
+func (f *fakeMTA) received() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.lines...)
+}
+
+func (f *fakeMTA) port() string {
+	_, p, _ := net.SplitHostPort(f.ln.Addr().String())
+	return p
+}
+
+// verifierFor points a real SMTPVerifier at the fake MTA with DNS disabled. The
+// lookupHosts seam is the whole reason this test can exist without touching the
+// network: nothing here resolves MX, and nothing dials :25.
+func verifierFor(t *testing.T, f *fakeMTA, cfg Config) *SMTPVerifier {
+	t.Helper()
+	v := New(cfg)
+	v.smtpPort = f.port()
+	v.lookupHosts = func(_ context.Context, _ string) ([]string, error) {
+		return []string{"127.0.0.1"}, nil
+	}
+	return v
+}
+
+func findLine(lines []string, prefix string) string {
+	for _, l := range lines {
+		if strings.HasPrefix(strings.ToUpper(l), prefix) {
+			return l
+		}
+	}
+	return ""
+}
+
+// TestProbeAnnouncesConfiguredIdentityOnTheWire is the proof the whole fix
+// hangs on: whatever EMAIL_VERIFY_HELO_HOST / EMAIL_VERIFY_MAIL_FROM are set
+// to is exactly what leaves the socket. Every value below is an example.* /
+// .invalid placeholder — no real mailbox, domain, or credential appears.
+func TestProbeAnnouncesConfiguredIdentityOnTheWire(t *testing.T) {
+	const (
+		helo   = "verify.example.org"
+		sender = "probe@verify.example.org"
+	)
+	// Second RCPT (the random catch-all control) is refused, so the real
+	// address comes back VALID rather than RISKY.
+	f := newFakeMTA(t, "250 2.1.5 Ok", "550 5.1.1 User unknown")
+	v := verifierFor(t, f, Config{HeloHost: helo, MailFrom: sender})
+
+	res := v.Verify(context.Background(), "someone@example.com")
+	if res.Status != StatusValid {
+		t.Fatalf("accepted recipient on a non-catch-all domain must be VALID, got %s (%s)", res.Status, res.Reason)
+	}
+
+	lines := f.received()
+	if got := findLine(lines, "EHLO"); got != "EHLO "+helo {
+		t.Fatalf("wire EHLO = %q, want %q (lines: %v)", got, "EHLO "+helo, lines)
+	}
+	if got := findLine(lines, "MAIL FROM"); got != "MAIL FROM:<"+sender+">" {
+		t.Fatalf("wire MAIL FROM = %q, want %q (lines: %v)", got, "MAIL FROM:<"+sender+">", lines)
+	}
+	// The "localhost" that produced the contaminated production verdicts must
+	// appear nowhere on the wire.
+	for _, l := range lines {
+		if strings.Contains(strings.ToLower(l), "localhost") {
+			t.Fatalf("prober announced localhost on the wire: %q", l)
+		}
+	}
+}
+
+// TestDerivedSenderStillMatchesConfiguredHelo: when only HELO is configured the
+// derived MAIL FROM must stay on the configured FQDN, never on a fallback host.
+func TestDerivedSenderStillMatchesConfiguredHelo(t *testing.T) {
+	const helo = "mx-probe.example.net"
+	f := newFakeMTA(t, "250 2.1.5 Ok", "550 5.1.1 User unknown")
+	v := verifierFor(t, f, Config{HeloHost: helo})
+
+	if res := v.Verify(context.Background(), "someone@example.com"); res.Status != StatusValid {
+		t.Fatalf("want VALID, got %s (%s)", res.Status, res.Reason)
+	}
+	if got := findLine(f.received(), "MAIL FROM"); got != "MAIL FROM:<verify@"+helo+">" {
+		t.Fatalf("derived sender = %q, want verify@%s", got, helo)
+	}
+}
+
+// TestCatchAllDomainIsRisky: both RCPTs accepted means acceptance proves
+// nothing. Kept here because the fake MTA is the only place the control-probe
+// path is exercised end to end.
+func TestCatchAllDomainIsRisky(t *testing.T) {
+	f := newFakeMTA(t, "250 2.1.5 Ok")
+	v := verifierFor(t, f, Config{HeloHost: "verify.example.org"})
+
+	res := v.Verify(context.Background(), "someone@example.com")
+	if res.Status != StatusRisky || !res.IsCatchAll {
+		t.Fatalf("catch-all domain must be RISKY, got %s catchAll=%v", res.Status, res.IsCatchAll)
+	}
+}
+
+// TestWireIdentityRefusalNeverMarksRecipientInvalid closes the loop end to end:
+// a server that refuses the RCPT while naming our own reverse DNS must leave
+// the address UNKNOWN and carry the rDNS code — the exact production shape that
+// previously produced a false INVALID.
+func TestWireIdentityRefusalNeverMarksRecipientInvalid(t *testing.T) {
+	f := newFakeMTA(t, "550 5.7.1 Client host rejected: cannot find your reverse hostname")
+	v := verifierFor(t, f, Config{HeloHost: "verify.example.org"})
+
+	res := v.Verify(context.Background(), "someone@example.com")
+	if res.Status != StatusUnknown {
+		t.Fatalf("identity refusal must be UNKNOWN, got %s (%s)", res.Status, res.Reason)
+	}
+	if res.Code != ReasonIdentityRDNSMissing {
+		t.Fatalf("want %s, got %q (%s)", ReasonIdentityRDNSMissing, res.Code, res.Reason)
+	}
+}
+
+// TestVerifyNeverDialsWithoutIdentity: the unconfigured guard must short-circuit
+// before any TCP connection, not merely reinterpret the reply.
+func TestVerifyNeverDialsWithoutIdentity(t *testing.T) {
+	f := newFakeMTA(t, "250 2.1.5 Ok")
+	v := verifierFor(t, f, Config{})
+
+	res := v.Verify(context.Background(), "someone@example.com")
+	if res.Status != StatusUnknown || res.Code != ReasonIdentityNotConfigured {
+		t.Fatalf("want UNKNOWN/%s, got %s/%q", ReasonIdentityNotConfigured, res.Status, res.Code)
+	}
+	if lines := f.received(); len(lines) != 0 {
+		t.Fatalf("no SMTP command may reach the wire without an identity, got %v", lines)
+	}
+}


### PR DESCRIPTION
Delivery PR for the CONFENGE fork. This is the branch production deploys from; the generic `emailverify` half is also proposed upstream separately as warmbly/warmbly#163.

Every defect below was observed on the live cohort `4d52c6cd` on 2026-08-23, not inferred.

## What was wrong, and where it actually lived

**The verifier announced `localhost`.** The running backend had neither `EMAIL_VERIFY_HELO_HOST` nor `EMAIL_VERIFY_MAIL_FROM` in its environment — the canonical values were already in the host env file and nothing propagated them. Three of five candidates came back carrying `need fully-qualified hostname` and `Invalid HELO name`, which are statements about *us*, recorded as if the recipient's mailbox were bad. rDNS became a reason code of its own rather than a synonym for a HELO fault, because Postfix phrases a missing PTR as a `Helo command rejected`.

**`next_slot_at` contradicted the window.** The panel said "fora da janela" on a Sunday while offering a slot on that same Sunday. Outbound was paused, and the paused branch derived the slot from `now+MinGap` — arithmetic that never consults the business-day rule that produced `in_send_window=false`.

**Copy QA passed copy that was not shippable.** The frozen manifest carried a label stutter, a repeated three-gram, shouted residue and `,.`, all admitted with `copy_qa=passed`. The doubled run is genuinely in the PNCP object text and extra-cli passes it through unmodified, so the feed is faithful and every fix belongs in this repository's outreach projection. Raw fact and provenance are untouched.

**An approval could outlive the copy it approved.** The drift guard only fired when the located touchpoint already carried both a content hash and a body, so a legacy `APPROVED` row with neither kept its approval while the apply loop wrote different copy into it.

**There was no way to correct a message.** Reproduce copies the frozen manifest byte for byte, so the only options were to authorize copy the founder had rejected, or abandon the cohort.

## What is new

`POST /v1/confenge/cohorts/{id}/candidates/{candidateId}/adjust` forks a version into N+1 under the same `cohort_id`. The parent stays byte-identical. Only subject and body are editable — mailbox, evidence, source, policy, route class and composer version are refused *by name*, detected on the raw request body, because a key silently dropped by a typed struct reads as a key that was accepted. The new version inherits no validation, no review and no GO, which falls out of the schema rather than from discipline. Guarded by `expected_frozen_hash` and a typed `vN` confirmation; two concurrent adjusts cannot both win; the prior authority is revoked in the same transaction or the adjustment rolls back.

Migration `000117` makes CREATE / REPRODUCE / RECOMPOSE / ADJUST durable, with a per-candidate audit carrying both hashes, the diff, reason, actor, correlation and receipt. RECOMPOSE is reserved, not implemented.

Images now carry `org.opencontainers.image.revision` and the container carries the SHA, with `deploy/verify-release.sh` as the acceptance gate — the previous rollout could only be accepted on "health 200", which proves a process answered, not which code answered.

## Consequences worth reading before merge

- **`ComposerVersion` moves to v4**, so a v3 grant cannot authorize v4 text. `release_manifest.go` already fails closed on that drift.
- **The live v1 cohort cannot be adjusted; it must be recomposed.** `hashControlledContent` binds the package-level composer constant rather than the member's frozen one, so recomputing a hash for a v3 manifest would rebase it onto a composer that never produced that text. Adjust refuses with `composer_drift`. Since v1's copy is the copy we are refusing to ship, recomposing is the right path anyway.
- **The backend now fails closed at boot** when `APP_ENV=production`, `CONFENGE_OUTREACH_ENABLED=true` and the verifier identity is unusable. Interpolation was verified against the real production env before any deploy.

## Verification

Adjust proved against real PostgreSQL 16 (27 tests: concurrent double-adjust, crash-retry, atomic revocation, byte-identical parent, every immutable field by name). Migration reversibility exercised up/down/up/down. The verifier identity is proved on the wire by an in-process fake SMTP listener asserting the literal `EHLO` line, and a YAML test fails if either variable stops reaching the backend. The window fix touches the dispatch package, so a send-neutrality test asserts `TryReserve` decisions are unchanged, since the existing file-level guard only diffs the worktree against HEAD.

REAL_EMAIL_SENT=false
DISPATCH_CONFIRM_RUN=false
OUTBOUND_RESUMED=false
AUTO_SEND_ENABLED=false