### PR TITLE
chore(confenge): use .invalid for the stale-approval test mailboxes

### DIFF
--- a/internal/app/confenge/cohort_apply_stale_approval_test.go
+++ b/internal/app/confenge/cohort_apply_stale_approval_test.go
@@ -32,7 +32,7 @@ func cleanCohortMember(accID, candID uuid.UUID, mailbox string) FrozenCohortMemb
 // through and kept its approval.
 func TestApprovedTouchpointCannotCarryApprovalOntoNewCopy(t *testing.T) {
 	orgID, accID, candID := uuid.New(), uuid.New(), uuid.New()
-	mailbox := "contato@empresa-stale.com.br"
+	mailbox := "contato@empresa-stale.invalid"
 	approver := uuid.New()
 	approvedAt := time.Now().UTC().Add(-72 * time.Hour)
 
@@ -115,7 +115,7 @@ func TestApprovedTouchpointCannotCarryApprovalOntoNewCopy(t *testing.T) {
 // not force the founder to re-approve identical text.
 func TestApprovalSurvivesWhenContentIsIdentical(t *testing.T) {
 	orgID, accID, candID := uuid.New(), uuid.New(), uuid.New()
-	mailbox := "contato@empresa-igual.com.br"
+	mailbox := "contato@empresa-igual.invalid"
 	approver := uuid.New()
 	approvedAt := time.Now().UTC().Add(-time.Hour)
 	member := cleanCohortMember(accID, candID, mailbox)


### PR DESCRIPTION
Every other fixture in this package uses `.invalid`, which RFC 2606 reserves precisely so a test address can never resolve to someone's real domain. These two used `.com.br`.

The tests do no network I/O, so nothing was ever sent anywhere — but a fabricated `.com.br` in a fixture is a real domain someone could register, and the convention exists to make that impossible to get wrong.

REAL_EMAIL_SENT=false
DISPATCH_CONFIRM_RUN=false
OUTBOUND_RESUMED=false
AUTO_SEND_ENABLED=false