### PR TITLE
fix(confenge): recover drafts with stale target fit

### DIFF
--- a/internal/app/confenge/drafts.go
+++ b/internal/app/confenge/drafts.go
@@ -27,10 +27,6 @@ func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uu
 	if acc.DoNotContact || acc.Blocked {
 		return nil, errx.New(errx.BadRequest, "account is blocked or DO_NOT_CONTACT")
 	}
-	if err := RequireTargetFit(acc); err != nil {
-		return nil, errx.New(errx.BadRequest, err.Error())
-	}
-
 	var cand *models.OutreachContactCandidate
 	if contactID != nil {
 		cand, err = s.repo.GetCandidate(ctx, orgID, *contactID)
@@ -47,8 +43,9 @@ func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uu
 	if cand == nil {
 		return nil, errx.New(errx.BadRequest, "no contact candidate; resolve NEEDS_CONTACT first")
 	}
-	if err := RequireEmailOutbound(acc, cand); err != nil {
-		return nil, errx.New(errx.BadRequest, err.Error())
+	targetFitRecoveryReason, gateErr := requireEmailCandidateForDraft(acc, cand)
+	if gateErr != nil {
+		return nil, errx.New(errx.BadRequest, gateErr.Error())
 	}
 
 	allCands, listErr := s.repo.ListCandidates(ctx, orgID, accountID)
@@ -171,6 +168,12 @@ func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uu
 			val.Errors = appendUnique(val.Errors, rec.Reason)
 		}
 	}
+	if targetFitRecoveryReason != "" {
+		flags = appendUnique(flags, strings.ToLower(targetFitRecoveryReason))
+		risk = "RED"
+		val.OK = false
+		val.Errors = appendUnique(val.Errors, targetFitRecoveryReason)
+	}
 	val.Claims = out.Claims
 	val.Rationale = out.Rationale
 	val.Channel = out.Channel
@@ -202,6 +205,8 @@ func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uu
 	case rec.State == RecipientBlocked:
 		draft.Status = models.OutreachDraftBlocked
 		draft.Subject, draft.BodyText = "", ""
+	case targetFitRecoveryReason != "":
+		draft.Status = models.OutreachDraftEnrichmentPending
 	case !RecipientStateAuthorizable(rec.State) || plan.Messageability != MessageabilityReady:
 		draft.Status = models.OutreachDraftEnrichmentPending
 		draft.Subject, draft.BodyText = "", ""
@@ -214,6 +219,10 @@ func (s *service) GenerateDraft(ctx context.Context, orgID, userID, accountID uu
 	}
 	if err := s.repo.UpsertDraft(ctx, draft); err != nil {
 		return nil, errx.New(errx.Internal, "failed to save draft: "+err.Error())
+	}
+	if targetFitRecoveryReason != "" {
+		did := draft.ID
+		s.recordEditorialSignal(ctx, orgID, &did, nil, models.OutreachDraftEnrichmentPending, targetFitRecoveryReason, draft.Channel)
 	}
 
 	// Move account into review queue only when the message is sendable.

--- a/internal/app/confenge/target_fit.go
+++ b/internal/app/confenge/target_fit.go
@@ -68,9 +68,46 @@ func RequireTargetFit(acc *models.OutreachAccount) error {
 	return nil
 }
 
+// targetFitForDraft distinguishes a missing or stale fit assertion from a
+// current negative commercial decision. Drafting may continue for the former
+// so the lead remains recoverable, but approval and transport stay fail-closed
+// through RequireTargetFit.
+func targetFitForDraft(acc *models.OutreachAccount) (string, error) {
+	d := EvaluateTargetFit(acc)
+	if d.Eligible {
+		return "", nil
+	}
+	if d.Reason == TargetFitReasonMissing || d.Reason == TargetFitReasonStale {
+		return d.Reason, nil
+	}
+	return "", fmt.Errorf("commercial outreach blocked: %s", d.Reason)
+}
+
 func RequireEmailOutbound(acc *models.OutreachAccount, cand *models.OutreachContactCandidate) error {
 	if err := RequireTargetFit(acc); err != nil {
 		return err
+	}
+	return requireEmailCandidate(acc, cand, true)
+}
+
+// requireEmailCandidateForDraft keeps recipient suppressions strict while
+// allowing target-fit absence or staleness to land in ENRICHMENT_PENDING. A
+// stale fit reconciliation also clears account EMAIL_SEND_READY, so that
+// derived bit is ignored only for this recoverable drafting path.
+func requireEmailCandidateForDraft(acc *models.OutreachAccount, cand *models.OutreachContactCandidate) (string, error) {
+	recoveryReason, err := targetFitForDraft(acc)
+	if err != nil {
+		return "", err
+	}
+	if err := requireEmailCandidate(acc, cand, recoveryReason == ""); err != nil {
+		return "", err
+	}
+	return recoveryReason, nil
+}
+
+func requireEmailCandidate(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, requireAccountReady bool) error {
+	if acc == nil {
+		return fmt.Errorf("account is missing")
 	}
 	if acc.DoNotContact || acc.Blocked {
 		return fmt.Errorf("account blocked or DNC")
@@ -90,7 +127,7 @@ func RequireEmailOutbound(acc *models.OutreachAccount, cand *models.OutreachCont
 		}
 		return nil
 	}
-	if !acc.EmailSendReady {
+	if requireAccountReady && !acc.EmailSendReady {
 		return fmt.Errorf("company EMAIL_SEND_READY is false")
 	}
 	if !cand.EmailSendReady {

--- a/internal/app/confenge/target_fit_recovery_test.go
+++ b/internal/app/confenge/target_fit_recovery_test.go
@@ -1,0 +1,92 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func targetFitRecoveryFixture(t *testing.T) (*service, *memRepo, uuid.UUID, uuid.UUID, uuid.UUID) {
+	t.Helper()
+	repo := newMemRepo()
+	svc := NewService(Config{
+		Enabled: true, DefaultDailyLimit: 100, MaxInitialEmailWords: 120,
+		RequireHumanApproval: true,
+	}, repo, nil).(*service)
+	ctx := context.Background()
+	orgID, actorID := uuid.New(), uuid.New()
+	feed := Feed{
+		SchemaVersion: models.OutreachSchemaV1,
+		GeneratedAt:   time.Now().UTC().Format(time.RFC3339),
+		Source: FeedSource{
+			System: "test", RunID: "target-fit-recovery", SnapshotHash: "target-fit-recovery-snapshot",
+			ProfileID: "test", ProfileVersion: "1",
+		},
+		Leads: []FeedLead{sampleLeadWithActivation(80, ActivationActionableNow)},
+	}
+	raw, _ := json.Marshal(feed)
+	if _, xerr := svc.ImportFromBytes(ctx, orgID, &actorID, raw, ImportOptions{IdempotencyKey: "target-fit-recovery"}); xerr != nil {
+		t.Fatal(xerr)
+	}
+	acc, err := repo.GetAccountByCNPJ(ctx, orgID, "11222333000181")
+	if err != nil || acc == nil {
+		t.Fatal("imported account missing")
+	}
+	touchpoints, xerr := svc.PlanAccountCadence(ctx, orgID, actorID, acc.ID, nil, models.OutreachChannelEmail)
+	if xerr != nil || len(touchpoints) == 0 {
+		t.Fatalf("plan: %v", xerr)
+	}
+	return svc, repo, orgID, actorID, touchpoints[0].ID
+}
+
+func TestStaleTargetFitKeepsDraftAndTouchpointRecoverable(t *testing.T) {
+	svc, repo, orgID, actorID, touchpointID := targetFitRecoveryFixture(t)
+	tp, _ := repo.GetTouchpoint(context.Background(), orgID, touchpointID)
+	acc := repo.byID[tp.AccountID]
+	acc.TargetFitFresh = false
+	acc.TargetFitEligible = false
+	acc.TargetFitSuppressionReason = TargetFitReasonStale
+	acc.EmailSendReady = false
+	acc.QueueState = models.OutreachQueueTargetFitSuppressed
+
+	generated, xerr := svc.GenerateTouchpointDraft(context.Background(), orgID, actorID, touchpointID)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if generated.State != models.TouchpointEnrichmentPending {
+		t.Fatalf("stale target fit discarded the touchpoint: state=%s", generated.State)
+	}
+	if strings.TrimSpace(generated.BodyText) == "" || generated.DraftID == nil {
+		t.Fatal("recoverable target fit must retain useful draft copy")
+	}
+	if generated.ApprovedBy != nil || generated.ApprovedContentHash != "" {
+		t.Fatal("recoverable target fit must not retain approval")
+	}
+	draft, _ := repo.GetDraft(context.Background(), orgID, *generated.DraftID)
+	if draft == nil || draft.Status != models.OutreachDraftEnrichmentPending || !strings.Contains(string(draft.ValidationJSON), TargetFitReasonStale) {
+		t.Fatalf("draft did not record stale-fit recovery: %+v", draft)
+	}
+	if _, approveErr := svc.ApproveTouchpoint(context.Background(), orgID, actorID, generated.ID, ApprovalOptions{}); approveErr == nil {
+		t.Fatal("stale target fit must remain fail-closed for approval")
+	}
+}
+
+func TestCurrentTargetFitOutRemainsHardGenerationGate(t *testing.T) {
+	svc, repo, orgID, actorID, touchpointID := targetFitRecoveryFixture(t)
+	tp, _ := repo.GetTouchpoint(context.Background(), orgID, touchpointID)
+	acc := repo.byID[tp.AccountID]
+	acc.TargetFitClass = TargetFitOutOfScope
+	acc.TargetFitFresh = true
+	acc.TargetFitEligible = false
+	acc.TargetFitSuppressionReason = TargetFitReasonOut
+
+	if _, xerr := svc.GenerateTouchpointDraft(context.Background(), orgID, actorID, touchpointID); xerr == nil || !strings.Contains(xerr.Message, TargetFitReasonOut) {
+		t.Fatalf("current target-fit OUT must stay blocked, got %v", xerr)
+	}
+}

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -309,16 +309,22 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 	if acc.DoNotContact || acc.Blocked {
 		return nil, errx.New(errx.BadRequest, "account blocked or DNC")
 	}
-	if err := RequireTargetFit(acc); err != nil {
-		return nil, errx.New(errx.BadRequest, err.Error())
-	}
 	var cand *models.OutreachContactCandidate
 	if tp.ContactCandidateID != nil {
 		cand, _ = s.repo.GetCandidate(ctx, orgID, *tp.ContactCandidateID)
 	}
+	var targetFitRecoveryReason string
 	if tp.Channel != models.OutreachChannelWhatsApp {
-		if err := RequireEmailOutbound(acc, cand); err != nil {
-			return nil, errx.New(errx.BadRequest, err.Error())
+		var gateErr error
+		targetFitRecoveryReason, gateErr = requireEmailCandidateForDraft(acc, cand)
+		if gateErr != nil {
+			return nil, errx.New(errx.BadRequest, gateErr.Error())
+		}
+	} else {
+		var gateErr error
+		targetFitRecoveryReason, gateErr = targetFitForDraft(acc)
+		if gateErr != nil {
+			return nil, errx.New(errx.BadRequest, gateErr.Error())
 		}
 	}
 	allCands, listErr := s.repo.ListCandidates(ctx, orgID, tp.AccountID)
@@ -478,6 +484,10 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 			val.Errors = appendUnique(val.Errors, rec.Reason)
 		}
 	}
+	if targetFitRecoveryReason != "" {
+		val.OK = false
+		val.Errors = appendUnique(val.Errors, targetFitRecoveryReason)
+	}
 	risk, flags := ClassifyRisk(acc, cand, synth, val)
 	for _, code := range editorialReasons {
 		flags = appendUnique(flags, "editorial_"+code)
@@ -491,6 +501,10 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 		risk = "RED"
 		flags = appendUnique(flags, "recipient_"+strings.ToLower(rec.State))
 		flags = appendUnique(flags, rec.ReasonCodes...)
+	}
+	if targetFitRecoveryReason != "" {
+		risk = "RED"
+		flags = appendUnique(flags, strings.ToLower(targetFitRecoveryReason))
 	}
 	valJSON := PackValidationWithPlan(val, st, plan, recipient)
 	allowTemplateGREEN := false
@@ -526,6 +540,8 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 	case rec.State == RecipientBlocked:
 		draftStatus = models.OutreachDraftBlocked
 		subject, body = "", ""
+	case targetFitRecoveryReason != "":
+		draftStatus = models.OutreachDraftEnrichmentPending
 	case !RecipientStateAuthorizable(rec.State):
 		draftStatus = models.OutreachDraftEnrichmentPending
 	case plan.Messageability == MessageabilityBlocked:
@@ -583,7 +599,9 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 	}
 	if draftStatus == models.OutreachDraftAIRewritePending || draftStatus == models.OutreachDraftEnrichmentPending {
 		reason := "suboptimal_copy"
-		if len(editorialReasons) > 0 {
+		if targetFitRecoveryReason != "" {
+			reason = targetFitRecoveryReason
+		} else if len(editorialReasons) > 0 {
 			reason = editorialReasons[0]
 		} else if len(plan.ReasonCodes) > 0 {
 			reason = plan.ReasonCodes[0]
@@ -609,7 +627,7 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 		tp.State = models.TouchpointDrafted
 	}
 	if draftStatus != models.OutreachDraftNeedsReview {
-		tp.StopReason = firstNonEmpty(rec.Reason, plan.Reason, "recipient_"+strings.ToLower(rec.State), "messageability_"+strings.ToLower(plan.Messageability))
+		tp.StopReason = firstNonEmpty(targetFitRecoveryReason, rec.Reason, plan.Reason, "recipient_"+strings.ToLower(rec.State), "messageability_"+strings.ToLower(plan.Messageability))
 	}
 	tp.ServiceCode, tp.FactUsed, tp.EvidenceIDs = acc.ServiceCode, draft.FactUsed, draft.EvidenceIDs
 	// Capture message-material context at generation for stale-approval guard.


### PR DESCRIPTION
## Summary
- keep missing or stale target-fit leads recoverable instead of returning HTTP 400
- generate and preserve useful copy in ENRICHMENT_PENDING while approval and transport remain fail-closed
- keep current TARGET_FIT_OUT and downgraded decisions as hard generation gates
- record an editorial/enrichment signal for CLI issue synchronization

## Validation
- focused stale/out regression tests
- full internal/app/confenge suite on Go 1.25 Debian
- handler and repository tests
- cmd/confenge tests without injected database
- all Go packages compile

Production dispatch remains paused. This closes the stale-fit gap found while recomposing the 52 active legacy touchpoints.