### PR TITLE
feat(confenge): the composer that wrote a message decides whether it can still be sent

### DIFF
--- a/deploy/confenge-vps/env.example
+++ b/deploy/confenge-vps/env.example
@@ -51,6 +51,10 @@ CONFENGE_GREEN_AUTORUN_ENABLED=false
 # Set CONFENGE_REPOSITORY_SHA to the exact Warmbly image/git SHA being deployed.
 # GIT_SHA / GITHUB_SHA are accepted fallbacks.
 CONFENGE_REPOSITORY_SHA=
+# Stamped onto the built images as org.opencontainers.image.revision so
+# deploy/verify-release.sh can prove which commit is running. up.sh derives it
+# from the checkout when this is empty; set it only to override that.
+WARMBLY_RELEASE_SHA=
 CONFENGE_FEED_SCHEMA_VERSION=confenge.outreach.v1
 CONFENGE_EVIDENCE_VERSION=controlled-email-policy.v1
 CONFENGE_SENDING_PAUSED=false

--- a/deploy/confenge-vps/up.sh
+++ b/deploy/confenge-vps/up.sh
@@ -19,6 +19,14 @@ export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}"
 # Fail closed on unsafe profile flips
 # shellcheck disable=SC1090
 set -a; . "$ENVF"; set +a
+# The image has to be able to prove which commit built it. Derive it from the
+# checkout so an operator cannot forget to pass it; an explicit value still wins.
+if [[ -z "${WARMBLY_RELEASE_SHA:-}" || "${WARMBLY_RELEASE_SHA}" == "local" ]]; then
+  WARMBLY_RELEASE_SHA="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo local)"
+fi
+export WARMBLY_RELEASE_SHA
+echo "Release SHA for this build: ${WARMBLY_RELEASE_SHA}"
+
 if [[ "${CONFENGE_GREEN_AUTORUN_ENABLED:-false}" == "true" ]]; then
   echo "REFUSE: CONFENGE_GREEN_AUTORUN_ENABLED=true is not allowed on VPS execution plane bootstrap" >&2
   exit 3

--- a/docs/confenge/copy-generation.md
+++ b/docs/confenge/copy-generation.md
@@ -14,10 +14,44 @@ There is **no research** in this path: the model receives structured JSON and re
 | `confenge.draft.v5` | Authorizable NEEDS_REVIEW. Renderer reads only `RecipientFacingCopy`. `validation_ok` means only human authorization remains. P0 hard QA: leak phrases, crédito frame, near-dup, stale composer, dumps, empty copy, missing CTA `?`. |
 | `confenge.draft.v6` | Semantic brief first, written event subjects, safe company-context fallback when a specific fact is absent, deterministic editorial QA, and bounded AI rewrite recovery. Suboptimal copy remains recoverable and always returns to human review. |
 
-Constant: `internal/app/confenge/validators.go` → `PromptVersion`.
-Doctrine: `OutreachDoctrineVersion` + `internal/app/confenge/outreach_playbook/`.
+Constant: `internal/app/confenge/validators.go` → `PromptVersion`. Current: `confenge.draft.v6`.
+Doctrine: `OutreachDoctrineVersion` + `internal/app/confenge/outreach_playbook/`. Current: `confenge-outreach-v2`.
 
 Bump the constant when the system prompt schema or hard safety rules change. Store the version on each `OutreachDraft.PromptVersion` for audit.
+
+## Composer version
+
+| Version | Notes |
+| --- | --- |
+| `confenge.composer.v2` | Messageability gate and outbound-safe plan. Internal strategy fields are never interpolated. |
+| `confenge.composer.v3` | Fail-closed last-mile authorizable outreach. |
+| `confenge.composer.v4` | De-shouts edital prose, collapses verbatim repeated n-grams, stops label stutter, terminates a fact without producing `,.`. |
+| `confenge.composer.v5` | Editorial composer: semantic brief, deterministic fact selection, editorial QA, corpus QA across the cohort, and bounded recompose recovery. **Current.** |
+
+Constant: `internal/app/confenge/messageability.go` → `ComposerVersion`. Current: `confenge.composer.v5`.
+
+The composer stamp is what identifies frozen copy. A cohort snapshot and each of its members stamp `ComposerVersion`; a draft or touchpoint is identified by its `PromptVersion`, which is the composer that wrote the text.
+
+## Editorial authority (frozen copy is operational only while its composer ships)
+
+Warmbly ships one composer at a time. `internal/app/confenge/editorial_authority.go` is the single place that decides whether frozen copy is still operational, and every approve, authorize, queue and transport path asks it instead of comparing version strings itself.
+
+| State | Meaning |
+| --- | --- |
+| `CURRENT` | The current composer (and, for cohorts, the current bounded-cohort policy) wrote this text. It can still be reviewed, approved, authorized, queued and sent. |
+| `LEGACY_SUPERSEDED` | An earlier composer or policy wrote it. It stays readable for audit and is refused by every operational path. |
+
+Reason codes: `composer_superseded`, `composer_unstamped` (fail-closed: no stamp is no proof), `policy_superseded`. Superseded artifacts also carry `EditorialLegacyNotice`, the PT-BR line a reader must see above the text.
+
+Rules:
+
+- `EvaluateCohortEditorialAuthority` checks composer plus `BoundedCohortPolicyV1`. `EvaluateDraftEditorialAuthority` checks `PromptVersion` only: the cadence policy stamped on a touchpoint is a schedule, not a composer.
+- `SnapshotEditorialAuthority` is current only when the snapshot stamp and every member stamp are current, so a member left behind by a partial recompose cannot ride under a current header.
+- `APPROVE` on a cohort candidate is refused with `composer_superseded`; `HOLD` and `REJECT` stay open so an old version can be closed out. `GO` is blocked by the same codes. Touchpoint approve, queue and transport are refused the same way.
+- The transport check is absolute, not relative: a grant and its copy can agree with each other and still both be the work of a composer this build no longer ships.
+- The way forward is `POST /confenge/cohorts/:id/recompose`, which forks version N+1 with the current composer and inherits no approval, no `GO` and no queue state.
+
+Customer-facing docs: `docs/content/docs/guides/confenge-editorial-lifecycle.mdx`.
 
 ## Generation channels
 
@@ -90,6 +124,8 @@ Hard fails include:
 - anti-template / AI clichés / generic subjects / artificial company-name spam
 - excessive paragraphs or bullets
 - WhatsApp too long or looking like a pasted email
+- `generic_cta`: the paragraph carrying the closing question neither states in the first person what the sender does (`trabalho`, `atuo`, `apoio`, ...) nor shares a content word with the observed fact, so the ask fits any company in the corpus
+- `personalization_without_fact`: observation language (`Vi que`, `Notei`, `Reparei`, ...) while no observed fact is carried, which asserts something the system cannot evidence
 
 Near-duplicate (character n-gram Jaccard, threshold `0.72`):
 

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -80,6 +80,16 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | POST | `/contacts/research/batch` | `AI_RESEARCH` |
 | POST | `/confenge/pilot/cohort/prepare` | `WRITE_CONTACTS` |
 | POST | `/confenge/drafts/invalidate-prior-composer` | `WRITE_CONTACTS` |
+| GET | `/confenge/cohorts` | `READ_CONTACTS` |
+| GET | `/confenge/cohorts/:id` | `READ_CONTACTS` |
+| GET | `/confenge/cohorts/:id/candidates/:candidateId` | `READ_CONTACTS` |
+| POST | `/confenge/cohorts/:id/candidates/:candidateId/review` | `WRITE_CONTACTS` |
+| POST | `/confenge/cohorts/:id/recompose` | `WRITE_CONTACTS` |
+| POST | `/confenge/cohorts/:id/decision` | `WRITE_CAMPAIGNS` |
+| GET | `/confenge/review/drafts` | `READ_CONTACTS` |
+| POST | `/confenge/review/drafts/:id/decision` | `WRITE_CONTACTS` |
+| POST | `/confenge/touchpoints/:id/approve` | `WRITE_CONTACTS` |
+| POST | `/confenge/touchpoints/:id/queue` | `WRITE_CONTACTS` |
 | GET | `/confenge/cockpit` | `READ_CONTACTS` |
 | GET | `/confenge/inbound` | `READ_CONTACTS` |
 | POST | `/confenge/inbound/:leadId/outcome` | `WRITE_CONTACTS` |
@@ -124,6 +134,12 @@ Public `GET /api/v1/webhooks/confenge/inbound/health` advertises `accepted_event
 `GET /confenge/intel/report` is the inbound learning observability payload (IQP, lanes, exceptions, latency baseline, learning candidates, `READY_FOR_REAL_EVENTS` / `ADJUST` / `NO_GO`). It is not a CRM and not a forecast.
 
 `GET /confenge/intel/exceptions` is the operator queue. Filter with `type`, `lane`, `source`, `severity`, `status`, `age_min_seconds`, and `age_max_seconds`. Each row includes evidence, history, `next_action` or an explicit open status, and only the legal actions `link`, `defer`, `reject`, and `mark_external_evidence_required`. `GET /confenge/intel/exceptions/:id` is the detail. `POST /confenge/intel/exceptions/:id/resolve` records before/after, actor, and reason. Send `Idempotency-Key`. The same command replays the first result. Illegal lifecycle moves and any attempt to invent WON, LOST, revenue, or identity are refused and the exception stays open.
+
+`GET /confenge/cohorts/:id` returns one immutable cohort version with its manifest, candidates and decision, plus the editorial verdict on the frozen copy: `editorial_state` (`CURRENT` or `LEGACY_SUPERSEDED`), `actionable`, `editorial_reason_codes`, `editorial_notice`, and the pointers `is_current_version`, `current_version` and `current_version_id`. Each candidate repeats `editorial_state`, `actionable` and `editorial_reason_codes`, and a superseded candidate carries the same codes in `blocked_by`. A version is current only when the version stamp and every member stamp are current.
+
+Superseded copy is readable and never operational. `POST /confenge/cohorts/:id/candidates/:candidateId/review` refuses `decision=APPROVE` with `409` and code `composer_superseded` (`HOLD` and `REJECT` still work), and `POST /confenge/cohorts/:id/decision` blocks `GO` with the same reason codes. `POST /confenge/cohorts/:id/recompose` is the way forward: it forks version N+1 with the current composer, requires `Idempotency-Key`, `reason`, `confirmation` and `expected_frozen_hash`, preserves every recipient and provenance fact byte-identical (drift is refused, not stored), and is born with no validation, no review, no approval and no `GO`.
+
+`GET /confenge/review/drafts` (and its alias `GET /confenge/touchpoints/review`) returns the same verdict per row as `editorial_state`, `editorial_actionable`, `editorial_reason_codes`, `editorial_notice`, `composer_version` and `prompt_version`, alongside the judging context `route_class`, `fact_source` and `target_fit`. Next to superseded copy `composer_version` is empty on purpose, because naming the current composer there would read as if it wrote the text. `POST /confenge/touchpoints/:id/approve`, `POST /confenge/touchpoints/:id/queue`, and `POST /confenge/review/drafts/:id/decision` when the decision approves return `409` on a draft an earlier composer wrote, and transport refuses the send grant by the same rule. See [CONFENGE editorial lifecycle](/guides/confenge-editorial-lifecycle/) and [error codes](/api/error-codes/).
 
 AI contact research charges credits (2 per run, billable even when it finds nothing) and only saves cited findings. See the [AI contact research](/guides/ai-contact-research/) guide. The batch endpoint accepts up to 500 contact ids and drains in the background.
 

--- a/docs/content/docs/api/error-codes.mdx
+++ b/docs/content/docs/api/error-codes.mdx
@@ -286,6 +286,43 @@ Common reason codes include `feed_missing`, `feed_stale`, `account_not_found`, `
 
 These are per-account workflow results, not transport errors. Fix the indicated data or policy gate and retry with the same `Idempotency-Key`.
 
+## CONFENGE editorial authority
+
+Frozen CONFENGE copy is operational only while the composer that wrote it is the one the platform ships. Once it is not, the artifact is `LEGACY_SUPERSEDED`: still readable for audit, never actionable. The full model is described in [CONFENGE editorial lifecycle](/guides/confenge-editorial-lifecycle/).
+
+`POST /confenge/cohorts/:id/candidates/:candidateId/review` with `decision=APPROVE` returns `409` and the stable code that names the refusal. `HOLD` and `REJECT` stay open so a reviewer can still close an old version out.
+
+```json
+{
+  "error": "Conflict",
+  "message": "APPROVE refused on LEGACY_SUPERSEDED copy (composer_superseded): composer confenge.composer.v4 wrote this text, current is confenge.composer.v5. Recompose the cohort and decide on the current version.",
+  "code": "composer_superseded",
+  "request_id": "4bbbd1b2-8f86-47dd-8a7f-9476501ad20e"
+}
+```
+
+| Code | Meaning |
+|------|---------|
+| `composer_superseded` | The stamped composer is not the one this build ships |
+| `composer_unstamped` | The artifact carries no composer stamp, so authorship cannot be proven (evaluation fails closed) |
+| `policy_superseded` | The stamped bounded-cohort policy version is not the current one |
+| `superseded_by_version` | A later version of the same cohort exists; the response carries `current_version` and `current_version_id` |
+
+The same three codes are also read fields, not only errors. `GET /confenge/cohorts/:id` returns them in `editorial_reason_codes` on the version and on each candidate, superseded candidates repeat them in `blocked_by`, and a `GO` decision lists them among the version blockers instead of minting send authority.
+
+`POST /confenge/touchpoints/:id/approve`, `POST /confenge/touchpoints/:id/queue`, and `POST /confenge/review/drafts/:id/decision` when the decision approves return `409` with code `conflict` and a message naming the same reason codes. Transport refuses a send grant by the same rule, so an already approved item cannot ship after the composer moves on.
+
+**How to fix:** recompose the cohort with `POST /confenge/cohorts/:id/recompose`, then take the review, approval and `GO` decisions again on the new version. Editing the old version is not possible: it is history.
+
+### Editorial QA reason codes
+
+Editorial QA codes are not HTTP errors. They appear in draft QA findings and in the recompose report (`exclusions` and `by_reason_code`), where they explain why a member was left out of version N+1.
+
+| Code | Meaning |
+|------|---------|
+| `generic_cta` | The paragraph carrying the closing question neither states in the first person what the sender does nor shares a word with the observed public fact, so the ask fits any company |
+| `personalization_without_fact` | Observation language ("Vi que", "Notei", "Reparei") is used while the message carries no observed fact |
+
 ## Error handling best practices
 
 ### Implement retry logic

--- a/docs/content/docs/guides/confenge-editorial-lifecycle.mdx
+++ b/docs/content/docs/guides/confenge-editorial-lifecycle.mdx
@@ -1,0 +1,89 @@
+---
+title: CONFENGE editorial lifecycle
+description: A cohort version is operational only while the composer that wrote its copy is the one the platform ships. Older versions stay readable and are recomposed, never approved.
+---
+
+CONFENGE freezes outbound copy into immutable cohort versions. A frozen version records what one composer wrote at one moment, so the question a version number cannot answer is whether that text is still the text the platform would write today. Editorial authority answers that question in a single place, and every approve, authorize, queue and transport path asks it instead of comparing version strings on its own.
+
+## Two editorial states
+
+Every frozen artifact carries an editorial state: the cohort version, each candidate inside it, and each review draft.
+
+| State | Meaning |
+|-------|---------|
+| `CURRENT` | The composer and policy this build ships produced the copy. It can still be reviewed, approved, authorized, queued and sent. |
+| `LEGACY_SUPERSEDED` | An earlier composer or policy wrote it. It stays readable for audit and is refused by every operational path. |
+
+The same verdict is exposed as a boolean (`actionable`) so an interface never has to compare composer strings itself. Superseded artifacts also carry reason codes and a notice that must be shown above the text before the reader judges it:
+
+```json
+{
+  "editorial_state": "LEGACY_SUPERSEDED",
+  "actionable": false,
+  "editorial_reason_codes": ["composer_superseded"],
+  "editorial_notice": "Versão histórica, mantida apenas para auditoria. Não é enviável e não aceita aprovação."
+}
+```
+
+Evaluation fails closed. Copy with no composer stamp is treated as superseded, because nothing in it proves the current composer wrote it.
+
+## Reason codes
+
+| Code | Meaning |
+|------|---------|
+| `composer_superseded` | The stamped composer is not the one this build ships. |
+| `composer_unstamped` | The artifact carries no composer stamp at all, so authorship cannot be proven. |
+| `policy_superseded` | The stamped bounded-cohort policy version is not the current one. |
+
+A cohort artifact stamps both a composer and the bounded-cohort policy, and both are checked. A draft or touchpoint is identified by its `prompt_version`, which is the composer that wrote the text. The cadence policy stamped on a touchpoint is a schedule rather than a composer, so it is deliberately not read here.
+
+A version is current only when the version stamp and every member stamp are current. A member left behind by a partial recompose cannot ride under a current header.
+
+## What legacy copy can and cannot do
+
+| Action | `CURRENT` | `LEGACY_SUPERSEDED` |
+|--------|-----------|---------------------|
+| Read the version, its candidates and its audit trail | Allowed | Allowed |
+| `HOLD` or `REJECT` a candidate | Allowed | Allowed, so a reviewer can close an old version out |
+| `APPROVE` a candidate | Allowed | Refused with `409` |
+| `GO` on the cohort | Allowed | Blocked, and the reason codes appear in the version blockers |
+| Approve or queue a touchpoint | Allowed | Refused with `409` |
+| Transport and send | Allowed | Refused at the transport gate |
+| Recompose into version N+1 | Allowed | Allowed, and it is the only way forward |
+
+The transport check is absolute rather than relative. A send grant and the copy it authorizes can agree with each other and still both be the work of a composer this build no longer ships, so the grant is compared against the current composer and policy, not against the copy.
+
+Nothing is deleted when a version becomes legacy. The version, its candidates, its decisions and its receipts stay queryable, which is what makes the refusal safe: history remains auditable and only its ability to act is removed.
+
+## Recompose is the way forward
+
+`POST /confenge/cohorts/:id/recompose` creates version N+1 of the same cohort with the current composer. It never mutates the parent.
+
+The composer reads each member's own preserved fact, so recipient, mailbox, account, route class, evidence, provenance and source must survive byte-identical. Anything else is drift, and the whole operation is refused with `recompose_drift` instead of being stored. Re-reading upstream would be a new cohort, not a recompose.
+
+The request carries no copy. It requires an `Idempotency-Key`, a reason, a `confirmation` naming the version being recomposed (for example `v1`), and the `expected_frozen_hash` of that version. Canonical source evidence must still be `FRESH`: recompose rewrites copy, it cannot refresh evidence.
+
+Version N+1 is born with no validation, no review, no approval and no `GO`. It queues nothing, dispatches nothing, sends nothing and resumes nothing. Every decision is taken again on the new version.
+
+The response includes a report of what the composer kept, dropped and rewrote: `parent_members`, `kept_members`, `excluded_members`, `exclusions`, `by_reason_code`, `composer_before` and `composer_after`. Each member passes editorial QA again, so a member whose rewritten copy fails is excluded with its reason code rather than carried forward, and corpus QA still refuses survivors that read as the same mail merge as a neighbour.
+
+## Two editorial QA refusals worth knowing
+
+Editorial QA gained two deterministic checks that mostly show up as recompose exclusions:
+
+| Code | What it refuses |
+|------|-----------------|
+| `generic_cta` | The paragraph carrying the closing question neither says in the first person what the sender does nor shares a word with the observed public fact. A routing ask that does neither is copy that fits any company in the corpus. |
+| `personalization_without_fact` | Observation language ("Vi que", "Notei", "Reparei") is used while the message carries no observed fact. Observation language is a factual claim, so with no record behind it the mail asserts something the system cannot evidence. |
+
+## Where the state travels in the API
+
+- `GET /confenge/cohorts/:id` returns `editorial_state`, `actionable`, `editorial_reason_codes` and `editorial_notice` for the version, plus `is_current_version`, `current_version` and `current_version_id` so the reader can open the version that is still live. A superseded version also lists `superseded_by_version` among its reasons.
+- Each candidate in that version carries `editorial_state`, `actionable` and `editorial_reason_codes`, and superseded candidates list the same codes in `blocked_by`.
+- `GET /confenge/review/drafts` returns `editorial_state`, `editorial_actionable`, `editorial_reason_codes`, `editorial_notice`, `composer_version` and `prompt_version` per row, alongside the judging context the reviewer needs on the same request: `route_class`, `fact_source` and `target_fit`. Beside superseded copy `composer_version` is left empty on purpose, because naming the current composer there would read as if it wrote the text.
+
+## See also
+
+- [CONFENGE outreach staging](/guides/confenge-outreach/)
+- [Error codes](/api/error-codes/)
+- [Endpoint scope map](/api/endpoints/)

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -72,6 +72,8 @@ Cadence uses a versioned policy (`confenge.cadence.v1`): initial touch plus spac
 
 Dominant stops: `DO_NOT_CONTACT`, opt-out, bounce, and human reply cancel open future touches atomically. Reimport does not reactivate `SENT` or `DNC` touchpoints.
 
+Approval is also bounded in time, not only in scope. Frozen copy can be approved, authorized, queued and sent only while the composer that wrote it is the one the platform ships. Copy from an earlier composer becomes `LEGACY_SUPERSEDED`: readable for audit, refused by every operational path, and moved forward by recomposing the cohort into a new version. See [CONFENGE editorial lifecycle](/guides/confenge-editorial-lifecycle/).
+
 ## Import
 
 `POST /api/v1/confenge/import` accepts:
@@ -136,7 +138,11 @@ Target-fit is updated only by a current authoritative decision. A downgrade take
 | `POST /confenge/import` | Dry-run or apply feed |
 | `GET /confenge/import-runs` | Import audit history |
 | `GET /confenge/touchpoints/review` | Human review queue, including recoverable editorial states |
-| `GET /confenge/review/drafts` | Control Center review alias with exact content hashes |
+| `GET /confenge/review/drafts` | Control Center review alias with exact content hashes and the editorial verdict per row |
+| `GET /confenge/cohorts/:id` | One immutable cohort version, its candidates, and its editorial state |
+| `POST /confenge/cohorts/:id/candidates/:candidateId/review` | Human `APPROVE`, `HOLD` or `REJECT` on one candidate |
+| `POST /confenge/cohorts/:id/recompose` | Fork version N+1 with the current composer; inherits no approval and no `GO` |
+| `POST /confenge/cohorts/:id/decision` | `GO` or `NO_GO` on the version |
 | `GET /confenge/accounts/:id/touchpoints` | Account touch timeline |
 | `POST /confenge/accounts/:id/plan` | Plan cadence chain |
 | `POST /confenge/pilot/cohort/prepare` | Prepare up to 30 selected accounts with one explicit result per account |

--- a/docs/content/docs/guides/meta.json
+++ b/docs/content/docs/guides/meta.json
@@ -31,6 +31,7 @@
     "webhooks",
     "integrations",
     "confenge-outreach",
+    "confenge-editorial-lifecycle",
     "zapier",
     "make",
     "---Account and team---",

--- a/internal/app/confenge/cohort_operator.go
+++ b/internal/app/confenge/cohort_operator.go
@@ -86,6 +86,16 @@ func NormalizeBoundedCohortGrant(auth *BoundedCohortAuthorization, now time.Time
 	if auth.ComposerVersion == "" {
 		auth.ComposerVersion = ComposerVersion
 	}
+	// A grant may not be stamped with the current composer over copy an older
+	// one wrote: defaulting the field would otherwise launder the manifest.
+	if auth.FrozenManifest != nil {
+		if a := SnapshotEditorialAuthority(auth.FrozenManifest); !a.Actionable {
+			return fmt.Errorf("%s", a.Blocker("AUTHORIZE"))
+		}
+	}
+	if a := EvaluateCohortEditorialAuthority(auth.ComposerVersion, auth.PolicyVersion); !a.Actionable {
+		return fmt.Errorf("%s", a.Blocker("AUTHORIZE"))
+	}
 	if auth.EvidenceVersion == "" {
 		auth.EvidenceVersion = DefaultEvidenceVersion
 	}

--- a/internal/app/confenge/cohort_prepare.go
+++ b/internal/app/confenge/cohort_prepare.go
@@ -64,6 +64,11 @@ type FrozenCohortMember struct {
 	CTASource        string   `json:"cta_source"`
 	AdmissionReasons []string `json:"admission_reasons"`
 	RouteReasons     []string `json:"route_reasons"`
+	// SourceFact is the public record the copy was written from, kept verbatim
+	// so a later recomposition reads the record again instead of re-reading the
+	// sentence the last composer wrote. omitempty on purpose: manifests frozen
+	// before this field existed must keep hashing exactly as they did.
+	SourceFact string `json:"source_fact,omitempty"`
 }
 
 // CohortExclusion is one account left out of the frozen set.
@@ -358,6 +363,7 @@ func PrepareControlledCohort(accounts []CohortAccountInput, opts CohortPrepareOp
 			Company:          accountCompany(&in.Account),
 			MailboxPurpose:   strings.TrimSpace(cand.MailboxPurpose),
 			ObservedFact:     comp.ObservedFact,
+			SourceFact:       firstNonEmpty(in.Account.FactToMention, in.Account.MomentSummary),
 			FactSource:       comp.FactSource,
 			CTA:              comp.CTA,
 			CTASource:        comp.CTASource,

--- a/internal/app/confenge/editorial_authority.go
+++ b/internal/app/confenge/editorial_authority.go
@@ -1,0 +1,147 @@
+package confenge
+
+import "strings"
+
+// Editorial authority answers the one question a version number cannot: was
+// this frozen text written by the composer this build ships? The moment the
+// answer is no the text is history, and history is readable but never
+// operational. This is the only place that decision is made; every approve,
+// authorize, queue and dispatch path asks here instead of re-deriving it.
+
+const (
+	// EditorialStateCurrent means the current composer and policy produced this
+	// text, so it may still be reviewed, approved, authorized and queued.
+	EditorialStateCurrent = "CURRENT"
+	// EditorialStateSuperseded means an earlier composer or policy wrote it. It
+	// stays readable for audit and is refused by every operational path.
+	EditorialStateSuperseded = "LEGACY_SUPERSEDED"
+)
+
+// Reason codes stamped on superseded copy and returned by every refusal.
+const (
+	ReasonComposerSuperseded = "composer_superseded"
+	ReasonComposerUnstamped  = "composer_unstamped"
+	ReasonPolicySuperseded   = "policy_superseded"
+	// A member whose stamp is older than the snapshot header's.
+	ReasonMemberComposerSuperseded = "member_composer_superseded"
+)
+
+// EditorialLegacyNotice is the line a reader must see before the text itself.
+const EditorialLegacyNotice = "Versão histórica, mantida apenas para auditoria. Não é enviável e não aceita aprovação."
+
+// EditorialAuthority is the operational verdict on one frozen artifact.
+type EditorialAuthority struct {
+	State                  string   `json:"editorial_state"`
+	Actionable             bool     `json:"actionable"`
+	ReasonCodes            []string `json:"reason_codes"`
+	ComposerVersion        string   `json:"composer_version"`
+	CurrentComposerVersion string   `json:"current_composer_version"`
+	PolicyVersion          string   `json:"policy_version,omitempty"`
+	CurrentPolicyVersion   string   `json:"current_policy_version,omitempty"`
+	Notice                 string   `json:"notice,omitempty"`
+}
+
+// ComposerSuperseded fails closed: an unstamped artifact is superseded, because
+// nothing in it proves the current composer wrote the text.
+func ComposerSuperseded(stamped string) bool {
+	return strings.TrimSpace(stamped) != ComposerVersion
+}
+
+// EvaluateCohortEditorialAuthority judges a frozen cohort artifact, which
+// stamps both the composer and the bounded-cohort policy.
+func EvaluateCohortEditorialAuthority(composerVersion, policyVersion string) EditorialAuthority {
+	a := newEditorialAuthority(composerVersion)
+	a.PolicyVersion = strings.TrimSpace(policyVersion)
+	a.CurrentPolicyVersion = BoundedCohortPolicyV1
+	if a.PolicyVersion != BoundedCohortPolicyV1 {
+		a.ReasonCodes = append(a.ReasonCodes, ReasonPolicySuperseded)
+	}
+	return sealEditorialAuthority(a)
+}
+
+// EvaluateDraftEditorialAuthority judges a draft or touchpoint, where the
+// composer that wrote the text is identified by the stored prompt version.
+// The cadence policy stamped on a touchpoint is a schedule, not a composer, so
+// it is deliberately not read here.
+func EvaluateDraftEditorialAuthority(promptVersion string) EditorialAuthority {
+	a := EditorialAuthority{
+		ReasonCodes:            []string{},
+		ComposerVersion:        strings.TrimSpace(promptVersion),
+		CurrentComposerVersion: PromptVersion,
+	}
+	switch {
+	case a.ComposerVersion == "":
+		a.ReasonCodes = append(a.ReasonCodes, ReasonComposerUnstamped)
+	case !CurrentComposerPrompt(a.ComposerVersion):
+		a.ReasonCodes = append(a.ReasonCodes, ReasonComposerSuperseded)
+	}
+	return sealEditorialAuthority(a)
+}
+
+func newEditorialAuthority(composerVersion string) EditorialAuthority {
+	a := EditorialAuthority{
+		ReasonCodes:            []string{},
+		ComposerVersion:        strings.TrimSpace(composerVersion),
+		CurrentComposerVersion: ComposerVersion,
+	}
+	switch {
+	case a.ComposerVersion == "":
+		a.ReasonCodes = append(a.ReasonCodes, ReasonComposerUnstamped)
+	case a.ComposerVersion != ComposerVersion:
+		a.ReasonCodes = append(a.ReasonCodes, ReasonComposerSuperseded)
+	}
+	return a
+}
+
+func sealEditorialAuthority(a EditorialAuthority) EditorialAuthority {
+	if len(a.ReasonCodes) == 0 {
+		a.State = EditorialStateCurrent
+		a.Actionable = true
+		return a
+	}
+	a.State = EditorialStateSuperseded
+	a.Actionable = false
+	a.Notice = EditorialLegacyNotice
+	return a
+}
+
+// Blocker names the refusal for an operational action, or "" when the artifact
+// is still current. The action verb is carried so the audit trail records what
+// was attempted, not only that something was refused.
+func (a EditorialAuthority) Blocker(action string) string {
+	if a.Actionable {
+		return ""
+	}
+	return action + " refused on " + EditorialStateSuperseded + " copy (" +
+		strings.Join(a.ReasonCodes, ",") + "): composer " + editorialStampOrNone(a.ComposerVersion) +
+		" wrote this text, current is " + a.CurrentComposerVersion +
+		". Recompose the cohort and decide on the current version."
+}
+
+func editorialStampOrNone(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "(unstamped)"
+	}
+	return v
+}
+
+// SnapshotEditorialAuthority judges a frozen snapshot as a whole. A snapshot is
+// current only when the snapshot stamp and every member stamp are current, so a
+// member left behind by a partial recompose cannot ride a current header.
+func SnapshotEditorialAuthority(snap *FrozenCohortSnapshot) EditorialAuthority {
+	if snap == nil {
+		return sealEditorialAuthority(newEditorialAuthority(""))
+	}
+	a := EvaluateCohortEditorialAuthority(snap.ComposerVersion, snap.PolicyVersion)
+	if !a.Actionable {
+		return a
+	}
+	for i := range snap.Members {
+		if ComposerSuperseded(snap.Members[i].ComposerVersion) {
+			a.ReasonCodes = append(a.ReasonCodes, ReasonMemberComposerSuperseded)
+			a.ComposerVersion = snap.Members[i].ComposerVersion
+			return sealEditorialAuthority(a)
+		}
+	}
+	return a
+}

--- a/internal/app/confenge/editorial_authority_test.go
+++ b/internal/app/confenge/editorial_authority_test.go
@@ -1,0 +1,277 @@
+package confenge
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// The production v3 cohort the founder opened in the Control Center. It froze
+// with copy_qa=passed under its own gate, which is precisely why authority has
+// to be decided from the composer stamp and not from the stored verdict.
+const legacyProdComposer = "confenge.composer.v3"
+
+func legacyMember() FrozenCohortMember {
+	return FrozenCohortMember{
+		AccountID: uuid.New(), CandidateID: uuid.New(),
+		AccountRef: "cnpj:00507949000182", Company: "Jatobeton Engenharia",
+		Mailbox: "jatobeton@jatobeton.test", RouteClass: "GENERIC_COMPANY",
+		ComposerVersion: legacyProdComposer,
+		Subject:         "contratação pública: contratação DE Empresa Especializada Para",
+		BodyText: "Olá, equipe,\n\nSou da CONFENGE.\n\ncontratação pública: contratação DE Empresa " +
+			"Especializada Para Execução DOS Serviços Necessários DOS Serviços Necessários À " +
+			"Recuperação Estrutural DA Ponte SOB O RIO Sapucaí,.\n\nQueria falar com quem acompanha " +
+			"a carteira de contratos públicos por aí. Você consegue me indicar a pessoa responsável?",
+		AdmissionReasons: []string{"copy_qa=passed"},
+	}
+}
+
+func currentMember() FrozenCohortMember {
+	m := legacyMember()
+	m.ComposerVersion = ComposerVersion
+	return m
+}
+
+func snapshotOf(m FrozenCohortMember, composer string) FrozenCohortSnapshot {
+	return FrozenCohortSnapshot{
+		ComposerVersion: composer, PolicyVersion: BoundedCohortPolicyV1,
+		Members: []FrozenCohortMember{m},
+	}
+}
+
+func TestSupersededComposerIsNeverActionable(t *testing.T) {
+	for _, stamped := range []string{legacyProdComposer, "confenge.composer.v4", "", "  "} {
+		a := EvaluateCohortEditorialAuthority(stamped, BoundedCohortPolicyV1)
+		if a.Actionable {
+			t.Fatalf("composer %q must not be actionable", stamped)
+		}
+		if a.State != EditorialStateSuperseded {
+			t.Fatalf("composer %q must read %s, got %s", stamped, EditorialStateSuperseded, a.State)
+		}
+		if len(a.ReasonCodes) == 0 || a.Notice == "" {
+			t.Fatalf("composer %q must carry a reason code and a notice: %+v", stamped, a)
+		}
+	}
+	a := EvaluateCohortEditorialAuthority(ComposerVersion, BoundedCohortPolicyV1)
+	if !a.Actionable || a.State != EditorialStateCurrent || len(a.ReasonCodes) != 0 {
+		t.Fatalf("current composer must stay actionable: %+v", a)
+	}
+	if a.Notice != "" {
+		t.Fatalf("current copy must carry no legacy notice: %q", a.Notice)
+	}
+}
+
+func TestSupersededPolicyIsNeverActionable(t *testing.T) {
+	a := EvaluateCohortEditorialAuthority(ComposerVersion, "bounded-cohort-policy.v0")
+	if a.Actionable || !slices.Contains(a.ReasonCodes, ReasonPolicySuperseded) {
+		t.Fatalf("an old policy must fail closed: %+v", a)
+	}
+}
+
+// A current snapshot header must not launder a member an old composer wrote.
+func TestSnapshotIsOnlyCurrentWhenEveryMemberIs(t *testing.T) {
+	snap := snapshotOf(currentMember(), ComposerVersion)
+	if a := SnapshotEditorialAuthority(&snap); !a.Actionable {
+		t.Fatalf("all-current snapshot must be actionable: %+v", a)
+	}
+	mixed := FrozenCohortSnapshot{
+		ComposerVersion: ComposerVersion, PolicyVersion: BoundedCohortPolicyV1,
+		Members: []FrozenCohortMember{currentMember(), legacyMember()},
+	}
+	a := SnapshotEditorialAuthority(&mixed)
+	if a.Actionable || !slices.Contains(a.ReasonCodes, ReasonMemberComposerSuperseded) {
+		t.Fatalf("one legacy member must make the whole snapshot history: %+v", a)
+	}
+	if a := SnapshotEditorialAuthority(nil); a.Actionable {
+		t.Fatal("a nil snapshot must fail closed")
+	}
+}
+
+// GO mints send authority. It is the decision that must never reach history.
+func TestGOIsRefusedOnLegacyAndReachedOnCurrent(t *testing.T) {
+	approved := &HumanGateReview{Decision: "APPROVE", Effective: true}
+	valid := &HumanGateValidation{Status: "VALID"}
+
+	legacy := &HumanGateCohort{
+		Freshness: "FRESH", Manifest: snapshotOf(legacyMember(), legacyProdComposer),
+		Candidates: []HumanGateCandidate{{
+			FrozenCohortMember: legacyMember(), Validation: valid, Review: approved,
+		}},
+	}
+	blocked := humanGateDecisionBlockers(legacy)
+	if !slices.Contains(blocked, ReasonComposerSuperseded) {
+		t.Fatalf("GO on legacy copy must be blocked by %s: %v", ReasonComposerSuperseded, blocked)
+	}
+
+	m := currentMember()
+	current := &HumanGateCohort{
+		Freshness: "FRESH", Manifest: snapshotOf(m, ComposerVersion),
+		Candidates: []HumanGateCandidate{{
+			FrozenCohortMember: m, Validation: valid, Review: approved,
+		}},
+	}
+	if blocked := humanGateDecisionBlockers(current); len(blocked) != 0 {
+		t.Fatalf("a valid current version must be able to reach GO: %v", blocked)
+	}
+}
+
+// A recomposition is a new decision surface, never an inherited one.
+func TestRecomposeMovesToCurrentComposerAndInheritsNoAuthority(t *testing.T) {
+	parent := snapshotOf(legacyMember(), legacyProdComposer)
+	parent.AuthorizationID = uuid.New()
+
+	next, report, err := RecomposeManifest(&parent)
+	if err != nil {
+		t.Fatalf("recompose: %v", err)
+	}
+	if report.ComposerBefore != legacyProdComposer || report.ComposerAfter != ComposerVersion {
+		t.Fatalf("report must name both composers: %+v", report)
+	}
+	if next.ComposerVersion != ComposerVersion {
+		t.Fatalf("recomposed snapshot must carry the current composer, got %q", next.ComposerVersion)
+	}
+	if report.KeptMembers+report.ExcludedMembers != report.ParentMembers {
+		t.Fatalf("recompose accounting must reconcile: %+v", report)
+	}
+	// The parent is preserved byte-identical: history is evidence.
+	if parent.ComposerVersion != legacyProdComposer || parent.Members[0].BodyText != legacyMember().BodyText {
+		t.Fatal("recompose must never mutate the parent snapshot")
+	}
+	for _, m := range next.Members {
+		if m.ComposerVersion != ComposerVersion {
+			t.Fatalf("kept member kept a stale composer stamp: %q", m.ComposerVersion)
+		}
+		if m.ContentHash == legacyMember().ContentHash && m.BodyText == legacyMember().BodyText {
+			t.Fatal("recomposed copy must differ from the copy it replaces")
+		}
+	}
+	if a := SnapshotEditorialAuthority(next); !a.Actionable {
+		t.Fatalf("a recomposed snapshot must be operable again: %+v", a)
+	}
+}
+
+// Superseded copy stays fully readable. Auditing history is the whole point of
+// keeping it, so nothing here may blank the text.
+func TestSupersededVersionStaysReadableForAudit(t *testing.T) {
+	m := legacyMember()
+	snap := snapshotOf(m, legacyProdComposer)
+	a := SnapshotEditorialAuthority(&snap)
+	if a.Actionable {
+		t.Fatal("legacy must not be actionable")
+	}
+	if snap.Members[0].Subject == "" || snap.Members[0].BodyText == "" {
+		t.Fatal("legacy copy must remain readable")
+	}
+	if !strings.Contains(a.Blocker("APPROVE"), legacyProdComposer) {
+		t.Fatalf("the refusal must name the composer that wrote the text: %q", a.Blocker("APPROVE"))
+	}
+	if !strings.Contains(a.Blocker("APPROVE"), ComposerVersion) {
+		t.Fatalf("the refusal must name the current composer: %q", a.Blocker("APPROVE"))
+	}
+}
+
+// The blocker text must name the attempted action, so an audit trail records
+// what was tried and not merely that something was refused.
+func TestBlockerNamesTheAttemptedAction(t *testing.T) {
+	a := EvaluateCohortEditorialAuthority(legacyProdComposer, BoundedCohortPolicyV1)
+	for _, action := range []string{"APPROVE", "GO", "QUEUE", "TRANSPORT"} {
+		if !strings.HasPrefix(a.Blocker(action), action+" refused") {
+			t.Fatalf("blocker must name %s: %q", action, a.Blocker(action))
+		}
+	}
+	if EvaluateCohortEditorialAuthority(ComposerVersion, BoundedCohortPolicyV1).Blocker("APPROVE") != "" {
+		t.Fatal("current copy must produce no blocker")
+	}
+}
+
+// Drafts and touchpoints are stamped by prompt version, not composer version.
+func TestDraftAuthorityReadsThePromptStamp(t *testing.T) {
+	if a := EvaluateDraftEditorialAuthority(PromptVersion); !a.Actionable {
+		t.Fatalf("current prompt must be actionable: %+v", a)
+	}
+	if a := EvaluateDraftEditorialAuthority(PromptVersion + "+touch"); !a.Actionable {
+		t.Fatalf("a touch suffix is the same composer: %+v", a)
+	}
+	for _, stale := range []string{"confenge.draft.v3", "confenge.draft.v4+touch", ""} {
+		if a := EvaluateDraftEditorialAuthority(stale); a.Actionable {
+			t.Fatalf("prompt %q must fail closed: %+v", stale, a)
+		}
+	}
+}
+
+// Transport is the last gate. A grant and its copy can agree with each other
+// and still both be the work of a composer this build no longer ships.
+func TestTransportRefusesAGrantMintedByAnOldComposer(t *testing.T) {
+	actor := uuid.New()
+	authID := uuid.New()
+	tp := &models.OutreachTouchpoint{
+		AuthorizationMode: AuthorizationModeBoundedCohort,
+		State:             models.TouchpointApproved,
+		ApprovedBy:        &actor, CampaignPolicyAuthorizationID: &authID,
+		ContentHash: "h", ApprovedContentHash: "h",
+	}
+	auth := &BoundedCohortAuthorization{
+		ID: authID, ComposerVersion: legacyProdComposer, PolicyVersion: BoundedCohortPolicyV1,
+	}
+	err := CanTransportCohort(tp, auth, CohortTransportInput{})
+	if err == nil {
+		t.Fatal("transport must refuse a legacy-composer grant")
+	}
+	if !strings.Contains(err.Error(), ReasonComposerSuperseded) &&
+		!strings.Contains(err.Error(), "does not match") &&
+		!strings.Contains(err.Error(), "hash mismatch") {
+		t.Fatalf("unexpected refusal: %v", err)
+	}
+}
+
+// A recomposition has to stay repeatable. The member keeps the record it was
+// written from, so the next composer bump reads the record again instead of
+// re-digesting the sentence the last composer wrote and throwing the lead away.
+func TestRecomposeIsRepeatableBecauseTheRecordIsPreserved(t *testing.T) {
+	t.Setenv(EnvSenderName, "Tiago Sasaki")
+	const record = "objeto: recuperação estrutural da ponte sobre o Rio Sapucaí; órgão: DNIT; UF MG"
+
+	m := legacyMember()
+	m.ObservedFact = record
+	m.SourceFact = ""
+	parent := snapshotOf(m, legacyProdComposer)
+
+	first, rep1, err := RecomposeManifest(&parent)
+	if err != nil {
+		t.Fatalf("first recompose: %v", err)
+	}
+	if rep1.KeptMembers != 1 {
+		t.Fatalf("first recompose kept %d members, want 1: %v", rep1.KeptMembers, rep1.ByReasonCode)
+	}
+	if got := first.Members[0].SourceFact; got != record {
+		t.Fatalf("the record was not carried forward: %q", got)
+	}
+	if first.Members[0].ObservedFact == record {
+		t.Fatal("observed_fact must be the written sentence, not the raw record")
+	}
+
+	// Stamp it legacy again, exactly as a composer bump would leave it.
+	second := *first
+	second.ComposerVersion = legacyProdComposer
+	second.Members = append([]FrozenCohortMember(nil), first.Members...)
+	second.Members[0].ComposerVersion = legacyProdComposer
+
+	next, rep2, err := RecomposeManifest(&second)
+	if err != nil {
+		t.Fatalf("second recompose: %v", err)
+	}
+	if rep2.KeptMembers != 1 {
+		t.Fatalf("second recompose kept %d members, want 1: %v", rep2.KeptMembers, rep2.ByReasonCode)
+	}
+	if next.Members[0].SourceFact != record {
+		t.Fatalf("the record was lost on the second pass: %q", next.Members[0].SourceFact)
+	}
+	if next.Members[0].Subject != first.Members[0].Subject {
+		t.Fatalf("recomposing the same record twice must be stable: %q vs %q",
+			first.Members[0].Subject, next.Members[0].Subject)
+	}
+}

--- a/internal/app/confenge/editorial_compose.go
+++ b/internal/app/confenge/editorial_compose.go
@@ -149,6 +149,11 @@ func BuildMessageBrief(acc *models.OutreachAccount, cand *models.OutreachContact
 		return b
 	}
 	b.Company = editorialCompanyName(acc)
+	if b.Company == "" && strings.TrimSpace(firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)) != "" {
+		// The account has a name and it is unsayable; enrichment, not copy.
+		b.ReasonCodes = append(b.ReasonCodes, "company_name_unusable")
+		return b
+	}
 	b.Practice = practiceForAccount(acc)
 
 	// Only a proven person may be named, and only on a direct-person route.
@@ -168,6 +173,14 @@ func BuildMessageBrief(acc *models.OutreachAccount, cand *models.OutreachContact
 
 	b.Fact = DigestPublicFact(firstNonEmpty(acc.FactToMention, acc.MomentSummary))
 	if b.Fact.Phrase == "" {
+		// Our own earlier sentence is not evidence. Falling back on it would let
+		// a recompose launder its own output as a public record.
+		for _, r := range b.Fact.Reasons {
+			if r == "fact_is_composed_prose" {
+				b.ReasonCodes = append(b.ReasonCodes, r)
+				return b
+			}
+		}
 		// Tier B keeps the lead alive without laundering a missing procurement
 		// record into a claim. Target-fit/imported company identity is enough to
 		// ask a short routing question about contracts of engineering.
@@ -185,10 +198,29 @@ func BuildMessageBrief(acc *models.OutreachAccount, cand *models.OutreachContact
 	return b
 }
 
-// editorialCompanyName picks the readable trade name and drops legal form.
+// registryTailWords are the activity nouns a registry appends to a brand. A
+// person drops them and says the brand: "Inplenitus", not the whole entry.
+var registryTailWords = map[string]bool{
+	"projetos": true, "projeto": true, "gerenciamento": true,
+	"fiscalizacao": true, "consultoria": true, "assessoria": true,
+	"servicos": true, "servico": true, "empreendimentos": true,
+	"participacoes": true, "incorporacoes": true, "construcoes": true,
+	"montagens": true, "instalacoes": true, "representacoes": true,
+	"comercio": true, "industria": true, "terraplenagem": true,
+	"transportes": true, "locacoes": true, "obras": true, "sistemas": true,
+	"solucoes": true, "planejamento": true, "manutencao": true,
+}
+
+// editorialCompanyName picks the readable trade name and drops legal form. It
+// returns empty when the registry entry cannot be spoken, which refuses the
+// message rather than putting a cut name in front of a reader.
 func editorialCompanyName(acc *models.OutreachAccount) string {
 	name := firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial)
 	name = stripLegalVocative(strings.TrimSpace(name))
+	if name == "" {
+		return ""
+	}
+	name = shortTradingName(name)
 	if name == "" {
 		return ""
 	}
@@ -200,7 +232,35 @@ func editorialCompanyName(acc *models.OutreachAccount) string {
 			return titleWordPT(w)
 		}), " ")
 	}
-	return strings.TrimSpace(name)
+	name = strings.TrimSpace(name)
+	// A registry field cut at its width limit ends mid word; never say it.
+	if truncatedWordIn(name) {
+		return ""
+	}
+	return name
+}
+
+// shortTradingName reduces a registry entry to the brand a person says out
+// loud, dropping the enumerated activities the registry appends to it.
+func shortTradingName(name string) string {
+	if i := strings.IndexAny(name, ",;/"); i > 0 {
+		if head := strings.TrimSpace(name[:i]); head != "" {
+			name = head
+		}
+	}
+	fields := strings.Fields(name)
+	for len(fields) > 1 {
+		last := foldASCII(strings.ToLower(strings.Trim(fields[len(fields)-1], ".")))
+		if !registryTailWords[last] && !prepositionsPT[last] {
+			break
+		}
+		fields = fields[:len(fields)-1]
+	}
+	// Nobody says a five word company name in a first sentence.
+	if len(fields) > 4 {
+		fields = fields[:4]
+	}
+	return strings.Join(fields, " ")
 }
 
 func mapFields(in []string, f func(string) string) []string {

--- a/internal/app/confenge/editorial_fact.go
+++ b/internal/app/confenge/editorial_fact.go
@@ -2,6 +2,7 @@ package confenge
 
 import (
 	"regexp"
+	"sort"
 	"strings"
 	"unicode"
 )
@@ -57,6 +58,11 @@ var (
 	factBridgePrepRe = regexp.MustCompile(`(?i)\bsob\s+(o|a)\s+(rio|c[óo]rrego|ribeir[ãa]o)\b`)
 	// Pipeline telemetry describing our own ingestion, not the recipient's world.
 	factTelemetryRe = regexp.MustCompile(`\b(no input|observado com|contrato\(s\)|portfolio publico observado|registros? no feed|snapshot)\b`)
+	// Our own sentence coming back as a fact: a recompose reading the prose it
+	// wrote last time, never a public record.
+	factComposedProseRe = regexp.MustCompile(`(?i)^(vi|entrei|notei|reparei|percebi|observei|acompanhei|soube|retomo|escrevo|escrevi)\b|\bmeu nome e\b`)
+	// A record separates the work from its qualifier with a dash.
+	factDashQualifierRe = regexp.MustCompile(`\s+[-–—]\s+`)
 )
 
 // editalLeadIns are the procurement boilerplate openings that carry no
@@ -105,6 +111,43 @@ var editalLeadIns = []string{
 	"o presente objeto e a",
 	"tem por objeto a",
 	"tem por objeto o",
+}
+
+// factLeadIns is every boilerplate opening a phrase may lose, longest first, so
+// a full lead-in always wins over the shorter administrative label inside it.
+var factLeadIns = buildFactLeadIns()
+
+// buildFactLeadIns derives the bare openings a feed also publishes without the
+// "contratação de" head, e.g. "empresa especializada para execução de".
+func buildFactLeadIns() []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(editalLeadIns)*2)
+	add := func(v string) {
+		if v = strings.TrimSpace(v); v != "" && !seen[v] {
+			seen[v] = true
+			out = append(out, v)
+		}
+	}
+	for _, lead := range editalLeadIns {
+		add(lead)
+		for _, head := range []string{"contratacao de empresa", "contratacao de pessoa juridica"} {
+			if strings.HasPrefix(lead, head) {
+				add(strings.TrimPrefix(lead, "contratacao de "))
+			}
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool { return len(out[i]) > len(out[j]) })
+	return out
+}
+
+// factAdministrativeLabels is the subject gate's list of administrative
+// openings, longest first, reused so a label never has two definitions.
+var factAdministrativeLabels = sortedByLengthDesc(subjectAdministrativePrefixes)
+
+func sortedByLengthDesc(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.SliceStable(out, func(i, j int) bool { return len(out[i]) > len(out[j]) })
+	return out
 }
 
 // factStopPhrases mark the point where the object stops describing the work
@@ -175,8 +218,10 @@ func DigestPublicFact(raw string) PublicFactDigest {
 		return out
 	}
 	core = collapseRepeatedNGrams(core)
+	core = stripAdministrativeLabel(core)
 	core = stripEditalLeadIn(core)
 	core = truncateAtStopPhrase(core)
+	core = resolveDashQualifier(core)
 	core = strings.Trim(core, " \t.,;:-–—")
 	core = multiSpaceRe.ReplaceAllString(core, " ")
 	if core == "" {
@@ -191,7 +236,7 @@ func DigestPublicFact(raw string) PublicFactDigest {
 		out.Reasons = reasons
 		return out
 	}
-	subject := subjectFromPhrase(phrase)
+	subject := subjectFromPhrase(phrase, raw)
 	if subject == "" {
 		out.Reasons = []string{"fact_no_subject_head"}
 		return out
@@ -240,7 +285,7 @@ func stripEditalLeadIn(s string) string {
 	for changed := true; changed; {
 		changed = false
 		orig, folded := runeFold(s)
-		for _, lead := range editalLeadIns {
+		for _, lead := range factLeadIns {
 			n := len([]rune(lead))
 			if n > len(folded) || string(folded[:n]) != lead {
 				continue
@@ -256,6 +301,54 @@ func stripEditalLeadIn(s string) string {
 		}
 	}
 	return strings.TrimSpace(stripLeadingPrepositions(s))
+}
+
+// stripAdministrativeLabel drops a labelled procurement opening such as
+// "contratação pública: X", which otherwise survives into prose and makes the
+// sentence stutter. The separator is required so an object that merely starts
+// with one of those words is never cut mid sentence.
+func stripAdministrativeLabel(s string) string {
+	for changed := true; changed; {
+		changed = false
+		orig, folded := runeFold(s)
+		for _, label := range factAdministrativeLabels {
+			n := len([]rune(label))
+			if n >= len(folded) || string(folded[:n]) != label {
+				continue
+			}
+			rest := []rune(strings.TrimLeft(string(orig[n:]), " \t"))
+			if len(rest) == 0 || !strings.ContainsRune(":-–—", rest[0]) {
+				continue
+			}
+			trimmed := strings.TrimSpace(strings.TrimLeft(string(rest), ":-–— \t"))
+			if len(strings.Fields(trimmed)) < 2 {
+				continue
+			}
+			s = trimmed
+			changed = true
+			break
+		}
+	}
+	return strings.TrimSpace(s)
+}
+
+// resolveDashQualifier rewrites the record's "work - qualifier" shorthand as
+// prose: the head alone when it already says something, otherwise bound with
+// "para", which is how a person reads that dash out loud.
+func resolveDashQualifier(s string) string {
+	loc := factDashQualifierRe.FindStringIndex(s)
+	if loc == nil {
+		return s
+	}
+	head := strings.TrimSpace(s[:loc[0]])
+	tail := strings.TrimSpace(s[loc[1]:])
+	if head == "" || tail == "" {
+		return s
+	}
+	if len(strings.Fields(head)) >= 3 {
+		return head
+	}
+	return head + " para " + tail
 }
 
 // stripLeadingPrepositions drops the connective left behind by a lead-in cut,
@@ -376,6 +469,9 @@ func factPhraseDefects(phrase string) []string {
 	if factTelemetryRe.MatchString(foldASCII(strings.ToLower(phrase))) {
 		reasons = append(reasons, "fact_is_internal_telemetry")
 	}
+	if factComposedProseRe.MatchString(foldASCII(strings.ToLower(phrase))) {
+		reasons = append(reasons, "fact_is_composed_prose")
+	}
 	if strings.ContainsAny(phrase, "()[]{}") {
 		reasons = append(reasons, "fact_carries_record_punctuation")
 	}
@@ -414,27 +510,20 @@ func allCapsWordIn(s string) bool {
 }
 
 // subjectFromPhrase writes a short nominal head. It selects whole words from
-// the phrase's noun group; it never cuts at a character budget.
-func subjectFromPhrase(phrase string) string {
+// the phrase's noun group; it never cuts at a character budget. An empty
+// return refuses the fact, which is better than a subject naming no work.
+func subjectFromPhrase(phrase, raw string) string {
 	words := strings.Fields(phrase)
 	if len(words) < 2 {
 		return ""
 	}
 	folded := foldASCII(strings.ToLower(phrase))
+	foldedRaw := foldASCII(strings.ToLower(strings.TrimSpace(raw)))
 	// Event subjects are written from the meaning of the fact, not copied from
 	// its first N words. Besides reading better, this keeps the subject stable
 	// when upstream changes administrative wording around the same event.
-	switch {
-	case strings.Contains(folded, "reequilibr"):
-		return "Reequilíbrio do contrato público"
-	case strings.Contains(folded, "reajust"):
-		return "Reajuste do contrato público"
-	case strings.Contains(folded, "prorrog"):
-		return "Prorrogação do contrato público"
-	case strings.Contains(folded, "aditivo"):
-		return "Aditivo do contrato público"
-	case strings.Contains(folded, "edital"), strings.Contains(folded, "licit"):
-		return "Licitação pública"
+	if s := eventSubjectFor(folded); s != "" && subjectNamesSpecificWork(s) {
+		return s
 	}
 	// Prefer the group that names something real, so "recuperação estrutural
 	// da ponte sobre o Rio Sapucaí" yields "Ponte sobre o Rio Sapucaí".
@@ -443,7 +532,9 @@ func subjectFromPhrase(phrase string) string {
 		// A two-word place name alone ("Avenida Brasil") is vaguer than the
 		// work itself; only prefer the place group when it is descriptive.
 		if len(tail) >= 3 && len(tail) <= 6 {
-			return upperFirstRune(strings.Join(tail, " "))
+			if s := writtenSubject(tail, foldedRaw); s != "" {
+				return s
+			}
 		}
 	}
 	limit := len(words)
@@ -460,13 +551,43 @@ func subjectFromPhrase(phrase string) string {
 	if len(head) < 2 || prepositionsPT[foldASCII(strings.ToLower(head[0]))] {
 		return ""
 	}
-	if strings.Contains(folded, "contrat") {
-		return "Contrato público"
+	return writtenSubject(head, foldedRaw)
+}
+
+// eventSubjectFor names the procurement event the phrase is about.
+func eventSubjectFor(folded string) string {
+	switch {
+	case strings.Contains(folded, "reequilibr"):
+		return "Reequilíbrio do contrato público"
+	case strings.Contains(folded, "reajust"):
+		return "Reajuste do contrato público"
+	case strings.Contains(folded, "prorrog"):
+		return "Prorrogação do contrato público"
+	case strings.Contains(folded, "aditivo"):
+		return "Aditivo do contrato público"
 	}
-	// Prefixing with "Sobre" makes this a written subject rather than a raw
-	// record slice. It also preserves the useful nominal head for uncommon
-	// events that do not match the vocabulary above.
-	return "Sobre " + strings.ToLower(strings.Join(head, " "))
+	return ""
+}
+
+// writtenSubject turns a word group into a subject line. It refuses a group
+// that names no work, and prefixes "Sobre" only when the plain head would read
+// as a literal slice of the record.
+func writtenSubject(words []string, foldedRaw string) string {
+	if len(words) < 2 {
+		return ""
+	}
+	plain := strings.Join(words, " ")
+	if !subjectNamesSpecificWork(plain) {
+		return ""
+	}
+	folded := foldASCII(strings.ToLower(plain))
+	if foldedRaw == "" || !strings.Contains(foldedRaw, folded) {
+		return upperFirstRune(plain)
+	}
+	if strings.HasPrefix(folded, "sobre ") {
+		return ""
+	}
+	return "Sobre " + strings.ToLower(plain)
 }
 
 func indexOfProperCue(words []string) int {

--- a/internal/app/confenge/editorial_qa.go
+++ b/internal/app/confenge/editorial_qa.go
@@ -41,10 +41,16 @@ var (
 	qaURLRe       = regexp.MustCompile(`(?i)https?://`)
 	// Punctuation a person never types.
 	qaBadPunctRe = regexp.MustCompile(`,\.|\.\.|,,|;\.|::|:\.|!\.|\?\.|\s+[,.;:!?]|\(\s*\)`)
-	// A sentence that stops on a connective was cut, not written.
-	qaDanglingTailRe = regexp.MustCompile(`(?i)\b(de|da|do|dos|das|para|por|com|em|na|no|e|ou|a|o|que|sob|sobre|entre)\s*$`)
+	// A sentence that stops on a connective was cut, not written. The boundary
+	// is written out because \b is ASCII only and would split "mineração".
+	qaDanglingTailRe = regexp.MustCompile(`(?i)(^|\s)(de|da|do|dos|das|para|por|com|em|na|no|e|ou|a|o|que|sob|sobre|entre)\s*$`)
 	// Addressing the reader as the owner of a role nobody proved.
 	qaAssertedRoleRe = regexp.MustCompile(`(?i)\bcomo (o |a )?(respons[aá]vel|gestor|diretor|gerente|propriet[aá]rio|s[oó]cio)\b`)
+	// A first person statement of what the sender does. This is what turns a
+	// routing request into a reason the reader can act on.
+	qaPracticeRe = regexp.MustCompile(`(?i)\b(trabalho|atuo|apoio|ajudo|presto|acompanho|cuido|atendo|assessoro|represento)\b`)
+	// Language that claims a specific observation about this recipient.
+	qaObservationRe = regexp.MustCompile(`(?i)\b(vi que|vi uma|vi um|vi a|vi o|vi esse|vi essa|notei|reparei|percebi|observei|acompanhei|soube que|li que|encontrei|localizei)\b`)
 )
 
 // syntheticPhrases are the constructions that mark machine-written outbound.
@@ -110,6 +116,118 @@ var subjectAdministrativePrefixes = []string{
 	"tomada de precos",
 	"dispensa de licitacao",
 	"aviso de licitacao",
+}
+
+// administrativeSubjectWords is the procurement vocabulary that names a
+// category instead of a job. A line built only from these says nothing about
+// the reader, however grammatical it is.
+var administrativeSubjectWords = map[string]bool{
+	"contrato": true, "contratos": true, "contratacao": true, "contratacoes": true,
+	"contratada": true, "contratante": true, "publico": true, "publica": true,
+	"publicos": true, "publicas": true, "licitacao": true, "licitacoes": true,
+	"licitatorio": true, "pregao": true, "eletronico": true, "presencial": true,
+	"edital": true, "editais": true, "processo": true, "processos": true,
+	"administrativo": true, "administrativa": true, "objeto": true, "aviso": true,
+	"dispensa": true, "inexigibilidade": true, "tomada": true, "registro": true,
+	"preco": true, "precos": true, "ata": true, "termo": true, "servico": true,
+	"servicos": true, "prestacao": true, "execucao": true, "fornecimento": true,
+	"sobre": true, "o": true, "a": true, "os": true, "as": true, "um": true,
+	"uma": true, "de": true, "do": true, "da": true, "dos": true, "das": true,
+	"e": true, "em": true, "no": true, "na": true, "nos": true, "nas": true,
+	"para": true, "por": true, "com": true, "ao": true, "aos": true,
+}
+
+// truncatableWords are the long words a width-limited registry or feed field
+// cuts in half. A prose token that is a shortened one of these is a paste.
+var truncatableWords = []string{
+	"fiscalizacao", "gerenciamento", "administracao", "planejamento",
+	"manutencao", "terraplenagem", "saneamento", "incorporacao",
+	"participacoes", "empreendimentos", "edificacoes", "infraestrutura",
+	"instalacoes", "representacoes", "arquitetura", "engenharia",
+	"construcao", "construcoes", "construtora", "consultoria", "assessoria",
+	"tecnologia", "ambiental", "urbanismo", "eletrica", "hidraulica",
+	"mineracao", "licenciamento", "supervisao", "drenagem", "montagem",
+	"projetos", "servicos", "comercio", "industria", "transportes",
+	"materiais", "equipamentos", "sistemas", "solucoes", "energia",
+	"qualidade", "laboratorio", "topografia", "geotecnia", "rodovias",
+	"ferrovias", "aeroportos", "imobiliaria", "incorporadora", "empreiteira",
+}
+
+// wholeWordsPT are real words that happen to open one of the words above.
+// Listing them keeps the truncation check from firing on ordinary prose.
+var wholeWordsPT = map[string]bool{
+	"gerencia": true, "licencia": true, "elabora": true, "recupera": true,
+	"administra": true, "pavimenta": true, "sinaliza": true, "segura": true,
+	"educa": true, "projeta": true, "empresa": true, "servico": true,
+	"projeto": true, "sistema": true, "transporte": true, "industria": true,
+	"comercio": true, "material": true, "ambiente": true, "energia": true,
+	"obra": true, "ponte": true, "monta": true, "rodovia": true,
+	"ferrovia": true, "aeroporto": true, "equipamento": true,
+	"construtor": true, "incorporador": true,
+}
+
+// subjectNamesSpecificWork reports a subject carrying at least one word about
+// the job itself. "Contrato público" carries none and fits every recipient.
+func subjectNamesSpecificWork(subject string) bool {
+	for _, w := range strings.Fields(subject) {
+		key := foldASCII(strings.ToLower(strings.Trim(w, ".,;:!?()[]\"'")))
+		if key == "" || administrativeSubjectWords[key] {
+			continue
+		}
+		letters := 0
+		for _, r := range key {
+			if unicode.IsLetter(r) {
+				letters++
+			}
+		}
+		if letters >= 3 {
+			return true
+		}
+	}
+	return false
+}
+
+// truncatedWordIn reports a token cut mid word, e.g. the registry name
+// "Inplenitus Projetos, Gerenciamento E Fiscaliz".
+func truncatedWordIn(s string) bool {
+	for _, w := range strings.Fields(s) {
+		core := strings.Trim(w, ".,;:!?()[]\"'")
+		key := foldASCII(strings.ToLower(core))
+		if len([]rune(key)) < 4 || wholeWordsPT[key] {
+			continue
+		}
+		// No Portuguese word ends in "ç"; that is always a cut.
+		if strings.HasSuffix(strings.ToLower(core), "ç") {
+			return true
+		}
+		if len([]rune(key)) < 5 {
+			continue
+		}
+		for _, full := range truncatableWords {
+			if len(key) < len(full) && strings.HasPrefix(full, key) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// administrativeLabelIn reports an edital label sitting inside prose. The
+// leaked form has no colon: "na contratação pública licenciamento ambiental".
+func administrativeLabelIn(s string) bool {
+	tokens := make([]string, 0, 64)
+	for _, w := range strings.Fields(foldASCII(strings.ToLower(s))) {
+		if t := strings.Trim(w, ".,;:!?()[]\"'"); t != "" {
+			tokens = append(tokens, t)
+		}
+	}
+	padded := " " + strings.Join(tokens, " ") + " "
+	for _, p := range subjectAdministrativePrefixes {
+		if strings.Contains(padded, " "+p+" ") {
+			return true
+		}
+	}
+	return false
 }
 
 // EditorialQA returns the reason codes that block a message. Empty means the
@@ -181,6 +299,14 @@ func checkEditorialSubject(subject string, ctx EditorialQAContext, add func(stri
 	}
 	if containsDumpLabel(subject) || qaEnumRe.MatchString(subject) || qaScoreRe.MatchString(subject) {
 		add("subject_metadata")
+	}
+	// A subject built only from procurement vocabulary names no work, so every
+	// recipient in the cohort could receive it unchanged.
+	if !subjectNamesSpecificWork(subject) {
+		add("subject_generic_boilerplate")
+	}
+	if truncatedWordIn(subject) {
+		add("subject_truncated_word")
 	}
 	// A subject sliced out of the raw record reads as a paste, not a line
 	// somebody wrote. Any long literal overlap is treated as a slice.
@@ -275,6 +401,14 @@ func checkEditorialBody(body string, ctx EditorialQAContext, add func(string)) {
 	if containsDumpLabel(body) || looksLikeMetadataDump(body) {
 		add("metadata_dump")
 	}
+	// An edital label surviving into a sentence makes the prose stutter, as in
+	// "uma contratação envolvendo a empresa na contratação pública ...".
+	if administrativeLabelIn(body) {
+		add("body_administrative_label")
+	}
+	if truncatedWordIn(body) {
+		add("truncated_word")
+	}
 	if qaEnumRe.MatchString(body) {
 		add("raw_enum")
 	}
@@ -297,6 +431,56 @@ func checkEditorialBody(body string, ctx EditorialQAContext, add func(string)) {
 	if !ctx.PersonProven && qaAssertedRoleRe.MatchString(folded) {
 		add("unproven_role")
 	}
+	// Observation language is a factual claim. With no record behind it the
+	// mail asserts something the system cannot evidence, so it fails closed.
+	if qaObservationRe.MatchString(folded) && strings.TrimSpace(ctx.RawFact) == "" {
+		add("personalization_without_fact")
+	}
+	checkEditorialAsk(body, ctx, add)
+}
+
+// checkEditorialAsk refuses an ask with nothing tying it to this reader. The
+// paragraph carrying the question must either say in the first person what the
+// sender does or name a word from the observed public fact; a routing request
+// that does neither is copy that fits any company in the corpus.
+func checkEditorialAsk(body string, ctx EditorialQAContext, add func(string)) {
+	ask := ""
+	for _, p := range nonEmptyParagraphs(body) {
+		if strings.Contains(p, "?") {
+			ask = p
+			break
+		}
+	}
+	if ask == "" {
+		return
+	}
+	foldedAsk := foldASCII(strings.ToLower(ask))
+	if qaPracticeRe.MatchString(foldedAsk) {
+		return
+	}
+	if sharesContentWord(foldedAsk, foldASCII(strings.ToLower(ctx.RawFact))) {
+		return
+	}
+	add("generic_cta")
+}
+
+// sharesContentWord reports a word long enough to carry meaning present
+// verbatim in both texts.
+func sharesContentWord(a, b string) bool {
+	if strings.TrimSpace(b) == "" {
+		return false
+	}
+	have := map[string]bool{}
+	for _, w := range strings.Fields(b) {
+		have[strings.Trim(w, ".,;:!?()[]\"'")] = true
+	}
+	for _, w := range strings.Fields(a) {
+		w = strings.Trim(w, ".,;:!?()[]\"'")
+		if len([]rune(w)) >= 5 && have[w] {
+			return true
+		}
+	}
+	return false
 }
 
 func checkEditorialShared(subject, body string, ctx EditorialQAContext, add func(string)) {

--- a/internal/app/confenge/editorial_qa_screenshot_test.go
+++ b/internal/app/confenge/editorial_qa_screenshot_test.go
@@ -1,0 +1,185 @@
+package confenge
+
+import "testing"
+
+// The founder read these three messages side by side in the UI. v3 and v4 were
+// stamped copy_qa=passed while closing with an ask that fits any company in the
+// corpus; v5 is what the current composer emits and must stay sendable. These
+// fixtures are the exact strings from that screen, not paraphrases.
+
+const screenshotV3Subject = "contratação pública: contratação DE Empresa Especializada Para"
+
+const screenshotV3Body = "Olá, equipe,\n\n" +
+	"Sou da CONFENGE.\n\n" +
+	"contratação pública: contratação DE Empresa Especializada Para Execução DOS " +
+	"Serviços Necessários DOS Serviços Necessários À Recuperação Estrutural DA Ponte " +
+	"SOB O RIO Sapucaí,.\n\n" +
+	"Queria falar com quem acompanha a carteira de contratos públicos por aí. " +
+	"Você consegue me indicar a pessoa responsável?"
+
+const screenshotV4Subject = "contratação pública: empresa Especializada para Execução dos"
+
+const screenshotV4Body = "Olá, equipe,\n\n" +
+	"Sou da CONFENGE.\n\n" +
+	"contratação pública: empresa Especializada para Execução dos Serviços Necessários " +
+	"à Recuperação Estrutural da Ponte sob o Rio Sapucaí, Situada da Rodovia Federal.\n\n" +
+	"Queria falar com quem acompanha a carteira de contratos públicos por aí. " +
+	"Você consegue me indicar a pessoa responsável?"
+
+const screenshotV5Subject = "Ponte sobre o Rio Sapucaí"
+
+const screenshotV5Body = "Olá,\n\n" +
+	"Meu nome é Tiago, da CONFENGE. Vi uma contratação envolvendo a Jatobeton " +
+	"Engenharia na recuperação estrutural da ponte sobre o Rio Sapucaí.\n\n" +
+	"Trabalho com apoio a empresas de engenharia em contratos públicos e queria falar " +
+	"com quem cuida dessa frente por aí. Você consegue me indicar a pessoa certa?\n\n" +
+	"Obrigado,\nTiago"
+
+const screenshotRawFact = "contratação pública: contratação DE Empresa Especializada Para Execução DOS " +
+	"Serviços Necessários DOS Serviços Necessários À Recuperação Estrutural DA Ponte " +
+	"SOB O RIO Sapucaí, Situada da Rodovia Federal"
+
+func requireCode(t *testing.T, label string, got []string, want string) {
+	t.Helper()
+	if !codeSet(got)[want] {
+		t.Fatalf("%s: expected %s in %v", label, want, got)
+	}
+}
+
+func refuseCode(t *testing.T, label string, got []string, unwanted string) {
+	t.Helper()
+	if codeSet(got)[unwanted] {
+		t.Fatalf("%s: did not expect %s in %v", label, unwanted, got)
+	}
+}
+
+// TestLegacyClosingsAreNonActionable pins the two shipped messages whose only
+// closing was a routing request with nothing in it about this reader.
+func TestLegacyClosingsAreNonActionable(t *testing.T) {
+	cases := []struct {
+		name    string
+		subject string
+		body    string
+	}{
+		{"v3", screenshotV3Subject, screenshotV3Body},
+		{"v4", screenshotV4Subject, screenshotV4Body},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			codes := EditorialQA(tc.subject, tc.body, EditorialQAContext{
+				RouteClass:      RouteClassGenericCompany,
+				RawFact:         screenshotRawFact,
+				SenderFirstName: "Tiago",
+			})
+			requireCode(t, tc.name, codes, "generic_cta")
+		})
+	}
+}
+
+// TestCurrentComposerScreenshotStaysClean is the load bearing case: the copy
+// the composer emits today is real production output and must keep passing
+// with no codes at all.
+func TestCurrentComposerScreenshotStaysClean(t *testing.T) {
+	codes := EditorialQA(screenshotV5Subject, screenshotV5Body, EditorialQAContext{
+		RouteClass:      RouteClassGenericCompany,
+		SenderFirstName: "Tiago",
+		RawFact:         screenshotRawFact,
+	})
+	if len(codes) > 0 {
+		t.Fatalf("current composer output was refused: %v\n%s", codes, screenshotV5Body)
+	}
+}
+
+// TestPersonalizationWithoutFactFails pins the fail closed rule: a message may
+// not claim it saw something when no record was supplied.
+func TestPersonalizationWithoutFactFails(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "vi uma",
+			body: "Olá,\n\nMeu nome é Tiago, da CONFENGE. Vi uma contratação envolvendo a Jatobeton Engenharia na recuperação estrutural da ponte sobre o Rio Sapucaí.\n\n" +
+				"Trabalho com apoio a empresas de engenharia em contratos públicos e queria falar com quem cuida dessa frente por aí. Você consegue me indicar a pessoa certa?\n\nObrigado,\nTiago",
+		},
+		{
+			name: "vi que",
+			body: "Olá,\n\nMeu nome é Tiago, da CONFENGE. Vi que a Jatobeton Engenharia assumiu a recuperação estrutural da ponte sobre o Rio Sapucaí.\n\n" +
+				"Trabalho com apoio a empresas de engenharia em contratos públicos e queria falar com quem cuida dessa frente por aí. Você consegue me indicar a pessoa certa?\n\nObrigado,\nTiago",
+		},
+		{
+			name: "notei que",
+			body: "Olá,\n\nMeu nome é Tiago, da CONFENGE. Notei que a Jatobeton Engenharia atua na recuperação estrutural da ponte sobre o Rio Sapucaí.\n\n" +
+				"Trabalho com apoio a empresas de engenharia em contratos públicos e queria falar com quem cuida dessa frente por aí. Você consegue me indicar a pessoa certa?\n\nObrigado,\nTiago",
+		},
+		{
+			name: "acompanhei",
+			body: "Olá,\n\nMeu nome é Tiago, da CONFENGE. Acompanhei a recuperação estrutural da ponte sobre o Rio Sapucaí pela Jatobeton Engenharia.\n\n" +
+				"Trabalho com apoio a empresas de engenharia em contratos públicos e queria falar com quem cuida dessa frente por aí. Você consegue me indicar a pessoa certa?\n\nObrigado,\nTiago",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			codes := EditorialQA(screenshotV5Subject, tc.body, EditorialQAContext{
+				RouteClass:      RouteClassGenericCompany,
+				SenderFirstName: "Tiago",
+			})
+			requireCode(t, tc.name, codes, "personalization_without_fact")
+
+			with := EditorialQA(screenshotV5Subject, tc.body, EditorialQAContext{
+				RouteClass:      RouteClassGenericCompany,
+				SenderFirstName: "Tiago",
+				RawFact:         screenshotRawFact,
+			})
+			refuseCode(t, tc.name+" with fact", with, "personalization_without_fact")
+		})
+	}
+}
+
+// TestRoutingAskNeedsAnAnchor pins that asking to be routed is allowed and only
+// the bare, context free version of that ask is refused.
+func TestRoutingAskNeedsAnAnchor(t *testing.T) {
+	head := "Olá,\n\nMeu nome é Tiago, da CONFENGE. Vi uma contratação envolvendo a Jatobeton Engenharia na recuperação estrutural da ponte sobre o Rio Sapucaí.\n\n"
+	tail := "\n\nObrigado,\nTiago"
+
+	cases := []struct {
+		name string
+		ask  string
+		want bool
+	}{
+		{
+			name: "bare routing ask",
+			ask:  "Você consegue me indicar a pessoa responsável?",
+			want: true,
+		},
+		{
+			name: "bare ask with a wish clause in front",
+			ask:  "Queria falar com quem acompanha a carteira de contratos públicos por aí. Você consegue me indicar a pessoa responsável?",
+			want: true,
+		},
+		{
+			name: "ask anchored on the practice line",
+			ask:  "Trabalho com apoio a empresas de engenharia em contratos públicos e queria falar com quem cuida dessa frente por aí. Você consegue me indicar a pessoa certa?",
+			want: false,
+		},
+		{
+			name: "ask anchored on the observed fact",
+			ask:  "Queria entender como vocês tocam a recuperação estrutural dessa ponte. Você consegue me indicar a pessoa certa?",
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			codes := EditorialQA(screenshotV5Subject, head+tc.ask+tail, EditorialQAContext{
+				RouteClass:      RouteClassGenericCompany,
+				RawFact:         screenshotRawFact,
+				SenderFirstName: "Tiago",
+			})
+			if tc.want {
+				requireCode(t, tc.name, codes, "generic_cta")
+				return
+			}
+			refuseCode(t, tc.name, codes, "generic_cta")
+		})
+	}
+}

--- a/internal/app/confenge/editorial_recompose.go
+++ b/internal/app/confenge/editorial_recompose.go
@@ -106,9 +106,12 @@ func RecomposeManifest(parent *FrozenCohortSnapshot) (*FrozenCohortSnapshot, Rec
 
 // recomposeMember rewrites one member's copy from its own preserved facts.
 func recomposeMember(m *FrozenCohortMember) (FrozenCohortMember, []string) {
+	// The record, not the last composer's sentence: re-digesting our own prose
+	// is what made a second recomposition throw the lead away.
+	sourceFact := firstNonEmpty(m.SourceFact, m.ObservedFact)
 	acc := &models.OutreachAccount{
 		NomeFantasia:  m.Company,
-		FactToMention: m.ObservedFact,
+		FactToMention: sourceFact,
 	}
 	cand := &models.OutreachContactCandidate{
 		Email:          m.Mailbox,
@@ -124,7 +127,7 @@ func recomposeMember(m *FrozenCohortMember) (FrozenCohortMember, []string) {
 	}
 	qa := EditorialQA(composed.Subject, composed.Body, EditorialQAContext{
 		RouteClass:      m.RouteClass,
-		RawFact:         m.ObservedFact,
+		RawFact:         sourceFact,
 		SenderFirstName: sender.FirstName,
 		PersonProven:    !m.PersonUnknown && composerRouteNamesPerson(m.RouteClass),
 	})
@@ -137,6 +140,7 @@ func recomposeMember(m *FrozenCohortMember) (FrozenCohortMember, []string) {
 	out.BodyText = composed.Body
 	out.Greeting = composed.Greeting
 	out.ObservedFact = composed.ObservedFact
+	out.SourceFact = sourceFact
 	out.FactSource = composed.FactSource
 	out.CTA = composed.CTA
 	out.CTASource = composed.CTASource

--- a/internal/app/confenge/editorial_recompose_defects_test.go
+++ b/internal/app/confenge/editorial_recompose_defects_test.go
@@ -1,0 +1,202 @@
+package confenge
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// These are the exact strings the founder previewed on 2026-08-24, recomposed
+// from the real production manifests. Every one of them passed EditorialQA with
+// zero codes, so each is pinned twice: the composer must not write it and the
+// gate must refuse it even if some future composer or rewrite does.
+
+// The real PNCP facts carried by the v3 and v4 cohorts.
+const (
+	realFactAquaflot = "contratação pública: licenciamento Ambiental - Mineração, Exploração Florestal, " +
+		"Implantação DE Rodovias E Recuperação DE Áreas Degradadas (Renovado)"
+	realFactNovacap = "contratação pública: serviços Comuns DE Engenharia, Sendo Esses A Recuperação DE " +
+		"Pavimentação Asfáltica, DE Calçadas E Sinalização Viária, NO Âmbito DO Estado DO RIO DE Janeiro,"
+	realRegistryNameInplenitus = "INPLENITUS PROJETOS, GERENCIAMENTO E FISCALIZ"
+)
+
+// defectiveBody wraps one broken sentence in otherwise clean copy, so a test is
+// never green because the surrounding message was also wrong.
+func defectiveBody(observation string) string {
+	return "Olá,\n\nMeu nome é Tiago, da CONFENGE. " + observation + "\n\n" +
+		"Trabalho com apoio a empresas de engenharia em contratos públicos e queria falar " +
+		"com quem cuida dessa frente por aí. Você consegue me indicar a pessoa certa?\n\nObrigado,\nTiago"
+}
+
+// TestAdministrativeLabelNeverReachesProse pins defect 1: the "contratação
+// pública" label survived the digest and made the sentence stutter.
+func TestAdministrativeLabelNeverReachesProse(t *testing.T) {
+	leaked := []string{
+		"Vi uma contratação envolvendo a Aquaflot Ambiental na contratação pública licenciamento ambiental - mineração.",
+		"Vi uma contratação envolvendo a Novacap Engenharia na contratação pública serviços comuns de engenharia.",
+	}
+	for _, obs := range leaked {
+		t.Run(obs[:40], func(t *testing.T) {
+			codes := EditorialQA("Licenciamento ambiental", defectiveBody(obs), EditorialQAContext{
+				RouteClass:      RouteClassGenericCompany,
+				RawFact:         realFactAquaflot,
+				SenderFirstName: "Tiago",
+			})
+			requireCode(t, "leaked label", codes, "body_administrative_label")
+		})
+	}
+
+	for _, tc := range []struct{ raw, phrase, subject string }{
+		{realFactAquaflot, "licenciamento ambiental para mineração", "Licenciamento ambiental para mineração"},
+		{realFactNovacap, "serviços comuns de engenharia", "Sobre serviços comuns de engenharia"},
+	} {
+		d := DigestPublicFact(tc.raw)
+		if d.Phrase != tc.phrase {
+			t.Errorf("phrase=%q want %q (reasons=%v)", d.Phrase, tc.phrase, d.Reasons)
+		}
+		if d.Subject != tc.subject {
+			t.Errorf("subject=%q want %q", d.Subject, tc.subject)
+		}
+		if strings.Contains(foldASCII(strings.ToLower(d.Phrase)), "contratacao publica") {
+			t.Errorf("digest kept the administrative label: %q", d.Phrase)
+		}
+	}
+}
+
+// TestRealCohortFactsComposeCleanly is the positive half: the same production
+// facts must produce copy the gate accepts with no codes at all.
+func TestRealCohortFactsComposeCleanly(t *testing.T) {
+	cases := []struct {
+		company string
+		fact    string
+		want    string
+	}{
+		{"AQUAFLOT AMBIENTAL", realFactAquaflot, "no licenciamento ambiental para mineração"},
+		{"NOVACAP ENGENHARIA", realFactNovacap, "nos serviços comuns de engenharia"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.company, func(t *testing.T) {
+			acc := &models.OutreachAccount{NomeFantasia: tc.company, FactToMention: tc.fact}
+			out, reasons := ComposeEditorialInitial(acc, &models.OutreachContactCandidate{Email: "contato@exemplo.com.br"}, RouteClassGenericCompany)
+			if len(reasons) > 0 {
+				t.Fatalf("composer refused a sayable fact: %v", reasons)
+			}
+			if !strings.Contains(out.Body, tc.want) {
+				t.Fatalf("observation did not agree with the head noun, want %q:\n%s", tc.want, out.Body)
+			}
+			codes := EditorialQA(out.Subject, out.Body, EditorialQAContext{
+				RouteClass:      RouteClassGenericCompany,
+				RawFact:         tc.fact,
+				SenderFirstName: "Tiago",
+			})
+			if len(codes) > 0 {
+				t.Fatalf("composer emitted copy its own gate refuses: %v\n%s\n%s", codes, out.Subject, out.Body)
+			}
+		})
+	}
+}
+
+// TestGenericSubjectIsRefused pins defect 2: two members of one cohort both
+// shipped "Contrato público", a subject that names no work at all.
+func TestGenericSubjectIsRefused(t *testing.T) {
+	for _, subject := range []string{
+		"Contrato público",
+		"Contratos públicos",
+		"Licitação pública",
+		"Processo administrativo",
+		"Objeto do contrato",
+	} {
+		t.Run(subject, func(t *testing.T) {
+			codes := EditorialQA(subject, cleanEditorialBody(), EditorialQAContext{
+				RouteClass:      RouteClassGenericCompany,
+				RawFact:         liveV1RawFact,
+				SenderFirstName: "Tiago",
+			})
+			requireCode(t, subject, codes, "subject_generic_boilerplate")
+		})
+	}
+	// A subject naming the work is what the same check must let through.
+	for _, subject := range []string{
+		"Ponte sobre o Rio Sapucaí",
+		"Licenciamento ambiental para mineração",
+		"Contratos públicos de engenharia",
+		"Reequilíbrio do contrato público",
+	} {
+		t.Run("allowed/"+subject, func(t *testing.T) {
+			if !subjectNamesSpecificWork(subject) {
+				t.Fatalf("a subject naming real work was treated as boilerplate: %q", subject)
+			}
+		})
+	}
+	// The composer must not fall back to the generic head either.
+	for _, raw := range []string{realFactAquaflot, realFactNovacap} {
+		if d := DigestPublicFact(raw); d.Subject == "Contrato público" {
+			t.Fatalf("composer wrote the generic subject for %q", raw)
+		}
+	}
+}
+
+// TestTruncatedRegistryNameNeverReachesProse pins defect 3: a registry name cut
+// at its width limit was spoken as if it were the company's name.
+func TestTruncatedRegistryNameNeverReachesProse(t *testing.T) {
+	leaked := "Entrei em contato por causa da atuação da Inplenitus Projetos, Gerenciamento E Fiscaliz em contratos públicos de engenharia."
+	codes := EditorialQA("Contratos públicos de engenharia", defectiveBody(leaked), EditorialQAContext{
+		RouteClass:      RouteClassGenericCompany,
+		RawFact:         realFactNovacap,
+		SenderFirstName: "Tiago",
+	})
+	requireCode(t, "truncated registry name", codes, "truncated_word")
+
+	acc := &models.OutreachAccount{RazaoSocial: realRegistryNameInplenitus}
+	if got := editorialCompanyName(acc); got != "Inplenitus" {
+		t.Fatalf("company name=%q, want the short trading name", got)
+	}
+	out, reasons := ComposeEditorialInitial(acc, &models.OutreachContactCandidate{Email: "contato@exemplo.com.br"}, RouteClassGenericCompany)
+	if len(reasons) > 0 {
+		t.Fatalf("composer refused a recoverable company: %v", reasons)
+	}
+	if strings.Contains(out.Body, "Fiscaliz") || strings.Contains(out.Body, "Gerenciamento E") {
+		t.Fatalf("truncated registry name reached prose:\n%s", out.Body)
+	}
+}
+
+// TestTruncatedWordDetection keeps the truncation check honest in both
+// directions: ordinary Portuguese words are not cut words.
+func TestTruncatedWordDetection(t *testing.T) {
+	for _, s := range []string{"Fiscaliz", "Gerenciament", "caracterizaç", "Engenh"} {
+		if !truncatedWordIn(s) {
+			t.Errorf("%q was not detected as truncated", s)
+		}
+	}
+	for _, s := range []string{
+		"Inplenitus", "Aquaflot Ambiental", "Novacap Engenharia", "Jatobeton Engenharia",
+		"recuperação estrutural da ponte sobre o Rio Sapucaí",
+		"licenciamento ambiental para mineração",
+		"Você consegue me indicar a pessoa certa?",
+		"quem gerencia essa frente por aí",
+	} {
+		if truncatedWordIn(s) {
+			t.Errorf("%q was wrongly treated as truncated", s)
+		}
+	}
+}
+
+// TestComposedProseIsNotEvidence pins the recompose loop: the sentence this
+// composer wrote last time is our own output, never a public record, so it can
+// neither be re-digested into a fact nor laundered into the company fallback.
+func TestComposedProseIsNotEvidence(t *testing.T) {
+	prior := "Vi uma contratação envolvendo a Jatobeton Engenharia na recuperação estrutural da ponte sobre o Rio Sapucaí."
+	d := DigestPublicFact(prior)
+	if d.Phrase != "" {
+		t.Fatalf("our own sentence was digested as a fact: %q", d.Phrase)
+	}
+	if !codeSet(d.Reasons)["fact_is_composed_prose"] {
+		t.Fatalf("reasons=%v", d.Reasons)
+	}
+	acc := &models.OutreachAccount{NomeFantasia: "Jatobeton Engenharia", FactToMention: prior}
+	_, reasons := ComposeEditorialInitial(acc, &models.OutreachContactCandidate{Email: "contato@exemplo.com.br"}, RouteClassGenericCompany)
+	if !codeSet(reasons)["fact_is_composed_prose"] {
+		t.Fatalf("composer recomposed its own prose instead of refusing: %v", reasons)
+	}
+}

--- a/internal/app/confenge/editorial_regression_test.go
+++ b/internal/app/confenge/editorial_regression_test.go
@@ -206,7 +206,10 @@ func cleanEditorialBody() string {
 // everything, which would be an equally broken gate.
 func TestCleanEditorialBodyPasses(t *testing.T) {
 	codes := EditorialQA("Ponte sobre o Rio Sapucaí", cleanEditorialBody(), EditorialQAContext{
-		RouteClass:      RouteClassGenericCompany,
+		RouteClass: RouteClassGenericCompany,
+		// The body says "Vi uma contratação". The record it saw travels with it,
+		// because a claim to have observed something is only clean with evidence.
+		RawFact:         liveV1RawFact,
 		SenderFirstName: "Tiago",
 	})
 	if len(codes) > 0 {

--- a/internal/app/confenge/human_gate.go
+++ b/internal/app/confenge/human_gate.go
@@ -64,6 +64,11 @@ type HumanGateCandidate struct {
 	Validation *HumanGateValidation `json:"validation"`
 	Review     *HumanGateReview     `json:"review"`
 	BlockedBy  []string             `json:"blocked_by"`
+	// Editorial authority projection, so a renderer never has to compare
+	// composer strings itself to know whether this text is still operable.
+	EditorialState       string   `json:"editorial_state"`
+	Actionable           bool     `json:"actionable"`
+	EditorialReasonCodes []string `json:"editorial_reason_codes"`
 }
 
 type HumanGateDecision struct {
@@ -103,6 +108,16 @@ type HumanGateCohort struct {
 	Receipt          string               `json:"receipt"`
 	OperationReceipt string               `json:"-"`
 	CreatedAt        time.Time            `json:"created_at"`
+	// Editorial authority projection. The founder must be able to tell a
+	// current version from history without reading a version number, and must
+	// be handed the current version to open instead.
+	EditorialState       string     `json:"editorial_state"`
+	Actionable           bool       `json:"actionable"`
+	EditorialReasonCodes []string   `json:"editorial_reason_codes"`
+	EditorialNotice      string     `json:"editorial_notice,omitempty"`
+	IsCurrentVersion     bool       `json:"is_current_version"`
+	CurrentVersion       int        `json:"current_version"`
+	CurrentVersionID     *uuid.UUID `json:"current_version_id,omitempty"`
 }
 
 type HumanGateReviewInput struct {
@@ -393,8 +408,14 @@ func (s *service) GetHumanGateCohort(ctx context.Context, orgID, id uuid.UUID, n
 				c.Review.InvalidatedBy = append(c.Review.InvalidatedBy, liveReasons...)
 			}
 		}
+		ca := EvaluateCohortEditorialAuthority(m.ComposerVersion, v.PolicyVersion)
+		c.EditorialState, c.Actionable, c.EditorialReasonCodes = ca.State, ca.Actionable, ca.ReasonCodes
+		if !ca.Actionable {
+			c.BlockedBy = append(c.BlockedBy, ca.ReasonCodes...)
+		}
 		v.Candidates = append(v.Candidates, c)
 	}
+	s.projectHumanGateEditorialAuthority(ctx, orgID, v)
 	v.Decision = s.latestHumanGateDecision(ctx, orgID, id)
 	if v.Decision != nil && v.Decision.Decision == "GO" {
 		if blockers := humanGateDecisionBlockers(v); len(blockers) > 0 {
@@ -406,6 +427,34 @@ func (s *service) GetHumanGateCohort(ctx context.Context, orgID, id uuid.UUID, n
 		}
 	}
 	return v, nil
+}
+
+// projectHumanGateEditorialAuthority stamps the version-level verdict and, when
+// the version is history, names the version the founder should open instead.
+func (s *service) projectHumanGateEditorialAuthority(ctx context.Context, orgID uuid.UUID, v *HumanGateCohort) {
+	auth := SnapshotEditorialAuthority(&v.Manifest)
+	v.EditorialState, v.Actionable = auth.State, auth.Actionable
+	v.EditorialReasonCodes, v.EditorialNotice = auth.ReasonCodes, auth.Notice
+	if !auth.Actionable {
+		v.Reason = append(v.Reason, auth.ReasonCodes...)
+	}
+	v.CurrentVersion = v.Version
+	v.IsCurrentVersion = true
+	var latestID uuid.UUID
+	var latest int
+	err := s.humanGateDB.QueryRow(ctx,
+		`SELECT id,version FROM confenge_cohort_versions WHERE organization_id=$1 AND cohort_id=$2 ORDER BY version DESC LIMIT 1`,
+		orgID, v.CohortID).Scan(&latestID, &latest)
+	if err != nil {
+		return
+	}
+	v.CurrentVersion = latest
+	v.IsCurrentVersion = latest == v.Version
+	if !v.IsCurrentVersion {
+		id := latestID
+		v.CurrentVersionID = &id
+		v.Reason = append(v.Reason, "superseded_by_version")
+	}
 }
 
 func humanGateLiveInvalidations(m FrozenCohortMember, live CohortAccountInput, known bool) []string {
@@ -600,6 +649,17 @@ func (s *service) ReviewHumanGateCandidate(ctx context.Context, orgID, actorID, 
 	if c == nil {
 		return nil, humanGateError(errx.NotFound, "candidate_not_found", "candidate is not in this immutable version")
 	}
+	if in.Decision == "APPROVE" {
+		// History is readable, never approvable. HOLD and REJECT stay open so a
+		// reviewer can still close an old version out.
+		stamped := c.ComposerVersion
+		if ComposerSuperseded(v.Manifest.ComposerVersion) {
+			stamped = v.Manifest.ComposerVersion
+		}
+		if auth := EvaluateCohortEditorialAuthority(stamped, v.PolicyVersion); !auth.Actionable {
+			return nil, humanGateError(errx.Conflict, ReasonComposerSuperseded, auth.Blocker("APPROVE"))
+		}
+	}
 	if in.Decision == "APPROVE" && v.PolicyVersion != BoundedCohortPolicyV1 {
 		return nil, humanGateError(errx.Conflict, "policy_drift", "APPROVE requires a cohort created under the current policy version")
 	}
@@ -752,6 +812,12 @@ func humanGateDecisionBlockers(v *HumanGateCohort) []string {
 	blocked := []string{}
 	if v == nil || len(v.Candidates) == 0 {
 		blocked = append(blocked, "cohort_empty")
+	}
+	// GO mints send authority, so it is refused outright on superseded copy.
+	if v != nil {
+		if auth := SnapshotEditorialAuthority(&v.Manifest); !auth.Actionable {
+			blocked = append(blocked, auth.ReasonCodes...)
+		}
 	}
 	if v == nil || v.Freshness != "FRESH" {
 		blocked = append(blocked, "source_evidence_stale")

--- a/internal/app/confenge/human_gate_adjust.go
+++ b/internal/app/confenge/human_gate_adjust.go
@@ -394,7 +394,7 @@ func (s *service) humanGateCommitAdjust(ctx context.Context, orgID, actorID, ver
 		return uuid.Nil, 0, nil, humanGateError(errx.Conflict, "version_superseded", fmt.Sprintf("version %d is no longer the latest version of this cohort (latest is %d); re-read it before adjusting", lockedVersion, maxVersion))
 	}
 
-	revoked, x := humanGateRevokePriorAuthority(ctx, tx, orgID, actorID, versionID, adjustment.reason)
+	revoked, x := humanGateRevokePriorAuthority(ctx, tx, orgID, actorID, versionID, "human_gate_adjust:"+adjustment.reason)
 	if x != nil {
 		return uuid.Nil, 0, nil, x
 	}
@@ -449,6 +449,8 @@ func humanGateAdjustWriteError(err error, id, message string) *errx.Error {
 	return humanGateError(errx.Internal, id, message)
 }
 
+// The reason is stored verbatim, so the caller names the operation: a recompose
+// must not be filed in the audit trail as an adjust.
 // humanGateRevokePriorAuthority revokes, inside the caller's transaction, any
 // live bounded authority the parent version carries. There must never be two
 // valid authorities over the same cohort. If the authority cannot be proven
@@ -491,7 +493,7 @@ func humanGateRevokePriorAuthority(ctx context.Context, tx pgx.Tx, orgID, actorI
 	}
 	tag, err := tx.Exec(ctx, `UPDATE confenge_bounded_cohort_authorizations
 		SET revoked_at=$2, revoke_actor=$3, revoke_reason=$4, updated_at=$2
-		WHERE id=$1 AND organization_id=$5 AND revoked_at IS NULL`, *authorizationID, now, actorID, "human_gate_adjust:"+reason, orgID)
+		WHERE id=$1 AND organization_id=$5 AND revoked_at IS NULL`, *authorizationID, now, actorID, reason, orgID)
 	if err != nil || tag.RowsAffected() != 1 {
 		return nil, humanGateError(errx.Conflict, "authority_active", "the prior version's authorization could not be atomically revoked; revoke it explicitly, then adjust")
 	}

--- a/internal/app/confenge/human_gate_recompose_pg_test.go
+++ b/internal/app/confenge/human_gate_recompose_pg_test.go
@@ -1,0 +1,587 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// recomposeLegacyComposer is the stamp an earlier build left on frozen copy;
+// moving a version off it is the whole reason recompose exists.
+const recomposeLegacyComposer = "confenge.composer.v3"
+
+// recomposeFixture is one organization holding one immutable, legacy-stamped
+// human-gate version over a real Postgres, plus the in-memory canonical source
+// it was frozen from. Every test gets a fresh organization id, so tests never
+// observe each other's rows even though they share the schema.
+type recomposeFixture struct {
+	t         *testing.T
+	ctx       context.Context
+	pool      *pgxpool.Pool
+	svc       *service
+	repo      *memRepo
+	org       uuid.UUID
+	actor     uuid.UUID
+	runID     string
+	source    string
+	cohortID  uuid.UUID
+	versionID uuid.UUID
+	version   *HumanGateCohort
+}
+
+func newRecomposeFixture(t *testing.T) *recomposeFixture {
+	t.Helper()
+	dsn := testPostgresDSN(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	t.Cleanup(cancel)
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	applyBoundedCohortSchema(t, ctx, pool)
+	applyHumanGateSchema(t, pool)
+
+	f := &recomposeFixture{
+		t: t, ctx: ctx, pool: pool,
+		repo:   newMemRepo(),
+		org:    uuid.New(),
+		actor:  uuid.New(),
+		runID:  "run-recompose-" + uuid.NewString(),
+		source: "extra-cli",
+	}
+	f.svc = &service{
+		humanGateDB: pool,
+		repo:        f.repo,
+		cohortStore: NewPostgresCohortStore(pool),
+		cfg:         Config{Enabled: true, RepositorySHA: "sha-recompose", FeedMaxAge: 24 * time.Hour},
+	}
+	f.seedCanonicalSource()
+	f.freezeLegacyVersionOne()
+	return f
+}
+
+// seedCanonicalSource publishes three accounts with one controlled-eligible
+// generic-company mailbox each. Nothing here is a real mailbox: every domain is
+// .invalid, which can never resolve.
+func (f *recomposeFixture) seedCanonicalSource() {
+	f.t.Helper()
+	unknown := true
+	for _, spec := range []struct{ ref, cnpj, fact, mailbox string }{
+		// Record-shaped facts, because the composer digests a public record and
+		// refuses a generic phrase that names no work.
+		{"acc-recompose-a", "11111111000191", "objeto: recuperação estrutural da ponte sobre o Rio Sapucaí; órgão: DNIT; UF MG", "contato@empresa-ra.invalid"},
+		{"acc-recompose-b", "22222222000192", "objeto: licenciamento ambiental para mineração de calcário; órgão: SEMAD; UF MG", "contato@empresa-rb.invalid"},
+		{"acc-recompose-c", "33333333000193", "objeto: manutenção preventiva das estações elevatórias de esgoto; órgão: SANEAGO; UF GO", "contato@empresa-rc.invalid"},
+	} {
+		acc := cohortAccount(spec.ref, spec.cnpj, spec.fact)
+		acc.ID = uuid.New()
+		acc.OrganizationID = f.org
+		acc.SourceRunID = f.runID
+		cand := models.OutreachContactCandidate{
+			ID:              uuid.New(),
+			AccountID:       acc.ID,
+			Email:           spec.mailbox,
+			MailboxPurpose:  "GENERIC_CONTACT",
+			OwnershipStatus: "COMPANY_OWNED",
+			DiscoveryJSON:   eligibleDisc(f.t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unknown}),
+		}
+		f.repo.mu.Lock()
+		f.repo.byID[acc.ID] = &acc
+		f.repo.cands[acc.ID] = []models.OutreachContactCandidate{cand}
+		f.repo.mu.Unlock()
+	}
+}
+
+// freezeLegacyVersionOne runs the real freeze path, then stamps the manifest
+// with the legacy composer and its own legacy copy, exactly as a version frozen
+// by an earlier build would look on disk today.
+func (f *recomposeFixture) freezeLegacyVersionOne() {
+	f.t.Helper()
+	now := time.Now().UTC()
+	accounts, err := AccountsFromOrgForRun(f.ctx, f.repo, f.org, f.source, f.runID)
+	if err != nil {
+		f.t.Fatalf("load canonical source: %v", err)
+	}
+	freshness := &FeedSourceFreshness{
+		ContractVersion: AuthoritativeFreshnessContractV1,
+		Status:          "FRESH",
+		AsOf:            now.Add(-time.Hour).Format(time.RFC3339Nano),
+		ExpiresAt:       now.Add(23 * time.Hour).Format(time.RFC3339Nano),
+		RunID:           f.runID,
+	}
+	snap, err := PrepareControlledCohort(accounts, CohortPrepareOptions{
+		Now: now, Limit: 5, MaxDailyVolume: 5, TTL: DefaultCohortTTL,
+		RepositorySHA: "sha-recompose", FeedSchemaVersion: models.OutreachSchemaV1,
+		FeedIdentity: f.runID, PolicyVersion: BoundedCohortPolicyV1,
+		EvidenceVersion: DefaultEvidenceVersion, Source: f.source,
+		AuthoritativeSourceFreshness: freshness, RequireAuthoritativeFreshness: true,
+	})
+	if err != nil {
+		f.t.Fatalf("prepare: %v", err)
+	}
+	if len(snap.Members) != 3 {
+		f.t.Fatalf("members = %d, want 3", len(snap.Members))
+	}
+
+	snap.ComposerVersion = recomposeLegacyComposer
+	for i := range snap.Members {
+		m := &snap.Members[i]
+		m.ComposerVersion = recomposeLegacyComposer
+		m.Subject = "Assunto antigo sobre " + m.Company
+		m.BodyText = "Bom dia. Texto antigo escrito pelo composer anterior para " + m.Company + ". Posso enviar o recorte?"
+		m.ObservedFact = m.SourceFact
+		m.ContentHash = hashControlledContent(m.Mailbox, m.RouteClass, m.Subject, m.BodyText)
+	}
+	snap.CohortHash = HashFrozenCohort(snap)
+
+	f.cohortID, f.versionID = uuid.New(), uuid.New()
+	raw, err := json.Marshal(snap)
+	if err != nil {
+		f.t.Fatal(err)
+	}
+	_, err = f.pool.Exec(f.ctx, `INSERT INTO confenge_cohort_versions
+		(id,organization_id,cohort_id,version,source_run_id,source_system,source_as_of,freshness_expires_at,policy_version,frozen_hash,frozen_manifest,created_by,correlation_id,idempotency_key,request_hash)
+		VALUES($1,$2,$3,1,$4,$5,$6,$7,$8,$9,$10,$11,'corr-fixture',$12,'fixture-hash')`,
+		f.versionID, f.org, f.cohortID, f.runID, f.source, now.Add(-time.Hour), now.Add(23*time.Hour),
+		BoundedCohortPolicyV1, snap.CohortHash, raw, f.actor, "fixture-"+uuid.NewString())
+	if err != nil {
+		f.t.Fatalf("store version 1: %v", err)
+	}
+	v, x := f.svc.GetHumanGateCohort(f.ctx, f.org, f.versionID, time.Now().UTC())
+	if x != nil {
+		f.t.Fatalf("read version 1: %v", x)
+	}
+	if v.Freshness != "FRESH" {
+		f.t.Fatalf("fixture freshness = %s", v.Freshness)
+	}
+	if v.Derivation != DerivationCreate || v.ParentVersion != nil {
+		f.t.Fatalf("version 1 derivation = %q parent = %v, want CREATE/nil", v.Derivation, v.ParentVersion)
+	}
+	f.version = v
+}
+
+func (f *recomposeFixture) input(key string) HumanGateRecomposeInput {
+	return HumanGateRecomposeInput{
+		Reason:             "mover a copia legada para o composer atual",
+		Confirmation:       fmt.Sprintf("v%d", f.version.Version),
+		ExpectedFrozenHash: f.version.FrozenHash,
+		IdempotencyKey:     key,
+		CorrelationID:      "corr-" + key,
+	}
+}
+
+func (f *recomposeFixture) versionCount() int {
+	f.t.Helper()
+	var n int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM confenge_cohort_versions WHERE organization_id=$1 AND cohort_id=$2`, f.org, f.cohortID).Scan(&n); err != nil {
+		f.t.Fatal(err)
+	}
+	return n
+}
+
+func (f *recomposeFixture) maxVersion() int {
+	f.t.Helper()
+	var n int
+	if err := f.pool.QueryRow(f.ctx, `SELECT COALESCE(max(version),0) FROM confenge_cohort_versions WHERE organization_id=$1 AND cohort_id=$2`, f.org, f.cohortID).Scan(&n); err != nil {
+		f.t.Fatal(err)
+	}
+	return n
+}
+
+// versionRow returns the durable columns lineage is judged by, reading the
+// manifest as text so a byte comparison is a byte comparison.
+func (f *recomposeFixture) versionRow(versionID uuid.UUID) (manifest, frozenHash, derivation, composerVersion string) {
+	f.t.Helper()
+	if err := f.pool.QueryRow(f.ctx,
+		`SELECT frozen_manifest::text,frozen_hash,derivation,COALESCE(frozen_manifest->>'composer_version','') FROM confenge_cohort_versions WHERE id=$1 AND organization_id=$2`,
+		versionID, f.org).Scan(&manifest, &frozenHash, &derivation, &composerVersion); err != nil {
+		f.t.Fatal(err)
+	}
+	return manifest, frozenHash, derivation, composerVersion
+}
+
+func (f *recomposeFixture) parentMember(candidateID uuid.UUID) FrozenCohortMember {
+	f.t.Helper()
+	for _, m := range f.version.Manifest.Members {
+		if m.CandidateID == candidateID {
+			return m
+		}
+	}
+	f.t.Fatalf("candidate %s is not in the parent version", candidateID)
+	return FrozenCohortMember{}
+}
+
+// authorizeParent stores a real bounded authority bound to version 1's frozen
+// manifest plus the GO receipt that points at it.
+func (f *recomposeFixture) authorizeParent(expiresAt time.Time) uuid.UUID {
+	f.t.Helper()
+	snapshot := f.version.Manifest
+	snapshot.AuthorizationID = uuid.New()
+	// Production's legacy grants were minted while their composer was still the
+	// current one; the composer constant moved on afterwards and left them
+	// behind. Mint at that moment, then let the parent stay legacy.
+	snapshot.ComposerVersion = ComposerVersion
+	snapshot.PolicyVersion = BoundedCohortPolicyV1
+	snapshot.Members = append([]FrozenCohortMember(nil), snapshot.Members...)
+	for i := range snapshot.Members {
+		snapshot.Members[i].ComposerVersion = ComposerVersion
+	}
+	auth, err := GrantFromFrozenSnapshot(&snapshot, f.org, f.actor, time.Now().UTC())
+	if err != nil {
+		f.t.Fatalf("grant: %v", err)
+	}
+	auth.ExpiresAt = expiresAt
+	auth.TTL = expiresAt.Sub(auth.AuthorizedAt)
+	if err = f.svc.cohortStore.PutGrant(f.ctx, auth); err != nil {
+		f.t.Fatalf("put grant: %v", err)
+	}
+	if err = f.svc.cohortStore.RecordGOReview(f.ctx, auth.ID, f.actor, HumanGateReadyVerdict, "fixture", time.Now().UTC()); err != nil {
+		f.t.Fatalf("record go review: %v", err)
+	}
+	id := uuid.New()
+	if _, err := f.pool.Exec(f.ctx, `INSERT INTO confenge_cohort_go_decisions(id,organization_id,cohort_version_id,decision,reason,readiness_hash,authorization_id,actor_id,correlation_id,receipt,idempotency_key,request_hash)
+		VALUES($1,$2,$3,'GO','fixture','readiness',$4,$5,'corr',$6,$7,'h')`,
+		id, f.org, f.versionID, auth.ID, f.actor, humanGateReceipt("decision", id), "go-"+uuid.NewString()); err != nil {
+		f.t.Fatal(err)
+	}
+	return auth.ID
+}
+
+// approveEveryParentCandidate attaches a VALID validation and an APPROVE review
+// to every member of version 1, so the recomposed version has something real to
+// fail to inherit.
+func (f *recomposeFixture) approveEveryParentCandidate() {
+	f.t.Helper()
+	now := time.Now().UTC()
+	for _, m := range f.version.Manifest.Members {
+		validationID := uuid.New()
+		if _, err := f.pool.Exec(f.ctx, `INSERT INTO confenge_cohort_validations(id,organization_id,cohort_version_id,candidate_id,status,reason,provider,method,evidence_hash,checked_at,expires_at,actor_id,correlation_id,receipt,idempotency_key,request_hash)
+			VALUES($1,$2,$3,$4,'VALID','fixture','warmbly-emailverify','syntax-mx-smtp',$5,$6,$7,$8,'corr',$9,$10,'h')`,
+			validationID, f.org, f.versionID, m.CandidateID, m.EvidenceHash, now, now.Add(time.Hour), f.actor,
+			humanGateReceipt("validation", validationID), "val-"+uuid.NewString()); err != nil {
+			f.t.Fatal(err)
+		}
+		reviewID := uuid.New()
+		if _, err := f.pool.Exec(f.ctx, `INSERT INTO confenge_cohort_candidate_reviews(id,organization_id,cohort_version_id,candidate_id,decision,reason,recipient_hash,content_hash,policy_version,evidence_hash,validation_id,validation_expires_at,actor_id,correlation_id,receipt,idempotency_key,request_hash)
+			VALUES($1,$2,$3,$4,'APPROVE','fixture',$5,$6,$7,$8,$9,$10,$11,'corr',$12,$13,'h')`,
+			reviewID, f.org, f.versionID, m.CandidateID, HashRecipientSet([]string{m.Mailbox}), m.ContentHash,
+			BoundedCohortPolicyV1, m.EvidenceHash, validationID, now.Add(time.Hour), f.actor,
+			humanGateReceipt("review", reviewID), "rev-"+uuid.NewString()); err != nil {
+			f.t.Fatal(err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+// Two operators recomposing the same version at the same moment must not both
+// create version 2.
+func TestHumanGateRecomposeConcurrentForksOfOneVersionCreateOnlyOneNextVersion(t *testing.T) {
+	f := newRecomposeFixture(t)
+	const tabs = 2
+	results := make(chan *errx.Error, tabs)
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for i := 0; i < tabs; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			// Different idempotency keys on purpose: the intent lock cannot be
+			// what serializes these, only the parent row lock can.
+			_, x := f.svc.RecomposeHumanGateCohort(f.ctx, f.org, f.actor, f.versionID, f.input("recompose-race-"+uuid.NewString()))
+			results <- x
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(results)
+
+	accepted, refused := 0, []string{}
+	for x := range results {
+		if x == nil {
+			accepted++
+			continue
+		}
+		refused = append(refused, x.Identifier)
+	}
+	if accepted != 1 || len(refused) != tabs-1 {
+		t.Fatalf("accepted=%d refused=%v, want exactly one accepted", accepted, refused)
+	}
+	if refused[0] != "version_superseded" && refused[0] != "cohort_store_failed" {
+		t.Fatalf("refused with %q, want version_superseded or a serialization refusal", refused[0])
+	}
+	if n := f.versionCount(); n != 2 {
+		t.Fatalf("version rows = %d, want 2: concurrent recompositions forked the cohort", n)
+	}
+	if v := f.maxVersion(); v != 2 {
+		t.Fatalf("max(version) = %d, want 2", v)
+	}
+}
+
+// The browser retry after an ambiguous timeout must resolve to the version that
+// was already created, and a reused key with a new payload is a new intent.
+func TestHumanGateRecomposeReplayReturnsTheSameVersionAndCreatesNothing(t *testing.T) {
+	f := newRecomposeFixture(t)
+	key := "recompose-replay-" + uuid.NewString()
+
+	first, x := f.svc.RecomposeHumanGateCohort(f.ctx, f.org, f.actor, f.versionID, f.input(key))
+	if x != nil {
+		t.Fatalf("first recompose: %v", x)
+	}
+	if first.Cohort.Version != 2 {
+		t.Fatalf("first recompose produced version %d, want 2", first.Cohort.Version)
+	}
+	second, x := f.svc.RecomposeHumanGateCohort(f.ctx, f.org, f.actor, f.versionID, f.input(key))
+	if x != nil {
+		t.Fatalf("replay: %v", x)
+	}
+	if second.Cohort.ID != first.Cohort.ID || second.Cohort.Version != first.Cohort.Version {
+		t.Fatalf("replay produced another version: %s v%d vs %s v%d", second.Cohort.ID, second.Cohort.Version, first.Cohort.ID, first.Cohort.Version)
+	}
+	if second.Cohort.FrozenHash != first.Cohort.FrozenHash {
+		t.Fatalf("replay returned frozen hash %q, want %q", second.Cohort.FrozenHash, first.Cohort.FrozenHash)
+	}
+	if n := f.versionCount(); n != 2 {
+		t.Fatalf("version rows = %d, want 2 after a replay", n)
+	}
+
+	conflicting := f.input(key)
+	conflicting.Reason = "outro motivo completamente diferente"
+	if _, x = f.svc.RecomposeHumanGateCohort(f.ctx, f.org, f.actor, f.versionID, conflicting); x == nil || x.Identifier != "idempotency_payload_conflict" || x.Code != errx.Conflict {
+		t.Fatalf("got %#v, want 409 idempotency_payload_conflict", x)
+	}
+	if n := f.versionCount(); n != 2 {
+		t.Fatalf("version rows = %d, want 2 after a rejected payload conflict", n)
+	}
+}
+
+// Nothing that was approved about the old copy is evidence about the new copy,
+// and the authority the parent carried dies in the same transaction.
+func TestHumanGateRecomposedVersionInheritsNoAuthority(t *testing.T) {
+	f := newRecomposeFixture(t)
+	f.approveEveryParentCandidate()
+	authID := f.authorizeParent(time.Now().UTC().Add(6 * time.Hour))
+
+	parent, x := f.svc.GetHumanGateCohort(f.ctx, f.org, f.versionID, time.Now().UTC())
+	if x != nil {
+		t.Fatal(x)
+	}
+	if parent.Decision == nil || parent.Decision.Decision != "GO" {
+		t.Fatalf("fixture did not attach a GO to version 1: %+v", parent.Decision)
+	}
+	for _, c := range parent.Candidates {
+		if c.Review == nil || c.Review.Decision != "APPROVE" {
+			t.Fatalf("fixture did not attach an APPROVE to candidate %s", c.CandidateID)
+		}
+	}
+
+	got, x := f.svc.RecomposeHumanGateCohort(f.ctx, f.org, f.actor, f.versionID, f.input("recompose-authority-"+uuid.NewString()))
+	if x != nil {
+		t.Fatalf("recompose: %v", x)
+	}
+	if got.Cohort.Derivation != DerivationRecompose {
+		t.Fatalf("derivation = %q, want RECOMPOSE", got.Cohort.Derivation)
+	}
+	if got.Cohort.ParentVersion == nil || *got.Cohort.ParentVersion != f.version.Version {
+		t.Fatalf("parent_version = %v, want %d", got.Cohort.ParentVersion, f.version.Version)
+	}
+	if got.Cohort.Manifest.AuthorizationID != uuid.Nil {
+		t.Fatalf("recomposed manifest carries authorization id %s; N+1 must be born with no authority", got.Cohort.Manifest.AuthorizationID)
+	}
+	if got.Cohort.Decision != nil {
+		t.Fatalf("recomposed version inherited a decision: %+v", got.Cohort.Decision)
+	}
+	for _, c := range got.Cohort.Candidates {
+		if c.Review != nil && c.Review.Effective {
+			t.Fatalf("candidate %s inherited an effective review: %+v", c.CandidateID, c.Review)
+		}
+		if !containsString(c.BlockedBy, "approval_missing_or_invalid") {
+			t.Fatalf("candidate %s must be blocked as unapproved: %v", c.CandidateID, c.BlockedBy)
+		}
+	}
+	if got.RevokedAuthorizationID == nil || *got.RevokedAuthorizationID != authID {
+		t.Fatalf("revoked = %v, want %s", got.RevokedAuthorizationID, authID)
+	}
+	var revokedAt *time.Time
+	var revokeReason string
+	if err := f.pool.QueryRow(f.ctx, `SELECT revoked_at,COALESCE(revoke_reason,'') FROM confenge_bounded_cohort_authorizations WHERE id=$1 AND organization_id=$2`, authID, f.org).Scan(&revokedAt, &revokeReason); err != nil {
+		t.Fatal(err)
+	}
+	if revokedAt == nil {
+		t.Fatal("the authority bound to the parent is still live after a recompose")
+	}
+	if !strings.Contains(revokeReason, "human_gate_recompose:") {
+		t.Fatalf("revoke_reason = %q, want it to attribute the recompose", revokeReason)
+	}
+	var live int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM confenge_bounded_cohort_authorizations WHERE organization_id=$1 AND revoked_at IS NULL AND expires_at > now()`, f.org).Scan(&live); err != nil {
+		t.Fatal(err)
+	}
+	if live != 0 {
+		t.Fatalf("live authorities = %d, want 0: recompose must never leave two valid authorities", live)
+	}
+}
+
+// History is evidence: the parent row may not be rewritten by the operation
+// that forks it.
+func TestHumanGateRecomposeLeavesTheParentByteIdentical(t *testing.T) {
+	f := newRecomposeFixture(t)
+	beforeManifest, beforeHash, beforeDerivation, beforeComposer := f.versionRow(f.versionID)
+	if beforeComposer != recomposeLegacyComposer {
+		t.Fatalf("fixture composer stamp = %q, want %q", beforeComposer, recomposeLegacyComposer)
+	}
+
+	got, x := f.svc.RecomposeHumanGateCohort(f.ctx, f.org, f.actor, f.versionID, f.input("recompose-lineage-"+uuid.NewString()))
+	if x != nil {
+		t.Fatalf("recompose: %v", x)
+	}
+
+	afterManifest, afterHash, afterDerivation, afterComposer := f.versionRow(f.versionID)
+	for _, tc := range []struct{ field, got, want string }{
+		{"frozen_manifest", afterManifest, beforeManifest},
+		{"frozen_hash", afterHash, beforeHash},
+		{"derivation", afterDerivation, beforeDerivation},
+		{"composer_version", afterComposer, beforeComposer},
+	} {
+		if tc.got != tc.want {
+			t.Fatalf("parent %s was rewritten:\n got %s\nwant %s", tc.field, tc.got, tc.want)
+		}
+	}
+
+	// The child is a new row that names the parent, not a mutation of it.
+	_, childHash, childDerivation, childComposer := f.versionRow(got.Cohort.ID)
+	if childDerivation != DerivationRecompose {
+		t.Fatalf("child derivation = %q, want RECOMPOSE", childDerivation)
+	}
+	if childComposer != ComposerVersion {
+		t.Fatalf("child composer = %q, want %q", childComposer, ComposerVersion)
+	}
+	if childHash == beforeHash {
+		t.Fatal("the recomposed version kept the parent frozen hash; recomposed copy must be new bytes")
+	}
+	if got.Report.ComposerBefore != recomposeLegacyComposer || got.Report.ComposerAfter != ComposerVersion {
+		t.Fatalf("report composer %s -> %s", got.Report.ComposerBefore, got.Report.ComposerAfter)
+	}
+	if got.Report.KeptMembers < 1 || got.Report.ParentMembers != len(f.version.Manifest.Members) {
+		t.Fatalf("report parent=%d kept=%d, want a reconciling report over %d parent members",
+			got.Report.ParentMembers, got.Report.KeptMembers, len(f.version.Manifest.Members))
+	}
+	// Every surviving member is new copy under the current composer, addressed
+	// to the same mailbox on the same evidence.
+	for _, m := range got.Cohort.Manifest.Members {
+		was := f.parentMember(m.CandidateID)
+		if m.ComposerVersion != ComposerVersion {
+			t.Fatalf("member %s kept composer stamp %q", m.CandidateID, m.ComposerVersion)
+		}
+		if m.Subject == was.Subject && m.BodyText == was.BodyText {
+			t.Fatalf("member %s kept the legacy copy verbatim", m.CandidateID)
+		}
+		if m.Mailbox != was.Mailbox || m.EvidenceHash != was.EvidenceHash || m.RouteClass != was.RouteClass {
+			t.Fatalf("member %s changed a fact recompose may not change", m.CandidateID)
+		}
+	}
+}
+
+// The parent stays fully readable for audit and is loudly non-actionable.
+func TestHumanGateRecomposedParentStaysReadableButNonActionable(t *testing.T) {
+	f := newRecomposeFixture(t)
+	got, x := f.svc.RecomposeHumanGateCohort(f.ctx, f.org, f.actor, f.versionID, f.input("recompose-legacy-"+uuid.NewString()))
+	if x != nil {
+		t.Fatalf("recompose: %v", x)
+	}
+
+	parent, x := f.svc.GetHumanGateCohort(f.ctx, f.org, f.versionID, time.Now().UTC())
+	if x != nil {
+		t.Fatalf("re-read parent: %v", x)
+	}
+	if len(parent.Candidates) != len(f.version.Manifest.Members) {
+		t.Fatalf("parent candidates = %d, want %d", len(parent.Candidates), len(f.version.Manifest.Members))
+	}
+	for _, c := range parent.Candidates {
+		if strings.TrimSpace(c.Subject) == "" || strings.TrimSpace(c.BodyText) == "" {
+			t.Fatalf("candidate %s lost its text; history must stay readable", c.CandidateID)
+		}
+		if c.EditorialState != EditorialStateSuperseded || c.Actionable {
+			t.Fatalf("candidate %s editorial state = %q actionable = %v", c.CandidateID, c.EditorialState, c.Actionable)
+		}
+	}
+	if parent.EditorialState != EditorialStateSuperseded {
+		t.Fatalf("parent editorial state = %q, want %s", parent.EditorialState, EditorialStateSuperseded)
+	}
+	if parent.Actionable {
+		t.Fatal("a superseded parent must not be actionable")
+	}
+	if !containsString(parent.EditorialReasonCodes, ReasonComposerSuperseded) {
+		t.Fatalf("parent reason codes = %v, want %s", parent.EditorialReasonCodes, ReasonComposerSuperseded)
+	}
+	if parent.EditorialNotice != EditorialLegacyNotice {
+		t.Fatalf("parent notice = %q", parent.EditorialNotice)
+	}
+	if parent.IsCurrentVersion {
+		t.Fatal("the parent must not present itself as the current version")
+	}
+	if parent.CurrentVersion != got.Cohort.Version {
+		t.Fatalf("parent current_version = %d, want %d", parent.CurrentVersion, got.Cohort.Version)
+	}
+	if parent.CurrentVersionID == nil || *parent.CurrentVersionID != got.Cohort.ID {
+		t.Fatalf("parent current_version_id = %v, want %s", parent.CurrentVersionID, got.Cohort.ID)
+	}
+
+	// The version the founder is handed instead is the actionable one.
+	if got.Cohort.EditorialState != EditorialStateCurrent || !got.Cohort.Actionable || !got.Cohort.IsCurrentVersion {
+		t.Fatalf("recomposed version is not current: state=%q actionable=%v is_current=%v",
+			got.Cohort.EditorialState, got.Cohort.Actionable, got.Cohort.IsCurrentVersion)
+	}
+}
+
+// Closing out history must stay possible, so only APPROVE is refused on it.
+func TestHumanGateRecomposedParentRefusesApproveButAcceptsHoldAndReject(t *testing.T) {
+	f := newRecomposeFixture(t)
+	f.approveEveryParentCandidate()
+	if _, x := f.svc.RecomposeHumanGateCohort(f.ctx, f.org, f.actor, f.versionID, f.input("recompose-approve-"+uuid.NewString())); x != nil {
+		t.Fatalf("recompose: %v", x)
+	}
+	candidate := f.version.Manifest.Members[0].CandidateID
+
+	approve := HumanGateReviewInput{
+		Decision: "APPROVE", Reason: "quero aprovar a copia antiga", Acknowledged: true,
+		IdempotencyKey: "review-approve-" + uuid.NewString(), CorrelationID: "corr",
+	}
+	_, x := f.svc.ReviewHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, candidate, approve)
+	if x == nil || x.Identifier != ReasonComposerSuperseded || x.Code != errx.Conflict {
+		t.Fatalf("got %#v, want 409 %s", x, ReasonComposerSuperseded)
+	}
+
+	for _, decision := range []string{"HOLD", "REJECT"} {
+		in := HumanGateReviewInput{
+			Decision: decision, Reason: "encerrando a versao historica",
+			IdempotencyKey: "review-" + strings.ToLower(decision) + "-" + uuid.NewString(), CorrelationID: "corr",
+		}
+		v, x := f.svc.ReviewHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, candidate, in)
+		if x != nil {
+			t.Fatalf("%s on a superseded version must stay possible: %v", decision, x)
+		}
+		var stored string
+		if err := f.pool.QueryRow(f.ctx, `SELECT decision FROM confenge_cohort_candidate_reviews WHERE organization_id=$1 AND idempotency_key=$2`, f.org, in.IdempotencyKey).Scan(&stored); err != nil {
+			t.Fatal(err)
+		}
+		if stored != decision {
+			t.Fatalf("stored decision = %q, want %q", stored, decision)
+		}
+		if v.Actionable {
+			t.Fatal("recording a closing decision must not make history actionable again")
+		}
+	}
+}

--- a/internal/app/confenge/human_gate_test.go
+++ b/internal/app/confenge/human_gate_test.go
@@ -49,8 +49,8 @@ func TestHumanGateGOBlockersCoverEmptyStaleValidationAndLateState(t *testing.T) 
 	candidateID := uuid.New()
 	approved := &HumanGateReview{Decision: "APPROVE", Effective: true}
 	for _, status := range []string{"RISKY", "INVALID", "UNKNOWN", "STALE"} {
-		cohort := &HumanGateCohort{Freshness: "FRESH", Candidates: []HumanGateCandidate{{
-			FrozenCohortMember: FrozenCohortMember{CandidateID: candidateID},
+		cohort := &HumanGateCohort{Freshness: "FRESH", Manifest: currentComposerManifest(), Candidates: []HumanGateCandidate{{
+			FrozenCohortMember: FrozenCohortMember{CandidateID: candidateID, ComposerVersion: ComposerVersion},
 			Validation:         &HumanGateValidation{Status: status},
 			Review:             approved,
 		}}}
@@ -61,8 +61,8 @@ func TestHumanGateGOBlockersCoverEmptyStaleValidationAndLateState(t *testing.T) 
 	if got := humanGateDecisionBlockers(&HumanGateCohort{Freshness: "STALE"}); !slices.Contains(got, "cohort_empty") || !slices.Contains(got, "source_evidence_stale") {
 		t.Fatalf("empty stale cohort must report both blockers: %v", got)
 	}
-	validButSuppressed := &HumanGateCohort{Freshness: "FRESH", Candidates: []HumanGateCandidate{{
-		FrozenCohortMember: FrozenCohortMember{CandidateID: candidateID},
+	validButSuppressed := &HumanGateCohort{Freshness: "FRESH", Manifest: currentComposerManifest(), Candidates: []HumanGateCandidate{{
+		FrozenCohortMember: FrozenCohortMember{CandidateID: candidateID, ComposerVersion: ComposerVersion},
 		Validation:         &HumanGateValidation{Status: "VALID"},
 		Review:             approved,
 		BlockedBy:          []string{"late_recipient_suppression"},
@@ -181,4 +181,10 @@ func TestHumanGateValidApprovalRemainsEffectiveAndHoldNeverDoes(t *testing.T) {
 			t.Fatalf("%s effective=%v", decision, r.Effective)
 		}
 	}
+}
+
+// currentComposerManifest is a manifest stamped by the composer this build
+// ships, so a test about some other blocker is not refused for copy age.
+func currentComposerManifest() FrozenCohortSnapshot {
+	return FrozenCohortSnapshot{ComposerVersion: ComposerVersion, PolicyVersion: BoundedCohortPolicyV1}
 }

--- a/internal/app/confenge/killswitch_e2e_test.go
+++ b/internal/app/confenge/killswitch_e2e_test.go
@@ -63,6 +63,8 @@ func runKillSwitchE2E(t *testing.T, run int) error {
 		Subject: "Sobre ACME", BodyText: "Ola Ana,\n\nNotei a prorrogacao do contrato. Faz sentido conversarmos?\n\nPosso enviar checklist?",
 		FactUsed: "prorrogacao do contrato", ServiceCode: "ADDITIVE_REVIEW",
 		Status: models.OutreachDraftApproved, RiskClass: "GREEN", RecipientEmail: cand.Email,
+		// Current composer: this test is about the kill switch, not about copy age.
+		PromptVersion: PromptVersion,
 	}
 	ok := true
 	d.ValidationOK = &ok

--- a/internal/app/confenge/revoke_final_send_test.go
+++ b/internal/app/confenge/revoke_final_send_test.go
@@ -157,6 +157,9 @@ func TestQueueTouchpointAfterRevokeBlocks(t *testing.T) {
 		Channel: models.OutreachChannelEmail, Subject: "S", BodyText: "body",
 		RecipientEmail: cand.Email, Status: models.OutreachDraftApproved,
 		ServiceCode: "REAJUSTE", RiskClass: "GREEN",
+		// Stamped current on purpose: this test proves revoke blocks queue, so
+		// the copy must not be refused earlier for being a prior composer's.
+		PromptVersion: PromptVersion,
 	}
 	_ = repo.UpsertDraft(ctx, draft)
 

--- a/internal/app/confenge/touchpoint_sm.go
+++ b/internal/app/confenge/touchpoint_sm.go
@@ -230,6 +230,11 @@ func CanTransportCohort(tp *models.OutreachTouchpoint, auth *BoundedCohortAuthor
 	if auth == nil || auth.ID == uuid.Nil || auth.ID != *tp.CampaignPolicyAuthorizationID {
 		return fmt.Errorf("bounded cohort grant missing at transport")
 	}
+	// Absolute, not relative: a grant and its copy can agree with each other and
+	// still both be the work of a composer this build no longer ships.
+	if a := EvaluateCohortEditorialAuthority(auth.ComposerVersion, auth.PolicyVersion); !a.Actionable {
+		return fmt.Errorf("%s", a.Blocker("TRANSPORT"))
+	}
 	if strings.TrimSpace(tp.AuthorizationPolicyHash) == "" || tp.AuthorizationPolicyHash != auth.FrozenHash() {
 		return fmt.Errorf("bounded cohort hash mismatch")
 	}

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -205,6 +205,7 @@ func (s *service) ListReviewTouchpoints(ctx context.Context, orgID uuid.UUID, li
 			}
 			pack := BuildConsultantSendabilityPack(acc, cand, rec, plan, synth, val)
 			list[i].ConsultantSendability = pack.AsMap()
+			projectTouchpointEditorial(&list[i], acc, cand, promptVer)
 			// Live QA wins over a leftover stored true so the API cannot lie.
 			if d := list[i].Draft; d != nil {
 				ok := val.OK && pack.SendWithoutEditing == "sim"
@@ -823,6 +824,9 @@ func (s *service) ApproveTouchpoint(ctx context.Context, orgID, userID, id uuid.
 	if xerr := s.assertPriorReleased(ctx, orgID, tp); xerr != nil {
 		return nil, xerr
 	}
+	if xerr := s.assertTouchpointEditorialAuthority(ctx, orgID, tp, "APPROVE"); xerr != nil {
+		return nil, xerr
+	}
 	acc, _ := s.repo.GetAccount(ctx, orgID, tp.AccountID)
 	if acc == nil {
 		return nil, errx.New(errx.NotFound, "account not found")
@@ -1041,6 +1045,9 @@ func (s *service) QueueTouchpoint(ctx context.Context, orgID, userID, id uuid.UU
 		return nil, errx.New(errx.NotFound, "touchpoint not found")
 	}
 	if xerr := s.assertPriorReleased(ctx, orgID, tp); xerr != nil {
+		return nil, xerr
+	}
+	if xerr := s.assertTouchpointEditorialAuthority(ctx, orgID, tp, "QUEUE"); xerr != nil {
 		return nil, xerr
 	}
 	// Scheduling is allowed while transport is paused. The exact hash and
@@ -1301,4 +1308,65 @@ func (s *service) PromoteDueTouchpoints(ctx context.Context, orgID uuid.UUID) (i
 		n++
 	}
 	return n, nil
+}
+
+// assertTouchpointEditorialAuthority refuses any operational step on a
+// touchpoint whose copy an earlier composer wrote. Fail-closed: a touchpoint
+// with no draft to identify carries no proof the current composer wrote it.
+func (s *service) assertTouchpointEditorialAuthority(ctx context.Context, orgID uuid.UUID, tp *models.OutreachTouchpoint, action string) *errx.Error {
+	if tp == nil {
+		return errx.New(errx.NotFound, "touchpoint not found")
+	}
+	prompt := ""
+	if tp.Draft != nil {
+		prompt = tp.Draft.PromptVersion
+	} else if tp.DraftID != nil {
+		if d, _ := s.repo.GetDraft(ctx, orgID, *tp.DraftID); d != nil {
+			prompt = d.PromptVersion
+		}
+	}
+	if auth := EvaluateDraftEditorialAuthority(prompt); !auth.Actionable {
+		return errx.New(errx.Conflict, auth.Blocker(action))
+	}
+	return nil
+}
+
+// projectTouchpointEditorial fills the read-only judging context the review
+// screen shows next to the editable copy. Absent facts stay visible as absent
+// rather than being omitted, because a blank field a reader can see is honest
+// and a key that was never written is not.
+func projectTouchpointEditorial(tp *models.OutreachTouchpoint, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, promptVersion string) {
+	auth := EvaluateDraftEditorialAuthority(promptVersion)
+	tp.EditorialState = auth.State
+	tp.EditorialActionable = auth.Actionable
+	tp.EditorialReasonCodes = auth.ReasonCodes
+	tp.EditorialNotice = auth.Notice
+	tp.PromptVersion = promptVersion
+	tp.ComposerVersion = ComposerVersion
+	if !auth.Actionable {
+		// The stamp we can prove is the prompt version; naming the current
+		// composer beside superseded copy would read as if it wrote it.
+		tp.ComposerVersion = ""
+	}
+	if cand != nil {
+		tp.RouteClass = CandidateRouteClass(cand)
+	}
+	if acc != nil {
+		if strings.TrimSpace(acc.FactToMention) != "" && strings.TrimSpace(tp.FactUsed) == acc.FactToMention {
+			tp.FactSource = "fact_to_mention"
+		}
+		d := EvaluateTargetFit(acc)
+		fit := map[string]any{
+			"state":    acc.TargetFitClass,
+			"eligible": d.Eligible,
+			"reason":   d.Reason,
+			"fresh":    acc.TargetFitFresh,
+			"tier":     acc.TargetFitSendTier,
+			"version":  acc.TargetFitVersion,
+		}
+		if acc.TargetFitObservedAt != nil {
+			fit["as_of"] = acc.TargetFitObservedAt.UTC().Format(time.RFC3339)
+		}
+		tp.TargetFit = fit
+	}
 }

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -652,6 +652,18 @@ type OutreachTouchpoint struct {
 	// ConsultantSendability is operator-only: send without editing? yes/no.
 	ConsultantSendability map[string]any `json:"consultant_sendability,omitempty"`
 	GenerationError       string         `json:"generation_error,omitempty"`
+	// Editorial projection (not DB columns). The founder reads Comercial ->
+	// Rascunhos and has to judge the copy there, so what the judgement needs
+	// travels with the row instead of behind a second request.
+	EditorialState       string         `json:"editorial_state,omitempty"`
+	EditorialActionable  bool           `json:"editorial_actionable"`
+	EditorialReasonCodes []string       `json:"editorial_reason_codes,omitempty"`
+	EditorialNotice      string         `json:"editorial_notice,omitempty"`
+	ComposerVersion      string         `json:"composer_version,omitempty"`
+	PromptVersion        string         `json:"prompt_version,omitempty"`
+	RouteClass           string         `json:"route_class,omitempty"`
+	FactSource           string         `json:"fact_source,omitempty"`
+	TargetFit            map[string]any `json:"target_fit,omitempty"`
 }
 
 // Commercial action types. Semantic differences are load-bearing.


### PR DESCRIPTION
A founder opened the Control Center and read a frozen CONFENGE message that began "Olá, equipe, / Sou da CONFENGE." and then pasted the raw PNCP object back at the recipient, with APPROVE and GO controls beside it. That copy was written by composer v3. It carried `copy_qa=passed`, because it passed the gate v3 shipped with.

Nothing refused it. `version_superseded` only ever meant "not the newest version of this cohort", so a v3 or v4 cohort that was still its own newest version, under the current policy, was approvable and GO-able. Two such cohorts are live in production right now.

## The rule

`internal/app/confenge/editorial_authority.go` is the one place that decides whether frozen copy is operational, and it asks a question the version number cannot: did the composer this build ships write this text? Anything else, including an unstamped artifact, is `LEGACY_SUPERSEDED`. It stays readable and is refused by APPROVE, GO, queue, AUTHORIZE and transport. HOLD and REJECT stay open, because closing out history has to remain possible.

The transport check is absolute rather than relative. `ValidateBoundedCohortAuthorization` compares the grant to the live values, so a grant and its copy can agree with each other and still both be the work of a composer nobody ships any more.

`NormalizeBoundedCohortGrant` had a related hole worth naming: `ComposerVersion` defaults to the current constant when empty, so authorizing a legacy cohort would have minted a grant stamped current over old copy and laundered it past every downstream drift check.

## Recompose has to be repeatable

`PrepareControlledCohort` stored the composed sentence in the member's `observed_fact`, so a second recomposition re-digested our own prose and threw the lead away. The frozen member now keeps `source_fact`, the public record it was written from. It is `omitempty`, so manifests frozen before it existed hash exactly as they did.

## The gate was passing things a person would not write

Previewing the recomposition against the real production manifests produced copy that cleared the gate and should not have:

- `Vi uma contratação envolvendo a Aquaflot Ambiental na contratação pública licenciamento ambiental - mineração.` The `contratação pública:` label was never stripped, so it stuttered.
- Two members in one cohort both got the subject `Contrato público`.
- `Inplenitus Projetos, Gerenciamento E Fiscaliz`, a registry name cut mid word.

New refusals: `body_administrative_label`, `subject_generic_boilerplate`, `truncated_word` / `subject_truncated_word`, `fact_is_composed_prose`, `company_name_unusable`, plus `generic_cta` for a closing ask with nothing tying it to this recipient, and `personalization_without_fact` for observation language over no evidence.

One pre-existing bug fell out: `qaDanglingTailRe` used `\b`, which is ASCII-only in Go, so it matched the final `o` of `mineração` and failed every subject ending in `-ção` as `subject_truncated`.

Also: `humanGateRevokePriorAuthority` hardcoded `human_gate_adjust:` onto every revoke reason, so a recompose-triggered revocation was filed in the audit trail as `human_gate_adjust:human_gate_recompose:<reason>`.

## After

`contratação pública: contratação DE Empresa Especializada Para` / `Olá, equipe, / Sou da CONFENGE. / contratação pública: … DOS Serviços Necessários DOS Serviços Necessários …`

becomes

`Ponte sobre o Rio Sapucaí` / `Olá, / Meu nome é Tiago, da CONFENGE. Vi uma contratação envolvendo a Jatobeton Engenharia na recuperação estrutural da ponte sobre o Rio Sapucaí. / Trabalho com apoio a empresas de engenharia em contratos públicos e queria falar com quem cuida dessa frente por aí. Você consegue me indicar a pessoa certa? / Obrigado, Tiago`

Where the record cannot be said plainly the member is excluded with a reason code rather than shipped weak.

## Proof

Six Postgres-backed recompose tests, previously untested territory: concurrent forks produce exactly one next version, idempotent replay creates nothing, the recomposed version inherits no approval, GO or authorization and revokes the parent's, the parent stays byte-identical, and the parent stays readable while refusing APPROVE and accepting HOLD/REJECT. Plus unit tests pinning the production defect strings as negative fixtures.

`deploy/confenge-vps/up.sh` now derives `WARMBLY_RELEASE_SHA` from the checkout, so provenance no longer depends on an operator remembering to export it.