### PR TITLE
fix(deploy): stop a stale .env pin mislabelling every image after it

### DIFF
--- a/deploy/confenge-vps/env.example
+++ b/deploy/confenge-vps/env.example
@@ -52,9 +52,10 @@ CONFENGE_GREEN_AUTORUN_ENABLED=false
 # GIT_SHA / GITHUB_SHA are accepted fallbacks.
 CONFENGE_REPOSITORY_SHA=
 # Stamped onto the built images as org.opencontainers.image.revision so
-# deploy/verify-release.sh can prove which commit is running. up.sh derives it
-# from the checkout when this is empty; set it only to override that.
-WARMBLY_RELEASE_SHA=
+# deploy/verify-release.sh can prove which commit is running. Leave it unset:
+# the deploy scripts resolve it from the checkout, and a value pinned here would
+# survive the next deploy and mislabel the images it did not build. Override it
+# for one run by exporting it in the calling shell instead.
 CONFENGE_FEED_SCHEMA_VERSION=confenge.outreach.v1
 CONFENGE_EVIDENCE_VERSION=controlled-email-policy.v1
 CONFENGE_SENDING_PAUSED=false

--- a/deploy/confenge-vps/lib.sh
+++ b/deploy/confenge-vps/lib.sh
@@ -16,9 +16,12 @@ confenge_repo_root() {
 }
 
 load_vps_env() {
-  local root envf
+  local root envf caller_release_sha
   root="$(confenge_repo_root)"
   envf="${CONFENGE_VPS_ENV:-$root/deploy/confenge-vps/.env}"
+  # A caller that named the release explicitly outranks the file, and the
+  # checkout outranks a value the file kept from an earlier deploy.
+  caller_release_sha="${WARMBLY_RELEASE_SHA:-}"
   if [[ -f "$envf" ]]; then
     set -a
     # shellcheck disable=SC1090
@@ -31,6 +34,12 @@ load_vps_env() {
     . "$root/.env.confenge"
     set +a
   fi
+  if [[ -n "$caller_release_sha" ]]; then
+    WARMBLY_RELEASE_SHA="$caller_release_sha"
+  else
+    WARMBLY_RELEASE_SHA="$(git -C "$root" rev-parse HEAD 2>/dev/null || echo local)"
+  fi
+  export WARMBLY_RELEASE_SHA
 }
 
 compose_cmd() {

--- a/deploy/confenge-vps/up.sh
+++ b/deploy/confenge-vps/up.sh
@@ -19,13 +19,12 @@ export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}"
 # Fail closed on unsafe profile flips
 # shellcheck disable=SC1090
 set -a; . "$ENVF"; set +a
-# The image has to be able to prove which commit built it. Derive it from the
-# checkout so an operator cannot forget to pass it; an explicit value still wins.
-if [[ -z "${WARMBLY_RELEASE_SHA:-}" || "${WARMBLY_RELEASE_SHA}" == "local" ]]; then
-  WARMBLY_RELEASE_SHA="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo local)"
-fi
+WARMBLY_RELEASE_SHA="$RELEASE_SHA_RESOLVED"
 export WARMBLY_RELEASE_SHA
-echo "Release SHA for this build: ${WARMBLY_RELEASE_SHA}"
+# load_vps_env resolved this from the caller or from the checkout. Sourcing the
+# private .env below must not put a previous deploy's value back.
+RELEASE_SHA_RESOLVED="${WARMBLY_RELEASE_SHA}"
+echo "Release SHA for this build: ${RELEASE_SHA_RESOLVED}"
 
 if [[ "${CONFENGE_GREEN_AUTORUN_ENABLED:-false}" == "true" ]]; then
   echo "REFUSE: CONFENGE_GREEN_AUTORUN_ENABLED=true is not allowed on VPS execution plane bootstrap" >&2


### PR DESCRIPTION
Deploying `745da08d` produced fresh images that were labelled `07e1cc4d`, the previous release. `deploy/verify-release.sh` refused all three services, which is exactly what it is for.

The cause: `load_vps_env` sources the private `deploy/confenge-vps/.env` with `set -a`, and that file still carried `WARMBLY_RELEASE_SHA=07e1cc4d…` written during an earlier deploy. Sourcing it overwrote the value the caller had exported, so `docker compose build` stamped `org.opencontainers.image.revision` with a commit that did not build the image. Every deploy after the first would have inherited the same wrong label, and the only reason it was visible at all is that the provenance gate compares against the repository SHA rather than trusting the label.

The stamp now describes the checkout being built. `load_vps_env` resolves it as: a value the caller exported wins, otherwise `git rev-parse HEAD` of the checkout. The file value is never used, because a value kept in a file across deploys is the thing that goes stale. `env.example` now says to leave it unset and to export it in the calling shell for a one-off override.

Verified against the same failure: rebuilt on the VPS and all three services reconcile.