### PR TITLE
fix(deploy): up.sh referenced the release stamp before resolving it

### DIFF
--- a/deploy/confenge-vps/up.sh
+++ b/deploy/confenge-vps/up.sh
@@ -7,6 +7,11 @@ source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 load_vps_env
 cd "$ROOT"
 
+# Captured before the private .env is sourced below, because that file can
+# still carry a WARMBLY_RELEASE_SHA written by an earlier deploy.
+RELEASE_SHA_RESOLVED="${WARMBLY_RELEASE_SHA:-}"
+echo "Release SHA for this build: ${RELEASE_SHA_RESOLVED:-<unresolved>}"
+
 ENVF="${CONFENGE_VPS_ENV:-$ROOT/deploy/confenge-vps/.env}"
 if [[ ! -f "$ENVF" ]]; then
   echo "Missing $ENVF — run deploy/confenge-vps/gen-secrets.sh first" >&2
@@ -19,12 +24,10 @@ export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}"
 # Fail closed on unsafe profile flips
 # shellcheck disable=SC1090
 set -a; . "$ENVF"; set +a
+# load_vps_env already resolved this from the caller or from the checkout, and
+# the line above may have put a previous deploy's value back. Restore it.
 WARMBLY_RELEASE_SHA="$RELEASE_SHA_RESOLVED"
 export WARMBLY_RELEASE_SHA
-# load_vps_env resolved this from the caller or from the checkout. Sourcing the
-# private .env below must not put a previous deploy's value back.
-RELEASE_SHA_RESOLVED="${WARMBLY_RELEASE_SHA}"
-echo "Release SHA for this build: ${RELEASE_SHA_RESOLVED}"
 
 if [[ "${CONFENGE_GREEN_AUTORUN_ENABLED:-false}" == "true" ]]; then
   echo "REFUSE: CONFENGE_GREEN_AUTORUN_ENABLED=true is not allowed on VPS execution plane bootstrap" >&2


### PR DESCRIPTION
Follow-up to #146. The restore line landed above the capture, so `up.sh` aborted with `RELEASE_SHA_RESOLVED: unbound variable` under `set -u` and the deploy stopped after building, leaving the previous containers running.

The capture now happens immediately after `load_vps_env`, before the private `.env` is sourced, and the restore happens after. Verified all three resolution rules directly against `lib.sh`: a stale value in the env file loses to the checkout, a caller-exported value wins, and an absent env file falls back to the checkout.