### PR TITLE
feat: drain CONFENGE contact-ready accounts into reviewed drafts

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1112,6 +1112,9 @@ func main() {
 		// Suboptimal and explicitly rejected copy is recoverable. AI rewrites run
 		// asynchronously and always return to human review.
 		go confenge.NewEditorialRecoveryWorker(confengeServiceForHandler, time.Minute).Run(ctx)
+		// Contact-ready accounts are planned and drafted asynchronously. This
+		// worker has no approval, queueing, scheduling or transport authority.
+		go confenge.NewDraftGenerationWorker(confengeServiceForHandler, 30*time.Second).Run(ctx)
 		// Continuous feed sync (fail-closed OFF by default). Single-flight inside SyncFeedManifest.
 		if confengeCfg.FeedSyncEnabled {
 			if orgRaw := strings.TrimSpace(os.Getenv("CONFENGE_FEED_SYNC_ORG_ID")); orgRaw != "" {

--- a/docs/confenge/touchpoints.md
+++ b/docs/confenge/touchpoints.md
@@ -59,3 +59,16 @@ issue outbox item. Operators can inspect or publish those items with
 versioned guideline proposals are managed with
 `confenge editorial guidelines list|propose|activate`; activation also requires
 explicit confirmation.
+
+## Continuous generation into Comercial -> Rascunhos
+
+Accounts in `READY_TO_GENERATE` are leased with `FOR UPDATE SKIP LOCKED` and
+processed asynchronously. The worker creates the idempotent cadence, generates
+only its first due touchpoint, and stops at `NEEDS_REVIEW` (Comercial ->
+Rascunhos). Each tick drains a bounded burst of up to 100 accounts; failures
+use exponential retry from 15 minutes up to 24 hours.
+
+`ENRICHMENT_PENDING` touchpoints are also retried by the editorial recovery
+worker. When target fit or contact evidence becomes valid, the same touchpoint
+returns to `NEEDS_REVIEW` and its obsolete stop reason is cleared. Neither
+worker can approve, schedule, queue or send a message.

--- a/internal/app/confenge/draft_generation_worker.go
+++ b/internal/app/confenge/draft_generation_worker.go
@@ -1,0 +1,182 @@
+package confenge
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+const (
+	draftGenerationLease    = 5 * time.Minute
+	draftGenerationMaxBurst = 100
+)
+
+type draftGenerationProcessor interface {
+	ProcessDraftGenerationOnce(context.Context) (bool, error)
+}
+
+// DraftGenerationWorker drains contact-ready accounts into the human review
+// surface. It has no approval, scheduling, queueing or transport authority.
+type DraftGenerationWorker struct {
+	processor draftGenerationProcessor
+	interval  time.Duration
+}
+
+func NewDraftGenerationWorker(processor draftGenerationProcessor, interval time.Duration) *DraftGenerationWorker {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	return &DraftGenerationWorker{processor: processor, interval: interval}
+}
+
+func (w *DraftGenerationWorker) Run(ctx context.Context) {
+	if w == nil || w.processor == nil {
+		return
+	}
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		for i := 0; i < draftGenerationMaxBurst; i++ {
+			processed, err := w.processor.ProcessDraftGenerationOnce(ctx)
+			if !processed {
+				_ = err
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// ProcessDraftGenerationOnce atomically leases one eligible account, creates
+// its idempotent cadence, and generates only the first reviewable touchpoint.
+// Every transport and human-authorization gate remains downstream and intact.
+func (s *service) ProcessDraftGenerationOnce(ctx context.Context) (bool, error) {
+	if s == nil || s.humanGateDB == nil {
+		return false, nil
+	}
+	now := time.Now().UTC()
+	var orgID, accountID uuid.UUID
+	var attempts int
+	err := s.humanGateDB.QueryRow(ctx, `
+		WITH next AS (
+			SELECT a.id
+			FROM outreach_accounts a
+			WHERE a.queue_state = 'READY_TO_GENERATE'
+			  AND a.target_fit_eligible = true
+			  AND a.email_send_ready = true
+			  AND a.blocked = false
+			  AND a.do_not_contact = false
+			  AND a.draft_generation_retry_at <= $1
+			  AND (a.draft_generation_reserved_until IS NULL OR a.draft_generation_reserved_until <= $1)
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM outreach_touchpoints t
+				WHERE t.organization_id = a.organization_id
+				  AND t.account_id = a.id
+				  AND t.state IN (
+					'AI_REWRITE_PENDING','ENRICHMENT_PENDING','REJECTED_REWRITE_PENDING',
+					'NEEDS_REVIEW','APPROVED','QUEUED'
+				  )
+			  )
+			ORDER BY a.draft_generation_retry_at, a.created_at, a.id
+			LIMIT 1
+			FOR UPDATE SKIP LOCKED
+		)
+		UPDATE outreach_accounts a
+		SET draft_generation_reserved_until = $2,
+			draft_generation_attempts = a.draft_generation_attempts + 1,
+			updated_at = $1
+		FROM next
+		WHERE a.id = next.id
+		RETURNING a.organization_id, a.id, a.draft_generation_attempts`, now, now.Add(draftGenerationLease)).Scan(&orgID, &accountID, &attempts)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return false, nil
+		}
+		return false, err
+	}
+
+	actorID, err := s.repo.GetOrgOwnerUserID(ctx, orgID)
+	if err != nil || actorID == uuid.Nil {
+		s.deferDraftGeneration(ctx, accountID, attempts, "organization owner unavailable")
+		return true, err
+	}
+	touchpoints, xerr := s.PlanAccountCadence(ctx, orgID, actorID, accountID, nil, models.OutreachChannelEmail)
+	if xerr != nil {
+		s.deferDraftGeneration(ctx, accountID, attempts, xerr.Message)
+		return true, xerr
+	}
+	var touchpointID uuid.UUID
+	for i := range touchpoints {
+		if touchpoints[i].State == models.TouchpointDue || touchpoints[i].State == models.TouchpointDrafted {
+			touchpointID = touchpoints[i].ID
+			break
+		}
+	}
+	if touchpointID == uuid.Nil {
+		s.deferDraftGeneration(ctx, accountID, attempts, "no due touchpoint available for generation")
+		return true, nil
+	}
+
+	tp, xerr := s.GenerateTouchpointDraft(ctx, orgID, actorID, touchpointID)
+	if xerr != nil {
+		s.deferDraftGeneration(ctx, accountID, attempts, xerr.Message)
+		return true, xerr
+	}
+	if tp == nil {
+		s.deferDraftGeneration(ctx, accountID, attempts, "generation returned no touchpoint")
+		return true, nil
+	}
+	switch tp.State {
+	case models.TouchpointNeedsReview,
+		models.TouchpointAIRewritePending,
+		models.TouchpointEnrichmentPending,
+		models.TouchpointRejectedRewritePending:
+		_, err = s.humanGateDB.Exec(ctx, `
+			UPDATE outreach_accounts
+			SET draft_generation_reserved_until = NULL,
+				draft_generation_retry_at = now(),
+				draft_generation_last_error = '',
+				updated_at = now()
+			WHERE id = $1`, accountID)
+		return true, err
+	default:
+		s.deferDraftGeneration(ctx, accountID, attempts, "generation stopped in state "+tp.State)
+		return true, nil
+	}
+}
+
+func draftGenerationRetryDelay(attempts int) time.Duration {
+	delay := 15 * time.Minute
+	for i := 1; i < attempts && delay < 24*time.Hour; i++ {
+		delay *= 2
+	}
+	if delay > 24*time.Hour {
+		return 24 * time.Hour
+	}
+	return delay
+}
+
+func (s *service) deferDraftGeneration(ctx context.Context, accountID uuid.UUID, attempts int, reason string) {
+	_, _ = s.humanGateDB.Exec(ctx, `
+		UPDATE outreach_accounts
+		SET draft_generation_reserved_until = NULL,
+			draft_generation_retry_at = $2,
+			draft_generation_last_error = LEFT($3, 500),
+			updated_at = now()
+		WHERE id = $1`, accountID, time.Now().UTC().Add(draftGenerationRetryDelay(attempts)), reason)
+}

--- a/internal/app/confenge/draft_generation_worker_test.go
+++ b/internal/app/confenge/draft_generation_worker_test.go
@@ -1,0 +1,62 @@
+package confenge
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type draftGenerationProcessorStub struct {
+	remaining int
+	calls     atomic.Int32
+}
+
+func (s *draftGenerationProcessorStub) ProcessDraftGenerationOnce(context.Context) (bool, error) {
+	s.calls.Add(1)
+	if s.remaining == 0 {
+		return false, nil
+	}
+	s.remaining--
+	return true, errors.New("deferred account must not stop the remaining burst")
+}
+
+func TestDraftGenerationRetryDelay(t *testing.T) {
+	tests := []struct {
+		attempts int
+		want     time.Duration
+	}{
+		{attempts: 0, want: 15 * time.Minute},
+		{attempts: 1, want: 15 * time.Minute},
+		{attempts: 2, want: 30 * time.Minute},
+		{attempts: 7, want: 16 * time.Hour},
+		{attempts: 8, want: 24 * time.Hour},
+		{attempts: 99, want: 24 * time.Hour},
+	}
+	for _, tt := range tests {
+		if got := draftGenerationRetryDelay(tt.attempts); got != tt.want {
+			t.Fatalf("attempts=%d: got %s want %s", tt.attempts, got, tt.want)
+		}
+	}
+}
+
+func TestDraftGenerationWorkerDrainsBurstUntilIdle(t *testing.T) {
+	processor := &draftGenerationProcessorStub{remaining: 3}
+	ctx, cancel := context.WithCancel(context.Background())
+	worker := NewDraftGenerationWorker(processor, time.Hour)
+	done := make(chan struct{})
+	go func() {
+		worker.Run(ctx)
+		close(done)
+	}()
+	deadline := time.Now().Add(time.Second)
+	for processor.calls.Load() < 4 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	<-done
+	if processor.calls.Load() != 4 {
+		t.Fatalf("worker calls=%d want 4 (three processed plus idle)", processor.calls.Load())
+	}
+}

--- a/internal/app/confenge/editorial_recovery_worker.go
+++ b/internal/app/confenge/editorial_recovery_worker.go
@@ -45,17 +45,19 @@ func (w *EditorialRecoveryWorker) Run(ctx context.Context) {
 }
 
 func (s *service) ProcessEditorialRecoveryOnce(ctx context.Context) (bool, error) {
-	if s == nil || s.humanGateDB == nil || s.ai == nil {
+	if s == nil || s.humanGateDB == nil {
 		return false, nil
 	}
 	now := time.Now().UTC()
 	var orgID, touchpointID uuid.UUID
+	var state string
 	var attempts int
 	err := s.humanGateDB.QueryRow(ctx, `
 		WITH next AS (
 			SELECT id
 			FROM outreach_touchpoints
-			WHERE state IN ('AI_REWRITE_PENDING','REJECTED_REWRITE_PENDING')
+			WHERE (state = 'ENRICHMENT_PENDING'
+			       OR ($3 AND state IN ('AI_REWRITE_PENDING','REJECTED_REWRITE_PENDING')))
 			  AND editorial_retry_at <= $1
 			  AND (editorial_reserved_until IS NULL OR editorial_reserved_until <= $1)
 			ORDER BY editorial_retry_at, created_at, id
@@ -66,7 +68,7 @@ func (s *service) ProcessEditorialRecoveryOnce(ctx context.Context) (bool, error
 		SET editorial_reserved_until=$2, editorial_attempts=t.editorial_attempts+1, updated_at=$1
 		FROM next
 		WHERE t.id=next.id
-		RETURNING t.organization_id,t.id,t.editorial_attempts`, now, now.Add(editorialRecoveryLease)).Scan(&orgID, &touchpointID, &attempts)
+		RETURNING t.organization_id,t.id,t.state,t.editorial_attempts`, now, now.Add(editorialRecoveryLease), s.ai != nil).Scan(&orgID, &touchpointID, &state, &attempts)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return false, nil
@@ -83,8 +85,8 @@ func (s *service) ProcessEditorialRecoveryOnce(ctx context.Context) (bool, error
 		s.deferEditorialRecovery(ctx, touchpointID, attempts, xerr.Message)
 		return true, xerr
 	}
-	if tp == nil || tp.State == models.TouchpointAIRewritePending || tp.State == models.TouchpointRejectedRewritePending {
-		s.deferEditorialRecovery(ctx, touchpointID, attempts, "rewrite did not clear editorial gates")
+	if tp == nil || tp.State == models.TouchpointAIRewritePending || tp.State == models.TouchpointEnrichmentPending || tp.State == models.TouchpointRejectedRewritePending {
+		s.deferEditorialRecovery(ctx, touchpointID, attempts, "recovery did not clear "+state)
 		return true, nil
 	}
 	_, err = s.humanGateDB.Exec(ctx, `

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -103,6 +103,7 @@ type Service interface {
 	ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, attemptedAt time.Time) error
 	ProcessDispatchQueueOnce(ctx context.Context) (bool, error)
 	ProcessEditorialRecoveryOnce(ctx context.Context) (bool, error)
+	ProcessDraftGenerationOnce(ctx context.Context) (bool, error)
 
 	// Per-touchpoint human approval cadence.
 	PreparePilotCohort(ctx context.Context, orgID, userID uuid.UUID, accountIDs []uuid.UUID, operation PilotOperation) (*PilotCohortResult, *errx.Error)

--- a/internal/app/confenge/target_fit_recovery_test.go
+++ b/internal/app/confenge/target_fit_recovery_test.go
@@ -90,3 +90,38 @@ func TestCurrentTargetFitOutRemainsHardGenerationGate(t *testing.T) {
 		t.Fatalf("current target-fit OUT must stay blocked, got %v", xerr)
 	}
 }
+
+func TestEnrichmentPendingReturnsToReviewWhenTargetFitRecovers(t *testing.T) {
+	svc, repo, orgID, actorID, touchpointID := targetFitRecoveryFixture(t)
+	tp, _ := repo.GetTouchpoint(context.Background(), orgID, touchpointID)
+	acc := repo.byID[tp.AccountID]
+	acc.TargetFitFresh = false
+	acc.TargetFitEligible = false
+	acc.TargetFitSuppressionReason = TargetFitReasonStale
+	acc.EmailSendReady = false
+	acc.QueueState = models.OutreachQueueTargetFitSuppressed
+
+	pending, xerr := svc.GenerateTouchpointDraft(context.Background(), orgID, actorID, touchpointID)
+	if xerr != nil || pending.State != models.TouchpointEnrichmentPending {
+		t.Fatalf("create recoverable draft: state=%v err=%v", pending, xerr)
+	}
+	acc.TargetFitFresh = true
+	acc.TargetFitEligible = true
+	acc.TargetFitSuppressionReason = ""
+	acc.EmailSendReady = true
+	acc.QueueState = models.OutreachQueueReadyToGenerate
+
+	recovered, xerr := svc.GenerateTouchpointDraft(context.Background(), orgID, actorID, touchpointID)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if recovered.State != models.TouchpointNeedsReview {
+		t.Fatalf("recovered touchpoint must reach human review, got %s", recovered.State)
+	}
+	if recovered.StopReason != "" {
+		t.Fatalf("obsolete enrichment blocker was not cleared: %q", recovered.StopReason)
+	}
+	if recovered.ApprovedBy != nil || recovered.ApprovedContentHash != "" {
+		t.Fatal("recovery must not approve the touchpoint")
+	}
+}

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -616,6 +616,7 @@ func (s *service) GenerateTouchpointDraft(ctx context.Context, orgID, userID, to
 	tp.DraftID = &draft.ID
 	if draftStatus == models.OutreachDraftNeedsReview {
 		tp.State = models.TouchpointNeedsReview
+		tp.StopReason = ""
 	} else if draftStatus == models.OutreachDraftAIRewritePending {
 		tp.State = models.TouchpointAIRewritePending
 	} else if draftStatus == models.OutreachDraftEnrichmentPending {

--- a/internal/infrastructure/db/migrations/000119_confenge_draft_generation_worker.down.sql
+++ b/internal/infrastructure/db/migrations/000119_confenge_draft_generation_worker.down.sql
@@ -1,0 +1,11 @@
+DROP INDEX IF EXISTS outreach_accounts_draft_generation_idx;
+ALTER TABLE outreach_accounts
+    DROP COLUMN IF EXISTS draft_generation_last_error,
+    DROP COLUMN IF EXISTS draft_generation_attempts,
+    DROP COLUMN IF EXISTS draft_generation_reserved_until,
+    DROP COLUMN IF EXISTS draft_generation_retry_at;
+
+DROP INDEX IF EXISTS outreach_touchpoints_editorial_recovery_idx;
+CREATE INDEX outreach_touchpoints_editorial_recovery_idx
+    ON outreach_touchpoints (editorial_retry_at, created_at)
+    WHERE state IN ('AI_REWRITE_PENDING','REJECTED_REWRITE_PENDING');

--- a/internal/infrastructure/db/migrations/000119_confenge_draft_generation_worker.up.sql
+++ b/internal/infrastructure/db/migrations/000119_confenge_draft_generation_worker.up.sql
@@ -1,0 +1,20 @@
+-- Durable leasing for READY_TO_GENERATE accounts. This queue ends at human
+-- review and grants no approval, scheduling, queueing or transport authority.
+ALTER TABLE outreach_accounts
+    ADD COLUMN IF NOT EXISTS draft_generation_retry_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS draft_generation_reserved_until timestamptz,
+    ADD COLUMN IF NOT EXISTS draft_generation_attempts int NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS draft_generation_last_error text NOT NULL DEFAULT '';
+
+CREATE INDEX IF NOT EXISTS outreach_accounts_draft_generation_idx
+    ON outreach_accounts (draft_generation_retry_at, created_at, id)
+    WHERE queue_state = 'READY_TO_GENERATE'
+      AND target_fit_eligible = true
+      AND email_send_ready = true
+      AND blocked = false
+      AND do_not_contact = false;
+
+DROP INDEX IF EXISTS outreach_touchpoints_editorial_recovery_idx;
+CREATE INDEX outreach_touchpoints_editorial_recovery_idx
+    ON outreach_touchpoints (editorial_retry_at, created_at, id)
+    WHERE state IN ('AI_REWRITE_PENDING','ENRICHMENT_PENDING','REJECTED_REWRITE_PENDING');


### PR DESCRIPTION
## Outcome

Adds the missing asynchronous generation path for CONFENGE accounts in `READY_TO_GENERATE`. Accounts are leased with `FOR UPDATE SKIP LOCKED`, planned idempotently, and their first due touchpoint is drafted into `NEEDS_REVIEW`. The worker has no authority to approve, schedule, queue, or send.

Also makes `ENRICHMENT_PENDING` recoverable when target-fit/contact blockers disappear, without requiring the AI rewrite adapter. Obsolete stop reasons are cleared only after the draft reaches human review.

## Safety boundaries

- target-fit eligibility and freshness gates remain mandatory
- `email_send_ready`, blocked, and DNC gates remain mandatory
- no auto-approval, scheduling, dispatch, or transport code added
- bounded burst of 100, five-minute lease, exponential retry 15 minutes to 24 hours

## Verification

- `gofmt -l cmd internal`: clean
- `golangci-lint run ./...`: PASS
- full `go test ./internal/app/confenge`: PASS with Mailpit
- focused generation/recovery tests: PASS
- focused race tests: PASS

Advances #155 and #149; both remain open until the production feed is consumed and live draft recovery is reconciled.