### PR TITLE
feat: recover eligible cancelled CONFENGE cadences

### DIFF
--- a/internal/app/confenge/touchpoint_test.go
+++ b/internal/app/confenge/touchpoint_test.go
@@ -3,6 +3,7 @@ package confenge
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -246,6 +247,92 @@ func TestRestartPreservesStates(t *testing.T) {
 	r, x := svc2.GetTouchpoint(context.Background(), org, list[0].ID)
 	if x != nil || r.State != models.TouchpointNeedsReview || r.BodyText == "" {
 		t.Fatal("restart")
+	}
+}
+
+func TestPlanSupersedesOnlyRecoverableCancelledCadence(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo).(*service)
+	org, user := uuid.New(), uuid.New()
+	acc := &models.OutreachAccount{
+		ID: uuid.New(), OrganizationID: org, CNPJ14: "12345678000144",
+		RazaoSocial: "Empresa", QueueState: models.OutreachQueueReadyToGenerate,
+		SourceLeadID: "L-recovery", ServiceCode: "ADITIVOS",
+		FactToMention:     "termo aditivo 1 ao contrato 88/2021 publicado",
+		MomentEvidenceIDs: []string{"ev-recovery"},
+	}
+	_, _ = repo.UpsertAccount(context.Background(), acc)
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: org, AccountID: acc.ID,
+		Email: "contato@empresa.com.br", VerificationStatus: models.OutreachVerifyOfficialSource,
+	}
+	applyValidatedIdentity(cand)
+	_, _ = repo.UpsertCandidate(context.Background(), cand)
+	_, _ = repo.UpsertEvidence(context.Background(), &models.OutreachEvidence{
+		OrganizationID: org, AccountID: acc.ID, SourceEvidenceID: "ev-recovery",
+		Synthesis: acc.FactToMention, EpistemicClass: models.OutreachEpistemicConfirmedFact,
+	})
+	cancelledAt := time.Now().UTC().Add(-time.Hour)
+	oldIDs := map[uuid.UUID]bool{}
+	for ordinal := 1; ordinal <= len(CadencePolicyV1()); ordinal++ {
+		old := &models.OutreachTouchpoint{
+			ID: uuid.New(), OrganizationID: org, AccountID: acc.ID, Ordinal: ordinal,
+			Channel: models.OutreachChannelEmail, State: models.TouchpointCancelled,
+			StopReason: StopComposerStale, UpdatedAt: cancelledAt,
+			IdempotencyKey: "legacy-cadence:" + uuid.NewString(),
+		}
+		oldIDs[old.ID] = true
+		_ = repo.InsertTouchpoint(context.Background(), old)
+	}
+
+	planned, xerr := svc.PlanAccountCadence(context.Background(), org, user, acc.ID, &cand.ID, models.OutreachChannelEmail)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if len(planned) != len(CadencePolicyV1()) || planned[0].State != models.TouchpointDue {
+		t.Fatalf("recoverable cadence was not replanned: %+v", planned)
+	}
+	for _, tp := range planned {
+		if oldIDs[tp.ID] || !strings.Contains(tp.IdempotencyKey, ":recovery:"+PromptVersion+":") {
+			t.Fatalf("cancelled history was reused instead of superseded: %+v", tp)
+		}
+	}
+	again, xerr := svc.PlanAccountCadence(context.Background(), org, user, acc.ID, &cand.ID, models.OutreachChannelEmail)
+	if xerr != nil {
+		t.Fatalf("recovery plan is not idempotent: %+v err=%v", again, xerr)
+	}
+	foundPlannedDue := false
+	for _, tp := range again {
+		if tp.ID == planned[0].ID && tp.State == models.TouchpointDue {
+			foundPlannedDue = true
+			break
+		}
+	}
+	all, _ := repo.ListTouchpoints(context.Background(), org, acc.ID, "", 50, 0)
+	if !foundPlannedDue || len(all) != 2*len(CadencePolicyV1()) {
+		t.Fatalf("recovery plan duplicated or lost the active cadence: %+v all=%+v", again, all)
+	}
+}
+
+func TestPlanDoesNotRecoverHumanRejectedCadence(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo).(*service)
+	org, user := uuid.New(), uuid.New()
+	acc := &models.OutreachAccount{
+		ID: uuid.New(), OrganizationID: org, CNPJ14: "12345678000133",
+		RazaoSocial: "Empresa", QueueState: models.OutreachQueueReadyToGenerate, SourceLeadID: "L-rejected",
+	}
+	_, _ = repo.UpsertAccount(context.Background(), acc)
+	rejected := &models.OutreachTouchpoint{
+		ID: uuid.New(), OrganizationID: org, AccountID: acc.ID, Ordinal: 1,
+		Channel: models.OutreachChannelEmail, State: models.TouchpointRejected,
+		StopReason: "human_rejected", IdempotencyKey: "human-rejected",
+	}
+	_ = repo.InsertTouchpoint(context.Background(), rejected)
+
+	planned, xerr := svc.PlanAccountCadence(context.Background(), org, user, acc.ID, nil, models.OutreachChannelEmail)
+	if xerr != nil || len(planned) != 1 || planned[0].ID != rejected.ID || planned[0].State != models.TouchpointRejected {
+		t.Fatalf("human rejection was silently replanned: %+v err=%v", planned, xerr)
 	}
 }
 

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -33,6 +33,9 @@ func (s *service) PlanAccountCadence(ctx context.Context, orgID, userID, account
 	if err != nil {
 		return nil, errx.New(errx.Internal, "list touchpoints failed")
 	}
+	recoveryRevision := ""
+	latestRecoverableCancellation := time.Time{}
+	recoverableCancelledCadence := len(existing) > 0
 	for _, t := range existing {
 		if t.State == models.TouchpointSent || t.State == models.TouchpointDNC {
 			return nil, errx.New(errx.BadRequest, "cannot replan cadence: account has SENT or DNC touchpoints")
@@ -40,6 +43,22 @@ func (s *service) PlanAccountCadence(ctx context.Context, orgID, userID, account
 		if IsOpen(t.State) {
 			return existing, nil
 		}
+		if !recoverableCadenceCancellation(t.State, t.StopReason) {
+			recoverableCancelledCadence = false
+		}
+		if t.UpdatedAt.After(latestRecoverableCancellation) {
+			latestRecoverableCancellation = t.UpdatedAt
+		}
+	}
+	if len(existing) > 0 && !recoverableCancelledCadence {
+		return existing, nil
+	}
+	if recoverableCancelledCadence {
+		revision := latestRecoverableCancellation.UTC().Format("20060102T150405.000000000Z")
+		if latestRecoverableCancellation.IsZero() {
+			revision = existing[len(existing)-1].ID.String()
+		}
+		recoveryRevision = ":recovery:" + PromptVersion + ":" + revision
 	}
 	var cand *models.OutreachContactCandidate
 	if contactID != nil {
@@ -90,7 +109,7 @@ func (s *service) PlanAccountCadence(ctx context.Context, orgID, userID, account
 		if i == 0 {
 			state = models.TouchpointDue
 		}
-		idem := fmt.Sprintf("tp:%s:%s:%d:%s", orgID, accountID, step.Ordinal, step.CadenceStep)
+		idem := fmt.Sprintf("tp:%s:%s:%d:%s%s", orgID, accountID, step.Ordinal, step.CadenceStep, recoveryRevision)
 		tp := &models.OutreachTouchpoint{
 			OrganizationID: orgID, AccountID: accountID, Ordinal: step.Ordinal,
 			CadenceStep: step.CadenceStep, Channel: ch, Purpose: step.Purpose,
@@ -116,6 +135,14 @@ func (s *service) PlanAccountCadence(ctx context.Context, orgID, userID, account
 	}
 	_ = userID
 	return out, nil
+}
+
+func recoverableCadenceCancellation(state, reason string) bool {
+	if state != models.TouchpointCancelled {
+		return false
+	}
+	reason = strings.TrimSpace(reason)
+	return strings.EqualFold(reason, StopComposerStale) || strings.EqualFold(reason, TargetFitReasonStale)
 }
 
 func (s *service) ListReviewTouchpoints(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]models.OutreachTouchpoint, *errx.Error) {


### PR DESCRIPTION
## Outcome

Allows the asynchronous CONFENGE draft worker to supersede cadence rows cancelled solely because target fit or composer freshness was stale. Cancellation history is preserved; a new version-bound cadence is created idempotently.

## Safety

- never reopens SENT, DNC, human-rejected, bounced, or arbitrary terminal histories
- does not approve, schedule, queue, or send
- keeps human review and the production kill switch unchanged

## Verification

- `go test ./internal/app/confenge -count=1`
- `golangci-lint run ./...`
- focused recovery and human-rejection regression tests

Supports #155 and #149; live evidence will be posted only after merge/deploy/reconciliation.
