### PR TITLE
feat: allow legacy public company routes into CONFENGE review

### DIFF
--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -44,11 +44,11 @@ The browser skips login, registration, workspace selection, and onboarding. Inte
 
 ## Recipient and messageability gates
 
-Every target ends in `VALIDATED`, `EXCEPTION`, or `BLOCKED`. A generic mailbox is never auto-promoted to `VALIDATED`. Warmbly never invents a name, role, ownership, personal email, consent, or evidence.
+Every target ends in `VALIDATED`, `CONTROLLED_ELIGIBLE`, `EXCEPTION`, or `BLOCKED`. A public role, department, generic-company, or company-associated freemail route may be `CONTROLLED_ELIGIBLE` without a known person, but it is never auto-promoted to `VALIDATED`. Warmbly never invents a name, role, ownership, personal email, consent, or evidence. Pre-contract institutional candidates remain eligible only when the imported record already says `email_send_ready=true`, `COMPANY_OWNED`, carries a defensible public verification status, and is not inferred, suppressed, blocked, bounced, or freemail without explicit company evidence.
 
 Copy is planned only after extra-cli intelligence is reduced to an internal `OutreachStrategy`. The messageability gate then decides `READY`, `NEEDS_ENRICHMENT`, or `BLOCKED`. Only a `READY` plan is rendered into a recipient-safe facing copy (greeting, public observation, relevance, micro-offer, CTA). Internal hypothesis, rationale, and operator warnings never enter the email. `NEEDS_REVIEW` and `validation_ok=true` mean the exact body is already sendable if a human presses Approve. Unready items go to a separate exception or enrichment queue. Passive MX or DNS from extra-cli never becomes `VERIFIED`, `VALIDATED`, or `email_send_ready`.
 
-`NEEDS_REVIEW` is assigned only when recipient resolution is `VALIDATED`, the contact tier is `DIRECT_EMAIL_VALIDATED`, messageability is `READY`, and the composed body is non-empty. An `EXCEPTION` never becomes `NEEDS_REVIEW`. Two individually valid named humans on the same account stay `EXCEPTION` and land in `MANUAL_OUTREACH` until a human picks one recipient.
+`NEEDS_REVIEW` is assigned only when recipient resolution is `VALIDATED` or `CONTROLLED_ELIGIBLE`, messageability is `READY`, and the composed body is non-empty. `CONTROLLED_ELIGIBLE` preserves the institutional route class and an unknown person instead of pretending to validate an individual. An `EXCEPTION` never becomes `NEEDS_REVIEW`. Two individually valid named humans on the same account stay `EXCEPTION` and land in `MANUAL_OUTREACH` until a human picks one recipient.
 
 Human `APPROVE`, `EDIT`, `REJECT`, `RECIPIENT_CHANGE`, and `SKIP` persist as `HumanCorrection`. Edits keep before/after. AI never substitutes the human gate.
 

--- a/internal/app/confenge/commercial_action_test.go
+++ b/internal/app/confenge/commercial_action_test.go
@@ -95,11 +95,11 @@ func TestReachabilityContractualFixtures(t *testing.T) {
 	}
 
 	r4 := byLead["r4-role-mailbox"]
-	if r4.Action.ActionType != models.ActionRoleEmail || r4.Action.Lane != models.LaneRoleEmailQueue {
+	if r4.Action.ActionType != models.ActionRoleEmail || r4.Action.Lane != models.LaneEmailNeedsReview {
 		t.Fatalf("R4 want ROLE_EMAIL: %+v", r4.Action)
 	}
-	if r4.Action.PersonName != "" || r4.Action.EmailSendable {
-		t.Fatalf("R4 must not become personal email: %+v", r4.Action)
+	if r4.Action.PersonName != "" || !r4.Action.EmailSendable || r4.Action.Dispatchable || r4.RecipientState != RecipientControlledEligible {
+		t.Fatalf("R4 must be reviewable without becoming personal or dispatchable: %+v rec=%s", r4.Action, r4.RecipientState)
 	}
 
 	r5 := byLead["r5-corporate-generic"]
@@ -291,9 +291,10 @@ func TestCommercialAdversarialPromotions(t *testing.T) {
 		t.Fatal("duplicate snapshot must reuse id")
 	}
 
-	// Manual action never becomes email send.
-	if r3.Action.EmailSendable || r3.Action.Dispatchable || r4.Action.EmailSendable {
-		t.Fatal("manual route must not create email send bypass")
+	// A manual call stays outside email. A public role route is reviewable but
+	// never dispatchable without the downstream human and transport gates.
+	if r3.Action.EmailSendable || r3.Action.Dispatchable || !r4.Action.EmailSendable || r4.Action.Dispatchable {
+		t.Fatal("route classification created an action or dispatch bypass")
 	}
 
 	// Unknown reachability fails closed.
@@ -509,7 +510,7 @@ func TestCommercialTodaySurvivesKillSwitchAndPause(t *testing.T) {
 		if _, ok := ids[c.ActionID]; !ok {
 			t.Fatalf("pause invented a new card: %+v", c)
 		}
-		if c.Dispatchable || (c.ActionType != models.ActionDirectEmail && c.EmailSendable) {
+		if c.Dispatchable || c.EmailSendable != ids[c.ActionID].EmailSendable {
 			t.Fatalf("pause must not promote sendability: %+v", c)
 		}
 		if c.ActionType == models.ActionRoutedCall && !c.Actionable {

--- a/internal/app/confenge/contact_tier_test.go
+++ b/internal/app/confenge/contact_tier_test.go
@@ -100,7 +100,7 @@ func TestContactTiersContractualFixture(t *testing.T) {
 	}
 }
 
-func TestContactTierGenericCannotApproveViaHumanPath(t *testing.T) {
+func TestContactTierGenericCanReachHumanReviewWithoutPersonValidation(t *testing.T) {
 	repo := newMemRepo()
 	svc := testSvc(repo).(*service)
 	org, user := uuid.New(), uuid.New()
@@ -127,15 +127,15 @@ func TestContactTierGenericCannotApproveViaHumanPath(t *testing.T) {
 	if xerr != nil {
 		t.Fatal(xerr)
 	}
-	if tp.State == models.TouchpointNeedsReview {
-		t.Fatalf("generic cannot enter NEEDS_REVIEW: %+v", tp)
+	if (tp.State != models.TouchpointNeedsReview && tp.State != models.TouchpointAIRewritePending) || strings.TrimSpace(tp.BodyText) == "" {
+		t.Fatalf("generic company route must enter the editorial review pipeline: %+v", tp)
 	}
-	if _, xerr := svc.ApproveTouchpoint(context.Background(), org, user, tp.ID, ApprovalOptions{GenericRecipientAcknowledged: true}); xerr == nil {
-		t.Fatal("generic acknowledgement must not approve")
+	if tp.ApprovedBy != nil {
+		t.Fatalf("generation must not approve or schedule: %+v", tp)
 	}
 }
 
-func TestContactTierRoleMailboxGenerateNeverNeedsReview(t *testing.T) {
+func TestContactTierRoleMailboxGeneratesForHumanReview(t *testing.T) {
 	repo := newMemRepo()
 	svc := testSvc(repo).(*service)
 	org, user := uuid.New(), uuid.New()
@@ -164,8 +164,11 @@ func TestContactTierRoleMailboxGenerateNeverNeedsReview(t *testing.T) {
 	if xerr != nil {
 		t.Fatal(xerr)
 	}
-	if tp.State == models.TouchpointNeedsReview {
-		t.Fatalf("role mailbox must not enter NEEDS_REVIEW: %+v", tp)
+	if tp.State != models.TouchpointNeedsReview || strings.TrimSpace(tp.BodyText) == "" {
+		t.Fatalf("role mailbox must enter NEEDS_REVIEW with copy: %+v", tp)
+	}
+	if tp.ApprovedBy != nil {
+		t.Fatalf("generation must not approve or schedule: %+v", tp)
 	}
 }
 

--- a/internal/app/confenge/controlled_email_adversarial_test.go
+++ b/internal/app/confenge/controlled_email_adversarial_test.go
@@ -102,6 +102,104 @@ func TestUnassociatedGmailAndInferredStayOut(t *testing.T) {
 	}
 }
 
+func TestLegacyPublicInstitutionalRoutesAreControlledWithoutPersonValidation(t *testing.T) {
+	now := time.Now().UTC()
+	account := &models.OutreachAccount{CNPJ14: "12345678000190", RazaoSocial: "EMPRESA"}
+	for _, tc := range []struct {
+		name         string
+		email        string
+		purpose      string
+		verification string
+		wantClass    string
+	}{
+		{
+			name: "official generic", email: "contato@empresa.com.br", purpose: "GENERIC_CONTACT",
+			verification: models.OutreachVerifyOfficialSource, wantClass: RouteClassGenericCompany,
+		},
+		{
+			name: "verified department", email: "licitacoes@empresa.com.br", purpose: "LICITACOES",
+			verification: models.OutreachVerifyVerified, wantClass: RouteClassRoleOrDepartment,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			candidate := &models.OutreachContactCandidate{
+				Email: tc.email, MailboxPurpose: tc.purpose, VerificationStatus: tc.verification,
+				EmailSendReady: true, OwnershipStatus: "COMPANY_OWNED",
+			}
+			if !CandidateControlledEligible(candidate) {
+				t.Fatal("legacy public institutional route should be controlled eligible")
+			}
+			if CandidateEmailValidated(candidate) {
+				t.Fatal("institutional route must not become EMAIL_VALIDATED")
+			}
+			resolved := ResolveRecipient(account, []models.OutreachContactCandidate{*candidate}, now)
+			if resolved.State != RecipientControlledEligible {
+				t.Fatalf("state=%s reasons=%v", resolved.State, resolved.ReasonCodes)
+			}
+			if resolved.Name != "" || CandidatePersonUnknown(candidate) == false {
+				t.Fatalf("person truth was invented: name=%q unknown=%v", resolved.Name, CandidatePersonUnknown(candidate))
+			}
+			if CandidateRouteClass(candidate) != tc.wantClass {
+				t.Fatalf("class=%s want=%s", CandidateRouteClass(candidate), tc.wantClass)
+			}
+		})
+	}
+}
+
+func TestLegacyControlledFallbackRemainsFailClosed(t *testing.T) {
+	base := models.OutreachContactCandidate{
+		Email: "contato@empresa.com.br", MailboxPurpose: "GENERIC_CONTACT",
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+		EmailSendReady:     true, OwnershipStatus: "COMPANY_OWNED",
+	}
+
+	withoutOwnership := base
+	withoutOwnership.OwnershipStatus = "UNKNOWN"
+	if CandidateControlledEligible(&withoutOwnership) {
+		t.Fatal("missing company ownership must stay ineligible")
+	}
+
+	unverified := base
+	unverified.VerificationStatus = models.OutreachVerifyCandidateUnverified
+	if CandidateControlledEligible(&unverified) {
+		t.Fatal("unverified legacy route must stay ineligible")
+	}
+
+	inferred := base
+	inferred.EmailDerivation = "INFERRED"
+	if CandidateControlledEligible(&inferred) {
+		t.Fatal("inferred legacy route must stay ineligible")
+	}
+
+	invalid := base
+	invalid.Email = "contato@empresa"
+	if CandidateControlledEligible(&invalid) {
+		t.Fatal("syntactically invalid legacy route must stay ineligible")
+	}
+
+	unsuitable := base
+	unsuitable.RecipientCommercialSuitability = "UNSUITABLE_ROLE"
+	if CandidateControlledEligible(&unsuitable) {
+		t.Fatal("commercially unsuitable legacy route must stay ineligible")
+	}
+
+	freemail := base
+	freemail.Email = "comercial@gmail.com"
+	freemail.MailboxPurpose = "COMERCIAL"
+	if CandidateControlledEligible(&freemail) {
+		t.Fatal("legacy freemail without observed mailbox-company evidence must stay ineligible")
+	}
+
+	explicitlyRefused := base
+	eligible := false
+	explicitlyRefused.DiscoveryJSON = discoveryJSON(t, controlledDiscovery{
+		RouteClass: RouteClassGenericCompany, ControlledEmailEligible: &eligible,
+	})
+	if CandidateControlledEligible(&explicitlyRefused) {
+		t.Fatal("explicit controlled_email_eligible=false must override legacy fields")
+	}
+}
+
 func TestCopyQARejectsInventionAndGmailCorporateClaim(t *testing.T) {
 	c := &models.OutreachContactCandidate{Email: "contato@empresa.com.br"}
 	errs := ValidateCopyForRouteClass(RouteClassGenericCompany, "Olá, Ana, você é o gerente.", "Oi Ana", c)

--- a/internal/app/confenge/controlled_route.go
+++ b/internal/app/confenge/controlled_route.go
@@ -83,11 +83,14 @@ func CandidateControlledEligible(c *models.OutreachContactCandidate) bool {
 		return false
 	}
 	d := parseControlledDiscovery(c)
-	if d.ControlledEmailEligible == nil || !*d.ControlledEmailEligible {
+	if d.ControlledEmailEligible == nil {
 		class := CandidateRouteClass(c)
 		if class == RouteClassDirectPerson {
 			return c.EmailSendReady && provenPersonName(c)
 		}
+		return legacyControlledPublicRoute(c, class)
+	}
+	if !*d.ControlledEmailEligible {
 		return false
 	}
 	class := CandidateRouteClass(c)
@@ -95,6 +98,43 @@ func CandidateControlledEligible(c *models.OutreachContactCandidate) bool {
 		return false
 	}
 	return defaultPilotRouteClasses[class]
+}
+
+// legacyControlledPublicRoute bridges pre-contract institutional candidates
+// whose imported fields already prove a public company-owned route.
+func legacyControlledPublicRoute(c *models.OutreachContactCandidate, class string) bool {
+	if c == nil || !c.EmailSendReady || c.MailboxPurposeSendBlocked || !c.EnrollableIgnoringVerification() {
+		return false
+	}
+	if !validExactEmail(c.Email) {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(c.OwnershipStatus), "COMPANY_OWNED") {
+		return false
+	}
+	if isFreemailAddress(c.Email) || (class != RouteClassRoleOrDepartment && class != RouteClassGenericCompany) {
+		return false
+	}
+	if strings.EqualFold(strings.TrimSpace(c.EmailDerivation), "INFERRED") {
+		return false
+	}
+	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(c.RecipientCommercialSuitability)), "UNSUITABLE") {
+		return false
+	}
+	if suppression := strings.ToUpper(strings.TrimSpace(c.RouteSuppression)); suppression != "" && suppression != "NONE" {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(c.VerificationStatus)) {
+	case models.OutreachVerifyOfficialSource,
+		models.OutreachVerifyPublicDocumentRecent,
+		models.OutreachVerifyMultipleSources,
+		models.OutreachVerifyInstitutionalGeneric,
+		models.OutreachVerifyHumanConfirmed,
+		models.OutreachVerifyVerified:
+		return true
+	default:
+		return false
+	}
 }
 
 // CandidateEnrollable is the controlled-route enrollability rule: a classified

--- a/internal/app/confenge/execution_pipeline_test.go
+++ b/internal/app/confenge/execution_pipeline_test.go
@@ -88,7 +88,7 @@ func TestResolveRecipientValidatedRequiresProvenIdentity(t *testing.T) {
 	}
 }
 
-func TestGenerateTouchpointDraftGenericMailboxFailClosed(t *testing.T) {
+func TestGenerateTouchpointDraftGenericMailboxNeedsHumanReview(t *testing.T) {
 	repo := newMemRepo()
 	svc := testSvc(repo).(*service)
 	org, user := uuid.New(), uuid.New()
@@ -122,11 +122,11 @@ func TestGenerateTouchpointDraftGenericMailboxFailClosed(t *testing.T) {
 	if xerr != nil {
 		t.Fatal(xerr)
 	}
-	if strings.TrimSpace(tp.BodyText) != "" {
-		t.Fatalf("generic mailbox must not produce a sendable body: %q", tp.BodyText)
+	if strings.TrimSpace(tp.BodyText) == "" {
+		t.Fatal("generic mailbox must produce reviewable copy")
 	}
-	if tp.State == models.TouchpointNeedsReview {
-		t.Fatalf("generic mailbox must not enter NEEDS_REVIEW: %+v", tp)
+	if (tp.State != models.TouchpointNeedsReview && tp.State != models.TouchpointAIRewritePending) || tp.ApprovedBy != nil {
+		t.Fatalf("generic mailbox must stop in the unapproved editorial pipeline: %+v", tp)
 	}
 	if tp.DraftID == nil {
 		t.Fatal("fail-closed draft must still be persisted")
@@ -135,18 +135,15 @@ func TestGenerateTouchpointDraftGenericMailboxFailClosed(t *testing.T) {
 	if err != nil || draft == nil {
 		t.Fatalf("draft: %v", err)
 	}
-	if draft.Status == models.OutreachDraftNeedsReview || strings.TrimSpace(draft.BodyText) != "" {
-		t.Fatalf("draft must not be sendable: status=%s body=%q", draft.Status, draft.BodyText)
+	if (draft.Status != models.OutreachDraftNeedsReview && draft.Status != models.OutreachDraftAIRewritePending) || strings.TrimSpace(draft.BodyText) == "" {
+		t.Fatalf("draft must be reviewable: status=%s body=%q", draft.Status, draft.BodyText)
 	}
-	if rec := recipientFromDraft(draft); rec == nil || rec.State == RecipientValidated {
-		t.Fatalf("recipient must not be VALIDATED: %+v", rec)
-	}
-	if _, xerr := svc.ApproveTouchpoint(context.Background(), org, user, tp.ID, ApprovalOptions{GenericRecipientAcknowledged: true}); xerr == nil {
-		t.Fatal("acknowledgement must not authorize a generic mailbox")
+	if rec := recipientFromDraft(draft); rec == nil || rec.State != RecipientControlledEligible {
+		t.Fatalf("recipient must preserve CONTROLLED_ELIGIBLE instead of VALIDATED: %+v", rec)
 	}
 }
 
-func TestResolveRecipientNeverPromotesGeneric(t *testing.T) {
+func TestResolveRecipientNeverPromotesGenericToPersonValidation(t *testing.T) {
 	now := time.Date(2026, 8, 1, 12, 0, 0, 0, time.UTC)
 	acc := testAccount("REAJUSTE", "ANUALIDADE", "contrato 1149/2022 atingiu aniversário de reajuste")
 	c := validatedCand("Pessoa Histórica", "Contato", "contato@encopav.com.br")
@@ -155,14 +152,14 @@ func TestResolveRecipientNeverPromotesGeneric(t *testing.T) {
 	if res.State == RecipientValidated {
 		t.Fatal("generic mailbox must not be VALIDATED")
 	}
-	if res.State != RecipientException {
-		t.Fatalf("generic want EXCEPTION got %s %v", res.State, res.ReasonCodes)
+	if res.State != RecipientControlledEligible {
+		t.Fatalf("generic want CONTROLLED_ELIGIBLE got %s %v", res.State, res.ReasonCodes)
 	}
 	if res.Name != "" {
 		t.Fatalf("must not surface invented/generic name: %q", res.Name)
 	}
-	if res.HumanDecision == "" || res.NextAction == "" {
-		t.Fatal("exception must tell the human what to decide")
+	if !CandidatePersonUnknown(&c) {
+		t.Fatal("controlled generic route must preserve unknown person")
 	}
 }
 

--- a/internal/app/confenge/pilot_cohort_test.go
+++ b/internal/app/confenge/pilot_cohort_test.go
@@ -485,7 +485,7 @@ func TestPilotEditInvalidatesApproval(t *testing.T) {
 	}
 }
 
-func TestGenericRecipientApprovalNeverSucceeds(t *testing.T) {
+func TestGenericRecipientCanPrepareAndRequiresExplicitHumanApproval(t *testing.T) {
 	fixture := newPilotFixture(t)
 	accountID := fixture.addReadyAccount(t, 51)
 	valid := fixture.repo.cands[accountID][1]
@@ -498,23 +498,22 @@ func TestGenericRecipientApprovalNeverSucceeds(t *testing.T) {
 	if xerr != nil {
 		t.Fatal(xerr)
 	}
-	if result.Prepared != 0 || result.Results[0].Status == PilotPrepared {
-		t.Fatalf("generic mailbox must not prepare a sendable review item: %+v", result.Results[0])
+	if result.Prepared != 1 || result.Results[0].Status != PilotPrepared {
+		t.Fatalf("generic mailbox must prepare a human review item: %+v", result.Results[0])
 	}
-	candidateID := valid.ID
-	touchpoints, pxerr := fixture.service.PlanAccountCadence(context.Background(), fixture.orgID, fixture.userID, accountID, &candidateID, models.OutreachChannelEmail)
-	if pxerr != nil || len(touchpoints) == 0 {
-		t.Fatalf("plan: %v", pxerr)
+	if result.Results[0].TouchpointID == nil {
+		t.Fatal("prepared generic route must bind a touchpoint")
 	}
-	generated, gxerr := fixture.service.GenerateTouchpointDraft(context.Background(), fixture.orgID, fixture.userID, touchpoints[0].ID)
-	if gxerr != nil {
-		t.Fatal(gxerr)
+	generated, err := fixture.repo.GetTouchpoint(context.Background(), fixture.orgID, *result.Results[0].TouchpointID)
+	if err != nil || generated == nil {
+		t.Fatalf("touchpoint: %v", err)
 	}
-	if strings.TrimSpace(generated.BodyText) != "" || generated.State == models.TouchpointNeedsReview {
-		t.Fatalf("generic must fail closed: state=%s body=%q", generated.State, generated.BodyText)
+	if strings.TrimSpace(generated.BodyText) == "" || generated.State != models.TouchpointNeedsReview || generated.ApprovedBy != nil {
+		t.Fatalf("generic route must stop at unapproved NEEDS_REVIEW: %+v", generated)
 	}
-	if _, axerr := fixture.service.ApproveTouchpoint(context.Background(), fixture.orgID, fixture.userID, generated.ID, ApprovalOptions{GenericRecipientAcknowledged: true}); axerr == nil {
-		t.Fatal("acknowledgement must not authorize a generic mailbox")
+	approved, axerr := fixture.service.ApproveTouchpoint(context.Background(), fixture.orgID, fixture.userID, generated.ID, ApprovalOptions{GenericRecipientAcknowledged: true})
+	if axerr != nil || approved.ApprovedBy == nil {
+		t.Fatalf("explicit human approval of exact generic draft failed: %+v err=%v", approved, axerr)
 	}
 }
 


### PR DESCRIPTION
Addresses the residual blockers in #149 and #155 without closing either before live reconciliation.

- bridges pre-contract ROLE/GENERIC candidates only when already imported as email_send_ready, COMPANY_OWNED, publicly verified, syntactically valid, non-inferred and unsuppressed
- keeps explicit controlled_email_eligible=false authoritative
- keeps unassociated freemail and probabilistic routes outside the legacy fallback
- preserves person_unknown and never promotes an institutional mailbox to EMAIL_VALIDATED
- updates stale tests/docs to the current product policy

Safety: generation stops in the editorial/human-review pipeline; it never approves, queues, dispatches or sends.

Local gates: targeted route/draft/cohort tests; full confenge package excluding the Mailpit-dependent acceptance test; golangci-lint; docs typecheck/lint (two pre-existing warnings, zero errors).