### PR TITLE
fix(confenge): rebuild VPS images during deploy

### DIFF
--- a/deploy/confenge-vps/test_vps_pack.py
+++ b/deploy/confenge-vps/test_vps_pack.py
@@ -105,6 +105,11 @@ class TestConfengeVpsPack(unittest.TestCase):
             self.fail(f"validate.sh exit {proc.returncode}\n{proc.stdout}\n{proc.stderr}")
         self.assertIn("VALIDATE=PASS", proc.stdout)
 
+    def test_up_rebuilds_release_images(self) -> None:
+        """A new checkout must not silently reuse the previous app images."""
+        text = (PACK / "up.sh").read_text(encoding="utf-8")
+        self.assertIn("compose_cmd up -d --build --remove-orphans", text)
+
     def test_inbound_edge_nginx_allowlist_is_the_shipped_config(self) -> None:
         """Drive the real nginx files that install.sh copies onto the VPS."""
         https = (PACK / "nginx/site-https.conf").read_text(encoding="utf-8")

--- a/deploy/confenge-vps/up.sh
+++ b/deploy/confenge-vps/up.sh
@@ -84,7 +84,10 @@ if [[ "${CONFENGE_VPS_SEED:-false}" == "true" ]]; then
 fi
 
 echo "Bringing up project=$COMPOSE_PROJECT_NAME ..."
-compose_cmd up -d --remove-orphans
+# A release checkout is not a release deployment until the local application
+# images have been rebuilt from that checkout.  Compose otherwise reuses the
+# previous tag and can report healthy containers that still run the prior SHA.
+compose_cmd up -d --build --remove-orphans
 
 
 # Keep the kill-switch volume private and writable by the backend user (uid 1000).


### PR DESCRIPTION
## Summary
- rebuild application images from the checked-out release in the VPS deploy entrypoint
- add a structural regression test so a healthy prior image cannot masquerade as the new SHA

## Verification
- `python3 deploy/confenge-vps/test_vps_pack.py`
- `bash deploy/confenge-vps/validate.sh`
- `git diff --check`

The dispatch kill switch and all existing fail-closed safety checks remain unchanged.