### PR TITLE
fix(confenge): reconcile legacy approvals after feed refresh

### DIFF
--- a/docs/confenge/human-gate-api.md
+++ b/docs/confenge/human-gate-api.md
@@ -91,6 +91,14 @@ invalidates approval and cancels unsent queue work. RISKY, INVALID, UNKNOWN and
 STALE cannot be approved. A later `HOLD` or `REJECT` also cancels the unsent
 message immediately.
 
+The live lookup starts with the frozen source run and falls back to the same
+canonical account/candidate IDs when a later import has advanced
+`source_run_id`. Refreshing a canonical row is therefore not mistaken for
+`live_candidate_state_unknown`; the current suppression, opt-out, bounce,
+eligibility and mailbox fields are still checked. A missing canonical row or a
+read failure remains fail-closed. This makes reconciliation of approvals from
+the former no-scheduling contract possible without bypassing last-mile safety.
+
 The scheduling row has `auto_send=true` per approved message. This means the
 Warmbly worker may collect it; it does **not** enable the prohibited global
 `CONFENGE_AUTO_SEND_ENABLED` or GREEN autorun flags. The worker still enforces

--- a/internal/app/confenge/human_gate.go
+++ b/internal/app/confenge/human_gate.go
@@ -467,9 +467,8 @@ func (s *service) GetHumanGateCohort(ctx context.Context, orgID, id uuid.UUID, n
 		for _, account := range accounts {
 			current[account.Account.ID] = account
 		}
-	} else {
-		v.Reason = append(v.Reason, "live_suppression_state_unknown")
 	}
+	liveStateUnknown := false
 	for _, m := range v.Manifest.Members {
 		c := HumanGateCandidate{FrozenCohortMember: m, BlockedBy: []string{}}
 		c.Validation = s.latestHumanGateValidation(ctx, orgID, id, m.CandidateID, now)
@@ -486,7 +485,10 @@ func (s *service) GetHumanGateCohort(ctx context.Context, orgID, id uuid.UUID, n
 		if !policyCurrent {
 			c.BlockedBy = append(c.BlockedBy, "policy_drift")
 		}
-		live, ok := current[m.AccountID]
+		live, ok := s.humanGateCurrentAccount(ctx, orgID, m.AccountID, current)
+		if !ok {
+			liveStateUnknown = true
+		}
 		liveReasons := humanGateLiveInvalidations(m, live, ok)
 		if len(liveReasons) > 0 {
 			c.BlockedBy = append(c.BlockedBy, liveReasons...)
@@ -502,6 +504,9 @@ func (s *service) GetHumanGateCohort(ctx context.Context, orgID, id uuid.UUID, n
 		}
 		v.Candidates = append(v.Candidates, c)
 	}
+	if liveStateUnknown {
+		v.Reason = append(v.Reason, "live_suppression_state_unknown")
+	}
 	s.projectHumanGateEditorialAuthority(ctx, orgID, v)
 	v.Decision = s.latestHumanGateDecision(ctx, orgID, id)
 	if v.Decision != nil && v.Decision.Decision == "GO" {
@@ -514,6 +519,45 @@ func (s *service) GetHumanGateCohort(ctx context.Context, orgID, id uuid.UUID, n
 		}
 	}
 	return v, nil
+}
+
+// humanGateCurrentAccount reads late suppression from the original feed-run
+// projection when it is still addressable, and falls back to the same
+// canonical account/candidate rows by immutable IDs when a newer import has
+// advanced source_run_id. A frozen review does not become unknowable merely
+// because the account was refreshed by a later feed; deletion and read failure
+// remain distinct, fail-closed states.
+func (s *service) humanGateCurrentAccount(
+	ctx context.Context,
+	orgID, accountID uuid.UUID,
+	fromOriginalRun map[uuid.UUID]CohortAccountInput,
+) (CohortAccountInput, bool) {
+	if live, ok := fromOriginalRun[accountID]; ok {
+		return live, true
+	}
+	if s == nil || s.repo == nil {
+		return CohortAccountInput{}, false
+	}
+	account, err := s.repo.GetAccount(ctx, orgID, accountID)
+	if err != nil {
+		return CohortAccountInput{}, false
+	}
+	if account == nil {
+		// A successful canonical read that finds no account is known deletion,
+		// not an infrastructure unknown. An empty candidate list makes the
+		// existing invalidator report candidate_removed and refuse scheduling.
+		return CohortAccountInput{}, true
+	}
+	candidates, err := s.repo.ListCandidates(ctx, orgID, accountID)
+	if err != nil {
+		return CohortAccountInput{}, false
+	}
+	return CohortAccountInput{
+		Account:    *account,
+		Candidates: candidates,
+		Source:     account.SourceSystem,
+		Persisted:  true,
+	}, true
 }
 
 // projectHumanGateEditorialAuthority stamps the version-level verdict and, when
@@ -762,6 +806,19 @@ func (s *service) ReviewHumanGateCandidate(ctx context.Context, orgID, actorID, 
 	}
 	if in.Decision == "APPROVE" && (c.Validation == nil || c.Validation.Status != "VALID") {
 		return nil, humanGateError(errx.Conflict, "validation_blocks_approval", "APPROVE requires a current VALID result")
+	}
+	if in.Decision == "APPROVE" {
+		blockers := make([]string, 0, len(c.BlockedBy))
+		for _, blocker := range c.BlockedBy {
+			// This is the expected pre-decision state that APPROVE itself resolves.
+			// Every other current blocker must refuse before the durable review row.
+			if blocker != "approval_missing_or_invalid" {
+				blockers = append(blockers, blocker)
+			}
+		}
+		if len(blockers) > 0 {
+			return nil, humanGateError(errx.Conflict, "approval_not_schedulable", strings.Join(blockers, ","))
+		}
 	}
 	id := uuid.New()
 	receipt := humanGateReceipt("review", id)

--- a/internal/app/confenge/human_gate_scheduling_pg_test.go
+++ b/internal/app/confenge/human_gate_scheduling_pg_test.go
@@ -216,6 +216,90 @@ func TestHumanGateApproveSchedulesOnceAndReconcileIsIdempotentPostgres(t *testin
 	}
 }
 
+func TestHumanGateReconcileLegacyApprovalAfterSourceRunAdvancedPostgres(t *testing.T) {
+	f := newSchedulingPGFixture(t)
+
+	// Model the production shape left by the former contract: the durable
+	// APPROVE committed, but no scheduling path existed. Removing the governor
+	// makes today's method stop at precisely that boundary after storing review.
+	f.svc.WireDispatchGovernor(nil)
+	_, xerr := f.svc.ReviewHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidateID, HumanGateReviewInput{
+		Decision: "APPROVE", Reason: "legacy approval before atomic scheduling", Acknowledged: true,
+		IdempotencyKey: "legacy-approval", CorrelationID: "corr-legacy-approval",
+	})
+	if xerr == nil || xerr.Identifier != "dispatch_governor_unavailable" {
+		t.Fatalf("fixture must stop after durable review and before scheduling: %v", xerr)
+	}
+	if got := f.counts(); got != [4]int{1, 0, 0, 0} {
+		t.Fatalf("legacy setup must contain only the review: %v", got)
+	}
+
+	// A later feed refresh advances source_run_id on the canonical account. The
+	// frozen cohort still names the same immutable account/candidate IDs; this is
+	// the exact production condition that used to project
+	// live_candidate_state_unknown and make backfill fail.
+	if _, err := f.pool.Exec(f.ctx, `UPDATE outreach_accounts
+		SET source_run_id=$3,updated_at=now()
+		WHERE organization_id=$1 AND id=(SELECT account_id FROM outreach_contact_candidates WHERE organization_id=$1 AND id=$2)`,
+		f.org, f.candidateID, "newer-feed-run-"+uuid.NewString()); err != nil {
+		t.Fatal(err)
+	}
+	pgStore := dispatch.NewPGStore(f.pool)
+	f.svc.WireDispatchGovernor(dispatch.NewGovernor(dispatch.Config{
+		SendsPerHour: 10, MinGap: time.Minute, Timezone: "America/Sao_Paulo",
+		WindowStart: "09:00", WindowEnd: "18:00", BusinessDaysOnly: true,
+	}, pgStore, nil))
+
+	before, readErr := f.svc.GetHumanGateCohort(f.ctx, f.org, f.versionID, time.Now().UTC())
+	if readErr != nil || len(before.Candidates) != 1 || before.Candidates[0].Review == nil || !before.Candidates[0].Review.Effective {
+		t.Fatalf("canonical-id fallback must keep the approved review effective: cohort=%+v err=%v", before, readErr)
+	}
+	if containsString(before.Candidates[0].BlockedBy, "live_candidate_state_unknown") {
+		t.Fatalf("a newer feed run is not unknown live state: %v", before.Candidates[0].BlockedBy)
+	}
+
+	first, xerr := f.svc.ReconcileApprovedHumanGateCandidates(f.ctx, f.org, f.actor)
+	if xerr != nil || first.ApprovalRecords != 1 || first.LatestApprovedBindings != 1 ||
+		first.UniqueApprovedCandidates != 1 || first.Scheduled != 1 || first.AlreadyScheduled != 0 || first.Failed != 0 {
+		t.Fatalf("legacy backfill failed: report=%+v err=%v", first, xerr)
+	}
+	if got := f.counts(); got != [4]int{1, 1, 1, 1} {
+		t.Fatalf("legacy approval was not queued once: %v", got)
+	}
+	second, xerr := f.svc.ReconcileApprovedHumanGateCandidates(f.ctx, f.org, f.actor)
+	if xerr != nil || second.Scheduled != 0 || second.AlreadyScheduled != 1 || second.Failed != 0 {
+		t.Fatalf("legacy backfill rerun is not idempotent: report=%+v err=%v", second, xerr)
+	}
+	if got := f.counts(); got != [4]int{1, 1, 1, 1} {
+		t.Fatalf("legacy backfill rerun duplicated state: %v", got)
+	}
+}
+
+func TestHumanGateApproveAfterSourceRunAdvancedStillRefusesLateSuppressionPostgres(t *testing.T) {
+	f := newSchedulingPGFixture(t)
+	if _, err := f.pool.Exec(f.ctx, `UPDATE outreach_accounts
+		SET source_run_id=$3,updated_at=now()
+		WHERE organization_id=$1 AND id=(SELECT account_id FROM outreach_contact_candidates WHERE organization_id=$1 AND id=$2)`,
+		f.org, f.candidateID, "newer-feed-run-"+uuid.NewString()); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `UPDATE outreach_contact_candidates
+		SET blocked=true,block_reason='late suppression fixture',updated_at=now()
+		WHERE organization_id=$1 AND id=$2`, f.org, f.candidateID); err != nil {
+		t.Fatal(err)
+	}
+	_, xerr := f.svc.ReviewHumanGateCandidate(f.ctx, f.org, f.actor, f.versionID, f.candidateID, HumanGateReviewInput{
+		Decision: "APPROVE", Reason: "must not survive suppression", Acknowledged: true,
+		IdempotencyKey: "suppressed-approval", CorrelationID: "corr-suppressed-approval",
+	})
+	if xerr == nil || xerr.Identifier != "approval_not_schedulable" {
+		t.Fatalf("late suppression must refuse before review storage: %v", xerr)
+	}
+	if got := f.counts(); got != [4]int{0, 0, 0, 0} {
+		t.Fatalf("refused approval persisted work: %v", got)
+	}
+}
+
 func TestHumanGateHoldCancelsQueuedMessageAndLaterApproveGetsNewQueueKeyPostgres(t *testing.T) {
 	f := newSchedulingPGFixture(t)
 	f.review("APPROVE", "approve-before-hold")

--- a/internal/app/confenge/human_gate_test.go
+++ b/internal/app/confenge/human_gate_test.go
@@ -45,6 +45,39 @@ func TestHumanGateLateSuppressionOptOutBounceRemovalAndRecipientDriftInvalidate(
 	}
 }
 
+func TestHumanGateCanonicalFallbackKeepsLateSuppressionFailClosed(t *testing.T) {
+	orgID, accountID, candidateID := uuid.New(), uuid.New(), uuid.New()
+	repo := newMemRepo()
+	repo.byID[accountID] = &models.OutreachAccount{
+		ID: accountID, OrganizationID: orgID, Blocked: true, DoNotContact: true,
+	}
+	repo.cands[accountID] = []models.OutreachContactCandidate{{
+		ID: candidateID, OrganizationID: orgID, AccountID: accountID,
+		Email: "review@fixture.invalid", Blocked: true, DoNotContact: true, Bounced: true,
+	}}
+	svc := &service{repo: repo}
+	live, known := svc.humanGateCurrentAccount(t.Context(), orgID, accountID, map[uuid.UUID]CohortAccountInput{})
+	if !known {
+		t.Fatal("canonical account/candidate rows must be a known live reading")
+	}
+	reasons := humanGateLiveInvalidations(FrozenCohortMember{
+		AccountID: accountID, CandidateID: candidateID, Mailbox: "review@fixture.invalid",
+	}, live, known)
+	for _, want := range []string{
+		"late_account_suppression", "late_account_opt_out", "late_recipient_suppression",
+		"late_recipient_opt_out", "late_hard_bounce",
+	} {
+		if !slices.Contains(reasons, want) {
+			t.Fatalf("canonical fallback weakened %s: %v", want, reasons)
+		}
+	}
+
+	deleted, known := svc.humanGateCurrentAccount(t.Context(), orgID, uuid.New(), map[uuid.UUID]CohortAccountInput{})
+	if !known || !slices.Contains(humanGateLiveInvalidations(FrozenCohortMember{CandidateID: uuid.New()}, deleted, known), "candidate_removed") {
+		t.Fatal("known canonical deletion must fail closed as candidate_removed")
+	}
+}
+
 func TestHumanGateGOBlockersCoverEmptyStaleValidationAndLateState(t *testing.T) {
 	candidateID := uuid.New()
 	approved := &HumanGateReview{Decision: "APPROVE", Effective: true}


### PR DESCRIPTION
## Resultado

Mantém aprovações duráveis de cohort efetivas quando uma importação posterior avança `source_run_id`, usando os mesmos IDs canônicos para a leitura de segurança vigente.

## Segurança

- continua recusando supressão, opt-out, bounce, remoção, drift de destinatário e falha de leitura;
- impede um novo `APPROVE` antes da gravação quando existe qualquer bloqueio vigente além da ausência esperada da própria aprovação;
- permite que o reconciliador idempotente do contrato já implantado agende aprovações legadas sem GO.

## Provas

- `go test -count=1 ./...` com Mailpit: verde;
- `go test -count=1 ./internal/app/confenge` com PostgreSQL real e Mailpit: verde;
- `golangci-lint v1.64.8` compilado/executado com Go 1.25: verde;
- novo teste PostgreSQL reproduz APPROVE legado, avanço do feed, primeira reconciliação e segunda execução idempotente;
- novo teste PostgreSQL prova recusa de supressão tardia antes de qualquer review/touchpoint/fila.
