### PR TITLE
fix(confenge): select controlled routes for human review

### DIFF
--- a/internal/app/confenge/human_gate_selection.go
+++ b/internal/app/confenge/human_gate_selection.go
@@ -135,9 +135,10 @@ func humanGateAccountOperational(acc *models.OutreachAccount, sourceRunID string
 	if !acc.TargetFitEligible || acc.TargetFitClass != TargetFitConfirmed || !acc.TargetFitFresh || acc.TargetFitVersion == "" || acc.TargetFitSourceWatermark == "" || acc.TargetFitObservedAt == nil {
 		return "target_fit_not_operational"
 	}
-	if !acc.EmailSendReady {
-		return "account_email_not_ready"
-	}
+	// Company-level EMAIL_SEND_READY is the strict named-person autorun rollup.
+	// Human-gate cohorts also admit an explicitly classified controlled company
+	// mailbox (ROLE/GENERIC/FREEMAIL) whose live validation happens at APPROVE.
+	// The route-level gate below remains authoritative for that distinction.
 	return ""
 }
 
@@ -225,15 +226,15 @@ func (s *service) prepareHumanGateSelection(
 	} else {
 		for offset := 0; ; offset += humanGateSelectionPageSize {
 			page, readErr := s.repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{
-				Limit:                humanGateSelectionPageSize,
-				Offset:               offset,
-				DynamicPriority:      true,
-				ActivationState:      ActivationActionableNow,
-				ActivationDueNow:     true,
-				ActivationNotExpired: true,
-				ExcludeTerminal:      true,
-				RequireOperational:   true,
-				SourceRunID:          run.SourceRunID,
+				Limit:                    humanGateSelectionPageSize,
+				Offset:                   offset,
+				DynamicPriority:          true,
+				ActivationState:          ActivationActionableNow,
+				ActivationDueNow:         true,
+				ActivationNotExpired:     true,
+				ExcludeTerminal:          true,
+				RequireTargetFitEligible: true,
+				SourceRunID:              run.SourceRunID,
 			})
 			if readErr != nil {
 				return nil, report, nil, humanGateError(errx.ServiceUnavailable, "source_accounts_unavailable", "canonical source accounts could not be paged")
@@ -372,10 +373,22 @@ func finalizeHumanGateSelectionReport(ctx context.Context, tx pgx.Tx, orgID uuid
 		  AND a.target_fit_eligible=true AND a.target_fit_class='TARGET_CONFIRMED'
 		  AND a.target_fit_fresh=true AND a.target_fit_version<>''
 		  AND a.target_fit_source_watermark<>'' AND a.target_fit_observed_at IS NOT NULL
-		  AND a.email_send_ready=true AND a.do_not_contact=false AND a.blocked=false
+		  AND a.do_not_contact=false AND a.blocked=false
 		  AND a.queue_state NOT IN ('DO_NOT_CONTACT','BLOCKED','BOUNCED','REPLIED','MEETING','PROPOSAL','WON','LOST','SENT','ENROLLED')
 		  AND COALESCE(NULLIF(a.cnpj_root,''),left(a.cnpj14,8)) ~ '^[0-9]{8}$'
-		  AND EXISTS (SELECT 1 FROM outreach_contact_candidates c WHERE c.organization_id=a.organization_id AND c.account_id=a.id AND c.email_send_ready=true AND c.email<>'' AND c.blocked=false AND c.do_not_contact=false AND c.bounced=false AND c.mailbox_purpose_send_blocked=false AND c.verification_status NOT IN ('CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT'))
+		  AND EXISTS (
+			SELECT 1 FROM outreach_contact_candidates c
+			WHERE c.organization_id=a.organization_id AND c.account_id=a.id
+			  AND c.email<>'' AND c.blocked=false AND c.do_not_contact=false AND c.bounced=false
+			  AND c.mailbox_purpose_send_blocked=false
+			  AND (
+				(c.email_send_ready=true AND c.verification_status NOT IN ('CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT'))
+				OR (
+				  c.discovery_json @> '{"controlled_email_eligible":true}'::jsonb
+				  AND upper(COALESCE(c.discovery_json->>'route_class','')) IN ('DIRECT_PERSON','ROLE_OR_DEPARTMENT','GENERIC_COMPANY','PUBLIC_COMPANY_FREEMAIL')
+				)
+			  )
+		  )
 		  AND NOT EXISTS (SELECT 1 FROM confenge_cohort_selection_claims claim WHERE claim.organization_id=a.organization_id AND claim.source_run_id=a.source_run_id AND (claim.account_id=a.id OR claim.cnpj_root=COALESCE(NULLIF(a.cnpj_root,''),left(a.cnpj14,8))))
 		  AND NOT EXISTS (SELECT 1 FROM outreach_touchpoints tp WHERE tp.organization_id=a.organization_id AND tp.account_id=a.id)
 		  AND NOT EXISTS (SELECT 1 FROM confenge_cohort_versions cv CROSS JOIN LATERAL jsonb_array_elements(COALESCE(cv.frozen_manifest->'members','[]'::jsonb)) member WHERE cv.organization_id=a.organization_id AND member->>'account_id'=a.id::text)`, orgID, sourceRunID).Scan(&report.EligibleRemaining); err != nil {

--- a/internal/app/confenge/human_gate_selection_test.go
+++ b/internal/app/confenge/human_gate_selection_test.go
@@ -92,6 +92,12 @@ func TestHumanGateRecoveryReappliesOperationalSupplierGates(t *testing.T) {
 	if reason := humanGateAccountOperational(acc, "supplier-run", now); reason != "" {
 		t.Fatalf("operational supplier refused: %s", reason)
 	}
+	// Controlled institutional routes intentionally keep the named-person
+	// EMAIL_SEND_READY rollup false until APPROVE performs live validation.
+	acc.EmailSendReady = false
+	if reason := humanGateAccountOperational(acc, "supplier-run", now); reason != "" {
+		t.Fatalf("controlled-route supplier refused by named-person rollup: %s", reason)
+	}
 	acc.SourceRunID = "contracting-authority-run"
 	if reason := humanGateAccountOperational(acc, "supplier-run", now); reason != "source_run_mismatch" {
 		t.Fatalf("cross-run recovery = %q", reason)
@@ -187,7 +193,7 @@ func TestHumanGatePostgresCreatesOneHundredDisjointSupplierMessages(t *testing.T
 			TargetFitObservedAt:      &now,
 			TargetFitFresh:           true,
 			TargetFitEligible:        true,
-			EmailSendReady:           true,
+			EmailSendReady:           false,
 		}
 		if _, err = repo.UpsertAccount(ctx, acc); err != nil {
 			t.Fatalf("upsert supplier %d: %v", i, err)
@@ -199,10 +205,10 @@ func TestHumanGatePostgresCreatesOneHundredDisjointSupplierMessages(t *testing.T
 			Email:                          fmt.Sprintf("contato@fornecedor-%03d.com.br", i),
 			SourceURL:                      fmt.Sprintf("https://fornecedor-%03d.com.br/contato", i),
 			SourceDate:                     &now,
-			VerificationStatus:             models.OutreachVerifyOfficialSource,
+			VerificationStatus:             models.OutreachVerifyCandidateUnverified,
 			Confidence:                     "HIGH",
 			Recommended:                    true,
-			EmailSendReady:                 true,
+			EmailSendReady:                 false,
 			MailboxPurpose:                 "GENERIC_CONTACT",
 			OwnershipStatus:                "COMPANY_OWNED",
 			RecipientCommercialSuitability: "SUITABLE",


### PR DESCRIPTION
## Summary
- let NEXT_UNCLAIMED and RECOVER_PRIOR page target-fit-qualified suppliers whose explicit controlled company route is awaiting human-gate validation
- keep named-person EMAIL_SEND_READY as the strict autorun signal instead of misusing it as the human-review admission gate
- make remaining-capacity reporting recognize both strict named-person and classified controlled routes
- exercise the 100-message concurrent PostgreSQL path with account/contact EMAIL_SEND_READY false and CANDIDATE_UNVERIFIED, while controlled eligibility remains explicit

## Safety
- no change to DNC, bounce, blocked, source freshness, target-fit, prior-work, supplier-root, recipient, provenance, route-class, review, or dispatch gates
- APPROVE still performs live validation and is the only operation that schedules the exact reviewed message
- dispatch pause and global autorun remain unchanged

## Verification
- `WARMBLY_TEST_POSTGRES_DSN=... go test ./internal/app/confenge -run '^TestHumanGatePostgresCreatesOneHundredDisjointSupplierMessages$' -count=1 -v`
- `go test ./internal/app/confenge/... -count=1`
- `golangci-lint run --timeout=5m ./internal/app/confenge/...`
- `git diff --check`