### PR TITLE
fix(confenge): recover explicitly controlled routes

### DIFF
--- a/internal/app/confenge/contact_tier.go
+++ b/internal/app/confenge/contact_tier.go
@@ -365,6 +365,17 @@ func applyPublishedContactTier(c *models.OutreachContactCandidate, published str
 			c.MailboxPurpose = "GENERIC_CONTACT"
 		}
 	case ContactTierE:
+		// The published contact tier describes the strict/named-person lane.
+		// An explicit controlled-email route is a separate human-review lane:
+		// extra-cli may legitimately publish EXHAUSTED for autorun while also
+		// authorizing an institutional mailbox for controlled review. Preserve
+		// DNC, bounce, suppression and fixture blockers; only avoid inventing a
+		// generic Blocked flag from the strict tier itself.
+		d := parseControlledDiscovery(c)
+		if d.ControlledEmailEligible != nil && *d.ControlledEmailEligible &&
+			defaultPilotRouteClasses[CandidateRouteClass(c)] {
+			return
+		}
 		if !c.Blocked && !c.DoNotContact && !c.Bounced {
 			c.Blocked = true
 			if c.BlockReason == "" {

--- a/internal/app/confenge/contact_tier_test.go
+++ b/internal/app/confenge/contact_tier_test.go
@@ -31,6 +31,42 @@ func loadContactTierFeed(t *testing.T) *Feed {
 	return feed
 }
 
+func TestPublishedExhaustedTierDoesNotBlockExplicitControlledRoute(t *testing.T) {
+	controlled := true
+	purposeBlocked := true
+	provenanceValid := false
+	derivedFixture := false
+	c := leadToCandidate(uuid.New(), uuid.New(), uuid.New(), FeedContact{
+		SourceContactID:                "controlled-generic",
+		Email:                          "contato@fornecedor.com.br",
+		SourceURL:                      "https://fornecedor.com.br/contato",
+		RootSourceType:                 "company_website",
+		VerificationStatus:             models.OutreachVerifyOfficialSource,
+		OwnershipStatus:                "COMPANY_OWNED",
+		RecipientCommercialSuitability: "UNSUITABLE_PROVENANCE",
+		MailboxPurpose:                 "GENERIC_CONTACT",
+		MailboxPurposeSendBlocked:      &purposeBlocked,
+		ProvenanceChainValid:           &provenanceValid,
+		DerivedFromFixture:             &derivedFixture,
+		ControlledEmailEligible:        &controlled,
+		RouteClass:                     RouteClassGenericCompany,
+		RouteSuppression:               "NONE",
+		ContactTier:                    ContactTierE,
+	})
+	if c.Blocked || !CandidateControlledEligible(c) {
+		t.Fatalf("explicit controlled route was collapsed into strict EXHAUSTED lane: %+v", c)
+	}
+	if !c.MailboxPurposeSendBlocked || c.EmailSendReady {
+		t.Fatalf("strict autorun guards were weakened: %+v", c)
+	}
+
+	legacy := &models.OutreachContactCandidate{Email: "contato@fornecedor.com.br"}
+	applyPublishedContactTier(legacy, ContactTierE)
+	if !legacy.Blocked || legacy.BlockReason != "published_exhausted" {
+		t.Fatalf("unstamped EXHAUSTED route must remain blocked: %+v", legacy)
+	}
+}
+
 func TestContactTiersContractualFixture(t *testing.T) {
 	now := time.Date(2026, 8, 13, 12, 0, 0, 0, time.UTC)
 	feed := loadContactTierFeed(t)

--- a/internal/app/confenge/human_gate_selection.go
+++ b/internal/app/confenge/human_gate_selection.go
@@ -380,9 +380,9 @@ func finalizeHumanGateSelectionReport(ctx context.Context, tx pgx.Tx, orgID uuid
 			SELECT 1 FROM outreach_contact_candidates c
 			WHERE c.organization_id=a.organization_id AND c.account_id=a.id
 			  AND c.email<>'' AND c.blocked=false AND c.do_not_contact=false AND c.bounced=false
-			  AND c.mailbox_purpose_send_blocked=false
 			  AND (
-				(c.email_send_ready=true AND c.verification_status NOT IN ('CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT'))
+				(c.email_send_ready=true AND c.mailbox_purpose_send_blocked=false
+				  AND c.verification_status NOT IN ('CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT'))
 				OR (
 				  c.discovery_json @> '{"controlled_email_eligible":true}'::jsonb
 				  AND upper(COALESCE(c.discovery_json->>'route_class','')) IN ('DIRECT_PERSON','ROLE_OR_DEPARTMENT','GENERIC_COMPANY','PUBLIC_COMPANY_FREEMAIL')

--- a/internal/app/confenge/human_gate_selection_test.go
+++ b/internal/app/confenge/human_gate_selection_test.go
@@ -210,12 +210,43 @@ func TestHumanGatePostgresCreatesOneHundredDisjointSupplierMessages(t *testing.T
 			Recommended:                    true,
 			EmailSendReady:                 false,
 			MailboxPurpose:                 "GENERIC_CONTACT",
+			MailboxPurposeSendBlocked:      true,
 			OwnershipStatus:                "COMPANY_OWNED",
 			RecipientCommercialSuitability: "SUITABLE",
 			DiscoveryJSON:                  eligibleDisc(t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unknown}),
 		}
+		// Reproduce a route imported before the controlled-email contract. Its
+		// strict lane was exhausted and the repository persisted a recoverable
+		// provenance block. The current authoritative stamp must clear that
+		// non-terminal block without weakening DNC/bounce/manual suppression.
+		cand.Blocked = true
+		cand.BlockReason = "provenance_chain_invalid"
 		if _, err = repo.UpsertCandidate(ctx, cand); err != nil {
-			t.Fatalf("upsert recipient %d: %v", i, err)
+			t.Fatalf("upsert legacy recipient %d: %v", i, err)
+		}
+		cand.Blocked = false
+		if _, err = repo.UpsertCandidate(ctx, cand); err != nil {
+			t.Fatalf("recover controlled recipient %d: %v", i, err)
+		}
+		stored, getErr := repo.GetCandidate(ctx, orgID, cand.ID)
+		if getErr != nil || stored == nil || stored.Blocked {
+			t.Fatalf("controlled recipient %d stayed blocked: candidate=%+v err=%v", i, stored, getErr)
+		}
+		if i == 119 {
+			cand.Blocked = true
+			cand.BlockReason = "manual_suppression"
+			if _, err = repo.UpsertCandidate(ctx, cand); err != nil {
+				t.Fatalf("upsert manual suppression: %v", err)
+			}
+			cand.Blocked = false
+			cand.BlockReason = ""
+			if _, err = repo.UpsertCandidate(ctx, cand); err != nil {
+				t.Fatalf("replay after manual suppression: %v", err)
+			}
+			stored, getErr = repo.GetCandidate(ctx, orgID, cand.ID)
+			if getErr != nil || stored == nil || !stored.Blocked || stored.BlockReason != "manual_suppression" {
+				t.Fatalf("manual suppression was softened: candidate=%+v err=%v", stored, getErr)
+			}
 		}
 	}
 

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -1551,7 +1551,22 @@ func (r *outreachRepository) UpsertCandidate(ctx context.Context, c *models.Outr
 				recommended = EXCLUDED.recommended,
 				do_not_contact = outreach_contact_candidates.do_not_contact OR EXCLUDED.do_not_contact,
 				bounced = outreach_contact_candidates.bounced OR EXCLUDED.bounced,
-				blocked = outreach_contact_candidates.blocked OR EXCLUDED.blocked,
+				-- DNC and bounce are sticky in their own columns. Import-derived
+				-- strict-lane blocks may recover when a later authoritative feed
+				-- explicitly publishes a controlled route; manual/terminal blocks
+				-- remain sticky.
+				blocked = CASE
+					WHEN outreach_contact_candidates.blocked
+						AND outreach_contact_candidates.block_reason NOT IN ('published_exhausted','provenance_chain_invalid')
+						THEN true
+					ELSE EXCLUDED.blocked
+				END,
+				block_reason = CASE
+					WHEN outreach_contact_candidates.blocked
+						AND outreach_contact_candidates.block_reason NOT IN ('published_exhausted','provenance_chain_invalid')
+						THEN outreach_contact_candidates.block_reason
+					ELSE EXCLUDED.block_reason
+				END,
 				email_send_ready = EXCLUDED.email_send_ready,
 				mailbox_purpose = EXCLUDED.mailbox_purpose,
 				mailbox_purpose_send_blocked = EXCLUDED.mailbox_purpose_send_blocked,


### PR DESCRIPTION
## Resultado

Separa a elegibilidade de rota institucional controlada dos bloqueios exclusivos de autorun/pessoa nomeada. Rotas explicitamente publicadas como `controlled_email_eligible` podem entrar em revisão humana sem enfraquecer DNC, bounce, supressão manual ou taint de fixture.

## Segurança

- `mailbox_purpose_send_blocked` continua bloqueando o caminho estrito/autorun;
- DNC, bounce e bloqueios manuais continuam sticky;
- apenas bloqueios importados recuperáveis (`published_exhausted` e `provenance_chain_invalid`) podem ser substituídos por feed posterior;
- o lote continua sem aprovação, fila ou disparo até ação humana.

## Provas

- PostgreSQL real: 10 cohorts concorrentes/sequenciais, 100 CNPJs-raiz e 100 destinatários únicos;
- fixture inclui `EMAIL_SEND_READY=false`, `CANDIDATE_UNVERIFIED`, mailbox estrita bloqueada e recuperação de bloqueio legado;
- supressão manual permanece bloqueada;
- `go test ./internal/app/confenge/... -count=1`;
- golangci-lint v1.64.8 compilado com Go 1.25.0.