### PR TITLE
feat: lease controlled routes for asynchronous draft generation

### DIFF
--- a/docs/confenge/touchpoints.md
+++ b/docs/confenge/touchpoints.md
@@ -63,7 +63,10 @@ explicit confirmation.
 ## Continuous generation into Comercial -> Rascunhos
 
 Accounts in `READY_TO_GENERATE` are leased with `FOR UPDATE SKIP LOCKED` and
-processed asynchronously. The worker creates the idempotent cadence, generates
+processed asynchronously when they have either a strict send-ready mailbox or
+an explicitly controlled DIRECT/ROLE/GENERIC/FREEMAIL route. A missing named
+person is not a generation blocker, while target fit, suppression, bounce and
+opt-out remain fail-closed. The worker creates the idempotent cadence, generates
 only its first due touchpoint, and stops at `NEEDS_REVIEW` (Comercial ->
 Rascunhos). Each tick drains a bounded burst of up to 100 accounts; failures
 use exponential retry from 15 minutes up to 24 hours.

--- a/internal/app/confenge/draft_generation_worker.go
+++ b/internal/app/confenge/draft_generation_worker.go
@@ -77,9 +77,31 @@ func (s *service) ProcessDraftGenerationOnce(ctx context.Context) (bool, error) 
 			FROM outreach_accounts a
 			WHERE a.queue_state = 'READY_TO_GENERATE'
 			  AND a.target_fit_eligible = true
-			  AND a.email_send_ready = true
 			  AND a.blocked = false
 			  AND a.do_not_contact = false
+			  AND EXISTS (
+				SELECT 1
+				FROM outreach_contact_candidates c
+				WHERE c.organization_id = a.organization_id
+				  AND c.account_id = a.id
+				  AND c.email <> ''
+				  AND c.blocked = false
+				  AND c.do_not_contact = false
+				  AND c.bounced = false
+				  AND (
+					(c.email_send_ready = true
+					  AND c.mailbox_purpose_send_blocked = false
+					  AND c.verification_status NOT IN (
+						'CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT'
+					  ))
+					OR (
+					  c.discovery_json @> '{"controlled_email_eligible":true}'::jsonb
+					  AND upper(COALESCE(c.discovery_json->>'route_class','')) IN (
+						'DIRECT_PERSON','ROLE_OR_DEPARTMENT','GENERIC_COMPANY','PUBLIC_COMPANY_FREEMAIL'
+					  )
+					)
+				  )
+			  )
 			  AND a.draft_generation_retry_at <= $1
 			  AND (a.draft_generation_reserved_until IS NULL OR a.draft_generation_reserved_until <= $1)
 			  AND NOT EXISTS (

--- a/internal/app/confenge/draft_generation_worker_pg_test.go
+++ b/internal/app/confenge/draft_generation_worker_pg_test.go
@@ -1,0 +1,105 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func TestDraftGenerationWorkerLeasesControlledRouteWithoutNamedPersonRollup(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, testPostgresDSN(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	applyHumanGateSchema(t, pool)
+
+	actor, orgID := uuid.New(), uuid.New()
+	if _, err = pool.Exec(ctx, `INSERT INTO users (id,first_name,last_name,email) VALUES($1,'Draft','Worker',$2)`, actor, "draft-worker-"+actor.String()+"@example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO organizations (id,name,slug,owner_user_id) VALUES($1,'Draft Worker Fixture',$2,$3)`, orgID, "draft-worker-"+orgID.String(), actor); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM organizations WHERE id=$1`, orgID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM users WHERE id=$1`, actor)
+	})
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	repo := repository.NewOutreachRepository(pool)
+	account := &models.OutreachAccount{
+		OrganizationID:           orgID,
+		SourceLeadID:             "controlled-draft-lease",
+		CNPJ14:                   "76271049000185",
+		CNPJRoot:                 "76271049",
+		RazaoSocial:              "Controlled Route Fixture Ltda",
+		NomeFantasia:             "Controlled Route Fixture",
+		QueueState:               models.OutreachQueueReadyToGenerate,
+		SourceSystem:             "extra-cli",
+		SourceRunID:              "controlled-draft-run",
+		ActivationState:          ActivationActionableNow,
+		TargetFitSendTier:        "A_AUTOMATIC",
+		TargetFitClass:           TargetFitConfirmed,
+		TargetFitVersion:         "target-fit.v1",
+		TargetFitComputedAt:      &now,
+		TargetFitSourceWatermark: now.Format(time.RFC3339Nano),
+		TargetFitObservedAt:      &now,
+		TargetFitFresh:           true,
+		TargetFitEligible:        true,
+		EmailSendReady:           false,
+	}
+	if _, err = repo.UpsertAccount(ctx, account); err != nil {
+		t.Fatal(err)
+	}
+	personUnknown := true
+	candidate := &models.OutreachContactCandidate{
+		OrganizationID:                 orgID,
+		AccountID:                      account.ID,
+		SourceContactID:                "controlled-generic-route",
+		Email:                          "contato@controlled-route.example",
+		SourceURL:                      "https://controlled-route.example/contato",
+		SourceDate:                     &now,
+		VerificationStatus:             models.OutreachVerifyCandidateUnverified,
+		Confidence:                     "HIGH",
+		Recommended:                    true,
+		EmailSendReady:                 false,
+		MailboxPurpose:                 "GENERIC_CONTACT",
+		MailboxPurposeSendBlocked:      true,
+		OwnershipStatus:                "COMPANY_OWNED",
+		RecipientCommercialSuitability: "SUITABLE_GENERIC",
+		DiscoveryJSON: eligibleDisc(
+			t,
+			RouteClassGenericCompany,
+			true,
+			controlledDiscovery{PersonUnknown: &personUnknown},
+		),
+	}
+	if _, err = repo.UpsertCandidate(ctx, candidate); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true}, repo, nil).(*service)
+	svc.WireHumanGate(pool)
+	processed, _ := svc.ProcessDraftGenerationOnce(ctx)
+	if !processed {
+		t.Fatal("controlled route was not leased while account email_send_ready=false")
+	}
+	var attempts int
+	if err = pool.QueryRow(ctx, `SELECT draft_generation_attempts FROM outreach_accounts WHERE id=$1`, account.ID).Scan(&attempts); err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 1 {
+		t.Fatalf("draft_generation_attempts=%d want 1", attempts)
+	}
+}


### PR DESCRIPTION
Closes the remaining accidental gate in #155 and unblocks #154/#149 after enriched feed ingestion.

Production evidence on 2026-08-25:
- 133 accounts were in `READY_TO_GENERATE` after a real feed sync;
- 146 imported candidates were route-ready, but the account roll-up remained `email_send_ready=false` because that field represents the strict named-person lane;
- `ResolveRecipient` already authorizes `CONTROLLED_ELIGIBLE`, while `ProcessDraftGenerationOnce` still required the legacy account roll-up, so attempts stayed at zero.

Change:
- lease `READY_TO_GENERATE` accounts only when they have a live candidate that is either strict send-ready or explicitly `controlled_email_eligible` in DIRECT/ROLE/GENERIC/FREEMAIL;
- continue to require fresh/eligible target fit, account and mailbox suppression clear, no bounce/DNC, lease/backoff, and no active review touchpoint;
- add a PostgreSQL integration test proving a controlled GENERIC route is leased while account `email_send_ready=false`;
- document the generation contract.

Validation:
- PostgreSQL integration test passed against a fresh migrated database;
- focused generation worker tests passed;
- `gofmt -l` clean;
- golangci-lint v1.64.8 built with Go 1.25.14 passed.

The worker still cannot approve, schedule, queue or send. No composer, rate-limit, mailbox, suppression, target-fit or auto-send change.
