### PR TITLE
Wake eligible ENRICHMENT_PENDING recovery after feed sync

### DIFF
--- a/docs/confenge/touchpoints.md
+++ b/docs/confenge/touchpoints.md
@@ -72,6 +72,8 @@ Rascunhos). Each tick drains a bounded burst of up to 100 accounts; failures
 use exponential retry from 15 minutes up to 24 hours.
 
 `ENRICHMENT_PENDING` touchpoints are also retried by the editorial recovery
-worker. When target fit or contact evidence becomes valid, the same touchpoint
-returns to `NEEDS_REVIEW` and its obsolete stop reason is cleared. Neither
-worker can approve, schedule, queue or send a message.
+worker. After a complete feed import, newly fresh and eligible accounts with a
+usable strict or controlled route have stale retry timers moved to `now`; stale,
+suppressed, bounced and probabilistic-only routes stay untouched. The same
+touchpoint can then return to `NEEDS_REVIEW`. Neither worker can approve,
+schedule, queue or send a message.

--- a/internal/app/confenge/editorial_recovery_wakeup_pg_test.go
+++ b/internal/app/confenge/editorial_recovery_wakeup_pg_test.go
@@ -1,0 +1,104 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func TestFeedSyncWakeupOnlyAdvancesFactuallyEligibleEnrichmentPending(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, testPostgresDSN(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	applyHumanGateSchema(t, pool)
+
+	actor, orgID := uuid.New(), uuid.New()
+	if _, err = pool.Exec(ctx, `INSERT INTO users (id,first_name,last_name,email) VALUES($1,'Recovery','Wakeup',$2)`, actor, "recovery-wakeup-"+actor.String()+"@example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO organizations (id,name,slug,owner_user_id) VALUES($1,'Recovery Wakeup Fixture',$2,$3)`, orgID, "recovery-wakeup-"+orgID.String(), actor); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM organizations WHERE id=$1`, orgID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM users WHERE id=$1`, actor)
+	})
+
+	repo := repository.NewOutreachRepository(pool)
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	makeAccount := func(sourceID, cnpj string, fresh bool) *models.OutreachAccount {
+		account := &models.OutreachAccount{
+			OrganizationID: orgID, SourceLeadID: sourceID, CNPJ14: cnpj, CNPJRoot: cnpj[:8],
+			RazaoSocial: "Recovery Wakeup Fixture Ltda", QueueState: models.OutreachQueueReadyToGenerate,
+			SourceSystem: "extra-cli", SourceRunID: "recovery-wakeup-run", ActivationState: ActivationActionableNow,
+			TargetFitSendTier: "A_AUTOMATIC", TargetFitClass: TargetFitConfirmed, TargetFitVersion: "target-fit.v1",
+			TargetFitComputedAt: &now, TargetFitSourceWatermark: now.Format(time.RFC3339Nano), TargetFitObservedAt: &now,
+			TargetFitFresh: fresh, TargetFitEligible: fresh,
+		}
+		if _, upsertErr := repo.UpsertAccount(ctx, account); upsertErr != nil {
+			t.Fatal(upsertErr)
+		}
+		return account
+	}
+	eligible := makeAccount("recovery-wakeup-eligible", "76271049000185", true)
+	stale := makeAccount("recovery-wakeup-stale", "37174657000188", false)
+	unknown := true
+	for _, account := range []*models.OutreachAccount{eligible, stale} {
+		candidate := &models.OutreachContactCandidate{
+			OrganizationID: orgID, AccountID: account.ID, SourceContactID: "route-" + account.SourceLeadID,
+			Email: "contato@recovery-wakeup.example", SourceURL: "https://recovery-wakeup.example/contato",
+			SourceDate: &now, VerificationStatus: models.OutreachVerifyCandidateUnverified,
+			Confidence: "HIGH", Recommended: true, MailboxPurpose: "GENERIC_CONTACT",
+			MailboxPurposeSendBlocked: true, OwnershipStatus: "COMPANY_OWNED",
+			DiscoveryJSON: eligibleDisc(t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unknown}),
+		}
+		if _, upsertErr := repo.UpsertCandidate(ctx, candidate); upsertErr != nil {
+			t.Fatal(upsertErr)
+		}
+		if _, insertErr := pool.Exec(ctx, `INSERT INTO outreach_touchpoints
+			(id,organization_id,account_id,state,recipient,editorial_retry_at,editorial_reserved_until,editorial_attempts,stop_reason)
+			VALUES($1,$2,$3,'ENRICHMENT_PENDING',$4,$5,$6,6,'recovery did not clear ENRICHMENT_PENDING')`,
+			uuid.New(), orgID, account.ID, candidate.Email, now.Add(24*time.Hour), now.Add(time.Hour)); insertErr != nil {
+			t.Fatal(insertErr)
+		}
+	}
+
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true}, repo, nil).(*service)
+	svc.WireHumanGate(pool)
+	woken, err := svc.wakeEligibleEnrichmentRecovery(ctx, orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if woken != 1 {
+		t.Fatalf("woken=%d want 1", woken)
+	}
+
+	var retryAt time.Time
+	var reserved *time.Time
+	var attempts int
+	var reason string
+	if err = pool.QueryRow(ctx, `SELECT editorial_retry_at,editorial_reserved_until,editorial_attempts,stop_reason FROM outreach_touchpoints WHERE account_id=$1`, eligible.ID).Scan(&retryAt, &reserved, &attempts, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if retryAt.After(time.Now().UTC().Add(time.Second)) || reserved != nil || attempts != 6 || reason != "eligibility restored by feed sync; editorial recovery due now" {
+		t.Fatalf("eligible wakeup mismatch retry=%s reserved=%v attempts=%d reason=%q", retryAt, reserved, attempts, reason)
+	}
+	if err = pool.QueryRow(ctx, `SELECT editorial_retry_at,editorial_reserved_until FROM outreach_touchpoints WHERE account_id=$1`, stale.ID).Scan(&retryAt, &reserved); err != nil {
+		t.Fatal(err)
+	}
+	if !retryAt.After(time.Now().UTC().Add(23*time.Hour)) || reserved == nil {
+		t.Fatalf("stale blocker was incorrectly woken retry=%s reserved=%v", retryAt, reserved)
+	}
+}

--- a/internal/app/confenge/editorial_recovery_worker.go
+++ b/internal/app/confenge/editorial_recovery_worker.go
@@ -110,3 +110,53 @@ func (s *service) deferEditorialRecovery(ctx context.Context, touchpointID uuid.
 			stop_reason=LEFT($3,500), updated_at=now()
 		WHERE id=$1`, touchpointID, time.Now().UTC().Add(delay), reason)
 }
+
+// wakeEligibleEnrichmentRecovery advances stale retry timers only after target and recipient blockers disappear.
+func (s *service) wakeEligibleEnrichmentRecovery(ctx context.Context, orgID uuid.UUID) (int, error) {
+	if s == nil || s.humanGateDB == nil {
+		return 0, nil
+	}
+	result, err := s.humanGateDB.Exec(ctx, `
+		UPDATE outreach_touchpoints t
+		SET editorial_retry_at=now(),
+			editorial_reserved_until=NULL,
+			stop_reason='eligibility restored by feed sync; editorial recovery due now',
+			updated_at=now()
+		FROM outreach_accounts a
+		WHERE t.organization_id=$1
+		  AND t.state='ENRICHMENT_PENDING'
+		  AND (t.editorial_retry_at > now() OR t.editorial_reserved_until IS NOT NULL)
+		  AND a.organization_id=t.organization_id
+		  AND a.id=t.account_id
+		  AND a.target_fit_fresh=true
+		  AND a.target_fit_eligible=true
+		  AND a.blocked=false
+		  AND a.do_not_contact=false
+		  AND EXISTS (
+			SELECT 1
+			FROM outreach_contact_candidates c
+			WHERE c.organization_id=t.organization_id
+			  AND c.account_id=t.account_id
+			  AND c.email <> ''
+			  AND c.blocked=false
+			  AND c.do_not_contact=false
+			  AND c.bounced=false
+			  AND (
+				(c.email_send_ready=true
+				  AND c.mailbox_purpose_send_blocked=false
+				  AND c.verification_status NOT IN (
+					'CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT'
+				  ))
+				OR (
+				  c.discovery_json @> '{"controlled_email_eligible":true}'::jsonb
+				  AND upper(COALESCE(c.discovery_json->>'route_class','')) IN (
+					'DIRECT_PERSON','ROLE_OR_DEPARTMENT','GENERIC_COMPANY','PUBLIC_COMPANY_FREEMAIL'
+				  )
+				)
+			  )
+		  )`, orgID)
+	if err != nil {
+		return 0, err
+	}
+	return int(result.RowsAffected()), nil
+}

--- a/internal/app/confenge/feed_sync.go
+++ b/internal/app/confenge/feed_sync.go
@@ -261,6 +261,14 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 			return result, errx.New(errx.ServiceUnavailable, "feed deactivations failed; snapshot not committed")
 		}
 		result.Deactivations = n
+		woken, wakeErr := s.wakeEligibleEnrichmentRecovery(ctx, orgID)
+		if wakeErr != nil {
+			result.Status = "partial"
+			result.Errors = append(result.Errors, "enrichment recovery wakeup: "+wakeErr.Error())
+			s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "partial", result, false, nil)
+			return result, errx.New(errx.ServiceUnavailable, "feed enrichment recovery wakeup failed; snapshot not committed")
+		}
+		result.Counts["enrichment_recovery_woken"] = woken
 		result.Status = "completed"
 		s.persistFeedSync(ctx, orgID, man.Source.SnapshotHash, man.Source.RunID, uri, "completed", result, true, &generatedAt)
 		return result, nil


### PR DESCRIPTION
Closes #149 after live deployment and reconciliation evidence.

A complete authoritative feed import now wakes only ENRICHMENT_PENDING touchpoints whose target fit is fresh/eligible and whose account has a strict-ready or controlled eligible DIRECT/ROLE/GENERIC/FREEMAIL route. Stale, suppressed, bounced, and probabilistic-only routes stay untouched. The wakeup preserves retry attempts and cannot approve, schedule, queue, or send.

Validation:
- go test -count=1 ./internal/app/confenge (without optional PostgreSQL suite): PASS
- focused PostgreSQL feed-sync wakeup test: PASS
- golangci-lint run ./...: PASS
- unrelated legacy PostgreSQL recomposition/cap failures reproduce unchanged on origin/main; no composer changes in this PR.