### PR TITLE
Preserve enrichment wake-up count in feed sync evidence

### DIFF
--- a/internal/app/confenge/feed_sync.go
+++ b/internal/app/confenge/feed_sync.go
@@ -394,12 +394,16 @@ func (s *service) persistFeedSync(ctx context.Context, orgID uuid.UUID, snap, ru
 		st.SourceGeneratedAt = sourceGeneratedAt
 	}
 	if res != nil {
-		b, _ := json.Marshal(map[string]any{
+		counts := map[string]any{
 			"chunks_total":    res.ChunksTotal,
 			"chunks_imported": res.ChunksImported,
 			"deactivations":   res.Deactivations,
 			"skipped_same":    res.SkippedSame,
-		})
+		}
+		for key, value := range res.Counts {
+			counts[key] = value
+		}
+		b, _ := json.Marshal(counts)
 		st.CountsJSON = b
 	}
 	_ = s.repo.UpsertFeedSyncState(ctx, st)

--- a/internal/app/confenge/feed_sync_test.go
+++ b/internal/app/confenge/feed_sync_test.go
@@ -90,6 +90,13 @@ func TestSyncFeedManifestIdempotentAndHashFailClosed(t *testing.T) {
 	if state.LastSuccessAt == nil || state.LastSuccessAt.Equal(wantSourceTime) {
 		t.Fatalf("sync completion and source age must remain distinct: %+v", state)
 	}
+	var persistedCounts map[string]any
+	if err := json.Unmarshal(state.CountsJSON, &persistedCounts); err != nil {
+		t.Fatalf("decode persisted sync counts: %v", err)
+	}
+	if got, ok := persistedCounts["enrichment_recovery_woken"]; !ok || got != float64(0) {
+		t.Fatalf("additional sync count was discarded: %s", state.CountsJSON)
+	}
 
 	// Same snapshot → noop
 	res2, xerr := svc.SyncFeedManifest(ctx, org, &user, uri)


### PR DESCRIPTION
Follow-up to #167.

The live intermediate import proved the wake-up behavior but exposed that persistFeedSync rebuilt the counts JSON from four fixed fields and discarded enrichment_recovery_woken. This PR merges additional result counters into the persisted evidence map; behavior and safety gates are unchanged.

Validation:
- focused feed sync contract test: PASS
- go test -count=1 ./internal/app/confenge: PASS
- golangci-lint run ./...: PASS