### PR TITLE
Drain editorial recovery in bounded bursts

### DIFF
--- a/internal/app/confenge/editorial_recovery_worker.go
+++ b/internal/app/confenge/editorial_recovery_worker.go
@@ -11,31 +11,49 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
-const editorialRecoveryLease = 5 * time.Minute
+const (
+	editorialRecoveryLease    = 5 * time.Minute
+	editorialRecoveryMaxBurst = 100
+)
+
+type editorialRecoveryProcessor interface {
+	ProcessEditorialRecoveryOnce(context.Context) (bool, error)
+}
 
 // EditorialRecoveryWorker gives recoverable drafts an asynchronous AI rewrite
 // opportunity. It never approves, queues or sends: a successful rewrite goes
 // back to NEEDS_REVIEW for an explicit human decision.
 type EditorialRecoveryWorker struct {
-	service  Service
-	interval time.Duration
+	processor editorialRecoveryProcessor
+	interval  time.Duration
 }
 
-func NewEditorialRecoveryWorker(service Service, interval time.Duration) *EditorialRecoveryWorker {
+func NewEditorialRecoveryWorker(processor editorialRecoveryProcessor, interval time.Duration) *EditorialRecoveryWorker {
 	if interval <= 0 {
 		interval = time.Minute
 	}
-	return &EditorialRecoveryWorker{service: service, interval: interval}
+	return &EditorialRecoveryWorker{processor: processor, interval: interval}
 }
 
 func (w *EditorialRecoveryWorker) Run(ctx context.Context) {
-	if w == nil || w.service == nil {
+	if w == nil || w.processor == nil {
 		return
 	}
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
 	for {
-		_, _ = w.service.ProcessEditorialRecoveryOnce(ctx)
+		for i := 0; i < editorialRecoveryMaxBurst; i++ {
+			processed, err := w.processor.ProcessEditorialRecoveryOnce(ctx)
+			if !processed {
+				_ = err
+				break
+			}
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+		}
 		select {
 		case <-ctx.Done():
 			return

--- a/internal/app/confenge/editorial_recovery_worker_test.go
+++ b/internal/app/confenge/editorial_recovery_worker_test.go
@@ -1,0 +1,43 @@
+package confenge
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type editorialRecoveryProcessorStub struct {
+	remaining int
+	calls     atomic.Int32
+}
+
+func (s *editorialRecoveryProcessorStub) ProcessEditorialRecoveryOnce(context.Context) (bool, error) {
+	s.calls.Add(1)
+	if s.remaining == 0 {
+		return false, nil
+	}
+	s.remaining--
+	return true, errors.New("deferred touchpoint must not stop the remaining burst")
+}
+
+func TestEditorialRecoveryWorkerDrainsBurstUntilIdle(t *testing.T) {
+	processor := &editorialRecoveryProcessorStub{remaining: 3}
+	ctx, cancel := context.WithCancel(context.Background())
+	worker := NewEditorialRecoveryWorker(processor, time.Hour)
+	done := make(chan struct{})
+	go func() {
+		worker.Run(ctx)
+		close(done)
+	}()
+	deadline := time.Now().Add(time.Second)
+	for processor.calls.Load() < 4 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+	cancel()
+	<-done
+	if processor.calls.Load() != 4 {
+		t.Fatalf("worker calls=%d want 4 (three processed plus idle)", processor.calls.Load())
+	}
+}


### PR DESCRIPTION
The live #149 reconciliation proved that feed sync wakes eligible ENRICHMENT_PENDING rows, but the existing worker processed only one row per minute. A 99-row due backlog would therefore take about 100 minutes despite having no remaining target/contact blocker.

This applies the existing DraftGenerationWorker pattern: a bounded burst of at most 100 calls per tick, stop on idle, continue past factually deferred rows, and preserve the existing FOR UPDATE SKIP LOCKED lease/backoff path. It adds no approval, scheduling, queueing, or transport authority.

Validation:
- focused bounded-burst test: PASS
- go test -count=1 ./internal/app/confenge: PASS
- golangci-lint run ./...: PASS