### PR TITLE
fix: replace stale review recipients from the current feed

### DIFF
--- a/docs/confenge/touchpoints.md
+++ b/docs/confenge/touchpoints.md
@@ -77,3 +77,10 @@ usable strict or controlled route have stale retry timers moved to `now`; stale,
 suppressed, bounced and probabilistic-only routes stay untouched. The same
 touchpoint can then return to `NEEDS_REVIEW`. Neither worker can approve,
 schedule, queue or send a message.
+
+After a complete feed refresh, a `NEEDS_REVIEW` first touch whose bound contact
+is absent from the account's current import is retired as `CANCELLED`; its draft
+is kept as `BLOCKED` for audit. The remaining unapproved cadence is retired with
+it. If the same supplier has another current eligible route, the account returns
+to `READY_TO_GENERATE` and a new cadence is bound only to that current route.
+Approved, queued and sent states are outside this recovery path.

--- a/internal/app/confenge/feed_sync.go
+++ b/internal/app/confenge/feed_sync.go
@@ -261,6 +261,15 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 			return result, errx.New(errx.ServiceUnavailable, "feed deactivations failed; snapshot not committed")
 		}
 		result.Deactivations = n
+		retired, requeued, staleErr := s.retireStaleReviewBacklog(ctx, orgID)
+		if staleErr != nil {
+			result.Status = "partial"
+			result.Errors = append(result.Errors, "stale review retirement: "+staleErr.Error())
+			s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "partial", result, false, nil)
+			return result, errx.New(errx.ServiceUnavailable, "feed stale review retirement failed; snapshot not committed")
+		}
+		result.Counts["stale_reviews_retired"] = retired
+		result.Counts["stale_review_accounts_requeued"] = requeued
 		woken, wakeErr := s.wakeEligibleEnrichmentRecovery(ctx, orgID)
 		if wakeErr != nil {
 			result.Status = "partial"

--- a/internal/app/confenge/stale_review_backlog.go
+++ b/internal/app/confenge/stale_review_backlog.go
@@ -1,0 +1,129 @@
+package confenge
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+const staleReviewStopReason = "recipient_not_in_current_snapshot"
+
+// retireStaleReviewBacklog removes review authority from first-touch drafts
+// whose bound recipient did not survive the account's newest import. Accounts
+// with another current eligible route are returned to asynchronous generation;
+// no approval, queue or transport authority is created here.
+func (s *service) retireStaleReviewBacklog(ctx context.Context, orgID uuid.UUID) (retired, requeued int, err error) {
+	if s == nil || s.humanGateDB == nil {
+		return 0, 0, nil
+	}
+	tx, err := s.humanGateDB.Begin(ctx)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := tx.Query(ctx, `
+		SELECT t.id,COALESCE(t.draft_id,'00000000-0000-0000-0000-000000000000'::uuid),t.account_id
+		FROM outreach_touchpoints t
+		JOIN outreach_accounts a
+		  ON a.organization_id=t.organization_id AND a.id=t.account_id
+		LEFT JOIN outreach_contact_candidates c
+		  ON c.organization_id=t.organization_id AND c.id=t.contact_candidate_id
+		WHERE t.organization_id=$1
+		  AND t.ordinal=1
+		  AND t.state='NEEDS_REVIEW'
+		  AND (a.last_import_run_id IS NULL OR c.id IS NULL OR c.last_import_run_id IS DISTINCT FROM a.last_import_run_id)
+		FOR UPDATE OF t,a`, orgID)
+	if err != nil {
+		return 0, 0, err
+	}
+	var touchpointIDs, accountIDs []uuid.UUID
+	accountSeen := map[uuid.UUID]bool{}
+	for rows.Next() {
+		var touchpointID, draftID, accountID uuid.UUID
+		if err = rows.Scan(&touchpointID, &draftID, &accountID); err != nil {
+			rows.Close()
+			return 0, 0, err
+		}
+		touchpointIDs = append(touchpointIDs, touchpointID)
+		if !accountSeen[accountID] {
+			accountSeen[accountID] = true
+			accountIDs = append(accountIDs, accountID)
+		}
+	}
+	if err = rows.Err(); err != nil {
+		rows.Close()
+		return 0, 0, err
+	}
+	rows.Close()
+	if len(touchpointIDs) == 0 {
+		return 0, 0, tx.Commit(ctx)
+	}
+
+	if _, err = tx.Exec(ctx, `
+			UPDATE outreach_drafts
+			SET status='BLOCKED',approved_by=NULL,approved_at=NULL,
+				campaign_id=NULL,enrollment_contact_id=NULL,enrolled_at=NULL,updated_at=now()
+			WHERE organization_id=$1 AND account_id=ANY($2::uuid[])
+			  AND status IN ('NOT_GENERATED','GENERATING','AI_REWRITE_PENDING','ENRICHMENT_PENDING','REJECTED_REWRITE_PENDING','NEEDS_REVIEW')`, orgID, accountIDs); err != nil {
+		return 0, 0, err
+	}
+	if _, err = tx.Exec(ctx, `
+		UPDATE outreach_touchpoints
+		SET state='CANCELLED',stop_reason=$3,approved_content_hash='',
+			approved_by=NULL,approved_at=NULL,authorization_mode='',
+			campaign_policy_authorization_id=NULL,authorization_policy_hash='',
+			authorization_at=NULL,signature_version='',queued_at=NULL,updated_at=now()
+		WHERE organization_id=$1 AND account_id=ANY($2::uuid[])
+		  AND state IN ('PLANNED','DUE','DRAFTED','AI_REWRITE_PENDING','ENRICHMENT_PENDING','REJECTED_REWRITE_PENDING','NEEDS_REVIEW')`,
+		orgID, accountIDs, staleReviewStopReason); err != nil {
+		return 0, 0, err
+	}
+	retired = len(touchpointIDs)
+
+	// First make the account state truthful even when no replacement route is
+	// available. The second update promotes only accounts with a current route.
+	if _, err = tx.Exec(ctx, `
+		UPDATE outreach_accounts a
+		SET queue_state='NEEDS_CONTACT',draft_generation_reserved_until=NULL,
+			draft_generation_last_error=$3,updated_at=now()
+		WHERE a.organization_id=$1 AND a.id=ANY($2::uuid[])
+		  AND a.queue_state='NEEDS_REVIEW'
+		  AND NOT EXISTS (
+			SELECT 1 FROM outreach_touchpoints active
+			WHERE active.organization_id=a.organization_id AND active.account_id=a.id
+			  AND active.state IN ('AI_REWRITE_PENDING','ENRICHMENT_PENDING','REJECTED_REWRITE_PENDING','NEEDS_REVIEW','APPROVED','QUEUED')
+		  )`, orgID, accountIDs, staleReviewStopReason); err != nil {
+		return 0, 0, err
+	}
+	tag, err := tx.Exec(ctx, `
+		UPDATE outreach_accounts a
+		SET queue_state='READY_TO_GENERATE',draft_generation_retry_at=now(),
+			draft_generation_reserved_until=NULL,draft_generation_last_error='',updated_at=now()
+		WHERE a.organization_id=$1 AND a.id=ANY($2::uuid[])
+		  AND a.queue_state='NEEDS_CONTACT'
+		  AND a.target_fit_eligible=true AND a.target_fit_fresh=true
+		  AND a.target_fit_class='TARGET_CONFIRMED'
+		  AND a.blocked=false AND a.do_not_contact=false
+		  AND EXISTS (
+			SELECT 1 FROM outreach_contact_candidates c
+			WHERE c.organization_id=a.organization_id AND c.account_id=a.id
+			  AND a.last_import_run_id IS NOT NULL AND c.last_import_run_id=a.last_import_run_id
+			  AND c.email<>'' AND c.blocked=false AND c.do_not_contact=false AND c.bounced=false
+			  AND (
+				(c.email_send_ready=true AND c.mailbox_purpose_send_blocked=false
+				 AND c.verification_status NOT IN ('CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT'))
+				OR (c.discovery_json @> '{"controlled_email_eligible":true}'::jsonb
+				 AND upper(COALESCE(c.discovery_json->>'route_class','')) IN
+				 ('DIRECT_PERSON','ROLE_OR_DEPARTMENT','GENERIC_COMPANY','PUBLIC_COMPANY_FREEMAIL'))
+			  )
+		  )`, orgID, accountIDs)
+	if err != nil {
+		return 0, 0, err
+	}
+	requeued = int(tag.RowsAffected())
+	if err = tx.Commit(ctx); err != nil {
+		return 0, 0, err
+	}
+	return retired, requeued, nil
+}

--- a/internal/app/confenge/stale_review_backlog_migration_test.go
+++ b/internal/app/confenge/stale_review_backlog_migration_test.go
@@ -1,0 +1,32 @@
+package confenge
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStaleReviewBacklogMigrationCannotCreateSendAuthority(t *testing.T) {
+	path := filepath.Join("..", "..", "infrastructure", "db", "migrations", "000124_confenge_stale_review_backlog.up.sql")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := strings.ToLower(string(raw))
+	for _, required := range []string{
+		"t.state='needs_review'", "c.last_import_run_id is distinct from a.last_import_run_id",
+		"status='blocked'", "state='cancelled'", "recipient_not_in_current_snapshot",
+		"queue_state='ready_to_generate'", "c.last_import_run_id=a.last_import_run_id",
+		"target_fit_class='target_confirmed'", "c.do_not_contact=false", "c.bounced=false",
+	} {
+		if !strings.Contains(sql, required) {
+			t.Fatalf("stale review migration missing guard %q", required)
+		}
+	}
+	for _, forbidden := range []string{"state='approved'", "state='queued'", "status='queued'", "insert into confenge_dispatch", "insert into confenge_cohort_candidate_dispatches"} {
+		if strings.Contains(sql, forbidden) {
+			t.Fatalf("stale review migration contains authority mutation %q", forbidden)
+		}
+	}
+}

--- a/internal/app/confenge/stale_review_backlog_pg_test.go
+++ b/internal/app/confenge/stale_review_backlog_pg_test.go
@@ -1,0 +1,146 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func TestRetireStaleReviewBacklogRequeuesOnlyAgainstCurrentRoute(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, testPostgresDSN(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	applyHumanGateSchema(t, pool)
+
+	actor, orgID := uuid.New(), uuid.New()
+	if _, err = pool.Exec(ctx, `INSERT INTO users (id,first_name,last_name,email) VALUES($1,'Stale','Review',$2)`, actor, "stale-review-"+actor.String()+"@example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO organizations (id,name,slug,owner_user_id) VALUES($1,'Stale Review Fixture',$2,$3)`, orgID, "stale-review-"+orgID.String(), actor); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cleanupCancel()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM organizations WHERE id=$1`, orgID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM users WHERE id=$1`, actor)
+	})
+
+	oldRun, currentRun := uuid.New(), uuid.New()
+	for _, run := range []struct {
+		id, source, snapshot string
+	}{
+		{oldRun.String(), "stale-review-old", "stale-review-old-snapshot"},
+		{currentRun.String(), "stale-review-current", "stale-review-current-snapshot"},
+	} {
+		if _, err = pool.Exec(ctx, `INSERT INTO outreach_import_runs
+			(id,organization_id,source_run_id,snapshot_hash,status,idempotency_key)
+			VALUES($1,$2,$3,$4,'completed',$5)`, run.id, orgID, run.source, run.snapshot, "stale-review-"+run.id); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	now := time.Now().UTC().Truncate(time.Millisecond)
+	repo := repository.NewOutreachRepository(pool)
+	account := &models.OutreachAccount{
+		OrganizationID: orgID, SourceLeadID: "stale-review-supplier", CNPJ14: "76271049000185", CNPJRoot: "76271049",
+		RazaoSocial: "Stale Review Supplier Ltda", QueueState: models.OutreachQueueNeedsReview,
+		SourceSystem: "extra-cli", SourceRunID: "stale-review-current", LastImportRunID: &currentRun,
+		ActivationState: ActivationActionableNow, TargetFitClass: TargetFitConfirmed,
+		TargetFitVersion: "target-fit.v1", TargetFitComputedAt: &now,
+		TargetFitSourceWatermark: now.Format(time.RFC3339Nano), TargetFitObservedAt: &now,
+		TargetFitFresh: true, TargetFitEligible: true,
+	}
+	if _, err = repo.UpsertAccount(ctx, account); err != nil {
+		t.Fatal(err)
+	}
+	unknown := true
+	makeCandidate := func(sourceID, email string, importID uuid.UUID) *models.OutreachContactCandidate {
+		return &models.OutreachContactCandidate{
+			OrganizationID: orgID, AccountID: account.ID, SourceContactID: sourceID,
+			Email: email, SourceURL: "https://stale-review.example/contato", SourceDate: &now,
+			VerificationStatus: models.OutreachVerifyOfficialSource, Confidence: "HIGH", Recommended: true,
+			OwnershipStatus: "COMPANY_OWNED", ChannelEpistemic: "OBSERVED", RouteFreshness: "FRESH", RouteSuppression: "NONE",
+			LastImportRunID: &importID,
+			DiscoveryJSON:   eligibleDisc(t, RouteClassGenericCompany, true, controlledDiscovery{PersonUnknown: &unknown}),
+		}
+	}
+	oldCandidate := makeCandidate("stale-review-old-route", "old@stale-review.example", oldRun)
+	currentCandidate := makeCandidate("stale-review-current-route", "current@stale-review.example", currentRun)
+	if _, err = repo.UpsertCandidate(ctx, oldCandidate); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = repo.UpsertCandidate(ctx, currentCandidate); err != nil {
+		t.Fatal(err)
+	}
+
+	draftID, touchpointID, followupID := uuid.New(), uuid.New(), uuid.New()
+	if _, err = pool.Exec(ctx, `INSERT INTO outreach_drafts
+		(id,organization_id,account_id,contact_candidate_id,recipient_email,subject,body_text,status)
+		VALUES($1,$2,$3,$4,$5,'Assunto','Mensagem','NEEDS_REVIEW')`,
+		draftID, orgID, account.ID, oldCandidate.ID, oldCandidate.Email); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO outreach_touchpoints
+		(id,organization_id,account_id,contact_candidate_id,ordinal,state,draft_id,recipient,subject,body_text,content_hash)
+		VALUES($1,$2,$3,$4,1,'NEEDS_REVIEW',$5,$6,'Assunto','Mensagem','hash')`,
+		touchpointID, orgID, account.ID, oldCandidate.ID, draftID, oldCandidate.Email); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO outreach_touchpoints
+		(id,organization_id,account_id,contact_candidate_id,ordinal,state,recipient)
+		VALUES($1,$2,$3,$4,2,'PLANNED',$5)`, followupID, orgID, account.ID, oldCandidate.ID, oldCandidate.Email); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true}, repo, nil).(*service)
+	svc.WireHumanGate(pool)
+	retired, requeued, err := svc.retireStaleReviewBacklog(ctx, orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retired != 1 || requeued != 1 {
+		t.Fatalf("retired=%d requeued=%d want 1/1", retired, requeued)
+	}
+	var touchpointState, stopReason, draftStatus, queueState string
+	if err = pool.QueryRow(ctx, `SELECT state,stop_reason FROM outreach_touchpoints WHERE id=$1`, touchpointID).Scan(&touchpointState, &stopReason); err != nil {
+		t.Fatal(err)
+	}
+	if err = pool.QueryRow(ctx, `SELECT status FROM outreach_drafts WHERE id=$1`, draftID).Scan(&draftStatus); err != nil {
+		t.Fatal(err)
+	}
+	if err = pool.QueryRow(ctx, `SELECT queue_state FROM outreach_accounts WHERE id=$1`, account.ID).Scan(&queueState); err != nil {
+		t.Fatal(err)
+	}
+	if touchpointState != models.TouchpointCancelled || stopReason != staleReviewStopReason ||
+		draftStatus != models.OutreachDraftBlocked || queueState != models.OutreachQueueReadyToGenerate {
+		t.Fatalf("touchpoint=%s reason=%s draft=%s account=%s", touchpointState, stopReason, draftStatus, queueState)
+	}
+	if err = pool.QueryRow(ctx, `SELECT state FROM outreach_touchpoints WHERE id=$1`, followupID).Scan(&touchpointState); err != nil {
+		t.Fatal(err)
+	}
+	if touchpointState != models.TouchpointCancelled {
+		t.Fatalf("stale follow-up state=%s", touchpointState)
+	}
+	retired, requeued, err = svc.retireStaleReviewBacklog(ctx, orgID)
+	if err != nil || retired != 0 || requeued != 0 {
+		t.Fatalf("replay retired=%d requeued=%d err=%v", retired, requeued, err)
+	}
+	replanned, xerr := svc.PlanAccountCadence(ctx, orgID, actor, account.ID, nil, models.OutreachChannelEmail)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if len(replanned) == 0 || replanned[0].ContactCandidateID == nil || *replanned[0].ContactCandidateID != currentCandidate.ID || replanned[0].Recipient != currentCandidate.Email {
+		t.Fatalf("cadence did not rebind to current candidate: %+v", replanned)
+	}
+}

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -71,7 +71,19 @@ func (s *service) PlanAccountCadence(ctx context.Context, orgID, userID, account
 		if err != nil {
 			return nil, errx.New(errx.Internal, "list candidates failed")
 		}
-		cand = pickRecommendedAny(list)
+		current := make([]models.OutreachContactCandidate, 0, len(list))
+		if acc.LastImportRunID != nil {
+			for i := range list {
+				if list[i].LastImportRunID != nil && *list[i].LastImportRunID == *acc.LastImportRunID {
+					current = append(current, list[i])
+				}
+			}
+		} else {
+			// Preserve the legacy/manual path for accounts that have never been
+			// bound to the versioned feed contract.
+			current = list
+		}
+		cand = pickRecommendedAny(current)
 	}
 	ch := strings.ToUpper(strings.TrimSpace(channel))
 	if ch == "" {
@@ -142,7 +154,9 @@ func recoverableCadenceCancellation(state, reason string) bool {
 		return false
 	}
 	reason = strings.TrimSpace(reason)
-	return strings.EqualFold(reason, StopComposerStale) || strings.EqualFold(reason, TargetFitReasonStale)
+	return strings.EqualFold(reason, StopComposerStale) ||
+		strings.EqualFold(reason, TargetFitReasonStale) ||
+		strings.EqualFold(reason, staleReviewStopReason)
 }
 
 func (s *service) ListReviewTouchpoints(ctx context.Context, orgID uuid.UUID, limit, offset int) ([]models.OutreachTouchpoint, *errx.Error) {

--- a/internal/infrastructure/db/migrations/000124_confenge_stale_review_backlog.down.sql
+++ b/internal/infrastructure/db/migrations/000124_confenge_stale_review_backlog.down.sql
@@ -1,0 +1,3 @@
+-- Deliberately irreversible: retired review drafts referenced a recipient that
+-- was absent from the current authoritative account snapshot.
+SELECT 1;

--- a/internal/infrastructure/db/migrations/000124_confenge_stale_review_backlog.up.sql
+++ b/internal/infrastructure/db/migrations/000124_confenge_stale_review_backlog.up.sql
@@ -1,0 +1,86 @@
+-- A NEEDS_REVIEW draft bound to a recipient absent from the newest account
+-- snapshot cannot be approved. Retire only those unapproved first touches and
+-- return accounts with another current eligible route to draft generation.
+WITH stale_accounts AS MATERIALIZED (
+  SELECT DISTINCT t.account_id,t.organization_id
+  FROM outreach_touchpoints t
+  JOIN outreach_accounts a
+    ON a.organization_id=t.organization_id AND a.id=t.account_id
+  LEFT JOIN outreach_contact_candidates c
+    ON c.organization_id=t.organization_id AND c.id=t.contact_candidate_id
+  WHERE t.ordinal=1 AND t.state='NEEDS_REVIEW'
+    AND (a.last_import_run_id IS NULL OR c.id IS NULL OR c.last_import_run_id IS DISTINCT FROM a.last_import_run_id)
+)
+UPDATE outreach_drafts d
+SET status='BLOCKED',approved_by=NULL,approved_at=NULL,
+    campaign_id=NULL,enrollment_contact_id=NULL,enrolled_at=NULL,updated_at=now()
+FROM stale_accounts
+WHERE d.organization_id=stale_accounts.organization_id
+  AND d.account_id=stale_accounts.account_id
+  AND d.status IN ('NOT_GENERATED','GENERATING','AI_REWRITE_PENDING','ENRICHMENT_PENDING','REJECTED_REWRITE_PENDING','NEEDS_REVIEW');
+
+WITH stale_accounts AS MATERIALIZED (
+  SELECT DISTINCT t.account_id,t.organization_id
+  FROM outreach_touchpoints t
+  JOIN outreach_accounts a
+    ON a.organization_id=t.organization_id AND a.id=t.account_id
+  LEFT JOIN outreach_contact_candidates c
+    ON c.organization_id=t.organization_id AND c.id=t.contact_candidate_id
+  WHERE t.ordinal=1 AND t.state='NEEDS_REVIEW'
+    AND (a.last_import_run_id IS NULL OR c.id IS NULL OR c.last_import_run_id IS DISTINCT FROM a.last_import_run_id)
+)
+UPDATE outreach_touchpoints t
+SET state='CANCELLED',stop_reason='recipient_not_in_current_snapshot',
+    approved_content_hash='',approved_by=NULL,approved_at=NULL,
+    authorization_mode='',campaign_policy_authorization_id=NULL,
+    authorization_policy_hash='',authorization_at=NULL,signature_version='',
+    queued_at=NULL,updated_at=transaction_timestamp()
+FROM stale_accounts
+WHERE t.organization_id=stale_accounts.organization_id
+  AND t.account_id=stale_accounts.account_id
+  AND t.state IN ('PLANNED','DUE','DRAFTED','AI_REWRITE_PENDING','ENRICHMENT_PENDING','REJECTED_REWRITE_PENDING','NEEDS_REVIEW');
+
+UPDATE outreach_accounts a
+SET queue_state='NEEDS_CONTACT',draft_generation_reserved_until=NULL,
+    draft_generation_last_error='recipient_not_in_current_snapshot',updated_at=now()
+WHERE a.queue_state='NEEDS_REVIEW'
+  AND EXISTS (
+    SELECT 1 FROM outreach_touchpoints retired
+    WHERE retired.organization_id=a.organization_id AND retired.account_id=a.id
+      AND retired.ordinal=1 AND retired.state='CANCELLED'
+      AND retired.stop_reason='recipient_not_in_current_snapshot'
+      AND retired.updated_at=transaction_timestamp()
+  )
+  AND NOT EXISTS (
+    SELECT 1 FROM outreach_touchpoints active
+    WHERE active.organization_id=a.organization_id AND active.account_id=a.id
+      AND active.state IN ('AI_REWRITE_PENDING','ENRICHMENT_PENDING','REJECTED_REWRITE_PENDING','NEEDS_REVIEW','APPROVED','QUEUED')
+  );
+
+UPDATE outreach_accounts a
+SET queue_state='READY_TO_GENERATE',draft_generation_retry_at=now(),
+    draft_generation_reserved_until=NULL,draft_generation_last_error='',updated_at=now()
+WHERE a.queue_state='NEEDS_CONTACT'
+  AND a.target_fit_eligible=true AND a.target_fit_fresh=true
+  AND a.target_fit_class='TARGET_CONFIRMED'
+  AND a.blocked=false AND a.do_not_contact=false
+  AND EXISTS (
+    SELECT 1 FROM outreach_touchpoints retired
+    WHERE retired.organization_id=a.organization_id AND retired.account_id=a.id
+      AND retired.ordinal=1 AND retired.state='CANCELLED'
+      AND retired.stop_reason='recipient_not_in_current_snapshot'
+      AND retired.updated_at=transaction_timestamp()
+  )
+  AND EXISTS (
+    SELECT 1 FROM outreach_contact_candidates c
+    WHERE c.organization_id=a.organization_id AND c.account_id=a.id
+      AND a.last_import_run_id IS NOT NULL AND c.last_import_run_id=a.last_import_run_id
+      AND c.email<>'' AND c.blocked=false AND c.do_not_contact=false AND c.bounced=false
+      AND (
+        (c.email_send_ready=true AND c.mailbox_purpose_send_blocked=false
+         AND c.verification_status NOT IN ('CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT'))
+        OR (c.discovery_json @> '{"controlled_email_eligible":true}'::jsonb
+         AND upper(COALESCE(c.discovery_json->>'route_class','')) IN
+         ('DIRECT_PERSON','ROLE_OR_DEPARTMENT','GENERIC_COMPANY','PUBLIC_COMPANY_FREEMAIL'))
+      )
+  );


### PR DESCRIPTION
## Summary
- retire unapproved review cadences whose bound recipient is absent from the account current import
- requeue only suppliers that still have a current target-confirmed eligible route
- make implicit cadence planning select candidates from the current account snapshot
- preserve approved, queued, sent, dispatch and human-decision state

## Production finding
The 100-item review backlog contained 100 unique supplier roots and 100 unique recipients, but 11 bound contact rows came from prior snapshots and would fail APPROVE. The migration retires those 11 review-only cadences and lets the bounded worker replenish them from current routes.

## Verification
- full `go test ./internal/app/confenge` passed with local Mailpit
- `go test ./... -run ^$` passed
- PostgreSQL integration proves stale retirement, current-route requeue, idempotency and cadence rebinding
- fresh PostgreSQL 16 migration run reached version 124 with dirty=false
- `git diff --check` clean

No action in this PR approves, schedules, queues, resumes or sends a message.