### PR TITLE
feat: add durable CONFENGE proposal v1 and delivery handoff canary

### DIFF
--- a/cmd/confenge-proposal-canary/main.go
+++ b/cmd/confenge-proposal-canary/main.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/proposal"
+)
+
+func main() {
+	proposalOnly := flag.Bool("proposal", false, "print the accepted proposal instead of the delivery handoff")
+	flag.Parse()
+	result, err := proposal.RunSyntheticCanary(context.Background())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	value := any(result.Handoff)
+	if *proposalOnly {
+		value = result.Proposal
+	}
+	if err := encoder.Encode(value); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/docs/contracts/proposal-v1/README.md
+++ b/docs/contracts/proposal-v1/README.md
@@ -20,6 +20,7 @@ The accepted row cannot be updated. A material change appends
 Every command has an organization-scoped idempotency receipt. Reusing the key
 with another payload fails closed. State writes use optimistic record versions.
 Proposal and event rows are durable Postgres state from migration `000125`.
+The service validates contract lengths and currency shape before persistence.
 
 ## Delivery handoff
 
@@ -35,6 +36,10 @@ The future real replacement for the synthetic source is the Warmbly-owned
 `confenge.financial_gate_reconciled.v1`. HTTP success, callback receipt,
 `PAYMENT_CONFIRMED`, checkout creation and the nested gate never prove received
 revenue.
+
+Delivery event identity uses a fixed-length SHA-256 digest of the accepted
+business key, financial state and source event. Long valid business IDs cannot
+overflow the published idempotency-key limit.
 
 ## Reproducible fixture
 

--- a/docs/contracts/proposal-v1/README.md
+++ b/docs/contracts/proposal-v1/README.md
@@ -1,0 +1,58 @@
+# CONFENGE proposal v1
+
+Warmbly owns proposal versions and commercial decision state under
+`tjsasakifln/warmbly#47`. Governance owns readiness, capacity, Work Orders and
+delivery state. web-cfg owns public offer and contracting producers. These
+contracts do not create a CRM, checkout, charge, billing ledger or Work Order.
+
+## State and immutability
+
+The implemented path is:
+
+`DRAFT -> PREPARED -> APPROVED_TO_SEND -> SENT -> NEGOTIATING -> ACCEPTED | REJECTED | EXPIRED | UNKNOWN`
+
+Direct `SENT -> ACCEPTED | REJECTED | EXPIRED | UNKNOWN` is also valid when no
+negotiation event occurred. `ACCEPTED` freezes a canonical SHA-256 snapshot.
+The accepted row cannot be updated. A material change appends
+`proposal_version + 1` in `DRAFT` while retaining the accepted version.
+`amount` uses minor currency units.
+
+Every command has an organization-scoped idempotency receipt. Reusing the key
+with another payload fails closed. State writes use optimistic record versions.
+Proposal and event rows are durable Postgres state from migration `000125`.
+
+## Delivery handoff
+
+Acceptance emits a stable `confenge.delivery_order_requested.v1` with
+`financial_gate.state=UNKNOWN`. Governance holds it. An explicit later command
+can emit another request for the same accepted business key with either:
+
+- `SYNTHETIC_VALID`, only from a labeled fixture and always
+  `received_revenue=false`;
+- `AUTHORIZED`, only with a non-synthetic source event and explicit evidence.
+
+The future real replacement for the synthetic source is the Warmbly-owned
+`confenge.financial_gate_reconciled.v1`. HTTP success, callback receipt,
+`PAYMENT_CONFIRMED`, checkout creation and the nested gate never prove received
+revenue.
+
+## Reproducible fixture
+
+The synthetic canary uses redacted identities and performs no network or money
+side effects:
+
+```sh
+go run ./cmd/confenge-proposal-canary
+```
+
+Its committed output is
+`fixtures/delivery-order-requested.synthetic.v1.json`.
+
+The accepted proposal fixture is reproducible with
+`go run ./cmd/confenge-proposal-canary --proposal`.
+
+Focused verification:
+
+```sh
+go test ./internal/app/confenge/proposal -count=1
+```

--- a/docs/contracts/proposal-v1/confenge.delivery_order_requested.v1.schema.json
+++ b/docs/contracts/proposal-v1/confenge.delivery_order_requested.v1.schema.json
@@ -1,0 +1,132 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confenge.com.br/contracts/confenge.delivery_order_requested.v1.schema.json",
+  "title": "confenge.delivery_order_requested.v1",
+  "description": "Warmbly-owned request consumed by Governance to evaluate delivery admission. Validity never implies readiness, capacity, Work Order creation or received revenue.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "event_id",
+    "synthetic",
+    "correlation_id",
+    "causation_id",
+    "idempotency_key",
+    "organization_id",
+    "account_id",
+    "client_ref",
+    "opportunity_id",
+    "qco_id",
+    "proposal_id",
+    "proposal_version",
+    "accepted_snapshot_hash",
+    "offer_id",
+    "offer_version",
+    "deliverable_id",
+    "deliverable_version",
+    "scope_version",
+    "price_version",
+    "terms_version",
+    "financial_gate",
+    "onboarding_ref",
+    "occurred_at",
+    "evidence_refs"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "confenge.delivery_order_requested.v1"
+    },
+    "event_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "synthetic": {
+      "type": "boolean"
+    },
+    "correlation_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "causation_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "idempotency_key": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "organization_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "account_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "client_ref": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "opportunity_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "qco_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "proposal_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "proposal_version": {
+      "type": "integer",
+      "minimum": 1
+    },
+    "accepted_snapshot_hash": {
+      "type": "string",
+      "pattern": "^(sha256:)?[a-f0-9]{64}$"
+    },
+    "offer_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "offer_version": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "deliverable_id": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "deliverable_version": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "scope_version": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "price_version": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "terms_version": {
+      "$ref": "#/$defs/nonEmptyId"
+    },
+    "financial_gate": {
+      "$ref": "confenge.financial_gate.v1.schema.json"
+    },
+    "onboarding_ref": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "maxLength": 200
+    },
+    "occurred_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "nonEmptyId": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 200
+    }
+  }
+}

--- a/docs/contracts/proposal-v1/confenge.financial_gate.v1.schema.json
+++ b/docs/contracts/proposal-v1/confenge.financial_gate.v1.schema.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confenge.com.br/contracts/confenge.financial_gate.v1.schema.json",
+  "title": "confenge.financial_gate.v1",
+  "description": "Fail-closed financial admission fact embedded in a delivery order request. It is not a billing ledger or received-revenue fact.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "state",
+    "synthetic",
+    "source_event_id",
+    "received_revenue",
+    "evidence_refs"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "confenge.financial_gate.v1"
+    },
+    "state": {
+      "enum": [
+        "UNKNOWN",
+        "SYNTHETIC_VALID",
+        "AUTHORIZED"
+      ]
+    },
+    "synthetic": {
+      "type": "boolean"
+    },
+    "source_event_id": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "minLength": 1,
+      "maxLength": 200
+    },
+    "received_revenue": {
+      "const": false
+    },
+    "evidence_refs": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 500
+      },
+      "uniqueItems": true
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "UNKNOWN"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "source_event_id": {
+            "type": "null"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "SYNTHETIC_VALID"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "synthetic": {
+            "const": true
+          },
+          "source_event_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_refs": {
+            "minItems": 1
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "state": {
+            "const": "AUTHORIZED"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "synthetic": {
+            "const": false
+          },
+          "source_event_id": {
+            "type": "string",
+            "minLength": 1
+          },
+          "evidence_refs": {
+            "minItems": 1
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/contracts/proposal-v1/confenge.proposal.v1.schema.json
+++ b/docs/contracts/proposal-v1/confenge.proposal.v1.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confenge.com.br/contracts/confenge.proposal.v1.schema.json",
+  "title": "confenge.proposal.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "proposal_id", "proposal_version", "organization_id",
+    "account_id", "client_ref", "opportunity_id", "qco_id", "correlation_id",
+    "offer_id", "offer_version", "deliverable_id", "deliverable_version",
+    "scope_version", "price_version", "terms_version", "amount", "currency",
+    "credits", "addons", "inputs", "exclusions", "deadline", "valid_until",
+    "decision_state", "evidence_refs", "created_by", "synthetic", "version",
+    "created_at", "updated_at"
+  ],
+  "properties": {
+    "schema_version": { "const": "confenge.proposal.v1" },
+    "proposal_id": { "$ref": "#/$defs/id" },
+    "proposal_version": { "type": "integer", "minimum": 1 },
+    "organization_id": { "$ref": "#/$defs/id" },
+    "account_id": { "$ref": "#/$defs/id" },
+    "client_ref": { "$ref": "#/$defs/id" },
+    "opportunity_id": { "$ref": "#/$defs/id" },
+    "qco_id": { "$ref": "#/$defs/id" },
+    "deal_id": { "$ref": "#/$defs/id" },
+    "source_lead_id": { "$ref": "#/$defs/id" },
+    "correlation_id": { "$ref": "#/$defs/id" },
+    "offer_id": { "$ref": "#/$defs/id" },
+    "offer_version": { "$ref": "#/$defs/id" },
+    "deliverable_id": { "$ref": "#/$defs/id" },
+    "deliverable_version": { "$ref": "#/$defs/id" },
+    "scope_version": { "$ref": "#/$defs/id" },
+    "price_version": { "$ref": "#/$defs/id" },
+    "terms_version": { "$ref": "#/$defs/id" },
+    "amount": { "type": "integer", "minimum": 0, "description": "Minor currency units." },
+    "currency": { "type": "string", "pattern": "^[A-Z]{3}$" },
+    "credits": { "$ref": "#/$defs/stringSet" },
+    "addons": { "$ref": "#/$defs/stringSet" },
+    "inputs": { "$ref": "#/$defs/nonEmptyStringSet" },
+    "exclusions": { "$ref": "#/$defs/stringSet" },
+    "deadline": { "type": "string", "format": "date-time" },
+    "valid_until": { "type": "string", "format": "date-time" },
+    "prepared_at": { "type": "string", "format": "date-time" },
+    "approved_at": { "type": "string", "format": "date-time" },
+    "sent_at": { "type": "string", "format": "date-time" },
+    "decision_state": {
+      "enum": ["DRAFT", "PREPARED", "APPROVED_TO_SEND", "SENT", "NEGOTIATING", "ACCEPTED", "REJECTED", "EXPIRED", "UNKNOWN"]
+    },
+    "decision_at": { "type": "string", "format": "date-time" },
+    "literal_reason_ref": { "$ref": "#/$defs/id" },
+    "accepted_snapshot_hash": { "type": "string", "pattern": "^sha256:[a-f0-9]{64}$" },
+    "evidence_refs": { "$ref": "#/$defs/stringSet" },
+    "created_by": { "$ref": "#/$defs/id" },
+    "synthetic": { "type": "boolean" },
+    "version": { "type": "integer", "minimum": 1 },
+    "created_at": { "type": "string", "format": "date-time" },
+    "updated_at": { "type": "string", "format": "date-time" }
+  },
+  "allOf": [
+    {
+      "if": { "properties": { "decision_state": { "const": "ACCEPTED" } } },
+      "then": { "required": ["decision_at", "accepted_snapshot_hash"] }
+    }
+  ],
+  "$defs": {
+    "id": { "type": "string", "minLength": 1, "maxLength": 500 },
+    "stringSet": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 },
+      "uniqueItems": true
+    },
+    "nonEmptyStringSet": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 },
+      "uniqueItems": true
+    }
+  }
+}

--- a/docs/contracts/proposal-v1/confenge.proposal_event.v1.schema.json
+++ b/docs/contracts/proposal-v1/confenge.proposal_event.v1.schema.json
@@ -1,0 +1,32 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://confenge.com.br/contracts/confenge.proposal_event.v1.schema.json",
+  "title": "confenge.proposal_event.v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version", "event_id", "event_type", "organization_id", "proposal_id",
+    "proposal_version", "state", "actor", "occurred_at", "evidence_refs"
+  ],
+  "properties": {
+    "schema_version": { "const": "confenge.proposal_event.v1" },
+    "event_id": { "$ref": "#/$defs/id" },
+    "event_type": { "type": "string", "pattern": "^proposal\\.[a-z_]+$" },
+    "organization_id": { "$ref": "#/$defs/id" },
+    "proposal_id": { "$ref": "#/$defs/id" },
+    "proposal_version": { "type": "integer", "minimum": 1 },
+    "state": {
+      "enum": ["DRAFT", "PREPARED", "APPROVED_TO_SEND", "SENT", "NEGOTIATING", "ACCEPTED", "REJECTED", "EXPIRED", "UNKNOWN"]
+    },
+    "actor": { "$ref": "#/$defs/id" },
+    "occurred_at": { "type": "string", "format": "date-time" },
+    "evidence_refs": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1, "maxLength": 500 },
+      "uniqueItems": true
+    }
+  },
+  "$defs": {
+    "id": { "type": "string", "minLength": 1, "maxLength": 500 }
+  }
+}

--- a/docs/contracts/proposal-v1/fixtures/delivery-order-requested.synthetic.v1.json
+++ b/docs/contracts/proposal-v1/fixtures/delivery-order-requested.synthetic.v1.json
@@ -1,10 +1,10 @@
 {
-  "event_id": "7bb44bf9-e37f-5833-8958-4e5c313eaceb",
+  "event_id": "e69e1dd3-7204-51d2-9768-36cf5ede789a",
   "schema_version": "confenge.delivery_order_requested.v1",
   "synthetic": true,
   "correlation_id": "corr-synthetic-cfg-diag-exp-001",
   "causation_id": "fixture-financial-gate-cfg-diag-exp-001",
-  "idempotency_key": "delivery-order:220f817a-5b2b-5799-b403-2ce8c731e4bf:1:sha256:7cbe3a5d5663e4ae15001e56f97b852287c94eea2836e200c3a5a309bc73f2bd:CFG-DIAG-EXP-v1:v1:SYNTHETIC_VALID:fixture-financial-gate-cfg-diag-exp-001",
+  "idempotency_key": "delivery-order:sha256:e1e93bd326036d3a399193c9e9492ffd6351c378c6866fda23e9e229f6493c76",
   "organization_id": "11111111-1111-4111-8111-000000000047",
   "account_id": "account-synthetic-cfg-diag-exp-001",
   "client_ref": "client:redacted:cfg-diag-exp-001",

--- a/docs/contracts/proposal-v1/fixtures/delivery-order-requested.synthetic.v1.json
+++ b/docs/contracts/proposal-v1/fixtures/delivery-order-requested.synthetic.v1.json
@@ -1,0 +1,43 @@
+{
+  "event_id": "7bb44bf9-e37f-5833-8958-4e5c313eaceb",
+  "schema_version": "confenge.delivery_order_requested.v1",
+  "synthetic": true,
+  "correlation_id": "corr-synthetic-cfg-diag-exp-001",
+  "causation_id": "fixture-financial-gate-cfg-diag-exp-001",
+  "idempotency_key": "delivery-order:220f817a-5b2b-5799-b403-2ce8c731e4bf:1:sha256:7cbe3a5d5663e4ae15001e56f97b852287c94eea2836e200c3a5a309bc73f2bd:CFG-DIAG-EXP-v1:v1:SYNTHETIC_VALID:fixture-financial-gate-cfg-diag-exp-001",
+  "organization_id": "11111111-1111-4111-8111-000000000047",
+  "account_id": "account-synthetic-cfg-diag-exp-001",
+  "client_ref": "client:redacted:cfg-diag-exp-001",
+  "opportunity_id": "opportunity-synthetic-cfg-diag-exp-001",
+  "qco_id": "qco-synthetic-cfg-diag-exp-001",
+  "proposal_id": "220f817a-5b2b-5799-b403-2ce8c731e4bf",
+  "proposal_version": 1,
+  "accepted_snapshot_hash": "sha256:7cbe3a5d5663e4ae15001e56f97b852287c94eea2836e200c3a5a309bc73f2bd",
+  "offer_id": "CFG-DIAG-EXP-v1",
+  "offer_version": "v1",
+  "deliverable_id": "CFG-DIAG-EXP-v1",
+  "deliverable_version": "v1",
+  "scope_version": "CFG-SCOPE-DIAG-EXP-v1",
+  "price_version": "CFG-OFFER-CATALOG-v1",
+  "terms_version": "CFG-TERMS-B2B-2026-08-17-v1",
+  "financial_gate": {
+    "schema_version": "confenge.financial_gate.v1",
+    "state": "SYNTHETIC_VALID",
+    "synthetic": true,
+    "source_event_id": "fixture-financial-gate-cfg-diag-exp-001",
+    "received_revenue": false,
+    "evidence_refs": [
+      "fixture:financial-gate:synthetic-valid"
+    ]
+  },
+  "onboarding_ref": "onboarding:synthetic:cfg-diag-exp-001",
+  "occurred_at": "2026-08-25T12:05:00Z",
+  "evidence_refs": [
+    "evidence:synthetic:ACCEPTED",
+    "evidence:synthetic:APPROVED_TO_SEND",
+    "evidence:synthetic:PREPARED",
+    "evidence:synthetic:SENT",
+    "fixture:cfg-diag-exp-v1:proposal",
+    "fixture:financial-gate:synthetic-valid"
+  ]
+}

--- a/docs/contracts/proposal-v1/fixtures/proposal.accepted.synthetic.v1.json
+++ b/docs/contracts/proposal-v1/fixtures/proposal.accepted.synthetic.v1.json
@@ -1,0 +1,53 @@
+{
+  "schema_version": "confenge.proposal.v1",
+  "proposal_id": "220f817a-5b2b-5799-b403-2ce8c731e4bf",
+  "proposal_version": 1,
+  "organization_id": "11111111-1111-4111-8111-000000000047",
+  "account_id": "account-synthetic-cfg-diag-exp-001",
+  "client_ref": "client:redacted:cfg-diag-exp-001",
+  "opportunity_id": "opportunity-synthetic-cfg-diag-exp-001",
+  "qco_id": "qco-synthetic-cfg-diag-exp-001",
+  "deal_id": "deal-synthetic-cfg-diag-exp-001",
+  "source_lead_id": "lead-synthetic-cfg-diag-exp-001",
+  "correlation_id": "corr-synthetic-cfg-diag-exp-001",
+  "offer_id": "CFG-DIAG-EXP-v1",
+  "offer_version": "v1",
+  "deliverable_id": "CFG-DIAG-EXP-v1",
+  "deliverable_version": "v1",
+  "scope_version": "CFG-SCOPE-DIAG-EXP-v1",
+  "price_version": "CFG-OFFER-CATALOG-v1",
+  "terms_version": "CFG-TERMS-B2B-2026-08-17-v1",
+  "amount": 250000,
+  "currency": "BRL",
+  "credits": [],
+  "addons": [],
+  "inputs": [
+    "company_context_ref",
+    "expansion_hypothesis_ref"
+  ],
+  "exclusions": [
+    "provider_charge",
+    "real_customer_data"
+  ],
+  "deadline": "2026-08-27T12:00:00Z",
+  "valid_until": "2026-09-01T12:00:00Z",
+  "prepared_at": "2026-08-25T12:01:00Z",
+  "approved_at": "2026-08-25T12:02:00Z",
+  "sent_at": "2026-08-25T12:03:00Z",
+  "decision_state": "ACCEPTED",
+  "decision_at": "2026-08-25T12:04:00Z",
+  "literal_reason_ref": "reason:synthetic:ACCEPTED",
+  "accepted_snapshot_hash": "sha256:7cbe3a5d5663e4ae15001e56f97b852287c94eea2836e200c3a5a309bc73f2bd",
+  "evidence_refs": [
+    "evidence:synthetic:ACCEPTED",
+    "evidence:synthetic:APPROVED_TO_SEND",
+    "evidence:synthetic:PREPARED",
+    "evidence:synthetic:SENT",
+    "fixture:cfg-diag-exp-v1:proposal"
+  ],
+  "created_by": "actor:synthetic-reviewer",
+  "synthetic": true,
+  "version": 5,
+  "created_at": "2026-08-25T12:00:00Z",
+  "updated_at": "2026-08-25T12:04:00Z"
+}

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/oschwald/geoip2-golang/v2 v2.0.0
 	github.com/redis/go-redis/v9 v9.11.0
 	github.com/rs/zerolog v1.34.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1
 	github.com/stretchr/testify v1.11.1
 	github.com/stripe/stripe-go/v76 v76.25.0
 	github.com/xuri/excelize/v2 v2.11.0
@@ -253,7 +254,6 @@ require (
 	github.com/ryancurrah/gomodguard v1.3.5 // indirect
 	github.com/ryanrolds/sqlclosecheck v0.5.1 // indirect
 	github.com/sanposhiho/wastedassign/v2 v2.1.0 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.1 // indirect
 	github.com/sashamelentyev/interfacebloat v1.1.0 // indirect
 	github.com/sashamelentyev/usestdlibvars v1.28.0 // indirect
 	github.com/securego/gosec/v2 v2.22.2 // indirect

--- a/internal/app/confenge/proposal/canary.go
+++ b/internal/app/confenge/proposal/canary.go
@@ -1,0 +1,82 @@
+package proposal
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var SyntheticCanaryOrganizationID = uuid.MustParse("11111111-1111-4111-8111-000000000047")
+
+var SyntheticCanaryTime = time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+
+type SyntheticCanaryResult struct {
+	Proposal Proposal               `json:"proposal"`
+	Handoff  DeliveryOrderRequested `json:"handoff"`
+}
+
+func RunSyntheticCanary(ctx context.Context) (SyntheticCanaryResult, error) {
+	service := NewService(NewMemoryStore(), func() time.Time { return SyntheticCanaryTime })
+	result, err := service.Create(ctx, CreateCommand{
+		OrganizationID: SyntheticCanaryOrganizationID,
+		IdempotencyKey: "fixture:cfg-diag-exp-v1:proposal:create",
+		CreatedBy:      "actor:synthetic-reviewer",
+		Draft:          SyntheticCanaryDraft(),
+	})
+	if err != nil {
+		return SyntheticCanaryResult{}, err
+	}
+	for index, target := range []State{StatePrepared, StateApprovedToSend, StateSent, StateAccepted} {
+		result, err = service.Transition(ctx, TransitionCommand{
+			OrganizationID: result.Proposal.OrganizationID,
+			ProposalID:     result.Proposal.ProposalID, ProposalVersion: result.Proposal.ProposalVersion,
+			ExpectedRecordVersion: result.Proposal.Version,
+			IdempotencyKey:        "fixture:cfg-diag-exp-v1:proposal:" + string(target),
+			Target:                target, Actor: "actor:synthetic-reviewer",
+			LiteralReasonRef: "reason:synthetic:" + string(target),
+			EvidenceRefs:     []string{"evidence:synthetic:" + string(target)},
+			OccurredAt:       SyntheticCanaryTime.Add(time.Duration(index+1) * time.Minute),
+		})
+		if err != nil {
+			return SyntheticCanaryResult{}, err
+		}
+	}
+	sourceEventID := "fixture-financial-gate-cfg-diag-exp-001"
+	authorized, err := service.AuthorizeDelivery(ctx, AuthorizeDeliveryCommand{
+		OrganizationID: result.Proposal.OrganizationID,
+		ProposalID:     result.Proposal.ProposalID, ProposalVersion: result.Proposal.ProposalVersion,
+		IdempotencyKey: "fixture:cfg-diag-exp-v1:delivery:SYNTHETIC_VALID",
+		CausationID:    sourceEventID, OnboardingRef: "onboarding:synthetic:cfg-diag-exp-001",
+		OccurredAt: SyntheticCanaryTime.Add(5 * time.Minute),
+		FinancialGate: FinancialGate{
+			SchemaVersion: FinancialGateSchema, State: FinancialGateSyntheticValid,
+			Synthetic: true, SourceEventID: &sourceEventID, ReceivedRevenue: false,
+			EvidenceRefs: []string{"fixture:financial-gate:synthetic-valid"},
+		},
+	})
+	if err != nil {
+		return SyntheticCanaryResult{}, err
+	}
+	if authorized.Handoff == nil {
+		return SyntheticCanaryResult{}, fmt.Errorf("synthetic canary produced no delivery handoff")
+	}
+	return SyntheticCanaryResult{Proposal: authorized.Proposal, Handoff: *authorized.Handoff}, nil
+}
+
+func SyntheticCanaryDraft() Draft {
+	return Draft{
+		AccountID: "account-synthetic-cfg-diag-exp-001", ClientRef: "client:redacted:cfg-diag-exp-001",
+		OpportunityID: "opportunity-synthetic-cfg-diag-exp-001", QCOID: "qco-synthetic-cfg-diag-exp-001",
+		DealID: "deal-synthetic-cfg-diag-exp-001", SourceLeadID: "lead-synthetic-cfg-diag-exp-001",
+		CorrelationID: "corr-synthetic-cfg-diag-exp-001", OfferID: "CFG-DIAG-EXP-v1", OfferVersion: "v1",
+		DeliverableID: "CFG-DIAG-EXP-v1", DeliverableVersion: "v1", ScopeVersion: "CFG-SCOPE-DIAG-EXP-v1",
+		PriceVersion: "CFG-OFFER-CATALOG-v1", TermsVersion: "CFG-TERMS-B2B-2026-08-17-v1", Amount: 250000,
+		Currency: "BRL", Credits: []string{}, Addons: []string{},
+		Inputs:     []string{"company_context_ref", "expansion_hypothesis_ref"},
+		Exclusions: []string{"real_customer_data", "provider_charge"},
+		Deadline:   SyntheticCanaryTime.Add(48 * time.Hour), ValidUntil: SyntheticCanaryTime.Add(7 * 24 * time.Hour),
+		EvidenceRefs: []string{"fixture:cfg-diag-exp-v1:proposal"}, Synthetic: true,
+	}
+}

--- a/internal/app/confenge/proposal/contract_test.go
+++ b/internal/app/confenge/proposal/contract_test.go
@@ -1,0 +1,91 @@
+package proposal
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestSyntheticCanaryMatchesGoldenAndConverges(t *testing.T) {
+	goldenPath := contractPath("fixtures", "delivery-order-requested.synthetic.v1.json")
+	raw, err := os.ReadFile(goldenPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.DisallowUnknownFields()
+	var golden DeliveryOrderRequested
+	if err := decoder.Decode(&golden); err != nil {
+		t.Fatal(err)
+	}
+	var first SyntheticCanaryResult
+	for run := 0; run < 3; run++ {
+		result, err := RunSyntheticCanary(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(result.Handoff, golden) {
+			t.Fatalf("run %d diverged from golden\n got: %+v\nwant: %+v", run+1, result.Handoff, golden)
+		}
+		if run == 0 {
+			first = result
+			continue
+		}
+		if result.Proposal.ProposalID != first.Proposal.ProposalID ||
+			result.Proposal.AcceptedSnapshotHash != first.Proposal.AcceptedSnapshotHash ||
+			result.Handoff.EventID != first.Handoff.EventID {
+			t.Fatalf("run %d generated unstable identities", run+1)
+		}
+	}
+	if golden.FinancialGate.ReceivedRevenue || !golden.Synthetic || golden.FinancialGate.State != FinancialGateSyntheticValid {
+		t.Fatalf("golden broke synthetic finance invariant: %+v", golden.FinancialGate)
+	}
+	proposalRaw, err := os.ReadFile(contractPath("fixtures", "proposal.accepted.synthetic.v1.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	proposalDecoder := json.NewDecoder(bytes.NewReader(proposalRaw))
+	proposalDecoder.DisallowUnknownFields()
+	var proposalGolden Proposal
+	if err := proposalDecoder.Decode(&proposalGolden); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(first.Proposal, proposalGolden) {
+		t.Fatalf("accepted proposal diverged from golden\n got: %+v\nwant: %+v", first.Proposal, proposalGolden)
+	}
+}
+
+func TestVersionedContractSchemasAreValidJSON(t *testing.T) {
+	for _, name := range []string{
+		"confenge.proposal.v1.schema.json",
+		"confenge.proposal_event.v1.schema.json",
+		"confenge.financial_gate.v1.schema.json",
+		"confenge.delivery_order_requested.v1.schema.json",
+	} {
+		raw, err := os.ReadFile(contractPath(name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var schema map[string]any
+		if err := json.Unmarshal(raw, &schema); err != nil {
+			t.Fatalf("%s: %v", name, err)
+		}
+		if !strings.HasPrefix(schema["title"].(string), "confenge.") {
+			t.Fatalf("%s has no versioned confenge title", name)
+		}
+		sum := sha256.Sum256(raw)
+		t.Logf("%s sha256=%s", name, hex.EncodeToString(sum[:]))
+	}
+}
+
+func contractPath(parts ...string) string {
+	base := []string{"..", "..", "..", "..", "docs", "contracts", "proposal-v1"}
+	return filepath.Join(append(base, parts...)...)
+}

--- a/internal/app/confenge/proposal/contract_test.go
+++ b/internal/app/confenge/proposal/contract_test.go
@@ -11,7 +11,16 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
 )
+
+var contractSchemaNames = []string{
+	"confenge.proposal.v1.schema.json",
+	"confenge.proposal_event.v1.schema.json",
+	"confenge.financial_gate.v1.schema.json",
+	"confenge.delivery_order_requested.v1.schema.json",
+}
 
 func TestSyntheticCanaryMatchesGoldenAndConverges(t *testing.T) {
 	goldenPath := contractPath("fixtures", "delivery-order-requested.synthetic.v1.json")
@@ -63,12 +72,7 @@ func TestSyntheticCanaryMatchesGoldenAndConverges(t *testing.T) {
 }
 
 func TestVersionedContractSchemasAreValidJSON(t *testing.T) {
-	for _, name := range []string{
-		"confenge.proposal.v1.schema.json",
-		"confenge.proposal_event.v1.schema.json",
-		"confenge.financial_gate.v1.schema.json",
-		"confenge.delivery_order_requested.v1.schema.json",
-	} {
+	for _, name := range contractSchemaNames {
 		raw, err := os.ReadFile(contractPath(name))
 		if err != nil {
 			t.Fatal(err)
@@ -83,6 +87,50 @@ func TestVersionedContractSchemasAreValidJSON(t *testing.T) {
 		sum := sha256.Sum256(raw)
 		t.Logf("%s sha256=%s", name, hex.EncodeToString(sum[:]))
 	}
+}
+
+func TestContractFixturesMatchPublishedSchemas(t *testing.T) {
+	compiler := jsonschema.NewCompiler()
+	compiler.AssertFormat()
+	for _, name := range contractSchemaNames {
+		raw, err := os.ReadFile(contractPath(name))
+		if err != nil {
+			t.Fatal(err)
+		}
+		var document any
+		if err := json.Unmarshal(raw, &document); err != nil {
+			t.Fatalf("decode %s: %v", name, err)
+		}
+		if err := compiler.AddResource(contractSchemaURL(name), document); err != nil {
+			t.Fatalf("add %s: %v", name, err)
+		}
+	}
+	for fixture, schemaName := range map[string]string{
+		"proposal.accepted.synthetic.v1.json":        "confenge.proposal.v1.schema.json",
+		"delivery-order-requested.synthetic.v1.json": "confenge.delivery_order_requested.v1.schema.json",
+	} {
+		t.Run(fixture, func(t *testing.T) {
+			schema, err := compiler.Compile(contractSchemaURL(schemaName))
+			if err != nil {
+				t.Fatal(err)
+			}
+			raw, err := os.ReadFile(contractPath("fixtures", fixture))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var instance any
+			if err := json.Unmarshal(raw, &instance); err != nil {
+				t.Fatal(err)
+			}
+			if err := schema.Validate(instance); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func contractSchemaURL(name string) string {
+	return "https://confenge.com.br/contracts/" + name
 }
 
 func contractPath(parts ...string) string {

--- a/internal/app/confenge/proposal/model.go
+++ b/internal/app/confenge/proposal/model.go
@@ -1,0 +1,228 @@
+package proposal
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	ProposalSchemaVersion      = "confenge.proposal.v1"
+	ProposalEventSchemaVersion = "confenge.proposal_event.v1"
+	DeliveryRequestSchema      = "confenge.delivery_order_requested.v1"
+	FinancialGateSchema        = "confenge.financial_gate.v1"
+	FinancialGateReconciled    = "confenge.financial_gate_reconciled.v1"
+)
+
+type State string
+
+const (
+	StateDraft          State = "DRAFT"
+	StatePrepared       State = "PREPARED"
+	StateApprovedToSend State = "APPROVED_TO_SEND"
+	StateSent           State = "SENT"
+	StateNegotiating    State = "NEGOTIATING"
+	StateAccepted       State = "ACCEPTED"
+	StateRejected       State = "REJECTED"
+	StateExpired        State = "EXPIRED"
+	StateUnknown        State = "UNKNOWN"
+)
+
+type Proposal struct {
+	SchemaVersion        string     `json:"schema_version"`
+	ProposalID           uuid.UUID  `json:"proposal_id"`
+	ProposalVersion      int        `json:"proposal_version"`
+	OrganizationID       uuid.UUID  `json:"organization_id"`
+	AccountID            string     `json:"account_id"`
+	ClientRef            string     `json:"client_ref"`
+	OpportunityID        string     `json:"opportunity_id"`
+	QCOID                string     `json:"qco_id"`
+	DealID               string     `json:"deal_id,omitempty"`
+	SourceLeadID         string     `json:"source_lead_id,omitempty"`
+	CorrelationID        string     `json:"correlation_id"`
+	OfferID              string     `json:"offer_id"`
+	OfferVersion         string     `json:"offer_version"`
+	DeliverableID        string     `json:"deliverable_id"`
+	DeliverableVersion   string     `json:"deliverable_version"`
+	ScopeVersion         string     `json:"scope_version"`
+	PriceVersion         string     `json:"price_version"`
+	TermsVersion         string     `json:"terms_version"`
+	Amount               int64      `json:"amount"`
+	Currency             string     `json:"currency"`
+	Credits              []string   `json:"credits"`
+	Addons               []string   `json:"addons"`
+	Inputs               []string   `json:"inputs"`
+	Exclusions           []string   `json:"exclusions"`
+	Deadline             time.Time  `json:"deadline"`
+	ValidUntil           time.Time  `json:"valid_until"`
+	PreparedAt           *time.Time `json:"prepared_at,omitempty"`
+	ApprovedAt           *time.Time `json:"approved_at,omitempty"`
+	SentAt               *time.Time `json:"sent_at,omitempty"`
+	DecisionState        State      `json:"decision_state"`
+	DecisionAt           *time.Time `json:"decision_at,omitempty"`
+	LiteralReasonRef     string     `json:"literal_reason_ref,omitempty"`
+	AcceptedSnapshotHash string     `json:"accepted_snapshot_hash,omitempty"`
+	EvidenceRefs         []string   `json:"evidence_refs"`
+	CreatedBy            string     `json:"created_by"`
+	Synthetic            bool       `json:"synthetic"`
+	Version              int64      `json:"version"`
+	CreatedAt            time.Time  `json:"created_at"`
+	UpdatedAt            time.Time  `json:"updated_at"`
+}
+
+type Draft struct {
+	AccountID          string
+	ClientRef          string
+	OpportunityID      string
+	QCOID              string
+	DealID             string
+	SourceLeadID       string
+	CorrelationID      string
+	OfferID            string
+	OfferVersion       string
+	DeliverableID      string
+	DeliverableVersion string
+	ScopeVersion       string
+	PriceVersion       string
+	TermsVersion       string
+	Amount             int64
+	Currency           string
+	Credits            []string
+	Addons             []string
+	Inputs             []string
+	Exclusions         []string
+	Deadline           time.Time
+	ValidUntil         time.Time
+	EvidenceRefs       []string
+	Synthetic          bool
+}
+
+type ProposalEvent struct {
+	SchemaVersion   string    `json:"schema_version"`
+	EventID         uuid.UUID `json:"event_id"`
+	EventType       string    `json:"event_type"`
+	OrganizationID  uuid.UUID `json:"organization_id"`
+	ProposalID      uuid.UUID `json:"proposal_id"`
+	ProposalVersion int       `json:"proposal_version"`
+	State           State     `json:"state"`
+	Actor           string    `json:"actor"`
+	OccurredAt      time.Time `json:"occurred_at"`
+	EvidenceRefs    []string  `json:"evidence_refs"`
+}
+
+type FinancialGateState string
+
+const (
+	FinancialGateUnknown        FinancialGateState = "UNKNOWN"
+	FinancialGateSyntheticValid FinancialGateState = "SYNTHETIC_VALID"
+	FinancialGateAuthorized     FinancialGateState = "AUTHORIZED"
+)
+
+type FinancialGate struct {
+	SchemaVersion   string             `json:"schema_version"`
+	State           FinancialGateState `json:"state"`
+	Synthetic       bool               `json:"synthetic"`
+	SourceEventID   *string            `json:"source_event_id"`
+	ReceivedRevenue bool               `json:"received_revenue"`
+	EvidenceRefs    []string           `json:"evidence_refs"`
+}
+
+type DeliveryOrderRequested struct {
+	EventID              uuid.UUID     `json:"event_id"`
+	SchemaVersion        string        `json:"schema_version"`
+	Synthetic            bool          `json:"synthetic"`
+	CorrelationID        string        `json:"correlation_id"`
+	CausationID          string        `json:"causation_id"`
+	IdempotencyKey       string        `json:"idempotency_key"`
+	OrganizationID       uuid.UUID     `json:"organization_id"`
+	AccountID            string        `json:"account_id"`
+	ClientRef            string        `json:"client_ref"`
+	OpportunityID        string        `json:"opportunity_id"`
+	QCOID                string        `json:"qco_id"`
+	ProposalID           uuid.UUID     `json:"proposal_id"`
+	ProposalVersion      int           `json:"proposal_version"`
+	AcceptedSnapshotHash string        `json:"accepted_snapshot_hash"`
+	OfferID              string        `json:"offer_id"`
+	OfferVersion         string        `json:"offer_version"`
+	DeliverableID        string        `json:"deliverable_id"`
+	DeliverableVersion   string        `json:"deliverable_version"`
+	ScopeVersion         string        `json:"scope_version"`
+	PriceVersion         string        `json:"price_version"`
+	TermsVersion         string        `json:"terms_version"`
+	FinancialGate        FinancialGate `json:"financial_gate"`
+	OnboardingRef        string        `json:"onboarding_ref"`
+	OccurredAt           time.Time     `json:"occurred_at"`
+	EvidenceRefs         []string      `json:"evidence_refs"`
+}
+
+type Result struct {
+	Proposal Proposal                `json:"proposal"`
+	Events   []ProposalEvent         `json:"events"`
+	Handoff  *DeliveryOrderRequested `json:"handoff,omitempty"`
+	Replay   bool                    `json:"replay"`
+}
+
+func (p Proposal) AcceptedHash() (string, error) {
+	if p.ProposalID == uuid.Nil || p.ProposalVersion < 1 {
+		return "", fmt.Errorf("proposal identity required")
+	}
+	snapshot := struct {
+		ProposalID         uuid.UUID `json:"proposal_id"`
+		ProposalVersion    int       `json:"proposal_version"`
+		OrganizationID     uuid.UUID `json:"organization_id"`
+		AccountID          string    `json:"account_id"`
+		ClientRef          string    `json:"client_ref"`
+		OpportunityID      string    `json:"opportunity_id"`
+		QCOID              string    `json:"qco_id"`
+		DealID             string    `json:"deal_id,omitempty"`
+		OfferID            string    `json:"offer_id"`
+		OfferVersion       string    `json:"offer_version"`
+		DeliverableID      string    `json:"deliverable_id"`
+		DeliverableVersion string    `json:"deliverable_version"`
+		ScopeVersion       string    `json:"scope_version"`
+		PriceVersion       string    `json:"price_version"`
+		TermsVersion       string    `json:"terms_version"`
+		Amount             int64     `json:"amount"`
+		Currency           string    `json:"currency"`
+		Credits            []string  `json:"credits"`
+		Addons             []string  `json:"addons"`
+		Inputs             []string  `json:"inputs"`
+		Exclusions         []string  `json:"exclusions"`
+		Deadline           time.Time `json:"deadline"`
+		ValidUntil         time.Time `json:"valid_until"`
+	}{
+		ProposalID: p.ProposalID, ProposalVersion: p.ProposalVersion,
+		OrganizationID: p.OrganizationID, AccountID: strings.TrimSpace(p.AccountID),
+		ClientRef: strings.TrimSpace(p.ClientRef), OpportunityID: strings.TrimSpace(p.OpportunityID),
+		QCOID: strings.TrimSpace(p.QCOID), DealID: strings.TrimSpace(p.DealID),
+		OfferID: strings.TrimSpace(p.OfferID), OfferVersion: strings.TrimSpace(p.OfferVersion),
+		DeliverableID: strings.TrimSpace(p.DeliverableID), DeliverableVersion: strings.TrimSpace(p.DeliverableVersion),
+		ScopeVersion: strings.TrimSpace(p.ScopeVersion), PriceVersion: strings.TrimSpace(p.PriceVersion),
+		TermsVersion: strings.TrimSpace(p.TermsVersion), Amount: p.Amount, Currency: strings.ToUpper(strings.TrimSpace(p.Currency)),
+		Credits: sortedCopy(p.Credits), Addons: sortedCopy(p.Addons), Inputs: sortedCopy(p.Inputs),
+		Exclusions: sortedCopy(p.Exclusions), Deadline: p.Deadline.UTC(), ValidUntil: p.ValidUntil.UTC(),
+	}
+	raw, err := json.Marshal(snapshot)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	return "sha256:" + hex.EncodeToString(sum[:]), nil
+}
+
+func sortedCopy(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			out = append(out, value)
+		}
+	}
+	slices.Sort(out)
+	return slices.Compact(out)
+}

--- a/internal/app/confenge/proposal/pg_store.go
+++ b/internal/app/confenge/proposal/pg_store.go
@@ -1,0 +1,263 @@
+package proposal
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type PGStore struct {
+	db *pgxpool.Pool
+}
+
+func NewPGStore(db *pgxpool.Pool) *PGStore {
+	return &PGStore{db: db}
+}
+
+func (s *PGStore) Get(ctx context.Context, orgID, proposalID uuid.UUID, version int) (*Proposal, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("proposal pg store unavailable")
+	}
+	return getProposal(ctx, s.db, orgID, proposalID, version)
+}
+
+func (s *PGStore) Latest(ctx context.Context, orgID, proposalID uuid.UUID) (*Proposal, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("proposal pg store unavailable")
+	}
+	var payload []byte
+	err := s.db.QueryRow(ctx, `
+		SELECT payload
+		FROM confenge_proposals
+		WHERE organization_id = $1 AND proposal_id = $2
+		ORDER BY proposal_version DESC
+		LIMIT 1`, orgID, proposalID).Scan(&payload)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var p Proposal
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func (s *PGStore) Receipt(ctx context.Context, orgID uuid.UUID, key string) (*CommandReceipt, error) {
+	if s == nil || s.db == nil {
+		return nil, fmt.Errorf("proposal pg store unavailable")
+	}
+	receipt, ok, err := getReceipt(ctx, s.db, orgID, key)
+	if err != nil || !ok {
+		return nil, err
+	}
+	return &receipt, nil
+}
+
+func (s *PGStore) Apply(ctx context.Context, mutation Mutation) (CommandReceipt, bool, error) {
+	if s == nil || s.db == nil {
+		return CommandReceipt{}, false, fmt.Errorf("proposal pg store unavailable")
+	}
+	tx, err := s.db.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.Serializable})
+	if err != nil {
+		return CommandReceipt{}, false, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if receipt, ok, rerr := getReceipt(ctx, tx, mutation.OrganizationID, mutation.IdempotencyKey); rerr != nil {
+		return CommandReceipt{}, false, rerr
+	} else if ok {
+		if receipt.PayloadHash != mutation.PayloadHash {
+			return CommandReceipt{}, false, ErrIdempotencyConflict
+		}
+		return receipt, true, nil
+	}
+
+	if mutation.Expected != nil {
+		var recordVersion int64
+		var state State
+		err = tx.QueryRow(ctx, `
+			SELECT record_version, decision_state
+			FROM confenge_proposals
+			WHERE organization_id = $1 AND proposal_id = $2 AND proposal_version = $3
+			FOR UPDATE`, mutation.OrganizationID, mutation.Proposal.ProposalID, mutation.Expected.ProposalVersion).
+			Scan(&recordVersion, &state)
+		if errors.Is(err, pgx.ErrNoRows) {
+			return CommandReceipt{}, false, ErrConflict
+		}
+		if err != nil {
+			return CommandReceipt{}, false, err
+		}
+		if recordVersion != mutation.Expected.RecordVersion {
+			return CommandReceipt{}, false, ErrConflict
+		}
+		if !mutation.Insert && !mutation.NoProposalWrite && state == StateAccepted {
+			return CommandReceipt{}, false, ErrAcceptedImmutable
+		}
+	}
+
+	payload, err := json.Marshal(mutation.Proposal)
+	if err != nil {
+		return CommandReceipt{}, false, err
+	}
+	if mutation.NoProposalWrite {
+		err = nil
+	} else if mutation.Insert {
+		err = insertProposal(ctx, tx, mutation.Proposal, payload)
+	} else {
+		err = updateProposal(ctx, tx, mutation.Proposal, payload, mutation.Expected)
+	}
+	if err != nil {
+		return CommandReceipt{}, false, err
+	}
+	if err := insertEvents(ctx, tx, mutation); err != nil {
+		return CommandReceipt{}, false, err
+	}
+	receipt := CommandReceipt{
+		OrganizationID: mutation.OrganizationID, IdempotencyKey: mutation.IdempotencyKey,
+		PayloadHash: mutation.PayloadHash, Proposal: mutation.Proposal,
+		Events: mutation.Events, Handoff: mutation.Handoff,
+	}
+	receiptPayload, err := json.Marshal(receipt)
+	if err != nil {
+		return CommandReceipt{}, false, err
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO confenge_proposal_command_receipts (
+			organization_id, idempotency_key, payload_hash, proposal_id, proposal_version, payload
+		) VALUES ($1, $2, $3, $4, $5, $6)`, mutation.OrganizationID, mutation.IdempotencyKey,
+		mutation.PayloadHash, mutation.Proposal.ProposalID, mutation.Proposal.ProposalVersion, receiptPayload)
+	if err != nil {
+		return CommandReceipt{}, false, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return CommandReceipt{}, false, err
+	}
+	return receipt, false, nil
+}
+
+type queryer interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+func getProposal(ctx context.Context, q queryer, orgID, proposalID uuid.UUID, version int) (*Proposal, error) {
+	var payload []byte
+	err := q.QueryRow(ctx, `
+		SELECT payload FROM confenge_proposals
+		WHERE organization_id = $1 AND proposal_id = $2 AND proposal_version = $3`, orgID, proposalID, version).
+		Scan(&payload)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var p Proposal
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return nil, err
+	}
+	return &p, nil
+}
+
+func getReceipt(ctx context.Context, q queryer, orgID uuid.UUID, key string) (CommandReceipt, bool, error) {
+	var payload []byte
+	err := q.QueryRow(ctx, `
+		SELECT payload FROM confenge_proposal_command_receipts
+		WHERE organization_id = $1 AND idempotency_key = $2`, orgID, key).Scan(&payload)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return CommandReceipt{}, false, nil
+	}
+	if err != nil {
+		return CommandReceipt{}, false, err
+	}
+	var receipt CommandReceipt
+	if err := json.Unmarshal(payload, &receipt); err != nil {
+		return CommandReceipt{}, false, err
+	}
+	return receipt, true, nil
+}
+
+func insertProposal(ctx context.Context, tx pgx.Tx, p Proposal, payload []byte) error {
+	_, err := tx.Exec(ctx, `
+		INSERT INTO confenge_proposals (
+			organization_id, proposal_id, proposal_version, account_id, client_ref,
+			opportunity_id, qco_id, deal_id, correlation_id, offer_id, offer_version,
+			deliverable_id, deliverable_version, scope_version, price_version, terms_version,
+			decision_state, accepted_snapshot_hash, synthetic, record_version, valid_until,
+			payload, created_at, updated_at
+		) VALUES (
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24
+		)`, p.OrganizationID, p.ProposalID, p.ProposalVersion, p.AccountID, p.ClientRef,
+		p.OpportunityID, p.QCOID, nullableText(p.DealID), p.CorrelationID, p.OfferID, p.OfferVersion,
+		p.DeliverableID, p.DeliverableVersion, p.ScopeVersion, p.PriceVersion, p.TermsVersion,
+		p.DecisionState, nullableText(p.AcceptedSnapshotHash), p.Synthetic, p.Version, p.ValidUntil,
+		payload, p.CreatedAt, p.UpdatedAt)
+	return err
+}
+
+func updateProposal(ctx context.Context, tx pgx.Tx, p Proposal, payload []byte, expected *ExpectedVersion) error {
+	if expected == nil {
+		return ErrConflict
+	}
+	tag, err := tx.Exec(ctx, `
+		UPDATE confenge_proposals
+		SET decision_state=$5, accepted_snapshot_hash=$6, record_version=$7, payload=$8, updated_at=$9
+		WHERE organization_id=$1 AND proposal_id=$2 AND proposal_version=$3 AND record_version=$4`,
+		p.OrganizationID, p.ProposalID, p.ProposalVersion, expected.RecordVersion,
+		p.DecisionState, nullableText(p.AcceptedSnapshotHash), p.Version, payload, p.UpdatedAt)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() != 1 {
+		return ErrConflict
+	}
+	return nil
+}
+
+func insertEvents(ctx context.Context, tx pgx.Tx, mutation Mutation) error {
+	for _, event := range mutation.Events {
+		payload, err := json.Marshal(event)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(ctx, `
+			INSERT INTO confenge_proposal_events (
+				event_id, organization_id, proposal_id, proposal_version, event_type,
+				idempotency_key, occurred_at, payload
+			) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`, event.EventID, event.OrganizationID,
+			event.ProposalID, event.ProposalVersion, event.EventType, mutation.IdempotencyKey,
+			event.OccurredAt, payload)
+		if err != nil {
+			return err
+		}
+	}
+	if mutation.Handoff == nil {
+		return nil
+	}
+	payload, err := json.Marshal(mutation.Handoff)
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		INSERT INTO confenge_proposal_events (
+			event_id, organization_id, proposal_id, proposal_version, event_type,
+			idempotency_key, occurred_at, payload
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,$8)`, mutation.Handoff.EventID, mutation.Handoff.OrganizationID,
+		mutation.Handoff.ProposalID, mutation.Handoff.ProposalVersion, DeliveryRequestSchema,
+		mutation.Handoff.IdempotencyKey, mutation.Handoff.OccurredAt, payload)
+	return err
+}
+
+func nullableText(value string) any {
+	if value == "" {
+		return nil
+	}
+	return value
+}

--- a/internal/app/confenge/proposal/service.go
+++ b/internal/app/confenge/proposal/service.go
@@ -234,6 +234,9 @@ func (s *Service) AuthorizeDelivery(ctx context.Context, command AuthorizeDelive
 	if p.DecisionState != StateAccepted || p.AcceptedSnapshotHash == "" {
 		return Result{}, fmt.Errorf("%w: delivery requires accepted proposal", ErrIllegalTransition)
 	}
+	if p.Synthetic != command.FinancialGate.Synthetic {
+		return Result{}, ErrSyntheticMismatch
+	}
 	at := command.OccurredAt.UTC()
 	if at.IsZero() {
 		at = s.clock().UTC()

--- a/internal/app/confenge/proposal/service.go
+++ b/internal/app/confenge/proposal/service.go
@@ -1,0 +1,439 @@
+package proposal
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var proposalNamespace = uuid.MustParse("206b7b3f-fbdf-5238-a45e-6ca74061baf2")
+
+type Clock func() time.Time
+
+type Service struct {
+	store Store
+	clock Clock
+}
+
+func NewService(store Store, clock Clock) *Service {
+	if clock == nil {
+		clock = func() time.Time { return time.Now().UTC() }
+	}
+	return &Service{store: store, clock: clock}
+}
+
+type CreateCommand struct {
+	OrganizationID uuid.UUID
+	IdempotencyKey string
+	CreatedBy      string
+	Draft          Draft
+}
+
+type ReviseCommand struct {
+	OrganizationID        uuid.UUID
+	ProposalID            uuid.UUID
+	ProposalVersion       int
+	ExpectedRecordVersion int64
+	IdempotencyKey        string
+	CreatedBy             string
+	Draft                 Draft
+}
+
+type TransitionCommand struct {
+	OrganizationID        uuid.UUID
+	ProposalID            uuid.UUID
+	ProposalVersion       int
+	ExpectedRecordVersion int64
+	IdempotencyKey        string
+	Target                State
+	Actor                 string
+	LiteralReasonRef      string
+	EvidenceRefs          []string
+	OccurredAt            time.Time
+}
+
+type AuthorizeDeliveryCommand struct {
+	OrganizationID  uuid.UUID
+	ProposalID      uuid.UUID
+	ProposalVersion int
+	IdempotencyKey  string
+	CausationID     string
+	OnboardingRef   string
+	FinancialGate   FinancialGate
+	OccurredAt      time.Time
+}
+
+func (s *Service) Create(ctx context.Context, command CreateCommand) (Result, error) {
+	if s == nil || s.store == nil {
+		return Result{}, fmt.Errorf("proposal store unavailable")
+	}
+	if err := validateCommand(command.OrganizationID, command.IdempotencyKey, command.CreatedBy); err != nil {
+		return Result{}, err
+	}
+	if err := validateDraft(command.Draft); err != nil {
+		return Result{}, err
+	}
+	payloadHash, err := hashCommand(command)
+	if err != nil {
+		return Result{}, err
+	}
+	if replay, ok, err := s.replay(ctx, command.OrganizationID, command.IdempotencyKey, payloadHash); err != nil || ok {
+		return replay, err
+	}
+	now := s.clock().UTC()
+	if !command.Draft.ValidUntil.After(now) {
+		return Result{}, ErrProposalExpired
+	}
+	proposalID := stableUUID("proposal", command.OrganizationID.String(), command.IdempotencyKey)
+	p := proposalFromDraft(command.OrganizationID, proposalID, 1, command.CreatedBy, command.Draft, now)
+	event := proposalEvent(p, StateDraft, command.CreatedBy, now, command.Draft.EvidenceRefs, command.IdempotencyKey)
+	receipt, replay, err := s.store.Apply(ctx, Mutation{
+		OrganizationID: p.OrganizationID, IdempotencyKey: command.IdempotencyKey,
+		PayloadHash: payloadHash, Insert: true, Proposal: p, Events: []ProposalEvent{event},
+	})
+	return resultFromReceipt(receipt, replay), err
+}
+
+func (s *Service) Revise(ctx context.Context, command ReviseCommand) (Result, error) {
+	if err := validateCommand(command.OrganizationID, command.IdempotencyKey, command.CreatedBy); err != nil {
+		return Result{}, err
+	}
+	if err := validateDraft(command.Draft); err != nil {
+		return Result{}, err
+	}
+	payloadHash, err := hashCommand(command)
+	if err != nil {
+		return Result{}, err
+	}
+	if replay, ok, err := s.replay(ctx, command.OrganizationID, command.IdempotencyKey, payloadHash); err != nil || ok {
+		return replay, err
+	}
+	current, err := s.load(ctx, command.OrganizationID, command.ProposalID, command.ProposalVersion)
+	if err != nil {
+		return Result{}, err
+	}
+	if current.Version != command.ExpectedRecordVersion {
+		return Result{}, ErrConflict
+	}
+	if current.Synthetic != command.Draft.Synthetic {
+		return Result{}, ErrSyntheticMismatch
+	}
+	if !materiallyDifferent(*current, command.Draft) {
+		return Result{}, ErrNoMaterialChange
+	}
+	now := s.clock().UTC()
+	if !command.Draft.ValidUntil.After(now) {
+		return Result{}, ErrProposalExpired
+	}
+	next := proposalFromDraft(current.OrganizationID, current.ProposalID, current.ProposalVersion+1, command.CreatedBy, command.Draft, now)
+	event := proposalEvent(next, StateDraft, command.CreatedBy, now, command.Draft.EvidenceRefs, command.IdempotencyKey)
+	receipt, replay, err := s.store.Apply(ctx, Mutation{
+		OrganizationID: next.OrganizationID, IdempotencyKey: command.IdempotencyKey,
+		PayloadHash: payloadHash, Expected: &ExpectedVersion{ProposalVersion: current.ProposalVersion, RecordVersion: current.Version},
+		Insert: true, Proposal: next, Events: []ProposalEvent{event},
+	})
+	return resultFromReceipt(receipt, replay), err
+}
+
+func (s *Service) Transition(ctx context.Context, command TransitionCommand) (Result, error) {
+	if err := validateCommand(command.OrganizationID, command.IdempotencyKey, command.Actor); err != nil {
+		return Result{}, err
+	}
+	payloadHash, err := hashCommand(command)
+	if err != nil {
+		return Result{}, err
+	}
+	if replay, ok, err := s.replay(ctx, command.OrganizationID, command.IdempotencyKey, payloadHash); err != nil || ok {
+		return replay, err
+	}
+	current, err := s.load(ctx, command.OrganizationID, command.ProposalID, command.ProposalVersion)
+	if err != nil {
+		return Result{}, err
+	}
+	if current.Version != command.ExpectedRecordVersion {
+		return Result{}, ErrConflict
+	}
+	if current.DecisionState == StateAccepted {
+		return Result{}, ErrAcceptedImmutable
+	}
+	if !canTransition(current.DecisionState, command.Target) {
+		return Result{}, fmt.Errorf("%w: %s -> %s", ErrIllegalTransition, current.DecisionState, command.Target)
+	}
+	at := command.OccurredAt.UTC()
+	if at.IsZero() {
+		at = s.clock().UTC()
+	}
+	if at.Before(current.UpdatedAt) {
+		return Result{}, ErrOutOfOrder
+	}
+	if command.Target == StateAccepted && at.After(current.ValidUntil) {
+		return Result{}, ErrProposalExpired
+	}
+	next := *cloneProposal(*current)
+	next.DecisionState = command.Target
+	next.Version++
+	next.UpdatedAt = at
+	next.LiteralReasonRef = strings.TrimSpace(command.LiteralReasonRef)
+	next.EvidenceRefs = sortedCopy(append(next.EvidenceRefs, command.EvidenceRefs...))
+	stampTransition(&next, at)
+	if command.Target == StateAccepted {
+		if len(sortedCopy(command.EvidenceRefs)) == 0 {
+			return Result{}, fmt.Errorf("acceptance evidence_refs required")
+		}
+		next.AcceptedSnapshotHash, err = next.AcceptedHash()
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	event := proposalEvent(next, command.Target, command.Actor, at, command.EvidenceRefs, command.IdempotencyKey)
+	var handoff *DeliveryOrderRequested
+	if command.Target == StateAccepted {
+		unknown := FinancialGate{SchemaVersion: FinancialGateSchema, State: FinancialGateUnknown, Synthetic: next.Synthetic, EvidenceRefs: []string{}}
+		handoff, err = deliveryRequest(next, unknown, "", event.EventID.String(), at)
+		if err != nil {
+			return Result{}, err
+		}
+	}
+	receipt, replay, err := s.store.Apply(ctx, Mutation{
+		OrganizationID: next.OrganizationID, IdempotencyKey: command.IdempotencyKey,
+		PayloadHash: payloadHash, Expected: &ExpectedVersion{ProposalVersion: next.ProposalVersion, RecordVersion: current.Version},
+		Proposal: next, Events: []ProposalEvent{event}, Handoff: handoff,
+	})
+	return resultFromReceipt(receipt, replay), err
+}
+
+func (s *Service) AuthorizeDelivery(ctx context.Context, command AuthorizeDeliveryCommand) (Result, error) {
+	if command.OrganizationID == uuid.Nil || command.ProposalID == uuid.Nil || strings.TrimSpace(command.IdempotencyKey) == "" {
+		return Result{}, fmt.Errorf("organization_id, proposal_id and idempotency_key required")
+	}
+	if err := validateFinancialGate(command.FinancialGate, true); err != nil {
+		return Result{}, err
+	}
+	if strings.TrimSpace(command.OnboardingRef) == "" || strings.TrimSpace(command.CausationID) == "" {
+		return Result{}, fmt.Errorf("onboarding_ref and causation_id required")
+	}
+	payloadHash, err := hashCommand(command)
+	if err != nil {
+		return Result{}, err
+	}
+	if replay, ok, err := s.replay(ctx, command.OrganizationID, command.IdempotencyKey, payloadHash); err != nil || ok {
+		return replay, err
+	}
+	p, err := s.load(ctx, command.OrganizationID, command.ProposalID, command.ProposalVersion)
+	if err != nil {
+		return Result{}, err
+	}
+	if p.DecisionState != StateAccepted || p.AcceptedSnapshotHash == "" {
+		return Result{}, fmt.Errorf("%w: delivery requires accepted proposal", ErrIllegalTransition)
+	}
+	at := command.OccurredAt.UTC()
+	if at.IsZero() {
+		at = s.clock().UTC()
+	}
+	handoff, err := deliveryRequest(*p, command.FinancialGate, command.OnboardingRef, command.CausationID, at)
+	if err != nil {
+		return Result{}, err
+	}
+	receipt, replay, err := s.store.Apply(ctx, Mutation{
+		OrganizationID: p.OrganizationID, IdempotencyKey: command.IdempotencyKey,
+		PayloadHash: payloadHash, Expected: &ExpectedVersion{ProposalVersion: p.ProposalVersion, RecordVersion: p.Version},
+		NoProposalWrite: true, Proposal: *p, Handoff: handoff,
+	})
+	return resultFromReceipt(receipt, replay), err
+}
+
+func (s *Service) load(ctx context.Context, orgID, proposalID uuid.UUID, version int) (*Proposal, error) {
+	if s == nil || s.store == nil {
+		return nil, fmt.Errorf("proposal store unavailable")
+	}
+	p, err := s.store.Get(ctx, orgID, proposalID, version)
+	if err != nil {
+		return nil, err
+	}
+	if p == nil {
+		return nil, ErrNotFound
+	}
+	return p, nil
+}
+
+func (s *Service) replay(ctx context.Context, orgID uuid.UUID, key, payloadHash string) (Result, bool, error) {
+	receipt, err := s.store.Receipt(ctx, orgID, key)
+	if err != nil || receipt == nil {
+		return Result{}, false, err
+	}
+	if receipt.PayloadHash != payloadHash {
+		return Result{}, false, ErrIdempotencyConflict
+	}
+	return resultFromReceipt(*receipt, true), true, nil
+}
+
+func proposalFromDraft(orgID, proposalID uuid.UUID, proposalVersion int, actor string, draft Draft, now time.Time) Proposal {
+	return Proposal{
+		SchemaVersion: ProposalSchemaVersion, ProposalID: proposalID, ProposalVersion: proposalVersion,
+		OrganizationID: orgID, AccountID: strings.TrimSpace(draft.AccountID), ClientRef: strings.TrimSpace(draft.ClientRef),
+		OpportunityID: strings.TrimSpace(draft.OpportunityID), QCOID: strings.TrimSpace(draft.QCOID), DealID: strings.TrimSpace(draft.DealID),
+		SourceLeadID: strings.TrimSpace(draft.SourceLeadID), CorrelationID: strings.TrimSpace(draft.CorrelationID),
+		OfferID: strings.TrimSpace(draft.OfferID), OfferVersion: strings.TrimSpace(draft.OfferVersion),
+		DeliverableID: strings.TrimSpace(draft.DeliverableID), DeliverableVersion: strings.TrimSpace(draft.DeliverableVersion),
+		ScopeVersion: strings.TrimSpace(draft.ScopeVersion), PriceVersion: strings.TrimSpace(draft.PriceVersion),
+		TermsVersion: strings.TrimSpace(draft.TermsVersion), Amount: draft.Amount, Currency: strings.ToUpper(strings.TrimSpace(draft.Currency)),
+		Credits: sortedCopy(draft.Credits), Addons: sortedCopy(draft.Addons), Inputs: sortedCopy(draft.Inputs),
+		Exclusions: sortedCopy(draft.Exclusions), Deadline: draft.Deadline.UTC(), ValidUntil: draft.ValidUntil.UTC(),
+		DecisionState: StateDraft, EvidenceRefs: sortedCopy(draft.EvidenceRefs), CreatedBy: strings.TrimSpace(actor),
+		Synthetic: draft.Synthetic, Version: 1, CreatedAt: now, UpdatedAt: now,
+	}
+}
+
+func validateCommand(orgID uuid.UUID, idempotencyKey, actor string) error {
+	if orgID == uuid.Nil || strings.TrimSpace(idempotencyKey) == "" || strings.TrimSpace(actor) == "" {
+		return fmt.Errorf("organization_id, idempotency_key and actor required")
+	}
+	return nil
+}
+
+func validateDraft(draft Draft) error {
+	required := map[string]string{
+		"account_id": draft.AccountID, "client_ref": draft.ClientRef, "opportunity_id": draft.OpportunityID,
+		"qco_id": draft.QCOID, "correlation_id": draft.CorrelationID, "offer_id": draft.OfferID,
+		"offer_version": draft.OfferVersion, "deliverable_id": draft.DeliverableID,
+		"deliverable_version": draft.DeliverableVersion, "scope_version": draft.ScopeVersion,
+		"price_version": draft.PriceVersion, "terms_version": draft.TermsVersion, "currency": draft.Currency,
+	}
+	for field, value := range required {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s required", field)
+		}
+	}
+	if draft.Amount < 0 || draft.Deadline.IsZero() || draft.ValidUntil.IsZero() {
+		return fmt.Errorf("non-negative amount, deadline and valid_until required")
+	}
+	if len(sortedCopy(draft.Inputs)) == 0 {
+		return fmt.Errorf("inputs required")
+	}
+	return nil
+}
+
+func materiallyDifferent(current Proposal, draft Draft) bool {
+	material := proposalFromDraft(current.OrganizationID, current.ProposalID, current.ProposalVersion, current.CreatedBy, draft, current.CreatedAt)
+	current.PreparedAt, current.ApprovedAt, current.SentAt, current.DecisionAt = nil, nil, nil, nil
+	current.LiteralReasonRef, current.AcceptedSnapshotHash = "", ""
+	current.DecisionState, current.Version, current.UpdatedAt = StateDraft, 1, current.CreatedAt
+	current.EvidenceRefs, current.CreatedBy, current.Synthetic = material.EvidenceRefs, material.CreatedBy, material.Synthetic
+	return !reflect.DeepEqual(current, material)
+}
+
+func canTransition(from, to State) bool {
+	allowed := map[State]map[State]bool{
+		StateDraft: {StatePrepared: true}, StatePrepared: {StateApprovedToSend: true},
+		StateApprovedToSend: {StateSent: true},
+		StateSent:           {StateNegotiating: true, StateAccepted: true, StateRejected: true, StateExpired: true, StateUnknown: true},
+		StateNegotiating:    {StateAccepted: true, StateRejected: true, StateExpired: true, StateUnknown: true},
+	}
+	return allowed[from][to]
+}
+
+func stampTransition(p *Proposal, at time.Time) {
+	switch p.DecisionState {
+	case StatePrepared:
+		p.PreparedAt = &at
+	case StateApprovedToSend:
+		p.ApprovedAt = &at
+	case StateSent:
+		p.SentAt = &at
+	case StateAccepted, StateRejected, StateExpired, StateUnknown:
+		p.DecisionAt = &at
+	}
+}
+
+func proposalEvent(p Proposal, state State, actor string, at time.Time, evidence []string, idempotencyKey string) ProposalEvent {
+	return ProposalEvent{
+		SchemaVersion: ProposalEventSchemaVersion,
+		EventID:       stableUUID("proposal-event", p.OrganizationID.String(), p.ProposalID.String(), fmt.Sprint(p.ProposalVersion), idempotencyKey),
+		EventType:     "proposal." + strings.ToLower(string(state)), OrganizationID: p.OrganizationID,
+		ProposalID: p.ProposalID, ProposalVersion: p.ProposalVersion, State: state,
+		Actor: strings.TrimSpace(actor), OccurredAt: at, EvidenceRefs: sortedCopy(evidence),
+	}
+}
+
+func deliveryRequest(p Proposal, gate FinancialGate, onboardingRef, causationID string, at time.Time) (*DeliveryOrderRequested, error) {
+	if err := validateFinancialGate(gate, false); err != nil {
+		return nil, err
+	}
+	businessKey := strings.Join([]string{p.ProposalID.String(), fmt.Sprint(p.ProposalVersion), p.AcceptedSnapshotHash, p.DeliverableID, p.DeliverableVersion}, ":")
+	source := "none"
+	if gate.SourceEventID != nil {
+		source = strings.TrimSpace(*gate.SourceEventID)
+	}
+	idempotencyKey := "delivery-order:" + businessKey + ":" + string(gate.State) + ":" + source
+	return &DeliveryOrderRequested{
+		EventID: stableUUID("delivery-order-request", idempotencyKey), SchemaVersion: DeliveryRequestSchema,
+		Synthetic: gate.Synthetic || p.Synthetic, CorrelationID: p.CorrelationID, CausationID: causationID,
+		IdempotencyKey: idempotencyKey, OrganizationID: p.OrganizationID, AccountID: p.AccountID,
+		ClientRef: p.ClientRef, OpportunityID: p.OpportunityID, QCOID: p.QCOID,
+		ProposalID: p.ProposalID, ProposalVersion: p.ProposalVersion, AcceptedSnapshotHash: p.AcceptedSnapshotHash,
+		OfferID: p.OfferID, OfferVersion: p.OfferVersion, DeliverableID: p.DeliverableID,
+		DeliverableVersion: p.DeliverableVersion, ScopeVersion: p.ScopeVersion,
+		PriceVersion: p.PriceVersion, TermsVersion: p.TermsVersion, FinancialGate: gate,
+		OnboardingRef: strings.TrimSpace(onboardingRef), OccurredAt: at,
+		EvidenceRefs: sortedCopy(append(p.EvidenceRefs, gate.EvidenceRefs...)),
+	}, nil
+}
+
+func validateFinancialGate(gate FinancialGate, authorizedOnly bool) error {
+	if gate.SchemaVersion != FinancialGateSchema {
+		return fmt.Errorf("financial_gate.schema_version must be %s", FinancialGateSchema)
+	}
+	if gate.ReceivedRevenue {
+		return fmt.Errorf("financial gate cannot claim received revenue")
+	}
+	source := ""
+	if gate.SourceEventID != nil {
+		source = strings.TrimSpace(*gate.SourceEventID)
+	}
+	switch gate.State {
+	case FinancialGateUnknown:
+		if authorizedOnly {
+			return fmt.Errorf("UNKNOWN financial gate fails closed")
+		}
+	case FinancialGateSyntheticValid:
+		if !gate.Synthetic || source == "" || len(sortedCopy(gate.EvidenceRefs)) == 0 {
+			return fmt.Errorf("SYNTHETIC_VALID requires synthetic=true, source_event_id and evidence_refs")
+		}
+	case FinancialGateAuthorized:
+		if gate.Synthetic || source == "" || len(sortedCopy(gate.EvidenceRefs)) == 0 {
+			return fmt.Errorf("AUTHORIZED requires synthetic=false, source_event_id and evidence_refs")
+		}
+	default:
+		return fmt.Errorf("unsupported financial gate state %q", gate.State)
+	}
+	return nil
+}
+
+func stableUUID(parts ...string) uuid.UUID {
+	return uuid.NewSHA1(proposalNamespace, []byte(strings.Join(parts, "\x00")))
+}
+
+func hashCommand(command any) (string, error) {
+	raw, err := json.Marshal(command)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(raw)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func resultFromReceipt(receipt CommandReceipt, replay bool) Result {
+	return Result{Proposal: receipt.Proposal, Events: receipt.Events, Handoff: receipt.Handoff, Replay: replay}
+}
+
+func IsConflict(err error) bool {
+	return errors.Is(err, ErrConflict) || errors.Is(err, ErrIdempotencyConflict)
+}

--- a/internal/app/confenge/proposal/service.go
+++ b/internal/app/confenge/proposal/service.go
@@ -10,11 +10,19 @@ import (
 	"reflect"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/google/uuid"
 )
 
 var proposalNamespace = uuid.MustParse("206b7b3f-fbdf-5238-a45e-6ca74061baf2")
+
+const (
+	contractIDMaxLength        = 200
+	proposalOnlyIDMaxLength    = 500
+	commandIdentityMaxLength   = 500
+	evidenceReferenceMaxLength = 500
+)
 
 type Clock func() time.Time
 
@@ -147,6 +155,12 @@ func (s *Service) Transition(ctx context.Context, command TransitionCommand) (Re
 	if err := validateCommand(command.OrganizationID, command.IdempotencyKey, command.Actor); err != nil {
 		return Result{}, err
 	}
+	if err := validateOptionalString("literal_reason_ref", command.LiteralReasonRef, proposalOnlyIDMaxLength); err != nil {
+		return Result{}, err
+	}
+	if err := validateStringSet("evidence_refs", command.EvidenceRefs, evidenceReferenceMaxLength, false); err != nil {
+		return Result{}, err
+	}
 	payloadHash, err := hashCommand(command)
 	if err != nil {
 		return Result{}, err
@@ -211,14 +225,20 @@ func (s *Service) Transition(ctx context.Context, command TransitionCommand) (Re
 }
 
 func (s *Service) AuthorizeDelivery(ctx context.Context, command AuthorizeDeliveryCommand) (Result, error) {
-	if command.OrganizationID == uuid.Nil || command.ProposalID == uuid.Nil || strings.TrimSpace(command.IdempotencyKey) == "" {
+	if command.OrganizationID == uuid.Nil || command.ProposalID == uuid.Nil {
 		return Result{}, fmt.Errorf("organization_id, proposal_id and idempotency_key required")
+	}
+	if err := validateRequiredString("idempotency_key", command.IdempotencyKey, commandIdentityMaxLength); err != nil {
+		return Result{}, err
 	}
 	if err := validateFinancialGate(command.FinancialGate, true); err != nil {
 		return Result{}, err
 	}
-	if strings.TrimSpace(command.OnboardingRef) == "" || strings.TrimSpace(command.CausationID) == "" {
-		return Result{}, fmt.Errorf("onboarding_ref and causation_id required")
+	if err := validateRequiredString("onboarding_ref", command.OnboardingRef, contractIDMaxLength); err != nil {
+		return Result{}, err
+	}
+	if err := validateRequiredString("causation_id", command.CausationID, contractIDMaxLength); err != nil {
+		return Result{}, err
 	}
 	payloadHash, err := hashCommand(command)
 	if err != nil {
@@ -240,6 +260,9 @@ func (s *Service) AuthorizeDelivery(ctx context.Context, command AuthorizeDelive
 	at := command.OccurredAt.UTC()
 	if at.IsZero() {
 		at = s.clock().UTC()
+	}
+	if at.Before(p.UpdatedAt) {
+		return Result{}, ErrOutOfOrder
 	}
 	handoff, err := deliveryRequest(*p, command.FinancialGate, command.OnboardingRef, command.CausationID, at)
 	if err != nil {
@@ -296,10 +319,13 @@ func proposalFromDraft(orgID, proposalID uuid.UUID, proposalVersion int, actor s
 }
 
 func validateCommand(orgID uuid.UUID, idempotencyKey, actor string) error {
-	if orgID == uuid.Nil || strings.TrimSpace(idempotencyKey) == "" || strings.TrimSpace(actor) == "" {
+	if orgID == uuid.Nil {
 		return fmt.Errorf("organization_id, idempotency_key and actor required")
 	}
-	return nil
+	if err := validateRequiredString("idempotency_key", idempotencyKey, commandIdentityMaxLength); err != nil {
+		return err
+	}
+	return validateRequiredString("actor", actor, proposalOnlyIDMaxLength)
 }
 
 func validateDraft(draft Draft) error {
@@ -311,15 +337,65 @@ func validateDraft(draft Draft) error {
 		"price_version": draft.PriceVersion, "terms_version": draft.TermsVersion, "currency": draft.Currency,
 	}
 	for field, value := range required {
-		if strings.TrimSpace(value) == "" {
-			return fmt.Errorf("%s required", field)
+		if err := validateRequiredString(field, value, contractIDMaxLength); err != nil {
+			return err
 		}
+	}
+	if err := validateOptionalString("deal_id", draft.DealID, proposalOnlyIDMaxLength); err != nil {
+		return err
+	}
+	if err := validateOptionalString("source_lead_id", draft.SourceLeadID, proposalOnlyIDMaxLength); err != nil {
+		return err
+	}
+	currency := strings.ToUpper(strings.TrimSpace(draft.Currency))
+	if len(currency) != 3 || currency[0] < 'A' || currency[0] > 'Z' ||
+		currency[1] < 'A' || currency[1] > 'Z' || currency[2] < 'A' || currency[2] > 'Z' {
+		return fmt.Errorf("currency must be a three-letter code")
 	}
 	if draft.Amount < 0 || draft.Deadline.IsZero() || draft.ValidUntil.IsZero() {
 		return fmt.Errorf("non-negative amount, deadline and valid_until required")
 	}
-	if len(sortedCopy(draft.Inputs)) == 0 {
-		return fmt.Errorf("inputs required")
+	for field, values := range map[string][]string{
+		"credits": draft.Credits, "addons": draft.Addons, "inputs": draft.Inputs,
+		"exclusions": draft.Exclusions, "evidence_refs": draft.EvidenceRefs,
+	} {
+		if err := validateStringSet(field, values, evidenceReferenceMaxLength, field == "inputs"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRequiredString(field, value string, maxLength int) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fmt.Errorf("%s required", field)
+	}
+	if utf8.RuneCountInString(value) > maxLength {
+		return fmt.Errorf("%s exceeds %d characters", field, maxLength)
+	}
+	return nil
+}
+
+func validateOptionalString(field, value string, maxLength int) error {
+	if value = strings.TrimSpace(value); value == "" {
+		return nil
+	}
+	if utf8.RuneCountInString(value) > maxLength {
+		return fmt.Errorf("%s exceeds %d characters", field, maxLength)
+	}
+	return nil
+}
+
+func validateStringSet(field string, values []string, maxLength int, required bool) error {
+	normalized := sortedCopy(values)
+	if required && len(normalized) == 0 {
+		return fmt.Errorf("%s required", field)
+	}
+	for _, value := range normalized {
+		if utf8.RuneCountInString(value) > maxLength {
+			return fmt.Errorf("%s entry exceeds %d characters", field, maxLength)
+		}
 	}
 	return nil
 }
@@ -370,12 +446,12 @@ func deliveryRequest(p Proposal, gate FinancialGate, onboardingRef, causationID 
 	if err := validateFinancialGate(gate, false); err != nil {
 		return nil, err
 	}
-	businessKey := strings.Join([]string{p.ProposalID.String(), fmt.Sprint(p.ProposalVersion), p.AcceptedSnapshotHash, p.DeliverableID, p.DeliverableVersion}, ":")
 	source := "none"
 	if gate.SourceEventID != nil {
 		source = strings.TrimSpace(*gate.SourceEventID)
 	}
-	idempotencyKey := "delivery-order:" + businessKey + ":" + string(gate.State) + ":" + source
+	idempotencyKey := stableDigest("delivery-order", p.ProposalID.String(), fmt.Sprint(p.ProposalVersion),
+		p.AcceptedSnapshotHash, p.DeliverableID, p.DeliverableVersion, string(gate.State), source)
 	return &DeliveryOrderRequested{
 		EventID: stableUUID("delivery-order-request", idempotencyKey), SchemaVersion: DeliveryRequestSchema,
 		Synthetic: gate.Synthetic || p.Synthetic, CorrelationID: p.CorrelationID, CausationID: causationID,
@@ -406,6 +482,9 @@ func validateFinancialGate(gate FinancialGate, authorizedOnly bool) error {
 		if authorizedOnly {
 			return fmt.Errorf("UNKNOWN financial gate fails closed")
 		}
+		if gate.SourceEventID != nil {
+			return fmt.Errorf("UNKNOWN financial gate requires null source_event_id")
+		}
 	case FinancialGateSyntheticValid:
 		if !gate.Synthetic || source == "" || len(sortedCopy(gate.EvidenceRefs)) == 0 {
 			return fmt.Errorf("SYNTHETIC_VALID requires synthetic=true, source_event_id and evidence_refs")
@@ -417,11 +496,24 @@ func validateFinancialGate(gate FinancialGate, authorizedOnly bool) error {
 	default:
 		return fmt.Errorf("unsupported financial gate state %q", gate.State)
 	}
+	if source != "" {
+		if err := validateRequiredString("financial_gate.source_event_id", source, contractIDMaxLength); err != nil {
+			return err
+		}
+	}
+	if err := validateStringSet("financial_gate.evidence_refs", gate.EvidenceRefs, evidenceReferenceMaxLength, false); err != nil {
+		return err
+	}
 	return nil
 }
 
 func stableUUID(parts ...string) uuid.UUID {
 	return uuid.NewSHA1(proposalNamespace, []byte(strings.Join(parts, "\x00")))
+}
+
+func stableDigest(prefix string, parts ...string) string {
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return prefix + ":sha256:" + hex.EncodeToString(sum[:])
 }
 
 func hashCommand(command any) (string, error) {

--- a/internal/app/confenge/proposal/service_test.go
+++ b/internal/app/confenge/proposal/service_test.go
@@ -3,6 +3,7 @@ package proposal
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -169,6 +170,35 @@ func TestProposalIdempotencyAndOptimisticConcurrency(t *testing.T) {
 	}
 }
 
+func TestProposalCommandsHonorPublishedContractBounds(t *testing.T) {
+	for name, mutate := range map[string]func(*Draft){
+		"long handoff identity": func(draft *Draft) { draft.AccountID = strings.Repeat("a", contractIDMaxLength+1) },
+		"long evidence ref":     func(draft *Draft) { draft.EvidenceRefs = []string{strings.Repeat("e", evidenceReferenceMaxLength+1)} },
+		"invalid currency":      func(draft *Draft) { draft.Currency = "br" },
+	} {
+		t.Run(name, func(t *testing.T) {
+			draft := fixtureDraft()
+			mutate(&draft)
+			_, err := NewService(NewMemoryStore(), fixedClock(testNow)).Create(context.Background(), CreateCommand{
+				OrganizationID: testOrg, IdempotencyKey: "fixture:invalid:" + name,
+				CreatedBy: "actor:synthetic-reviewer", Draft: draft,
+			})
+			if err == nil {
+				t.Fatal("invalid draft satisfied the published contract")
+			}
+		})
+	}
+
+	emptySource := ""
+	err := validateFinancialGate(FinancialGate{
+		SchemaVersion: FinancialGateSchema, State: FinancialGateUnknown,
+		Synthetic: true, SourceEventID: &emptySource,
+	}, false)
+	if err == nil {
+		t.Fatal("UNKNOWN financial gate accepted a non-null source_event_id")
+	}
+}
+
 func TestAuthorizedSyntheticHandoffNeverClaimsRevenue(t *testing.T) {
 	service := NewService(NewMemoryStore(), fixedClock(testNow))
 	accepted := transitionPath(t, service, createFixture(t, service, "fixture:authorized:create"), StateAccepted)
@@ -190,6 +220,9 @@ func TestAuthorizedSyntheticHandoffNeverClaimsRevenue(t *testing.T) {
 	if result.Handoff == nil || !result.Handoff.Synthetic || result.Handoff.FinancialGate.ReceivedRevenue ||
 		result.Handoff.OnboardingRef == "" || result.Handoff.AcceptedSnapshotHash != accepted.Proposal.AcceptedSnapshotHash {
 		t.Fatalf("invalid authorized handoff: %+v", result.Handoff)
+	}
+	if len(result.Handoff.IdempotencyKey) > contractIDMaxLength {
+		t.Fatalf("handoff idempotency key exceeds contract: %d", len(result.Handoff.IdempotencyKey))
 	}
 	replay, err := service.AuthorizeDelivery(context.Background(), command)
 	if err != nil || !replay.Replay || replay.Handoff.EventID != result.Handoff.EventID {
@@ -215,6 +248,14 @@ func TestAuthorizedSyntheticHandoffNeverClaimsRevenue(t *testing.T) {
 	_, err = service.AuthorizeDelivery(context.Background(), mismatched)
 	if !errors.Is(err, ErrSyntheticMismatch) {
 		t.Fatalf("synthetic proposal accepted real gate err=%v", err)
+	}
+
+	outOfOrder := command
+	outOfOrder.IdempotencyKey = "fixture:authorized:out-of-order"
+	outOfOrder.OccurredAt = accepted.Proposal.UpdatedAt.Add(-time.Second)
+	_, err = service.AuthorizeDelivery(context.Background(), outOfOrder)
+	if !errors.Is(err, ErrOutOfOrder) {
+		t.Fatalf("out-of-order delivery authorization err=%v", err)
 	}
 }
 

--- a/internal/app/confenge/proposal/service_test.go
+++ b/internal/app/confenge/proposal/service_test.go
@@ -203,6 +203,19 @@ func TestAuthorizedSyntheticHandoffNeverClaimsRevenue(t *testing.T) {
 	if err == nil {
 		t.Fatal("synthetic financial gate claimed received revenue")
 	}
+
+	realSourceEventID := "financial-gate-reconciled-real-001"
+	mismatched := command
+	mismatched.IdempotencyKey = "fixture:authorized:synthetic-mismatch"
+	mismatched.FinancialGate = FinancialGate{
+		SchemaVersion: FinancialGateSchema, State: FinancialGateAuthorized,
+		Synthetic: false, SourceEventID: &realSourceEventID,
+		EvidenceRefs: []string{"evidence:financial-authorization"},
+	}
+	_, err = service.AuthorizeDelivery(context.Background(), mismatched)
+	if !errors.Is(err, ErrSyntheticMismatch) {
+		t.Fatalf("synthetic proposal accepted real gate err=%v", err)
+	}
 }
 
 func transitionPath(t *testing.T, service *Service, start Proposal, terminal State) Result {

--- a/internal/app/confenge/proposal/service_test.go
+++ b/internal/app/confenge/proposal/service_test.go
@@ -1,0 +1,255 @@
+package proposal
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+var (
+	testOrg = uuid.MustParse("11111111-1111-4111-8111-000000000047")
+	testNow = time.Date(2026, 8, 25, 12, 0, 0, 0, time.UTC)
+)
+
+func TestProposalCreateVersionAcceptAndReplay(t *testing.T) {
+	store := NewMemoryStore()
+	service := NewService(store, fixedClock(testNow))
+	created, err := service.Create(context.Background(), CreateCommand{
+		OrganizationID: testOrg, IdempotencyKey: "fixture:cfg-diag-exp-v1:proposal:create",
+		CreatedBy: "actor:synthetic-reviewer", Draft: fixtureDraft(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.Proposal.ProposalVersion != 1 || created.Proposal.DecisionState != StateDraft || created.Proposal.Version != 1 {
+		t.Fatalf("unexpected create result: %+v", created.Proposal)
+	}
+	replayed, err := service.Create(context.Background(), CreateCommand{
+		OrganizationID: testOrg, IdempotencyKey: "fixture:cfg-diag-exp-v1:proposal:create",
+		CreatedBy: "actor:synthetic-reviewer", Draft: fixtureDraft(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !replayed.Replay || replayed.Proposal.ProposalID != created.Proposal.ProposalID {
+		t.Fatalf("create did not replay: %+v", replayed)
+	}
+
+	accepted := transitionPath(t, service, created.Proposal, StateAccepted)
+	if accepted.Proposal.AcceptedSnapshotHash == "" || accepted.Handoff == nil {
+		t.Fatalf("accepted proposal missing frozen hash/handoff: %+v", accepted)
+	}
+	if accepted.Handoff.FinancialGate.State != FinancialGateUnknown || accepted.Handoff.FinancialGate.ReceivedRevenue {
+		t.Fatalf("acceptance inferred finance: %+v", accepted.Handoff.FinancialGate)
+	}
+	acceptCommand := transitionCommand(accepted.Proposal, StateAccepted)
+	acceptCommand.ExpectedRecordVersion--
+	acceptCommand.OccurredAt = testNow.Add(time.Duration(acceptCommand.ExpectedRecordVersion) * time.Minute)
+	acceptReplay, err := service.Transition(context.Background(), acceptCommand)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !acceptReplay.Replay || acceptReplay.Handoff.EventID != accepted.Handoff.EventID ||
+		acceptReplay.Proposal.AcceptedSnapshotHash != accepted.Proposal.AcceptedSnapshotHash {
+		t.Fatalf("acceptance replay diverged: %+v", acceptReplay)
+	}
+
+	_, err = service.Transition(context.Background(), TransitionCommand{
+		OrganizationID: testOrg, ProposalID: accepted.Proposal.ProposalID,
+		ProposalVersion: 1, ExpectedRecordVersion: accepted.Proposal.Version,
+		IdempotencyKey: "fixture:accepted:mutate", Target: StateRejected,
+		Actor: "actor:synthetic-reviewer", EvidenceRefs: []string{"evidence:mutation-attempt"},
+	})
+	if !errors.Is(err, ErrAcceptedImmutable) {
+		t.Fatalf("accepted mutation err=%v", err)
+	}
+
+	revisionDraft := fixtureDraft()
+	revisionDraft.Amount = 275000
+	revised, err := service.Revise(context.Background(), ReviseCommand{
+		OrganizationID: testOrg, ProposalID: accepted.Proposal.ProposalID,
+		ProposalVersion: 1, ExpectedRecordVersion: accepted.Proposal.Version,
+		IdempotencyKey: "fixture:cfg-diag-exp-v1:proposal:revise:v2",
+		CreatedBy:      "actor:synthetic-reviewer", Draft: revisionDraft,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if revised.Proposal.ProposalVersion != 2 || revised.Proposal.DecisionState != StateDraft || revised.Proposal.AcceptedSnapshotHash != "" {
+		t.Fatalf("material revision did not create clean v2: %+v", revised.Proposal)
+	}
+	frozen, err := store.Get(context.Background(), testOrg, accepted.Proposal.ProposalID, 1)
+	if err != nil || frozen.AcceptedSnapshotHash != accepted.Proposal.AcceptedSnapshotHash || frozen.DecisionState != StateAccepted {
+		t.Fatalf("accepted v1 changed after v2: frozen=%+v err=%v", frozen, err)
+	}
+}
+
+func TestProposalRejectExpireAndIllegalTransition(t *testing.T) {
+	for _, terminal := range []State{StateRejected, StateExpired} {
+		t.Run(string(terminal), func(t *testing.T) {
+			service := NewService(NewMemoryStore(), fixedClock(testNow))
+			created := createFixture(t, service, "fixture:"+string(terminal)+":create")
+			result := transitionPath(t, service, created, terminal)
+			if result.Proposal.DecisionState != terminal || result.Proposal.DecisionAt == nil || result.Handoff != nil {
+				t.Fatalf("terminal result invalid: %+v", result)
+			}
+		})
+	}
+
+	service := NewService(NewMemoryStore(), fixedClock(testNow))
+	created := createFixture(t, service, "fixture:illegal:create")
+	_, err := service.Transition(context.Background(), TransitionCommand{
+		OrganizationID: testOrg, ProposalID: created.ProposalID, ProposalVersion: 1,
+		ExpectedRecordVersion: created.Version, IdempotencyKey: "fixture:illegal:accept",
+		Target: StateAccepted, Actor: "actor:synthetic-reviewer", EvidenceRefs: []string{"evidence:illegal"},
+	})
+	if !errors.Is(err, ErrIllegalTransition) {
+		t.Fatalf("illegal transition err=%v", err)
+	}
+
+	sent := created
+	for _, target := range []State{StatePrepared, StateApprovedToSend, StateSent} {
+		result, transitionErr := service.Transition(context.Background(), transitionCommand(sent, target))
+		if transitionErr != nil {
+			t.Fatal(transitionErr)
+		}
+		sent = result.Proposal
+	}
+	expiredAccept := transitionCommand(sent, StateAccepted)
+	expiredAccept.OccurredAt = sent.ValidUntil.Add(time.Second)
+	_, err = service.Transition(context.Background(), expiredAccept)
+	if !errors.Is(err, ErrProposalExpired) {
+		t.Fatalf("expired acceptance err=%v", err)
+	}
+}
+
+func TestProposalIdempotencyAndOptimisticConcurrency(t *testing.T) {
+	service := NewService(NewMemoryStore(), fixedClock(testNow))
+	created := createFixture(t, service, "fixture:idempotency:create")
+	changed := fixtureDraft()
+	changed.PriceVersion = "price-v2"
+	_, err := service.Create(context.Background(), CreateCommand{
+		OrganizationID: testOrg, IdempotencyKey: "fixture:idempotency:create",
+		CreatedBy: "actor:synthetic-reviewer", Draft: changed,
+	})
+	if !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("idempotency conflict err=%v", err)
+	}
+
+	_, err = service.Transition(context.Background(), TransitionCommand{
+		OrganizationID: testOrg, ProposalID: created.ProposalID, ProposalVersion: 1,
+		ExpectedRecordVersion: 99, IdempotencyKey: "fixture:stale:prepared",
+		Target: StatePrepared, Actor: "actor:synthetic-reviewer",
+	})
+	if !errors.Is(err, ErrConflict) {
+		t.Fatalf("stale expected version err=%v", err)
+	}
+
+	outOfOrder := transitionCommand(created, StatePrepared)
+	outOfOrder.IdempotencyKey = "fixture:out-of-order:prepared"
+	outOfOrder.OccurredAt = created.CreatedAt.Add(-time.Second)
+	_, err = service.Transition(context.Background(), outOfOrder)
+	if !errors.Is(err, ErrOutOfOrder) {
+		t.Fatalf("out-of-order command err=%v", err)
+	}
+
+	reclassified := fixtureDraft()
+	reclassified.Amount++
+	reclassified.Synthetic = false
+	_, err = service.Revise(context.Background(), ReviseCommand{
+		OrganizationID: testOrg, ProposalID: created.ProposalID, ProposalVersion: 1,
+		ExpectedRecordVersion: created.Version, IdempotencyKey: "fixture:synthetic-reclassification",
+		CreatedBy: "actor:synthetic-reviewer", Draft: reclassified,
+	})
+	if !errors.Is(err, ErrSyntheticMismatch) {
+		t.Fatalf("synthetic reclassification err=%v", err)
+	}
+}
+
+func TestAuthorizedSyntheticHandoffNeverClaimsRevenue(t *testing.T) {
+	service := NewService(NewMemoryStore(), fixedClock(testNow))
+	accepted := transitionPath(t, service, createFixture(t, service, "fixture:authorized:create"), StateAccepted)
+	sourceEventID := "fixture-financial-gate-cfg-diag-exp-001"
+	command := AuthorizeDeliveryCommand{
+		OrganizationID: testOrg, ProposalID: accepted.Proposal.ProposalID, ProposalVersion: 1,
+		IdempotencyKey: "fixture:authorized:handoff", CausationID: sourceEventID,
+		OnboardingRef: "onboarding:synthetic:cfg-diag-exp-001", OccurredAt: testNow.Add(10 * time.Minute),
+		FinancialGate: FinancialGate{
+			SchemaVersion: FinancialGateSchema, State: FinancialGateSyntheticValid,
+			Synthetic: true, SourceEventID: &sourceEventID, ReceivedRevenue: false,
+			EvidenceRefs: []string{"fixture:financial-gate:synthetic-valid"},
+		},
+	}
+	result, err := service.AuthorizeDelivery(context.Background(), command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Handoff == nil || !result.Handoff.Synthetic || result.Handoff.FinancialGate.ReceivedRevenue ||
+		result.Handoff.OnboardingRef == "" || result.Handoff.AcceptedSnapshotHash != accepted.Proposal.AcceptedSnapshotHash {
+		t.Fatalf("invalid authorized handoff: %+v", result.Handoff)
+	}
+	replay, err := service.AuthorizeDelivery(context.Background(), command)
+	if err != nil || !replay.Replay || replay.Handoff.EventID != result.Handoff.EventID {
+		t.Fatalf("authorized replay diverged: replay=%+v err=%v", replay, err)
+	}
+
+	bad := command
+	bad.IdempotencyKey = "fixture:authorized:received-revenue"
+	bad.FinancialGate.ReceivedRevenue = true
+	_, err = service.AuthorizeDelivery(context.Background(), bad)
+	if err == nil {
+		t.Fatal("synthetic financial gate claimed received revenue")
+	}
+}
+
+func transitionPath(t *testing.T, service *Service, start Proposal, terminal State) Result {
+	t.Helper()
+	current := start
+	for _, state := range []State{StatePrepared, StateApprovedToSend, StateSent, StateNegotiating, terminal} {
+		command := transitionCommand(current, state)
+		result, err := service.Transition(context.Background(), command)
+		if err != nil {
+			t.Fatalf("transition %s -> %s: %v", current.DecisionState, state, err)
+		}
+		current = result.Proposal
+		if state == terminal {
+			return result
+		}
+	}
+	t.Fatal("terminal transition not reached")
+	return Result{}
+}
+
+func transitionCommand(current Proposal, target State) TransitionCommand {
+	return TransitionCommand{
+		OrganizationID: current.OrganizationID, ProposalID: current.ProposalID,
+		ProposalVersion: current.ProposalVersion, ExpectedRecordVersion: current.Version,
+		IdempotencyKey: "fixture:" + current.ProposalID.String() + ":" + string(target),
+		Target:         target, Actor: "actor:synthetic-reviewer", LiteralReasonRef: "reason:synthetic:" + string(target),
+		EvidenceRefs: []string{"evidence:synthetic:" + string(target)},
+		OccurredAt:   testNow.Add(time.Duration(current.Version) * time.Minute),
+	}
+}
+
+func createFixture(t *testing.T, service *Service, idempotencyKey string) Proposal {
+	t.Helper()
+	result, err := service.Create(context.Background(), CreateCommand{
+		OrganizationID: testOrg, IdempotencyKey: idempotencyKey,
+		CreatedBy: "actor:synthetic-reviewer", Draft: fixtureDraft(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result.Proposal
+}
+
+func fixtureDraft() Draft {
+	return SyntheticCanaryDraft()
+}
+
+func fixedClock(at time.Time) Clock {
+	return func() time.Time { return at }
+}

--- a/internal/app/confenge/proposal/store.go
+++ b/internal/app/confenge/proposal/store.go
@@ -1,0 +1,175 @@
+package proposal
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+
+	"github.com/google/uuid"
+)
+
+var (
+	ErrNotFound            = errors.New("proposal not found")
+	ErrConflict            = errors.New("proposal optimistic concurrency conflict")
+	ErrIdempotencyConflict = errors.New("idempotency key reused with different command")
+	ErrAcceptedImmutable   = errors.New("accepted proposal version is immutable")
+	ErrIllegalTransition   = errors.New("illegal proposal transition")
+	ErrNoMaterialChange    = errors.New("revision has no material change")
+	ErrProposalExpired     = errors.New("proposal validity expired")
+	ErrOutOfOrder          = errors.New("proposal command occurred out of order")
+	ErrSyntheticMismatch   = errors.New("synthetic classification is immutable across proposal versions")
+)
+
+type ExpectedVersion struct {
+	ProposalVersion int
+	RecordVersion   int64
+}
+
+type Mutation struct {
+	OrganizationID  uuid.UUID
+	IdempotencyKey  string
+	PayloadHash     string
+	Expected        *ExpectedVersion
+	Insert          bool
+	NoProposalWrite bool
+	Proposal        Proposal
+	Events          []ProposalEvent
+	Handoff         *DeliveryOrderRequested
+}
+
+type CommandReceipt struct {
+	OrganizationID uuid.UUID               `json:"organization_id"`
+	IdempotencyKey string                  `json:"idempotency_key"`
+	PayloadHash    string                  `json:"payload_hash"`
+	Proposal       Proposal                `json:"proposal"`
+	Events         []ProposalEvent         `json:"events"`
+	Handoff        *DeliveryOrderRequested `json:"handoff,omitempty"`
+}
+
+type Store interface {
+	Get(context.Context, uuid.UUID, uuid.UUID, int) (*Proposal, error)
+	Latest(context.Context, uuid.UUID, uuid.UUID) (*Proposal, error)
+	Receipt(context.Context, uuid.UUID, string) (*CommandReceipt, error)
+	Apply(context.Context, Mutation) (CommandReceipt, bool, error)
+}
+
+type MemoryStore struct {
+	mu       sync.Mutex
+	rows     map[string]Proposal
+	receipts map[string]CommandReceipt
+}
+
+func NewMemoryStore() *MemoryStore {
+	return &MemoryStore{rows: make(map[string]Proposal), receipts: make(map[string]CommandReceipt)}
+}
+
+func proposalKey(orgID, proposalID uuid.UUID, version int) string {
+	return orgID.String() + "\x00" + proposalID.String() + fmt.Sprintf("\x00%d", version)
+}
+
+func receiptKey(orgID uuid.UUID, key string) string {
+	return orgID.String() + "\x00" + key
+}
+
+func (m *MemoryStore) Get(_ context.Context, orgID, proposalID uuid.UUID, version int) (*Proposal, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	row, ok := m.rows[proposalKey(orgID, proposalID, version)]
+	if !ok {
+		return nil, nil
+	}
+	return cloneProposal(row), nil
+}
+
+func (m *MemoryStore) Latest(_ context.Context, orgID, proposalID uuid.UUID) (*Proposal, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var latest *Proposal
+	for _, row := range m.rows {
+		if row.OrganizationID != orgID || row.ProposalID != proposalID {
+			continue
+		}
+		if latest == nil || row.ProposalVersion > latest.ProposalVersion {
+			latest = cloneProposal(row)
+		}
+	}
+	return latest, nil
+}
+
+func (m *MemoryStore) Receipt(_ context.Context, orgID uuid.UUID, key string) (*CommandReceipt, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	receipt, ok := m.receipts[receiptKey(orgID, key)]
+	if !ok {
+		return nil, nil
+	}
+	cloned := cloneReceipt(receipt)
+	return &cloned, nil
+}
+
+func (m *MemoryStore) Apply(_ context.Context, mutation Mutation) (CommandReceipt, bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	key := receiptKey(mutation.OrganizationID, mutation.IdempotencyKey)
+	if receipt, ok := m.receipts[key]; ok {
+		if receipt.PayloadHash != mutation.PayloadHash {
+			return CommandReceipt{}, false, ErrIdempotencyConflict
+		}
+		return cloneReceipt(receipt), true, nil
+	}
+	if mutation.Expected != nil {
+		current, ok := m.rows[proposalKey(mutation.OrganizationID, mutation.Proposal.ProposalID, mutation.Expected.ProposalVersion)]
+		if !ok || current.Version != mutation.Expected.RecordVersion {
+			return CommandReceipt{}, false, ErrConflict
+		}
+		if !mutation.Insert && !mutation.NoProposalWrite && current.DecisionState == StateAccepted {
+			return CommandReceipt{}, false, ErrAcceptedImmutable
+		}
+	}
+	rowKey := proposalKey(mutation.OrganizationID, mutation.Proposal.ProposalID, mutation.Proposal.ProposalVersion)
+	if _, exists := m.rows[rowKey]; exists && mutation.Insert {
+		return CommandReceipt{}, false, ErrConflict
+	}
+	if !mutation.NoProposalWrite {
+		m.rows[rowKey] = *cloneProposal(mutation.Proposal)
+	}
+	receipt := CommandReceipt{
+		OrganizationID: mutation.OrganizationID, IdempotencyKey: mutation.IdempotencyKey,
+		PayloadHash: mutation.PayloadHash, Proposal: mutation.Proposal,
+		Events: mutation.Events, Handoff: mutation.Handoff,
+	}
+	m.receipts[key] = cloneReceipt(receipt)
+	return receipt, false, nil
+}
+
+func cloneProposal(value Proposal) *Proposal {
+	value.Credits = cloneStrings(value.Credits)
+	value.Addons = cloneStrings(value.Addons)
+	value.Inputs = cloneStrings(value.Inputs)
+	value.Exclusions = cloneStrings(value.Exclusions)
+	value.EvidenceRefs = cloneStrings(value.EvidenceRefs)
+	return &value
+}
+
+func cloneReceipt(value CommandReceipt) CommandReceipt {
+	value.Proposal = *cloneProposal(value.Proposal)
+	value.Events = append([]ProposalEvent(nil), value.Events...)
+	for index := range value.Events {
+		value.Events[index].EvidenceRefs = cloneStrings(value.Events[index].EvidenceRefs)
+	}
+	if value.Handoff != nil {
+		handoff := *value.Handoff
+		handoff.EvidenceRefs = append([]string(nil), value.Handoff.EvidenceRefs...)
+		handoff.FinancialGate.EvidenceRefs = append([]string(nil), value.Handoff.FinancialGate.EvidenceRefs...)
+		value.Handoff = &handoff
+	}
+	return value
+}
+
+func cloneStrings(value []string) []string {
+	if value == nil {
+		return nil
+	}
+	return append(make([]string, 0, len(value)), value...)
+}

--- a/internal/infrastructure/db/migrations/000125_confenge_proposal_v1.down.sql
+++ b/internal/infrastructure/db/migrations/000125_confenge_proposal_v1.down.sql
@@ -1,0 +1,5 @@
+DROP TRIGGER IF EXISTS confenge_proposal_accepted_immutable_trigger ON confenge_proposals;
+DROP FUNCTION IF EXISTS confenge_proposal_accepted_immutable();
+DROP TABLE IF EXISTS confenge_proposal_command_receipts;
+DROP TABLE IF EXISTS confenge_proposal_events;
+DROP TABLE IF EXISTS confenge_proposals;

--- a/internal/infrastructure/db/migrations/000125_confenge_proposal_v1.up.sql
+++ b/internal/infrastructure/db/migrations/000125_confenge_proposal_v1.up.sql
@@ -76,7 +76,7 @@ CREATE TABLE IF NOT EXISTS confenge_proposal_command_receipts (
 CREATE OR REPLACE FUNCTION confenge_proposal_accepted_immutable()
 RETURNS trigger AS $$
 BEGIN
-    IF OLD.decision_state = 'ACCEPTED' AND NEW.payload IS DISTINCT FROM OLD.payload THEN
+    IF OLD.decision_state = 'ACCEPTED' AND NEW IS DISTINCT FROM OLD THEN
         RAISE EXCEPTION 'accepted proposal version is immutable';
     END IF;
     RETURN NEW;

--- a/internal/infrastructure/db/migrations/000125_confenge_proposal_v1.up.sql
+++ b/internal/infrastructure/db/migrations/000125_confenge_proposal_v1.up.sql
@@ -1,0 +1,93 @@
+-- Proposal v1 is Warmbly-owned commercial state. It does not create checkout,
+-- payment, billing, or delivery rows.
+
+CREATE TABLE IF NOT EXISTS confenge_proposals (
+    organization_id        uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    proposal_id            uuid NOT NULL,
+    proposal_version       integer NOT NULL,
+    account_id             text NOT NULL,
+    client_ref             text NOT NULL,
+    opportunity_id         text NOT NULL,
+    qco_id                 text NOT NULL,
+    deal_id                text,
+    correlation_id         text NOT NULL,
+    offer_id               text NOT NULL,
+    offer_version          text NOT NULL,
+    deliverable_id         text NOT NULL,
+    deliverable_version    text NOT NULL,
+    scope_version          text NOT NULL,
+    price_version          text NOT NULL,
+    terms_version          text NOT NULL,
+    decision_state         text NOT NULL,
+    accepted_snapshot_hash text,
+    synthetic              boolean NOT NULL DEFAULT false,
+    record_version         bigint NOT NULL,
+    valid_until            timestamptz NOT NULL,
+    payload                jsonb NOT NULL,
+    created_at             timestamptz NOT NULL,
+    updated_at             timestamptz NOT NULL,
+    PRIMARY KEY (organization_id, proposal_id, proposal_version),
+    CONSTRAINT confenge_proposals_version_check CHECK (proposal_version > 0 AND record_version > 0),
+    CONSTRAINT confenge_proposals_state_check CHECK (decision_state IN (
+        'DRAFT', 'PREPARED', 'APPROVED_TO_SEND', 'SENT', 'NEGOTIATING',
+        'ACCEPTED', 'REJECTED', 'EXPIRED', 'UNKNOWN'
+    )),
+    CONSTRAINT confenge_proposals_accept_hash_check CHECK (
+        (decision_state = 'ACCEPTED' AND accepted_snapshot_hash LIKE 'sha256:%') OR
+        (decision_state <> 'ACCEPTED' AND accepted_snapshot_hash IS NULL)
+    )
+);
+
+CREATE INDEX IF NOT EXISTS confenge_proposals_account_idx
+    ON confenge_proposals (organization_id, account_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS confenge_proposals_opportunity_idx
+    ON confenge_proposals (organization_id, opportunity_id, qco_id);
+
+CREATE TABLE IF NOT EXISTS confenge_proposal_events (
+    event_id          uuid PRIMARY KEY,
+    organization_id  uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    proposal_id       uuid NOT NULL,
+    proposal_version  integer NOT NULL,
+    event_type        text NOT NULL,
+    idempotency_key   text NOT NULL,
+    occurred_at       timestamptz NOT NULL,
+    payload           jsonb NOT NULL,
+    FOREIGN KEY (organization_id, proposal_id, proposal_version)
+        REFERENCES confenge_proposals (organization_id, proposal_id, proposal_version)
+        ON DELETE RESTRICT,
+    UNIQUE (organization_id, idempotency_key, event_type)
+);
+
+CREATE TABLE IF NOT EXISTS confenge_proposal_command_receipts (
+    organization_id  uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    idempotency_key   text NOT NULL,
+    payload_hash      text NOT NULL,
+    proposal_id       uuid NOT NULL,
+    proposal_version  integer NOT NULL,
+    payload           jsonb NOT NULL,
+    created_at        timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (organization_id, idempotency_key),
+    FOREIGN KEY (organization_id, proposal_id, proposal_version)
+        REFERENCES confenge_proposals (organization_id, proposal_id, proposal_version)
+        ON DELETE RESTRICT
+);
+
+CREATE OR REPLACE FUNCTION confenge_proposal_accepted_immutable()
+RETURNS trigger AS $$
+BEGIN
+    IF OLD.decision_state = 'ACCEPTED' AND NEW.payload IS DISTINCT FROM OLD.payload THEN
+        RAISE EXCEPTION 'accepted proposal version is immutable';
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER confenge_proposal_accepted_immutable_trigger
+BEFORE UPDATE ON confenge_proposals
+FOR EACH ROW EXECUTE FUNCTION confenge_proposal_accepted_immutable();
+
+COMMENT ON TABLE confenge_proposals IS
+'Warmbly-owned immutable proposal versions. Accepted rows may only be superseded by proposal_version + 1.';
+COMMENT ON TABLE confenge_proposal_events IS
+'Proposal state and reference-only delivery request events. No email or money side effects.';


### PR DESCRIPTION
## Summary

- adds the Warmbly-owned `confenge.proposal.v1` aggregate with append-only material revisions and the required commercial state machine
- persists typed proposal joins, immutable accepted snapshots, events and organization-scoped idempotency receipts in migration `000125`
- adds optimistic concurrency, expired/out-of-order rejection, stable accepted SHA-256 snapshots and replay-safe deterministic IDs
- emits an initial fail-closed `confenge.delivery_order_requested.v1` with `financial_gate.state=UNKNOWN`, then supports an explicitly gated `SYNTHETIC_VALID` or `AUTHORIZED` handoff for the same accepted business key
- commits byte-reproducible sanitized proposal and delivery fixtures plus a no-network canary command

## Adversarial corrections

- validates identifiers, evidence references and currency before persistence so service output cannot violate the published schemas
- derives a fixed-length SHA-256 delivery idempotency key instead of concatenating caller-controlled identifiers
- rejects a non-null source event on an `UNKNOWN` financial gate
- rejects delivery authorization timestamps older than the accepted proposal state
- makes the PostgreSQL accepted-row trigger reject any row mutation, not only payload changes
- compiles the JSON Schemas and validates both committed fixtures against them, with format assertions enabled

## Ownership and dependencies

Warmbly remains the sole owner of proposal and commercial decision state under `tjsasakifln/warmbly#47`. Governance remains the owner of readiness, capacity, Work Orders and delivery state. web-cfg remains the contracting producer. This PR does not add a CRM, checkout, billing ledger or Work Order.

Cross-repo contract producer/consumer work is intentionally compatible with `tjsasakifln/web-cfg#366` and the Governance vertical slice. Both shared schemas are byte-identical:

- `confenge.delivery_order_requested.v1`: `6464c124040bbadea9f719dcecacdcd3faa85febfa4610950f3791bb224fb0ba`
- `confenge.financial_gate.v1`: `5c0bdecf80fdfe1101ba1606f8a5462f035aae7c2a2b0d262af86de7b6d4a903`

The future real synthetic replacement is documented as the Warmbly-owned `confenge.financial_gate_reconciled.v1`. It is not implemented as a provider mutation in this PR.

## Verification

```sh
go test ./internal/app/confenge/proposal ./cmd/confenge-proposal-canary -count=1
go test -race ./internal/app/confenge/proposal ./cmd/confenge-proposal-canary -count=1
go mod tidy -diff
make lint
go run ./cmd/confenge-proposal-canary
go run ./cmd/confenge-proposal-canary --proposal
```

The contract test executes the canary three times, compares exact proposal/hash/event identities with committed goldens, compiles all four schemas, and validates both fixtures. Current head: `2b97512f`. Final handoff golden SHA-256: `5da63674063bc3e78f1bf610056107a6aa65f1052b69b6b613b224d558a9b87b`.

## Safety

- `synthetic=true`
- `received_revenue=false`
- no email transport
- no checkout or provider charge
- no real customer identity

Refs `tjsasakifln/warmbly#47`. The issue stays open for the broader live commercial loop.
