### PR TITLE
fix(confenge): report delegated flag accurately

### DIFF
--- a/deploy/confenge-vps/lib.sh
+++ b/deploy/confenge-vps/lib.sh
@@ -72,7 +72,7 @@ pass_fail() {
     printf '%-16s PASS\n' "$name"
   elif [[ "$ok" == "STALE" ]]; then
     printf '%-16s STALE\n' "$name"
-  elif [[ "$ok" == "ACTIVE" || "$ok" == "PAUSED" || "$ok" == "OFF" ]]; then
+  elif [[ "$ok" == "ACTIVE" || "$ok" == "PAUSED" || "$ok" == "OFF" || "$ok" == "ENABLED" ]]; then
     printf '%-16s %s\n' "$name" "$ok"
   else
     printf '%-16s FAIL\n' "$name"

--- a/deploy/confenge-vps/test_vps_pack.py
+++ b/deploy/confenge-vps/test_vps_pack.py
@@ -60,6 +60,23 @@ class TestConfengeVpsPack(unittest.TestCase):
         for m in re.finditer(r"CONFENGE_RATE_MAX_PER_HOUR=(\d+)", text):
             self.assertLessEqual(int(m.group(1)), 20)
 
+    def test_status_helper_renders_enabled_without_false_failure(self) -> None:
+        proc = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; pass_fail "DELEGATED FIRST TOUCH" ENABLED',
+                "status-test",
+                str(PACK / "lib.sh"),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertIn("DELEGATED FIRST TOUCH ENABLED", proc.stdout)
+        self.assertNotIn("FAIL", proc.stdout)
+
     def test_provider_vs_operational_documented(self) -> None:
         plane = (ROOT / "docs/confenge/vps-execution-plane.md").read_text(
             encoding="utf-8"


### PR DESCRIPTION
Corrige o falso-vermelho do status VPS: `pass_fail` agora trata `ENABLED` como estado explícito em vez de renderizar `FAIL`. A flag continua sendo apenas enablement; a autorização ativa permanece provada separadamente pelo CLI/audit store.

Prova local: 11 testes do deploy pack PASS; `bash -n` PASS.