### PR TITLE
feat: raise CONFENGE backend memory ceiling for fail-closed full authoritative feed ingestion

### DIFF
--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -167,9 +167,10 @@ services:
       resources:
         limits:
           cpus: "1.5"
-          memory: 1536M
+          # Full authoritative feeds are validated before the first DB mutation.
+          memory: ${CONFENGE_BACKEND_MEMORY_LIMIT:-5G}
         reservations:
-          memory: 384M
+          memory: ${CONFENGE_BACKEND_MEMORY_RESERVATION:-512M}
 
   consumer:
     <<: *restart


### PR DESCRIPTION
Raises the production backend cgroup ceiling so the existing validate-all-chunks-before-mutation feed contract can ingest the current full authoritative snapshot without an OOM restart. Deployment pack tests and shell syntax checks pass.