### PR TITLE
fix(confenge): preserve delegated source observation freshness

### DIFF
--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -166,9 +166,13 @@ func delegatedEntryFromCurrentState(acc *models.OutreachAccount, cand *models.Ou
 	if acc.ContractorRoleObservedAt != nil {
 		observedAt = acc.ContractorRoleObservedAt.UTC()
 	}
-	webObservedAt := cand.UpdatedAt.UTC()
-	if webObservedAt.IsZero() {
-		webObservedAt = observedAt
+	// SourceDate is the imported observation date for the public mailbox
+	// evidence. UpdatedAt is only the Warmbly row/import timestamp and must
+	// never refresh external evidence. Missing source provenance stays zero so
+	// delegatedWebSourceAllowed fails closed.
+	webObservedAt := time.Time{}
+	if cand.SourceDate != nil {
+		webObservedAt = cand.SourceDate.UTC()
 	}
 	key := "delegated-first-touch:" + acc.SourceRunID + ":" + acc.ID.String()
 	return DelegatedFirstTouchEntry{

--- a/internal/app/confenge/delegated_first_touch_worker_test.go
+++ b/internal/app/confenge/delegated_first_touch_worker_test.go
@@ -75,3 +75,26 @@ func TestDelegatedFirstTouchAutorunRequiresNarrowGateAndOperatorBinding(t *testi
 		t.Fatalf("valid delegated autorun config: %v", err)
 	}
 }
+
+func TestDelegatedEntryUsesSourceObservationDateNotImportTimestamp(t *testing.T) {
+	sourceDate := time.Date(2026, 8, 22, 0, 0, 0, 0, time.UTC)
+	importedAt := time.Date(2026, 8, 25, 20, 52, 0, 0, time.UTC)
+	acc := &models.OutreachAccount{
+		ID: uuid.New(), CNPJ14: "12345678000190", SourceRunID: "run-current",
+	}
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), AccountID: acc.ID, SourceURL: "https://empresa.example/contato",
+		SourceDate: &sourceDate, UpdatedAt: importedAt,
+	}
+
+	entry := delegatedEntryFromCurrentState(acc, cand, uuid.New(), "Assunto", "Corpo")
+	if got := entry.WebSources[0].ObservedAt; !got.Equal(sourceDate) {
+		t.Fatalf("web observation=%s want source date %s; import timestamp must not refresh evidence", got, sourceDate)
+	}
+
+	cand.SourceDate = nil
+	entry = delegatedEntryFromCurrentState(acc, cand, uuid.New(), "Assunto", "Corpo")
+	if got := entry.WebSources[0].ObservedAt; !got.IsZero() {
+		t.Fatalf("missing source date must fail closed, got observation %s", got)
+	}
+}


### PR DESCRIPTION
Fail closed on public mailbox evidence freshness in the persistent delegated first-touch worker.

- use the imported source_date as the public-source observation date
- never refresh evidence from the Warmbly row/import updated_at
- leave the observation zero when source provenance is absent so the existing gate returns HOLD
- add a regression test covering both import-timestamp drift and missing source date

Verification:
- focused internal/app/confenge tests pass under Go 1.25
- gofmt
- git diff --check

This is required before enabling CONFENGE_DELEGATED_FIRST_TOUCH_AUTORUN_ENABLED in production.