### PR TITLE
feat: bind CONFENGE rolling first-touch workers to the current authoritative feed run

### DIFF
--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -93,9 +93,11 @@ func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, err
 		SELECT t.id,t.account_id,t.contact_candidate_id
 		FROM outreach_touchpoints t
 		JOIN outreach_accounts a ON a.organization_id=t.organization_id AND a.id=t.account_id
+		JOIN outreach_feed_sync_state feed ON feed.organization_id=t.organization_id
 		WHERE t.organization_id=$1
 		  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
 		  AND t.state='NEEDS_REVIEW' AND t.contact_candidate_id IS NOT NULL
+		  AND feed.last_status='completed' AND a.source_run_id=feed.last_run_id
 		  AND NOT EXISTS (
 		    SELECT 1 FROM confenge_delegated_first_touch_decisions d
 		    WHERE d.organization_id=t.organization_id AND d.account_id=t.account_id

--- a/internal/app/confenge/draft_generation_worker.go
+++ b/internal/app/confenge/draft_generation_worker.go
@@ -79,16 +79,24 @@ func (s *service) ProcessDraftGenerationOnce(ctx context.Context) (bool, error) 
 		WITH next AS (
 			SELECT a.id
 			FROM outreach_accounts a
+			JOIN outreach_feed_sync_state feed
+			  ON feed.organization_id=a.organization_id
 			WHERE a.queue_state = 'READY_TO_GENERATE'
+			  AND feed.last_status='completed'
+			  AND a.source_run_id=feed.last_run_id
 			  AND (
 				SELECT count(*)
 				FROM outreach_touchpoints review_backlog
 				JOIN outreach_accounts review_account
 				  ON review_account.organization_id=review_backlog.organization_id
 				 AND review_account.id=review_backlog.account_id
+				JOIN outreach_feed_sync_state review_feed
+				  ON review_feed.organization_id=review_backlog.organization_id
 				WHERE review_backlog.organization_id=a.organization_id
 				  AND review_backlog.ordinal=1
 				  AND review_backlog.state='NEEDS_REVIEW'
+				  AND review_feed.last_status='completed'
+				  AND review_account.source_run_id=review_feed.last_run_id
 				  AND NOT EXISTS (
 					SELECT 1
 					FROM confenge_delegated_first_touch_decisions decision

--- a/internal/app/confenge/draft_generation_worker_pg_test.go
+++ b/internal/app/confenge/draft_generation_worker_pg_test.go
@@ -52,6 +52,13 @@ func TestDraftGenerationWorkerLeasesControlledRouteWithoutNamedPersonRollup(t *t
 
 	now := time.Now().UTC().Truncate(time.Millisecond)
 	repo := repository.NewOutreachRepository(pool)
+	if err = repo.UpsertFeedSyncState(ctx, &models.OutreachFeedSyncState{
+		OrganizationID: orgID, LastSnapshotHash: "controlled-draft-current-snapshot",
+		LastRunID: "controlled-draft-current", LastManifestURI: "file:///controlled-draft-current.json",
+		LastStatus: "completed", LastSuccessAt: &now, LastAttemptAt: &now, SourceGeneratedAt: &now,
+	}); err != nil {
+		t.Fatal(err)
+	}
 	account := &models.OutreachAccount{
 		OrganizationID:           orgID,
 		SourceLeadID:             "controlled-draft-lease",
@@ -108,6 +115,7 @@ func TestDraftGenerationWorkerLeasesControlledRouteWithoutNamedPersonRollup(t *t
 	staleAccount.ID = uuid.Nil
 	staleAccount.SourceLeadID = "controlled-draft-stale-route"
 	staleAccount.CNPJ14 = "76271049000347"
+	staleAccount.SourceRunID = "controlled-draft-stale"
 	staleAccount.QueueState = models.OutreachQueueReadyToGenerate
 	if _, err = repo.UpsertAccount(ctx, &staleAccount); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Bind both rolling draft preparation and delegated evaluation to the completed feed sync state and exact last_run_id. Stale NEEDS_REVIEW rows remain visible as exceptions but can no longer sit ahead of, consume capacity from, or be repeatedly evaluated instead of the current authoritative universe.

Verification:
- focused unit tests passed
- PostgreSQL integration regression passed against all current migrations
- gofmt clean
- golangci-lint passed