### PR TITLE
feat: complete delegated controlled-route gates

### DIFF
--- a/internal/app/confenge/contractor_role_contract_test.go
+++ b/internal/app/confenge/contractor_role_contract_test.go
@@ -1,11 +1,13 @@
 package confenge
 
 import (
+	"context"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/models"
 )
 
 func validFeedContractorRole(now time.Time) FeedContractorRole {
@@ -19,6 +21,50 @@ func validFeedContractorRole(now time.Time) FeedContractorRole {
 		BuyerCNPJ14: "99888777000166", BuyerIdentityRef: "cnpj:99888777000166",
 		RoleMatchMethod: "SUPPLIER_EXACT_CNPJ14", Confidence: "HIGH",
 	}
+}
+
+func TestContractorRoleAttestationMaterializesAsCurrentConfirmedEvidence(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	feed, err := ParseFeed(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	role := validFeedContractorRole(time.Now().UTC().Truncate(time.Second))
+	role.SourceRunID = feed.Source.RunID
+	role.SupplierCNPJ14 = feed.Leads[0].Company.CNPJ14
+	role.SupplierIdentityRef = "cnpj:" + role.SupplierCNPJ14
+	feed.Leads[0].ContractorRole = role
+	raw, err = jsonMarshal(feed)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	acc, err := repo.GetAccountByCNPJ(context.Background(), org, role.SupplierCNPJ14)
+	if err != nil || acc == nil {
+		t.Fatalf("typed supplier account missing: %v", err)
+	}
+	evidence, err := repo.ListEvidence(context.Background(), org, acc.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range evidence {
+		if evidence[i].SourceEvidenceID != "contract-1" {
+			continue
+		}
+		if evidence[i].EpistemicClass != models.OutreachEpistemicConfirmedFact ||
+			evidence[i].LastImportRunID == nil || *evidence[i].LastImportRunID != run.ID ||
+			evidence[i].ConsultedAt == nil {
+			t.Fatalf("contractor-role evidence lost current typed binding: %+v", evidence[i])
+		}
+		return
+	}
+	t.Fatal("typed contractor-role evidence was not materialized")
 }
 
 func TestContractorRoleProjectionPersistsWithoutRawPNCPReinterpretation(t *testing.T) {

--- a/internal/app/confenge/contractor_role_evidence_pg_test.go
+++ b/internal/app/confenge/contractor_role_evidence_pg_test.go
@@ -1,0 +1,87 @@
+package confenge
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func TestContractorRoleEvidenceMigrationBackfillsTypedAuthority(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, testPostgresDSN(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	actor, orgID, importID := uuid.New(), uuid.New(), uuid.New()
+	if _, err = pool.Exec(ctx, `INSERT INTO users(id,first_name,last_name,email) VALUES($1,'Evidence','Backfill',$2)`, actor, "evidence-"+actor.String()+"@example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO organizations(id,name,slug,owner_user_id) VALUES($1,'Evidence Backfill',$2,$3)`, orgID, "evidence-"+orgID.String(), actor); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_, _ = pool.Exec(context.Background(), `DELETE FROM organizations WHERE id=$1`, orgID)
+		_, _ = pool.Exec(context.Background(), `DELETE FROM users WHERE id=$1`, actor)
+	})
+	now := time.Now().UTC().Truncate(time.Second)
+	repo := repository.NewOutreachRepository(pool)
+	if err = repo.CreateImportRun(ctx, &models.OutreachImportRun{
+		ID: importID, OrganizationID: orgID, SourceSystem: "extra-cli", SourceRunID: "run-backfill",
+		SchemaVersion: models.OutreachSchemaV1, SnapshotHash: strings.Repeat("b", 64),
+		Status: models.OutreachImportCompleted, StartedAt: now, IdempotencyKey: "backfill-" + importID.String(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	hash := strings.Repeat("a", 64)
+	account := &models.OutreachAccount{
+		OrganizationID: orgID, SourceLeadID: "lead-backfill", CNPJ14: "11222333000144", CNPJRoot: "11222333",
+		RazaoSocial: "Empresa Backfill Ltda", QueueState: models.OutreachQueueNeedsReview,
+		SourceSystem: "extra-cli", SourceRunID: "run-backfill", LastImportRunID: &importID,
+		ContractorRoleStatus: ContractorRoleConfirmed, TargetPartyRole: "SUPPLIER",
+		ContractorRolePolicyVersion: DelegatedFirstTouchEvidenceV1,
+		ContractorRoleSource:        "extra-cli:v_contracts_canonical_v2", ContractorRoleSourceRunID: "run-backfill",
+		ContractorRoleObservedAt: &now, ContractorRoleEvidenceHash: hash,
+		ContractorRoleEvidenceReference: "extra-cli:v_contracts_canonical_v2:sha256:" + hash,
+		ContractorRoleEvidenceIDs:       []string{"contract-backfill"}, SupplierCNPJ14: "11222333000144",
+		SupplierIdentityRef: "cnpj:11222333000144", BuyerCNPJ14: "99888777000166",
+		BuyerIdentityRef: "cnpj:99888777000166", ContractorRoleMatchMethod: "SUPPLIER_EXACT_CNPJ14",
+		ContractorRoleConfidence: "HIGH", ContractorRoleReasonCodes: []string{"lead_matches_supplier", "lead_differs_from_buyer"},
+	}
+	if _, err = repo.UpsertAccount(ctx, account); err != nil {
+		t.Fatal(err)
+	}
+	_, file, _, _ := runtime.Caller(0)
+	migration := filepath.Join(filepath.Dir(file), "..", "..", "infrastructure", "db", "migrations", "000129_confenge_contractor_role_evidence.up.sql")
+	raw, err := os.ReadFile(migration)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, string(raw)); err != nil {
+		t.Fatal(err)
+	}
+	var evidenceType, epistemic, reliability string
+	var evidenceImport uuid.UUID
+	if err = pool.QueryRow(ctx, `
+		SELECT evidence_type,epistemic_class,reliability,last_import_run_id
+		FROM outreach_evidence
+		WHERE organization_id=$1 AND account_id=$2 AND source_evidence_id='contract-backfill'`, orgID, account.ID).
+		Scan(&evidenceType, &epistemic, &reliability, &evidenceImport); err != nil {
+		t.Fatal(err)
+	}
+	if evidenceType != "CONTRACTOR_ROLE_ATTESTATION" || epistemic != models.OutreachEpistemicConfirmedFact ||
+		reliability != "HIGH" || evidenceImport != importID {
+		t.Fatalf("typed evidence backfill drifted: type=%s epistemic=%s reliability=%s import=%s", evidenceType, epistemic, reliability, evidenceImport)
+	}
+}

--- a/internal/app/confenge/corpus_pipeline.go
+++ b/internal/app/confenge/corpus_pipeline.go
@@ -196,8 +196,9 @@ func feedLeadToModels(lead FeedLead) (*models.OutreachAccount, []models.Outreach
 		c := leadToCandidate(uuid.Nil, uuid.Nil, uuid.Nil, fc)
 		cands = append(cands, *c)
 	}
-	ev := make([]models.OutreachEvidence, 0, len(lead.Evidence))
-	for _, fe := range lead.Evidence {
+	leadEvidence := materializedLeadEvidence(lead)
+	ev := make([]models.OutreachEvidence, 0, len(leadEvidence))
+	for _, fe := range leadEvidence {
 		e := leadToEvidence(uuid.Nil, uuid.Nil, uuid.Nil, fe)
 		ev = append(ev, *e)
 	}

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -811,7 +811,7 @@ func (s *service) validateDelegatedEntry(ctx context.Context, orgID uuid.UUID, m
 	if !CandidateControlledEligible(cand) || !ControlledRouteAllowed(cand, nil) || !CandidateEnrollable(cand) {
 		add("recipient_not_controlled_eligible")
 	}
-	if !cand.EmailSendReady || strings.EqualFold(strings.TrimSpace(cand.EmailDerivation), "INFERRED") ||
+	if strings.EqualFold(strings.TrimSpace(cand.EmailDerivation), "INFERRED") ||
 		!strings.EqualFold(strings.TrimSpace(cand.ChannelEpistemic), "OBSERVED") ||
 		!strings.EqualFold(strings.TrimSpace(cand.RouteFreshness), "FRESH") ||
 		!strings.EqualFold(strings.TrimSpace(cand.OwnershipStatus), "COMPANY_OWNED") ||

--- a/internal/app/confenge/delegated_first_touch_adversarial_test.go
+++ b/internal/app/confenge/delegated_first_touch_adversarial_test.go
@@ -130,6 +130,29 @@ func TestDelegatedFirstTouchAttributedFreemailPasses(t *testing.T) {
 	}
 }
 
+func TestDelegatedFirstTouchControlledInstitutionalRouteDoesNotRequireNamedHumanReadiness(t *testing.T) {
+	f := newDelegatedValidationFixture(t, RouteClassGenericCompany, "contato@empresa.example")
+	f.candidate.EmailSendReady = false
+	f.candidate.VerificationStatus = models.OutreachVerifyInstitutionalGeneric
+	f.candidate.RecipientCommercialSuitability = "UNSUITABLE_HUMAN_EVIDENCE"
+	f.storeCandidate()
+	if blockers := f.validate(); len(blockers) != 0 {
+		t.Fatalf("typed controlled route inherited named-human readiness: %v", blockers)
+	}
+}
+
+func TestDelegatedFirstTouchUnclassifiedRecipientStillRequiresSendReadiness(t *testing.T) {
+	f := newDelegatedValidationFixture(t, RouteClassGenericCompany, "contato@empresa.example")
+	f.candidate.EmailSendReady = false
+	f.candidate.DiscoveryJSON = nil
+	f.candidate.VerificationStatus = models.OutreachVerifyCandidateUnverified
+	f.storeCandidate()
+	if blockers := f.validate(); !delegatedTestContains(blockers, "recipient_not_controlled_eligible") ||
+		!delegatedTestContains(blockers, "email_outbound_gate_failed") {
+		t.Fatalf("unclassified recipient without send readiness passed: %v", blockers)
+	}
+}
+
 func TestDelegatedFirstTouchFailsClosedOnRecipientComplianceAndSourceDrift(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -499,6 +499,7 @@ func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.Ou
 		}
 
 		if dryRun {
+			leadEvidence := materializedLeadEvidence(lead)
 			if existing == nil {
 				counts.Creates++
 			} else if existing.LastPayloadHash == contentHash {
@@ -513,13 +514,13 @@ func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.Ou
 				for _, e := range existingEv {
 					known[e.SourceEvidenceID] = true
 				}
-				for _, e := range lead.Evidence {
+				for _, e := range leadEvidence {
 					if e.ID != "" && !known[e.ID] {
 						counts.EvidenceAdded++
 					}
 				}
 			} else {
-				counts.EvidenceAdded += len(lead.Evidence)
+				counts.EvidenceAdded += len(leadEvidence)
 			}
 			counts.LeadsProcessed++
 			continue
@@ -550,7 +551,7 @@ func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.Ou
 				counts.Warnings++
 			}
 		}
-		for _, fe := range lead.Evidence {
+		for _, fe := range materializedLeadEvidence(lead) {
 			ev := leadToEvidence(orgID, acc.ID, run.ID, fe)
 			createdEv, err := s.repo.UpsertEvidence(ctx, ev)
 			if err != nil {
@@ -829,6 +830,40 @@ func leadToEvidence(orgID, accountID, runID uuid.UUID, fe FeedEvidence) *models.
 		ConsultedAt:      ParseDate(fe.ConsultedAt),
 		LastImportRunID:  &runID,
 	}
+}
+
+// materializedLeadEvidence projects the typed contractor_role attestation without reinterpreting raw contracts.
+func materializedLeadEvidence(lead FeedLead) []FeedEvidence {
+	out := append([]FeedEvidence(nil), lead.Evidence...)
+	role := lead.ContractorRole
+	if role.Status != ContractorRoleConfirmed || strings.ToUpper(strings.TrimSpace(role.TargetPartyRole)) != "SUPPLIER" {
+		return out
+	}
+	known := make(map[string]bool, len(out))
+	for i := range out {
+		if id := strings.TrimSpace(out[i].ID); id != "" {
+			known[id] = true
+		}
+	}
+	supplier := NormalizeCNPJ14(role.SupplierCNPJ14)
+	buyer := NormalizeCNPJ14(role.BuyerCNPJ14)
+	summary := fmt.Sprintf("extra-cli confirmou o CNPJ %s como CONTRATADA/FORNECEDORA, distinto do CNPJ contratante %s.", supplier, buyer)
+	for _, rawID := range role.EvidenceIDs {
+		id := strings.TrimSpace(rawID)
+		if id == "" || known[id] {
+			continue
+		}
+		known[id] = true
+		out = append(out, FeedEvidence{
+			ID: id, Type: "CONTRACTOR_ROLE_ATTESTATION",
+			Title:    "Papel de contratada confirmado pelo extra-cli",
+			Document: role.EvidenceReference, Date: role.ObservedAt,
+			Excerpt: summary, Synthesis: summary,
+			EpistemicClass: models.OutreachEpistemicConfirmedFact,
+			Reliability:    "HIGH", ConsultedAt: role.ObservedAt,
+		})
+	}
+	return out
 }
 
 func (s *service) GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, *errx.Error) {

--- a/internal/app/confenge/validators.go
+++ b/internal/app/confenge/validators.go
@@ -465,7 +465,9 @@ func ClassifyRisk(acc *models.OutreachAccount, cand *models.OutreachContactCandi
 			models.OutreachVerifyHumanConfirmed:
 			// Enrollable verified contacts stay GREEN-eligible.
 		case models.OutreachVerifyInstitutionalGeneric:
-			raise("YELLOW", "institutional_generic_recipient")
+			if !CandidateControlledEligible(cand) || !ControlledRouteAllowed(cand, nil) {
+				raise("YELLOW", "institutional_generic_recipient")
+			}
 		case models.OutreachVerifyPublicPossiblyStale:
 			raise("YELLOW", "possibly_stale_contact")
 		default:

--- a/internal/infrastructure/db/migrations/000129_confenge_contractor_role_evidence.down.sql
+++ b/internal/infrastructure/db/migrations/000129_confenge_contractor_role_evidence.down.sql
@@ -1,0 +1,2 @@
+DELETE FROM outreach_evidence
+WHERE evidence_type = 'CONTRACTOR_ROLE_ATTESTATION';

--- a/internal/infrastructure/db/migrations/000129_confenge_contractor_role_evidence.up.sql
+++ b/internal/infrastructure/db/migrations/000129_confenge_contractor_role_evidence.up.sql
@@ -1,0 +1,72 @@
+INSERT INTO outreach_evidence (
+    id,
+    organization_id,
+    account_id,
+    source_evidence_id,
+    evidence_type,
+    title,
+    document,
+    evidence_date,
+    excerpt,
+    synthesis,
+    epistemic_class,
+    reliability,
+    consulted_at,
+    last_import_run_id,
+    created_at,
+    updated_at
+)
+SELECT
+    gen_random_uuid(),
+    account.organization_id,
+    account.id,
+    trim(evidence.id),
+    'CONTRACTOR_ROLE_ATTESTATION',
+    'Papel de contratada confirmado pelo extra-cli',
+    left(account.contractor_role_evidence_reference, 500),
+    account.contractor_role_observed_at::date,
+    left(
+        'extra-cli confirmou o CNPJ ' || account.supplier_cnpj14 ||
+        ' como CONTRATADA/FORNECEDORA, distinto do CNPJ contratante ' || account.buyer_cnpj14 || '.',
+        4000
+    ),
+    left(
+        'extra-cli confirmou o CNPJ ' || account.supplier_cnpj14 ||
+        ' como CONTRATADA/FORNECEDORA, distinto do CNPJ contratante ' || account.buyer_cnpj14 || '.',
+        2000
+    ),
+    'CONFIRMED_FACT',
+    'HIGH',
+    account.contractor_role_observed_at::date,
+    account.last_import_run_id,
+    now(),
+    now()
+FROM outreach_accounts account
+CROSS JOIN LATERAL jsonb_array_elements_text(
+    CASE
+        WHEN jsonb_typeof(account.contractor_role_evidence_ids) = 'array'
+            THEN account.contractor_role_evidence_ids
+        ELSE '[]'::jsonb
+    END
+) AS evidence(id)
+WHERE account.contractor_role_status = 'CONTRACTOR_ROLE_CONFIRMED'
+  AND account.target_party_role = 'SUPPLIER'
+  AND account.contractor_role_policy_version = 'contract-party-role.v1'
+  AND account.contractor_role_source = 'extra-cli:v_contracts_canonical_v2'
+  AND account.contractor_role_source_run_id = account.source_run_id
+  AND account.contractor_role_observed_at IS NOT NULL
+  AND account.contractor_role_evidence_hash ~ '^[0-9a-f]{64}$'
+  AND account.contractor_role_evidence_reference =
+      'extra-cli:v_contracts_canonical_v2:sha256:' || account.contractor_role_evidence_hash
+  AND account.supplier_cnpj14 = account.cnpj14
+  AND account.supplier_identity_ref = 'cnpj:' || account.supplier_cnpj14
+  AND account.buyer_identity_ref = 'cnpj:' || account.buyer_cnpj14
+  AND account.supplier_cnpj14 ~ '^[0-9]{14}$'
+  AND account.buyer_cnpj14 ~ '^[0-9]{14}$'
+  AND left(account.supplier_cnpj14, 8) <> left(account.buyer_cnpj14, 8)
+  AND account.contractor_role_match_method = 'SUPPLIER_EXACT_CNPJ14'
+  AND account.contractor_role_confidence = 'HIGH'
+  AND account.contractor_role_reason_codes @> '["lead_matches_supplier","lead_differs_from_buyer"]'::jsonb
+  AND account.last_import_run_id IS NOT NULL
+  AND length(trim(evidence.id)) BETWEEN 1 AND 200
+ON CONFLICT (organization_id, account_id, source_evidence_id) DO NOTHING;


### PR DESCRIPTION
## Outcome

Completes the last fail-closed gates needed for `CFG-FIRST-TOUCH-ROUTING-v1` to authorize typed, attributed institutional routes without inheriting the legacy named-human `email_send_ready` bit.

- accepts controlled `ROLE_OR_DEPARTMENT`, `GENERIC_COMPANY`, and attributed `PUBLIC_COMPANY_FREEMAIL` only through the existing strict controlled-route contract;
- keeps inferred, stale, suppressed, unclassified, or unattributed recipients blocked;
- materializes typed `contractor_role` evidence IDs as current `CONFIRMED_FACT` rows without reinterpreting raw PNCP;
- backfills already imported strict supplier attestations through migration 129;
- preserves deterministic QA and GREEN risk requirements.

## Cross-repo authority

- Governance policy/authority: `tjsasakifln/Governance@d980cf2`, `CFG-FIRST-TOUCH-ROUTING-v1`, authority `tjsasakifln/Governance#129`.
- Typed supplier projection: `tjsasakifln/extra-cli@7101ae83da0c184fd8c5b3a5aba2072f662d7378` (`contract-party-role.v1`, `v_contracts_canonical_v2`).

## Verification

- `go test ./internal/app/confenge -count=1`
- `golangci-lint run --timeout=5m`
- fresh PostgreSQL 16, full migrations through 129
- PostgreSQL/unit regressions for typed evidence backfill/materialization and controlled institutional route

Transport remains paused; this PR does not send or enable autorun.
