### PR TITLE
fix: recover stale CONFENGE chunk imports

### DIFF
--- a/internal/app/confenge/feed_sync.go
+++ b/internal/app/confenge/feed_sync.go
@@ -30,6 +30,8 @@ type FeedSyncResult struct {
 	Counts         map[string]int `json:"counts,omitempty"`
 }
 
+const feedChunkStaleImportRecoveryAfter = 2 * time.Minute
+
 // outreachManifest is confenge.outreach.manifest.v1 (extra-cli export).
 type outreachManifest struct {
 	SchemaVersion string `json:"schema_version"`
@@ -235,8 +237,9 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 		chunkURI := joinURI(baseURI, ch.File)
 		idem := fmt.Sprintf("sync:%s:%s:%d", orgID, man.Source.SnapshotHash, ch.ChunkIndex)
 		importRun, xerr := s.ImportFromBytes(ctx, orgID, userID, chunkRaw, ImportOptions{
-			IdempotencyKey: idem,
-			SourceURI:      chunkURI,
+			IdempotencyKey:          idem,
+			SourceURI:               chunkURI,
+			resumeStaleRunningAfter: feedChunkStaleImportRecoveryAfter,
 		})
 		if xerr != nil {
 			partialErrs = append(partialErrs, fmt.Sprintf("%s import: %s", ch.File, xerr.Message))

--- a/internal/app/confenge/feed_sync_test.go
+++ b/internal/app/confenge/feed_sync_test.go
@@ -168,6 +168,90 @@ func TestSyncFeedManifestIdempotentAndHashFailClosed(t *testing.T) {
 	}
 }
 
+func TestSyncFeedManifestRecoversAbandonedChunkWithoutDuplicateRun(t *testing.T) {
+	dir := t.TempDir()
+	org := uuid.New()
+	r := newMemRepo()
+	svc := NewService(Config{
+		Enabled: true, DefaultDailyLimit: 100, MaxInitialEmailWords: 120,
+		RequireHumanApproval: true, MaxFeedPayloadBytes: 8 << 20,
+	}, r, nil).(*service)
+	generatedAt := time.Now().UTC().Add(-time.Minute).Truncate(time.Second).Format(time.RFC3339)
+	chunk := Feed{
+		SchemaVersion: models.OutreachSchemaV1,
+		GeneratedAt:   generatedAt,
+		Source: FeedSource{
+			System: "extra-cli", RunID: "run-stale-recovery", SnapshotHash: "snap-stale-recovery",
+			ProfileID: "p", ProfileVersion: "1",
+		},
+		Pagination: FeedPagination{HasMore: false},
+		Leads:      []FeedLead{sampleLeadWithActivation(70, ActivationActionableNow)},
+	}
+	chunkRaw, err := json.Marshal(chunk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chunkHash := sha256.Sum256(chunkRaw)
+	chunkName := "chunk_0000.json"
+	if err = os.WriteFile(filepath.Join(dir, chunkName), chunkRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := map[string]any{
+		"schema_version": "confenge.outreach.manifest.v1", "generated_at": generatedAt,
+		"source": map[string]any{
+			"system": "extra-cli", "run_id": "run-stale-recovery", "snapshot_hash": "snap-stale-recovery",
+			"profile_id": "p", "profile_version": "1",
+		},
+		"lead_count": 1, "chunk_count": 1,
+		"chunks": []map[string]any{{
+			"file": chunkName, "chunk_index": 0, "content_hash": hex.EncodeToString(chunkHash[:]), "lead_count": 1,
+		}},
+		"deactivations": []any{},
+	}
+	manifestRaw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err = os.WriteFile(manifestPath, manifestRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	staleAt := time.Now().UTC().Add(-10 * time.Minute)
+	stale := &models.OutreachImportRun{
+		ID: uuid.New(), OrganizationID: org, SourceSystem: "extra-cli",
+		SourceRunID: "run-stale-recovery", SchemaVersion: models.OutreachSchemaV1,
+		SnapshotHash: "snap-stale-recovery", PayloadHash: CanonicalPayloadHash(chunkRaw),
+		Status:         models.OutreachImportRunning,
+		IdempotencyKey: "sync:" + org.String() + ":snap-stale-recovery:0",
+		StartedAt:      staleAt, UpdatedAt: staleAt,
+	}
+	if err = r.CreateImportRun(context.Background(), stale); err != nil {
+		t.Fatal(err)
+	}
+
+	result, xerr := svc.SyncFeedManifest(context.Background(), org, nil, "file://"+manifestPath)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if result.Status != "completed" || result.ChunksImported != 1 {
+		t.Fatalf("stale chunk did not recover: %+v", result)
+	}
+	readback, err := r.GetImportRun(context.Background(), org, stale.ID)
+	if err != nil || readback == nil || readback.Status != models.OutreachImportCompleted ||
+		!containsString(readback.Warnings, "resumed_stale_running_import") {
+		t.Fatalf("recovery did not finalize original audit row: run=%+v err=%v", readback, err)
+	}
+	account, err := r.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if err != nil || account == nil || account.LastImportRunID == nil || *account.LastImportRunID != stale.ID {
+		t.Fatalf("recovery created a divergent import binding: account=%+v err=%v", account, err)
+	}
+	result, xerr = svc.SyncFeedManifest(context.Background(), org, nil, "file://"+manifestPath)
+	if xerr != nil || result.Status != "noop" || !result.SkippedSame {
+		t.Fatalf("recovered snapshot replay was not idempotent: result=%+v err=%v", result, xerr)
+	}
+}
+
 func TestLastAppliedSnapshotNeverPromotesPartialChunkRun(t *testing.T) {
 	orgID := uuid.New()
 	sourceTime := time.Now().UTC().Add(-time.Hour)

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -194,6 +194,11 @@ type ImportOptions struct {
 	DryRun         bool
 	IdempotencyKey string
 	SourceURI      string
+
+	// resumeStaleRunningAfter is set only by the manifest synchronizer, which
+	// holds the organization feed lock. Public imports keep the original
+	// idempotent readback behavior and never reclaim an in-flight run.
+	resumeStaleRunningAfter time.Duration
 }
 
 type ApprovalOptions struct {
@@ -314,7 +319,8 @@ func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *
 	}
 
 	payloadHash := CanonicalPayloadHash(raw)
-	var resumableRun *models.OutreachImportRun
+	var run *models.OutreachImportRun
+	resumedStaleRun := false
 	if opts.IdempotencyKey != "" {
 		existing, err := s.repo.GetImportRunByIdempotency(ctx, orgID, opts.IdempotencyKey)
 		if err != nil {
@@ -324,15 +330,14 @@ func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *
 			if existing.PayloadHash != payloadHash {
 				return nil, errx.New(errx.Conflict, "idempotency key already used with a different payload")
 			}
-			lastProgress := existing.UpdatedAt
-			if lastProgress.IsZero() {
-				lastProgress = existing.StartedAt
-			}
-			if existing.Status != models.OutreachImportRunning || time.Since(lastProgress) < 15*time.Minute {
+			// Completed and fresh in-flight runs retain ordinary idempotent
+			// readback. A manifest worker may reclaim only an abandoned running
+			// run after the lock from its prior process has disappeared.
+			if !staleRunningImport(existing, opts.resumeStaleRunningAfter, time.Now().UTC()) {
 				return existing, nil
 			}
-			// Reuse abandoned run identity so retries cannot duplicate the import.
-			resumableRun = existing
+			run = existing
+			resumedStaleRun = true
 		}
 	}
 
@@ -348,7 +353,6 @@ func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *
 		sourceGeneratedAt = &parsed
 	}
 
-	run := resumableRun
 	if run == nil {
 		run = &models.OutreachImportRun{
 			OrganizationID:    orgID,
@@ -369,29 +373,16 @@ func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *
 			Warnings:          nil,
 			Errors:            nil,
 		}
-	} else {
-		run.Status = models.OutreachImportRunning
-		run.FinishedAt = nil
-		run.Counts = models.OutreachImportCounts{}
-		run.Errors = nil
-		run.Warnings = nil
-		run.CreatedByUserID = userID
-		run.SourceURI = opts.SourceURI
-		run.SourceGeneratedAt = sourceGeneratedAt
-	}
-	if feed.Pagination.Cursor != nil {
-		run.CursorIn = *feed.Pagination.Cursor
-	}
-	if feed.Pagination.NextCursor != nil {
-		run.CursorOut = *feed.Pagination.NextCursor
-	}
+		if feed.Pagination.Cursor != nil {
+			run.CursorIn = *feed.Pagination.Cursor
+		}
+		if feed.Pagination.NextCursor != nil {
+			run.CursorOut = *feed.Pagination.NextCursor
+		}
 
-	if resumableRun == nil {
 		if err := s.repo.CreateImportRun(ctx, run); err != nil {
 			return nil, errx.New(errx.Internal, "failed to create import run: "+err.Error())
 		}
-	} else if err := s.repo.UpdateImportRun(ctx, run); err != nil {
-		return nil, errx.New(errx.Internal, "failed to resume import run: "+err.Error())
 	}
 
 	counts, leadErrs, warns := s.applyFeed(ctx, orgID, run, feed, run.DryRun)
@@ -399,6 +390,9 @@ func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *
 	applyOperatorSummary(&run.Counts, SummarizeOperatorProjection(feed))
 	run.Errors = leadErrs
 	run.Warnings = warns
+	if resumedStaleRun {
+		run.Warnings = appendUnique(run.Warnings, "resumed_stale_running_import")
+	}
 	now := time.Now().UTC()
 	run.FinishedAt = &now
 	if len(leadErrs) > 0 && counts.Creates+counts.Updates > 0 {
@@ -436,6 +430,17 @@ func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *
 		})
 	}
 	return run, nil
+}
+
+func staleRunningImport(run *models.OutreachImportRun, after time.Duration, now time.Time) bool {
+	if run == nil || run.Status != models.OutreachImportRunning || after <= 0 {
+		return false
+	}
+	lastActivity := run.UpdatedAt
+	if lastActivity.IsZero() {
+		lastActivity = run.StartedAt
+	}
+	return !lastActivity.IsZero() && lastActivity.Before(now.Add(-after))
 }
 
 func mustJSON(v any) []byte {

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -961,7 +961,7 @@ func TestImportIdempotencySameKeySamePayload(t *testing.T) {
 	}
 }
 
-func TestImportIdempotencyResumesStaleRunningRun(t *testing.T) {
+func TestImportIdempotencyDoesNotResumeStaleRunningPublicImport(t *testing.T) {
 	repo := newMemRepo()
 	svc := testSvc(repo)
 	org := uuid.New()
@@ -979,16 +979,16 @@ func TestImportIdempotencyResumesStaleRunningRun(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	resumed, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{IdempotencyKey: run.IdempotencyKey})
+	readback, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{IdempotencyKey: run.IdempotencyKey})
 	if xerr != nil {
 		t.Fatal(xerr)
 	}
-	if resumed.ID != run.ID || resumed.Status != models.OutreachImportCompleted {
-		t.Fatalf("expected stale run %s to complete in place, got %+v", run.ID, resumed)
+	if readback.ID != run.ID || readback.Status != models.OutreachImportRunning {
+		t.Fatalf("public import reclaimed stale run without the manifest lock: %+v", readback)
 	}
 	acc, err := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
-	if err != nil || acc == nil {
-		t.Fatalf("expected resumed import to apply the feed: account=%+v err=%v", acc, err)
+	if err != nil || acc != nil {
+		t.Fatalf("public stale readback mutated the feed: account=%+v err=%v", acc, err)
 	}
 }
 
@@ -1005,6 +1005,75 @@ func TestImportIdempotencyConflictOnDifferentPayload(t *testing.T) {
 	_, xerr := svc.ImportFromBytes(context.Background(), org, nil, other, opts)
 	if xerr == nil {
 		t.Fatal("expected conflict")
+	}
+}
+
+func TestImportIdempotencyRecoversOnlyStaleRunningManifestRun(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	key := "sync:" + org.String() + ":snapshot:0"
+	staleAt := time.Now().UTC().Add(-10 * time.Minute)
+	stale := &models.OutreachImportRun{
+		ID: uuid.New(), OrganizationID: org, SourceSystem: "extra-cli",
+		SourceRunID: "run-native-1", SchemaVersion: models.OutreachSchemaV1,
+		SnapshotHash: "snapshot", PayloadHash: CanonicalPayloadHash(raw),
+		Status: models.OutreachImportRunning, IdempotencyKey: key,
+		StartedAt: staleAt, UpdatedAt: staleAt,
+	}
+	if err := repo.CreateImportRun(context.Background(), stale); err != nil {
+		t.Fatal(err)
+	}
+
+	resumed, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{
+		IdempotencyKey: key, resumeStaleRunningAfter: time.Minute,
+	})
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if resumed.ID != stale.ID || resumed.Status != models.OutreachImportCompleted {
+		t.Fatalf("stale run was not resumed in place: %+v", resumed)
+	}
+	if !containsString(resumed.Warnings, "resumed_stale_running_import") {
+		t.Fatalf("stale recovery was not audited: %v", resumed.Warnings)
+	}
+	acc, err := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181")
+	if err != nil || acc == nil || acc.LastImportRunID == nil || *acc.LastImportRunID != stale.ID {
+		t.Fatalf("recovered import did not preserve run binding: account=%+v err=%v", acc, err)
+	}
+	again, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{
+		IdempotencyKey: key, resumeStaleRunningAfter: time.Minute,
+	})
+	if xerr != nil || again.ID != stale.ID || again.Status != models.OutreachImportCompleted {
+		t.Fatalf("completed recovery was not idempotent: run=%+v err=%v", again, xerr)
+	}
+}
+
+func TestImportIdempotencyDoesNotReclaimFreshRunningRun(t *testing.T) {
+	repo := newMemRepo()
+	svc := testSvc(repo)
+	org := uuid.New()
+	raw := mustReadFixture(t, "native_feed_v1.json")
+	key := "sync:" + org.String() + ":snapshot:0"
+	now := time.Now().UTC()
+	running := &models.OutreachImportRun{
+		ID: uuid.New(), OrganizationID: org, PayloadHash: CanonicalPayloadHash(raw),
+		Status: models.OutreachImportRunning, IdempotencyKey: key,
+		StartedAt: now, UpdatedAt: now,
+	}
+	if err := repo.CreateImportRun(context.Background(), running); err != nil {
+		t.Fatal(err)
+	}
+
+	readback, xerr := svc.ImportFromBytes(context.Background(), org, nil, raw, ImportOptions{
+		IdempotencyKey: key, resumeStaleRunningAfter: time.Hour,
+	})
+	if xerr != nil || readback.ID != running.ID || readback.Status != models.OutreachImportRunning {
+		t.Fatalf("fresh running import was reclaimed: run=%+v err=%v", readback, xerr)
+	}
+	if acc, err := repo.GetAccountByCNPJ(context.Background(), org, "11222333000181"); err != nil || acc != nil {
+		t.Fatalf("fresh running readback mutated feed: account=%+v err=%v", acc, err)
 	}
 }
 


### PR DESCRIPTION
## Live failure

The current authoritative feed repeatedly stopped at `chunk_3964.json` because the first backend process was recreated mid-chunk. The durable import row remained `running`; ordinary idempotent readback then returned that row forever and the manifest sync could never retry it.

Observed live run: `986fbc17-a713-4d46-b0b1-fdc4b68781e4`, source `run-7df61bfc4ea8a35b`, same payload/idempotency key, status `running` since 2026-08-25T22:01:16Z.

## Fix

- only the manifest synchronizer, already protected by the organization feed advisory lock, may reclaim a `running` chunk;
- requires the exact same idempotency key and payload hash;
- waits two minutes after the durable last activity timestamp;
- resumes in the same import-run ID and records `resumed_stale_running_import`;
- completed, failed, partial, hash-conflicting, fresh-running, and public import readbacks retain fail-closed/idempotent behavior;
- replay after recovery is a manifest `noop` with no duplicate run.

## Verification

- full `go test ./internal/app/confenge -count=1`
- `golangci-lint run --timeout=5m`
- focused stale/fresh/idempotency tests
- manifest-level abandoned chunk recovery and replay regression

This does not skip a chunk, weaken validation, or alter feed freshness.
