### PR TITLE
feat: bind delegated decision audit to the deployed release SHA

### DIFF
--- a/deploy/confenge-vps/lib.sh
+++ b/deploy/confenge-vps/lib.sh
@@ -42,6 +42,18 @@ load_vps_env() {
   export WARMBLY_RELEASE_SHA
 }
 
+bind_release_identity() {
+  local release_sha="${1:-${WARMBLY_RELEASE_SHA:-}}"
+  if [[ -z "$release_sha" || "$release_sha" == *[!0-9a-f]* ]] ||
+     { [[ ${#release_sha} -ne 40 ]] && [[ ${#release_sha} -ne 64 ]]; }; then
+    echo "REFUSE: immutable release SHA must be a full 40- or 64-character lowercase hex digest" >&2
+    return 3
+  fi
+  WARMBLY_RELEASE_SHA="$release_sha"
+  CONFENGE_REPOSITORY_SHA="$release_sha"
+  export WARMBLY_RELEASE_SHA CONFENGE_REPOSITORY_SHA
+}
+
 compose_cmd() {
   local root
   root="$(confenge_repo_root)"

--- a/deploy/confenge-vps/test_vps_pack.py
+++ b/deploy/confenge-vps/test_vps_pack.py
@@ -135,6 +135,57 @@ class TestConfengeVpsPack(unittest.TestCase):
         """A new checkout must not silently reuse the previous app images."""
         text = (PACK / "up.sh").read_text(encoding="utf-8")
         self.assertIn("compose_cmd up -d --build --remove-orphans", text)
+        env_load = text.index('set -a; . "$ENVF"; set +a')
+        identity_bind = text.index(
+            'bind_release_identity "$RELEASE_SHA_RESOLVED"'
+        )
+        compose_up = text.index("compose_cmd up -d --build --remove-orphans")
+        self.assertLess(env_load, identity_bind)
+        self.assertLess(identity_bind, compose_up)
+
+    def test_release_identity_binding_overrides_stale_audit_sha(self) -> None:
+        release_sha = "a" * 40
+        stale_sha = "b" * 40
+        proc = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; WARMBLY_RELEASE_SHA="$2"; '
+                'CONFENGE_REPOSITORY_SHA="$3"; '
+                'bind_release_identity "$WARMBLY_RELEASE_SHA"; '
+                'printf "%s\\n%s\\n" "$WARMBLY_RELEASE_SHA" "$CONFENGE_REPOSITORY_SHA"',
+                "release-identity-test",
+                str(PACK / "lib.sh"),
+                release_sha,
+                stale_sha,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        self.assertEqual(proc.stdout.splitlines(), [release_sha, release_sha])
+
+    def test_release_identity_binding_rejects_unproven_revision(self) -> None:
+        proc = subprocess.run(
+            [
+                "bash",
+                "-c",
+                'source "$1"; bind_release_identity local',
+                "release-identity-test",
+                str(PACK / "lib.sh"),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 3)
+        self.assertIn("REFUSE: immutable release SHA", proc.stderr)
+
+    def test_release_verifier_requires_decision_audit_sha(self) -> None:
+        text = (ROOT / "deploy/verify-release.sh").read_text(encoding="utf-8")
+        self.assertIn("CONFENGE_REPOSITORY_SHA", text)
+        self.assertIn('if [ "$auditsha" != "$EXPECTED" ]', text)
 
     def test_inbound_edge_nginx_allowlist_is_the_shipped_config(self) -> None:
         """Drive the real nginx files that install.sh copies onto the VPS."""

--- a/deploy/confenge-vps/up.sh
+++ b/deploy/confenge-vps/up.sh
@@ -7,10 +7,9 @@ source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 load_vps_env
 cd "$ROOT"
 
-# Captured before the private .env is sourced below, because that file can
-# still carry a WARMBLY_RELEASE_SHA written by an earlier deploy.
+# Captured before the private .env is sourced below because it can carry
+# release identity written by an earlier deploy.
 RELEASE_SHA_RESOLVED="${WARMBLY_RELEASE_SHA:-}"
-echo "Release SHA for this build: ${RELEASE_SHA_RESOLVED:-<unresolved>}"
 
 ENVF="${CONFENGE_VPS_ENV:-$ROOT/deploy/confenge-vps/.env}"
 if [[ ! -f "$ENVF" ]]; then
@@ -24,10 +23,10 @@ export COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}"
 # Fail closed on unsafe profile flips
 # shellcheck disable=SC1090
 set -a; . "$ENVF"; set +a
-# load_vps_env already resolved this from the caller or from the checkout, and
-# the line above may have put a previous deploy's value back. Restore it.
-WARMBLY_RELEASE_SHA="$RELEASE_SHA_RESOLVED"
-export WARMBLY_RELEASE_SHA
+# The checkout/caller release is authoritative for both image provenance and
+# the CONFENGE decision audit. A stale private env value cannot outrank it.
+bind_release_identity "$RELEASE_SHA_RESOLVED"
+echo "Release SHA for build and decision audit: $WARMBLY_RELEASE_SHA"
 
 if [[ "${CONFENGE_GREEN_AUTORUN_ENABLED:-false}" == "true" ]]; then
   echo "REFUSE: CONFENGE_GREEN_AUTORUN_ENABLED=true is not allowed on VPS execution plane bootstrap" >&2

--- a/deploy/verify-release.sh
+++ b/deploy/verify-release.sh
@@ -9,6 +9,14 @@ set -euo pipefail
 EXPECTED="${1:?usage: verify-release.sh <expected-sha> [container]}"
 CONTAINER="${2:-warmbly-confenge-backend-1}"
 
+if [ "${#EXPECTED}" -ne 40 ] && [ "${#EXPECTED}" -ne 64 ]; then
+  echo "FAIL: expected SHA must be a full 40- or 64-character digest"
+  exit 1
+fi
+case "$EXPECTED" in
+  *[!0-9a-f]*) echo "FAIL: expected SHA must be lowercase hexadecimal"; exit 1 ;;
+esac
+
 if ! docker inspect "$CONTAINER" >/dev/null 2>&1; then
   echo "FAIL: container ${CONTAINER} not found"
   exit 1
@@ -18,11 +26,13 @@ image_id=$(docker inspect "$CONTAINER" --format '{{.Image}}')
 running=$(docker inspect "$CONTAINER" --format '{{.State.Running}}')
 label=$(docker inspect "$image_id" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || echo "")
 envsha=$(docker inspect "$CONTAINER" --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^WARMBLY_RELEASE_SHA=//p' | head -1)
+auditsha=$(docker inspect "$CONTAINER" --format '{{range .Config.Env}}{{println .}}{{end}}' | sed -n 's/^CONFENGE_REPOSITORY_SHA=//p' | head -1)
 
 echo "container   : ${CONTAINER} (running=${running})"
 echo "image id    : ${image_id}"
 echo "image label : ${label:-<none>}"
-echo "runtime env : ${envsha:-<none>}"
+echo "release env : ${envsha:-<none>}"
+echo "audit env   : ${auditsha:-<none>}"
 
 if [ "$running" != "true" ]; then
   echo "-> FAIL: container is not running"
@@ -32,14 +42,20 @@ if [ -z "$label" ] || [ "$label" = "local" ]; then
   echo "-> FAIL: image carries no release revision label; the running code cannot be proven"
   exit 1
 fi
-case "$EXPECTED" in
-  "$label"*) ;;
-  *) echo "-> FAIL: image label ${label} does not match expected ${EXPECTED}"; exit 1 ;;
-esac
-if [ -n "$envsha" ]; then
-  case "$EXPECTED" in
-    "$envsha"*) ;;
-    *) echo "-> FAIL: runtime WARMBLY_RELEASE_SHA ${envsha} does not match expected ${EXPECTED}"; exit 1 ;;
-  esac
+if [ "$label" != "$EXPECTED" ]; then
+  echo "-> FAIL: image label ${label} does not match expected ${EXPECTED}"
+  exit 1
 fi
-echo "-> OK: repo ${EXPECTED} reconciles with image label and runtime"
+if [ -z "$envsha" ] || [ -z "$auditsha" ]; then
+  echo "-> FAIL: runtime release identity is incomplete"
+  exit 1
+fi
+if [ "$envsha" != "$EXPECTED" ]; then
+  echo "-> FAIL: runtime WARMBLY_RELEASE_SHA ${envsha} does not match expected ${EXPECTED}"
+  exit 1
+fi
+if [ "$auditsha" != "$EXPECTED" ]; then
+  echo "-> FAIL: CONFENGE_REPOSITORY_SHA ${auditsha} does not match expected ${EXPECTED}"
+  exit 1
+fi
+echo "-> OK: repo ${EXPECTED} reconciles with image label, runtime, and decision audit"


### PR DESCRIPTION
## Outcome

Binds CONFENGE_REPOSITORY_SHA to the same immutable checkout SHA used by WARMBLY_RELEASE_SHA during the existing VPS deploy. A stale private .env value can no longer be recorded in delegated first-touch decisions.

## Safety

- rejects missing, local, shortened, uppercase, or otherwise unproven release identities
- extends verify-release.sh to require both runtime identities and exact equality
- does not change send gates, scheduling, queues, or transport
- deploy remains fail-closed and starts with the kill switch engaged

## Verification

- python3 -m unittest deploy.confenge-vps.test_vps_pack
- deploy/confenge-vps/validate.sh
- bash -n on changed shell scripts
- git diff --check

Found by the dispatch-paused first-touch canary. The stale-SHA canary remains non-sendable and will be cancelled with preserved audit before the final canary.