### PR TITLE
feat: preserve release audit identity during CONFENGE compose maintenance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       site: ${{ steps.filter.outputs.site }}
       make: ${{ steps.filter.outputs.make }}
       ios: ${{ steps.filter.outputs.ios }}
+      confenge-vps: ${{ steps.filter.outputs.confenge-vps }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -59,6 +60,24 @@ jobs:
               - 'integrations/make/**'
             ios:
               - 'ios/**'
+            confenge-vps:
+              - 'deploy/confenge-vps/**'
+              - 'deploy/verify-release.sh'
+              - 'docker-compose.yml'
+
+  confenge-vps-pack:
+    name: CONFENGE VPS pack
+    needs: changes
+    if: needs.changes.outputs.confenge-vps == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run structural tests
+        run: python3 -m unittest deploy.confenge-vps.test_vps_pack
+
+      - name: Validate deployment pack
+        run: deploy/confenge-vps/validate.sh
 
   go-ci:
     name: Go CI
@@ -599,7 +618,7 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [changes, go-ci, web-ci, confenge-product-acceptance, admin-ci, site-ci, make-ci, rust-ci, elixir-ci, ios-ci, frontend-images, security]
+    needs: [changes, go-ci, web-ci, confenge-product-acceptance, confenge-vps-pack, admin-ci, site-ci, make-ci, rust-ci, elixir-ci, ios-ci, frontend-images, security]
     if: always()
     steps:
       - name: Check CI status
@@ -622,6 +641,13 @@ jobs:
               confenge_failed=1
             fi
           fi
+          vps_result="${{ needs.confenge-vps-pack.result }}"
+          vps_failed=0
+          if [[ "${{ needs.changes.outputs.confenge-vps }}" == "true" ]] && \
+             [[ "$vps_result" != "success" ]]; then
+            echo "CONFENGE VPS pack did not pass (result=$vps_result)"
+            vps_failed=1
+          fi
           if [[ "${{ needs.go-ci.result }}" == "failure" ]] || \
              [[ "${{ needs.web-ci.result }}" == "failure" ]] || \
              [[ "${{ needs.admin-ci.result }}" == "failure" ]] || \
@@ -632,8 +658,9 @@ jobs:
              [[ "${{ needs.elixir-ci.result }}" == "failure" ]] || \
              [[ "${{ needs.ios-ci.result }}" == "failure" ]] || \
              [[ "${{ needs.security.result }}" == "failure" ]] || \
-             [[ "$confenge_failed" -eq 1 ]]; then
-            echo "CI failed (confenge=$confenge_result)"
+             [[ "$confenge_failed" -eq 1 ]] || \
+             [[ "$vps_failed" -eq 1 ]]; then
+            echo "CI failed (confenge=$confenge_result vps=$vps_result)"
             exit 1
           fi
-          echo "CI passed (confenge=$confenge_result)"
+          echo "CI passed (confenge=$confenge_result vps=$vps_result)"

--- a/deploy/confenge-vps/lib.sh
+++ b/deploy/confenge-vps/lib.sh
@@ -57,6 +57,8 @@ bind_release_identity() {
 compose_cmd() {
   local root
   root="$(confenge_repo_root)"
+  # Compose maintenance must carry the same immutable decision-audit identity as a full deploy.
+  bind_release_identity "${WARMBLY_RELEASE_SHA:-}"
   local envf="${CONFENGE_VPS_ENV:-$root/deploy/confenge-vps/.env}"
   local -a args
   args=(docker compose)

--- a/deploy/confenge-vps/test_vps_pack.py
+++ b/deploy/confenge-vps/test_vps_pack.py
@@ -182,6 +182,17 @@ class TestConfengeVpsPack(unittest.TestCase):
         self.assertEqual(proc.returncode, 3)
         self.assertIn("REFUSE: immutable release SHA", proc.stderr)
 
+    def test_compose_maintenance_rebinds_decision_audit_sha(self) -> None:
+        text = (PACK / "lib.sh").read_text(encoding="utf-8")
+        compose_body = text.split("compose_cmd() {", maxsplit=1)[1].split(
+            "\n}", maxsplit=1
+        )[0]
+        identity_bind = compose_body.index(
+            'bind_release_identity "${WARMBLY_RELEASE_SHA:-}"'
+        )
+        docker_compose = compose_body.index("args=(docker compose)")
+        self.assertLess(identity_bind, docker_compose)
+
     def test_release_verifier_requires_decision_audit_sha(self) -> None:
         text = (ROOT / "deploy/verify-release.sh").read_text(encoding="utf-8")
         self.assertIn("CONFENGE_REPOSITORY_SHA", text)


### PR DESCRIPTION
## Outcome

Extends the immutable release/audit SHA binding from the full VPS deploy to every existing compose maintenance operation. Recreating only the backend can no longer restore a stale CONFENGE_REPOSITORY_SHA from the private env file.

## CI gate

Adds a path-scoped CONFENGE VPS pack job. Deployment changes now run the shipped structural suite and validate.sh in GitHub CI, and the aggregate check fails if that job is skipped or fails when applicable.

## Scope

No send, queue, scheduler, policy, or transport behavior changes.

## Verification

- python3 -m unittest deploy.confenge-vps.test_vps_pack (16/16)
- deploy/confenge-vps/validate.sh
- bash -n deploy/confenge-vps/lib.sh
- YAML parse and git diff --check

Follow-up hardening found during adversarial review of #187.