### PR TITLE
feat: keep delegated first-touch autorun advancing past historical idempotency bindings

### DIFF
--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -255,6 +255,85 @@ func TestDelegatedFirstTouchApprovesQueuesAuditsAndReplaysOncePostgres(t *testin
 	}
 }
 
+func TestDelegatedFirstTouchWorkerSkipsMismatchedDecisionBoundByCurrentIdempotencyKey(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	entry := f.manifest.Entries[0]
+	firstAccount, err := f.repo.GetAccount(f.ctx, f.orgID, entry.AccountID)
+	if err != nil || firstAccount == nil {
+		t.Fatalf("first account unavailable: account=%+v err=%v", firstAccount, err)
+	}
+	firstCandidate, err := f.repo.GetCandidate(f.ctx, f.orgID, entry.ContactCandidateID)
+	if err != nil || firstCandidate == nil {
+		t.Fatalf("first candidate unavailable: candidate=%+v err=%v", firstCandidate, err)
+	}
+	firstTouchpoint, _, err := f.svc.prepareDelegatedTouchpoint(f.ctx, f.orgID, firstAccount, firstCandidate, f.manifest, entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstTouchpoint.DueAt = time.Now().UTC().Add(-2 * time.Hour)
+	if err := f.repo.UpdateTouchpoint(f.ctx, firstTouchpoint); err != nil {
+		t.Fatal(err)
+	}
+
+	// Reproduce the production drift: the durable key names the current run,
+	// while a historical bad row carries an older evidence_source_run_id.
+	staleManifest := f.manifest
+	staleManifest.BatchID = "stale-key-" + uuid.NewString()
+	staleManifest.SourceRunID = "run-stale-evidence"
+	staleManifest.SourceSnapshotHash = strings.Repeat("e", 64)
+	staleEntry := entry
+	staleEntry.IdempotencyKey = delegatedFirstTouchIdempotencyPrefix + f.manifest.SourceRunID + ":" + firstAccount.ID.String()
+	if err := f.svc.reserveDelegatedBatch(f.ctx, f.orgID, staleManifest, manifestHash(staleManifest)); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.svc.persistDelegatedHold(f.ctx, f.orgID, staleManifest, staleEntry, []string{"historical_source_binding_drift"}); err != nil {
+		t.Fatal(err)
+	}
+
+	secondAccount := *firstAccount
+	secondAccount.ID = uuid.New()
+	secondAccount.SourceLeadID = "lead-delegated-next"
+	secondAccount.CNPJ14 = "22333444000155"
+	secondAccount.CNPJRoot = "22333444"
+	secondAccount.SupplierCNPJ14 = secondAccount.CNPJ14
+	secondAccount.SupplierIdentityRef = "cnpj:" + secondAccount.CNPJ14
+	if _, err := f.repo.UpsertAccount(f.ctx, &secondAccount); err != nil {
+		t.Fatal(err)
+	}
+	secondCandidate := *firstCandidate
+	secondCandidate.ID = uuid.New()
+	secondCandidate.AccountID = secondAccount.ID
+	secondCandidate.SourceContactID = "route-delegated-next"
+	secondCandidate.Email = "next@empresa.example"
+	if _, err := f.repo.UpsertCandidate(f.ctx, &secondCandidate); err != nil {
+		t.Fatal(err)
+	}
+	secondEntry := entry
+	secondEntry.IdempotencyKey = delegatedFirstTouchIdempotencyPrefix + f.manifest.SourceRunID + ":" + secondAccount.ID.String()
+	secondEntry.AccountID = secondAccount.ID
+	secondEntry.ContactCandidateID = secondCandidate.ID
+	secondEntry.CNPJ14 = secondAccount.CNPJ14
+	secondEntry.SupplierCNPJ14 = secondAccount.SupplierCNPJ14
+	secondEntry.SupplierIdentityRef = secondAccount.SupplierIdentityRef
+	secondEntry.Recipient = secondCandidate.Email
+	secondTouchpoint, _, err := f.svc.prepareDelegatedTouchpoint(f.ctx, f.orgID, &secondAccount, &secondCandidate, f.manifest, secondEntry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondTouchpoint.DueAt = time.Now().UTC().Add(-time.Hour)
+	if err := f.repo.UpdateTouchpoint(f.ctx, secondTouchpoint); err != nil {
+		t.Fatal(err)
+	}
+
+	touchpointID, accountID, candidateID, err := f.svc.nextDelegatedFirstTouchCandidate(f.ctx, f.orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if touchpointID != secondTouchpoint.ID || accountID != secondAccount.ID || candidateID != secondCandidate.ID {
+		t.Fatalf("historical key mismatch blocked rolling selection: touchpoint=%s account=%s candidate=%s", touchpointID, accountID, candidateID)
+	}
+}
+
 func TestDelegatedFirstTouchPartialBatchFailureDoesNotBlockEligibleItemPostgres(t *testing.T) {
 	f := newDelegatedPGFixture(t)
 	invalid := f.manifest.Entries[0]

--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -14,7 +14,10 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
-const delegatedFirstTouchMaxBurst = 100
+const (
+	delegatedFirstTouchMaxBurst          = 100
+	delegatedFirstTouchIdempotencyPrefix = "delegated-first-touch:"
+)
 
 type delegatedFirstTouchProcessor interface {
 	ProcessDelegatedFirstTouchOnce(context.Context) (bool, error)
@@ -88,23 +91,7 @@ func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, err
 		return false, err
 	}
 
-	var touchpointID, accountID, candidateID uuid.UUID
-	err = s.delegatedDB.QueryRow(ctx, `
-		SELECT t.id,t.account_id,t.contact_candidate_id
-		FROM outreach_touchpoints t
-		JOIN outreach_accounts a ON a.organization_id=t.organization_id AND a.id=t.account_id
-		JOIN outreach_feed_sync_state feed ON feed.organization_id=t.organization_id
-		WHERE t.organization_id=$1
-		  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
-		  AND t.state='NEEDS_REVIEW' AND t.contact_candidate_id IS NOT NULL
-		  AND feed.last_status='completed' AND a.source_run_id=feed.last_run_id
-		  AND NOT EXISTS (
-		    SELECT 1 FROM confenge_delegated_first_touch_decisions d
-		    WHERE d.organization_id=t.organization_id AND d.account_id=t.account_id
-		      AND d.evidence_source_run_id=a.source_run_id
-		  )
-		ORDER BY t.due_at,t.created_at,t.id
-		LIMIT 1`, orgID).Scan(&touchpointID, &accountID, &candidateID)
+	touchpointID, accountID, candidateID, err := s.nextDelegatedFirstTouchCandidate(ctx, orgID)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return false, nil
@@ -163,6 +150,28 @@ func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, err
 	return report != nil && len(report.Items) == 1, nil
 }
 
+func (s *service) nextDelegatedFirstTouchCandidate(ctx context.Context, orgID uuid.UUID) (uuid.UUID, uuid.UUID, uuid.UUID, error) {
+	var touchpointID, accountID, candidateID uuid.UUID
+	err := s.delegatedDB.QueryRow(ctx, `
+		SELECT t.id,t.account_id,t.contact_candidate_id
+		FROM outreach_touchpoints t
+		JOIN outreach_accounts a ON a.organization_id=t.organization_id AND a.id=t.account_id
+		JOIN outreach_feed_sync_state feed ON feed.organization_id=t.organization_id
+		WHERE t.organization_id=$1
+		  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+		  AND t.state='NEEDS_REVIEW' AND t.contact_candidate_id IS NOT NULL
+		  AND feed.last_status='completed' AND a.source_run_id=feed.last_run_id
+		  AND NOT EXISTS (
+		    SELECT 1 FROM confenge_delegated_first_touch_decisions d
+		    WHERE d.organization_id=t.organization_id AND d.account_id=t.account_id
+		      AND (d.evidence_source_run_id=a.source_run_id
+		        OR d.idempotency_key=$2 || a.source_run_id || ':' || a.id::text)
+		  )
+		ORDER BY t.due_at,t.created_at,t.id
+		LIMIT 1`, orgID, delegatedFirstTouchIdempotencyPrefix).Scan(&touchpointID, &accountID, &candidateID)
+	return touchpointID, accountID, candidateID, err
+}
+
 func delegatedEntryFromCurrentState(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, touchpointID uuid.UUID, subject, body string) DelegatedFirstTouchEntry {
 	observedAt := time.Time{}
 	if acc.ContractorRoleObservedAt != nil {
@@ -176,7 +185,7 @@ func delegatedEntryFromCurrentState(acc *models.OutreachAccount, cand *models.Ou
 	if cand.SourceDate != nil {
 		webObservedAt = cand.SourceDate.UTC()
 	}
-	key := "delegated-first-touch:" + acc.SourceRunID + ":" + acc.ID.String()
+	key := delegatedFirstTouchIdempotencyPrefix + acc.SourceRunID + ":" + acc.ID.String()
 	return DelegatedFirstTouchEntry{
 		IdempotencyKey: key, CorrelationID: "touchpoint:" + touchpointID.String(),
 		AccountID: acc.ID, ContactCandidateID: cand.ID, CNPJ14: acc.CNPJ14,


### PR DESCRIPTION
Fix the rolling delegated first-touch selector so a historical decision bound to the current durable idempotency key is treated as already evaluated even when its stored evidence source run drifted.

This preserves fail-closed replay semantics and prevents the autorun worker from repeatedly producing PARTIAL batches for the same account.

Verification:
- focused PostgreSQL regression suite against all migrations
- golangci-lint v1.64.8 built with Go 1.25
- gofmt and git diff checks