### PR TITLE
feat: add a fail-closed one-shot delegated first-touch canary command

### DIFF
--- a/cmd/confenge/first_touch.go
+++ b/cmd/confenge/first_touch.go
@@ -21,7 +21,7 @@ import (
 
 func cmdFirstTouch(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "first-touch requires authorize-policy, seal, apply, or status")
+		fmt.Fprintln(os.Stderr, "first-touch requires authorize-policy, seal, apply, status, or canary-queue-once")
 		return 2
 	}
 	switch args[0] {
@@ -33,10 +33,89 @@ func cmdFirstTouch(args []string) int {
 		return cmdFirstTouchApply(args[1:])
 	case "status":
 		return cmdFirstTouchStatus(args[1:])
+	case "canary-queue-once":
+		return cmdFirstTouchCanaryQueueOnce(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown first-touch command %q\n", args[0])
 		return 2
 	}
+}
+
+func validateFirstTouchCanaryConfig(cfg confenge.Config, orgID uuid.UUID, confirm, expectedSHA string) error {
+	if confirm != confenge.DelegatedFirstTouchPolicyV1 {
+		return fmt.Errorf("confirmation must equal %s", confenge.DelegatedFirstTouchPolicyV1)
+	}
+	if orgID == uuid.Nil || cfg.OperatorOrgID != orgID {
+		return fmt.Errorf("organization must match the configured operator organization")
+	}
+	if !cfg.DelegatedFirstTouchAutorunEnabled {
+		return fmt.Errorf("%s must be true for this one-shot evaluator", confenge.EnvDelegatedFirstTouchAutorun)
+	}
+	if !cfg.SendingPaused {
+		return fmt.Errorf("%s must be true for a zero-SMTP canary", confenge.EnvSendingPaused)
+	}
+	expectedSHA = strings.TrimSpace(expectedSHA)
+	if (len(expectedSHA) != 40 && len(expectedSHA) != 64) || strings.ToLower(expectedSHA) != expectedSHA {
+		return fmt.Errorf("expected release SHA must be a full lowercase digest")
+	}
+	for _, r := range expectedSHA {
+		if !strings.ContainsRune("0123456789abcdef", r) {
+			return fmt.Errorf("expected release SHA must be a full lowercase digest")
+		}
+	}
+	if cfg.RepositorySHA != expectedSHA {
+		return fmt.Errorf("runtime release SHA does not match the expected release")
+	}
+	return nil
+}
+
+func cmdFirstTouchCanaryQueueOnce(args []string) int {
+	fs := flag.NewFlagSet("first-touch canary-queue-once", flag.ContinueOnError)
+	orgRaw := fs.String("org-id", "", "operator organization UUID")
+	confirm := fs.String("confirm", "", "must equal CFG-FIRST-TOUCH-ROUTING-v1")
+	expectedSHA := fs.String("expected-release-sha", "", "exact deployed release SHA")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	orgID, err := uuid.Parse(strings.TrimSpace(*orgRaw))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "--org-id is required")
+		return 2
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	pool, svc, cfg, err := openFirstTouchService(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "first-touch canary: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+	if err := validateFirstTouchCanaryConfig(cfg, orgID, *confirm, *expectedSHA); err != nil {
+		fmt.Fprintf(os.Stderr, "first-touch canary: %v\n", err)
+		return 2
+	}
+	if !confenge.FileKillSwitchActive() {
+		fmt.Fprintln(os.Stderr, "first-touch canary: file kill switch must be engaged")
+		return 2
+	}
+	processed, err := svc.ProcessDelegatedFirstTouchOnce(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "first-touch canary: %v\n", err)
+		return 1
+	}
+	status := "IDLE"
+	if processed {
+		status = "PROCESSED"
+	}
+	printJSON(map[string]any{
+		"status": status, "policy_version": confenge.DelegatedFirstTouchPolicyV1,
+		"runtime_release_sha": cfg.RepositorySHA, "sending_paused": cfg.SendingPaused,
+		"kill_switch_engaged": true,
+	})
+	if !processed {
+		return 3
+	}
+	return 0
 }
 
 func cmdFirstTouchSeal(args []string) int {

--- a/cmd/confenge/first_touch_canary_test.go
+++ b/cmd/confenge/first_touch_canary_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge"
+)
+
+func TestValidateFirstTouchCanaryConfigFailsClosed(t *testing.T) {
+	orgID := uuid.New()
+	sha := strings.Repeat("a", 40)
+	valid := confenge.Config{
+		OperatorOrgID: orgID, DelegatedFirstTouchAutorunEnabled: true,
+		SendingPaused: true, RepositorySHA: sha,
+	}
+	if err := validateFirstTouchCanaryConfig(valid, orgID, confenge.DelegatedFirstTouchPolicyV1, sha); err != nil {
+		t.Fatalf("valid canary config: %v", err)
+	}
+
+	tests := []struct {
+		name, confirm, expectedSHA string
+		orgID                      uuid.UUID
+		mutate                     func(*confenge.Config)
+	}{
+		{name: "wrong policy confirmation", confirm: "HUMAN_APPROVE", expectedSHA: sha, orgID: orgID},
+		{name: "wrong organization", confirm: confenge.DelegatedFirstTouchPolicyV1, expectedSHA: sha, orgID: uuid.New()},
+		{name: "autorun disabled", confirm: confenge.DelegatedFirstTouchPolicyV1, expectedSHA: sha, orgID: orgID, mutate: func(c *confenge.Config) { c.DelegatedFirstTouchAutorunEnabled = false }},
+		{name: "sending open", confirm: confenge.DelegatedFirstTouchPolicyV1, expectedSHA: sha, orgID: orgID, mutate: func(c *confenge.Config) { c.SendingPaused = false }},
+		{name: "short release", confirm: confenge.DelegatedFirstTouchPolicyV1, expectedSHA: "abc123", orgID: orgID},
+		{name: "non-hex release", confirm: confenge.DelegatedFirstTouchPolicyV1, expectedSHA: strings.Repeat("z", 40), orgID: orgID},
+		{name: "release drift", confirm: confenge.DelegatedFirstTouchPolicyV1, expectedSHA: strings.Repeat("b", 40), orgID: orgID},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := valid
+			if tt.mutate != nil {
+				tt.mutate(&cfg)
+			}
+			if err := validateFirstTouchCanaryConfig(cfg, tt.orgID, tt.confirm, tt.expectedSHA); err == nil {
+				t.Fatal("unsafe canary config passed")
+			}
+		})
+	}
+}

--- a/cmd/confenge/main.go
+++ b/cmd/confenge/main.go
@@ -87,7 +87,7 @@ Usage:
   confenge cohort-auth create|show|revoke [flags]
   confenge editorial issues list|sync [flags]
   confenge editorial guidelines list|propose|activate [flags]
-  confenge first-touch authorize-policy|seal|apply|status [flags]
+  confenge first-touch authorize-policy|seal|apply|status|canary-queue-once [flags]
 
 Env: PRIMARY_DB, CONFENGE_*, REDIS, NATS_URL (see .env.confenge.example).
   CONFENGE_REPOSITORY_SHA, CONFENGE_FEED_SCHEMA_VERSION, CONFENGE_EVIDENCE_VERSION


### PR DESCRIPTION
## Outcome

Adds `confenge first-touch canary-queue-once`, a synchronous operator command over the existing `ProcessDelegatedFirstTouchOnce` unit. It exists to prove one policy evaluation and canonical queue handoff without leaving the background autorun enabled.

## Hard preconditions

- exact `CFG-FIRST-TOUCH-ROUTING-v1` confirmation
- configured operator organization match
- exact full deployed release SHA match
- delegated evaluator enabled only in the command process
- `CONFENGE_SENDING_PAUSED=true`
- file kill switch engaged

The command does not create a queue, scheduler, CRM, datastore, or approval path. It calls the same worker method and returns `PROCESSED` or fail-closed `IDLE`.

## Verification

- `go test ./cmd/confenge`
- gofmt clean
- git diff --check
- seven adversarial config cases: false policy, org mismatch, autorun off, sending open, short/non-hex SHA, and release drift

The production canary remains zero-SMTP; current dispatch and kill-switch controls stay paused.