### PR TITLE
feat: allow CONFENGE rolling campaigns to start from a read-back delegated queue

### DIFF
--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -10,19 +10,21 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	infrastructuredb "github.com/warmbly/warmbly/internal/infrastructure/db"
 	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
 type delegatedPGFixture struct {
-	ctx      context.Context
-	pool     *pgxpool.Pool
-	repo     repository.OutreachRepository
-	svc      *service
-	orgID    uuid.UUID
-	actorID  uuid.UUID
-	workerID uuid.UUID
-	manifest DelegatedFirstTouchManifest
+	ctx        context.Context
+	pool       *pgxpool.Pool
+	repo       repository.OutreachRepository
+	svc        *service
+	orgID      uuid.UUID
+	actorID    uuid.UUID
+	workerID   uuid.UUID
+	campaignID uuid.UUID
+	manifest   DelegatedFirstTouchManifest
 }
 
 func newDelegatedPGFixture(t *testing.T) *delegatedPGFixture {
@@ -75,6 +77,7 @@ func newDelegatedPGFixture(t *testing.T) *delegatedPGFixture {
 		VALUES($1,$2,$3,'CONFENGE delegated test','policy canary','paused',62,now(),now())`, campaignID, f.actorID, f.orgID); err != nil {
 		t.Fatal(err)
 	}
+	f.campaignID = campaignID
 
 	f.repo = repository.NewOutreachRepository(pool)
 	if err := f.repo.UpsertOrgSettings(ctx, &models.OutreachOrgSettings{
@@ -252,6 +255,34 @@ func TestDelegatedFirstTouchApprovesQueuesAuditsAndReplaysOncePostgres(t *testin
 		status.DuplicateLiveAccount != 0 || status.DuplicateLiveRoot != 0 || len(status.Items) != 1 ||
 		status.Items[0].ApprovalSource != DelegatedFirstTouchApprovalDecision {
 		t.Fatalf("control-center readback is incomplete: status=%+v err=%v", status, statusErr)
+	}
+}
+
+func TestCampaignReadyAcceptsReadBackDelegatedQueueWithoutContact(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	if _, err := f.pool.Exec(f.ctx, `
+		INSERT INTO sequences (id,campaign_id,organization_id,name,subject,body_plain,body_html,wait_after,position,kind)
+		VALUES($1,$2,$3,'Step 1','Subject','Body','<p>Body</p>',0,0,'email')`,
+		uuid.New(), f.campaignID, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+	campaignRepo := repository.NewCampaignRepostory(&infrastructuredb.DB{Pool: f.pool})
+	if err := campaignRepo.ValidateCampaignReady(f.ctx, f.campaignID); err == nil || !strings.Contains(err.Error(), "at least one contact") {
+		t.Fatalf("ordinary empty campaign unexpectedly ready: %v", err)
+	}
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 || len(report.Items) != 1 || report.Items[0].State != "QUEUED" {
+		t.Fatalf("delegated queue unavailable: report=%+v err=%v", report, xerr)
+	}
+	var contacts int
+	if err := f.pool.QueryRow(f.ctx, `SELECT count(*) FROM campaign_leads WHERE campaign_id=$1`, f.campaignID).Scan(&contacts); err != nil {
+		t.Fatal(err)
+	}
+	if contacts != 0 {
+		t.Fatalf("fixture already enrolled contacts: %d", contacts)
+	}
+	if err := campaignRepo.ValidateCampaignReady(f.ctx, f.campaignID); err != nil {
+		t.Fatalf("read-back delegated rolling queue did not make campaign startable: %v", err)
 	}
 }
 

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -1429,7 +1429,31 @@ func (r *campaignRepository) ValidateCampaignReady(ctx context.Context, campaign
 		return err
 	}
 	if contactCount == 0 {
-		return errx.New(errx.BadRequest, "campaign must have at least one contact")
+		// CONFENGE rolling campaigns enroll the exact approved draft just in time.
+		var delegatedQueued int
+		err = r.DB.QueryRow(ctx, `
+			SELECT COUNT(*)
+			FROM confenge_dispatch_queue q
+			JOIN outreach_touchpoints t
+			  ON t.organization_id=q.organization_id AND t.draft_id=q.draft_id
+			JOIN confenge_delegated_first_touch_decisions d
+			  ON d.organization_id=q.organization_id AND d.draft_id=q.draft_id
+			 AND d.queue_message_key=q.message_key
+			JOIN confenge_campaign_policy_authorizations a
+			  ON a.id=d.policy_authorization_id AND a.organization_id=d.organization_id
+			WHERE a.campaign_id=$1 AND a.revoked_at IS NULL AND a.effective_at <= now()
+			  AND q.channel='EMAIL' AND q.status IN ('queued','reserved')
+			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL' AND t.state='QUEUED'
+			  AND t.content_hash <> '' AND t.approved_content_hash=t.content_hash
+			  AND d.decision='DELEGATED_POLICY_APPROVE' AND d.state='QUEUED'
+			  AND d.policy_version='CFG-FIRST-TOUCH-ROUTING-v1'
+			  AND d.readback_at IS NOT NULL AND d.due_at=q.due_at`, campaignID).Scan(&delegatedQueued)
+		if err != nil {
+			return err
+		}
+		if delegatedQueued == 0 {
+			return errx.New(errx.BadRequest, "campaign must have at least one contact")
+		}
 	}
 
 	// Sender pool (unified): valid if it has any enabled explicit sender OR any


### PR DESCRIPTION
Fix the rolling pipeline bootstrap cycle where campaign start required an enrolled contact but the exact approved contact is enrolled only when its CONFENGE queue item becomes due.

The ordinary empty-campaign validation remains unchanged. The narrow exception requires a live policy authorization plus a read-back CFG-FIRST-TOUCH-ROUTING-v1 delegated approval whose exact content hash and durable queue are still current.

Verification:
- PostgreSQL regression proves an ordinary empty campaign is rejected
- PostgreSQL regression proves an exact read-back delegated queue is startable before just-in-time enrollment
- adjacent delegated queue/idempotency/restart regressions
- golangci-lint v1.64.8 built with Go 1.25
- gofmt and git diff checks