### PR TITLE
feat: keep CONFENGE rolling campaigns active while exact delegated first touches await just-in-time enrollment

### DIFF
--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -289,6 +289,14 @@ func (s *campaignService) enqueueCampaignWakeup(ctx context.Context, campaignID 
 			_ = s.campaignRepository.UpdateStatusWithLock(ctx, campaignID, "paused_no_accounts")
 			return errx.New(errx.BadRequest, "no active email accounts found for campaign's email tags")
 		case errors.Is(err, scheduler.ErrCampaignCompleted):
+			ready, readyErr := s.campaignRepository.HasReadyDelegatedFirstTouch(ctx, campaignID)
+			if readyErr != nil {
+				sentry.CaptureException(readyErr)
+				return errx.InternalError()
+			}
+			if ready {
+				return nil
+			}
 			_ = s.campaignRepository.UpdateStatusWithLock(ctx, campaignID, "completed")
 			return errx.New(errx.BadRequest, "campaign has no remaining contacts to send")
 		default:

--- a/internal/app/campaign/rolling_wakeup_test.go
+++ b/internal/app/campaign/rolling_wakeup_test.go
@@ -1,0 +1,89 @@
+package campaign
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/repository"
+	"github.com/warmbly/warmbly/internal/scheduler"
+	"github.com/warmbly/warmbly/internal/tasks/proto"
+)
+
+type rollingWakeupCampaignRepo struct {
+	repository.CampaignRepository
+	ready    bool
+	readyErr error
+	statuses []string
+}
+
+func (r *rollingWakeupCampaignRepo) HasReadyDelegatedFirstTouch(context.Context, uuid.UUID) (bool, error) {
+	return r.ready, r.readyErr
+}
+
+func (r *rollingWakeupCampaignRepo) UpdateStatusWithLock(_ context.Context, _ uuid.UUID, status string) error {
+	r.statuses = append(r.statuses, status)
+	return nil
+}
+
+type rollingWakeupTaskRepo struct{ repository.TaskRepository }
+
+type rollingWakeupScheduler struct{}
+
+func (rollingWakeupScheduler) CalculateNextWarmupTime(context.Context, uuid.UUID) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (rollingWakeupScheduler) CalculateNextCampaignTime(context.Context, uuid.UUID) (time.Time, *repository.ContactSequencePair, uuid.UUID, error) {
+	return time.Time{}, nil, uuid.Nil, scheduler.ErrCampaignCompleted
+}
+
+func (rollingWakeupScheduler) CalculateNextEmailTime(context.Context, uuid.UUID) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+type rollingWakeupTaskScheduler struct{}
+
+func (rollingWakeupTaskScheduler) CreateTask(context.Context, *proto.ProcessTask, time.Time) (string, error) {
+	return "", nil
+}
+
+func (rollingWakeupTaskScheduler) DeleteTask(context.Context, string) error { return nil }
+
+func TestEnqueueCampaignWakeupPreservesActiveRollingCampaign(t *testing.T) {
+	tests := []struct {
+		name       string
+		ready      bool
+		readyErr   error
+		wantErr    bool
+		wantStatus string
+	}{
+		{name: "ready delegated queue", ready: true},
+		{name: "ordinary completed campaign", wantErr: true, wantStatus: "completed"},
+		{name: "queue lookup failure", readyErr: errors.New("db unavailable"), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &rollingWakeupCampaignRepo{ready: tt.ready, readyErr: tt.readyErr}
+			svc := &campaignService{
+				campaignRepository: repo,
+				taskRepo:           &rollingWakeupTaskRepo{},
+				scheduler:          rollingWakeupScheduler{},
+				tasksClient:        rollingWakeupTaskScheduler{},
+			}
+			xerr := svc.enqueueCampaignWakeup(context.Background(), uuid.New())
+			if (xerr != nil) != tt.wantErr {
+				t.Fatalf("error mismatch: got=%v wantErr=%v", xerr, tt.wantErr)
+			}
+			if len(repo.statuses) == 0 && tt.wantStatus != "" {
+				t.Fatalf("missing status update %q", tt.wantStatus)
+			}
+			if len(repo.statuses) > 0 && repo.statuses[0] != tt.wantStatus {
+				t.Fatalf("unexpected status update: %v", repo.statuses)
+			}
+		})
+	}
+}

--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -267,6 +267,9 @@ func TestCampaignReadyAcceptsReadBackDelegatedQueueWithoutContact(t *testing.T) 
 		t.Fatal(err)
 	}
 	campaignRepo := repository.NewCampaignRepostory(&infrastructuredb.DB{Pool: f.pool})
+	if ready, err := campaignRepo.HasReadyDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || ready {
+		t.Fatalf("ordinary empty campaign unexpectedly has delegated work: ready=%v err=%v", ready, err)
+	}
 	if err := campaignRepo.ValidateCampaignReady(f.ctx, f.campaignID); err == nil || !strings.Contains(err.Error(), "at least one contact") {
 		t.Fatalf("ordinary empty campaign unexpectedly ready: %v", err)
 	}
@@ -281,8 +284,17 @@ func TestCampaignReadyAcceptsReadBackDelegatedQueueWithoutContact(t *testing.T) 
 	if contacts != 0 {
 		t.Fatalf("fixture already enrolled contacts: %d", contacts)
 	}
+	if ready, err := campaignRepo.HasReadyDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || !ready {
+		t.Fatalf("read-back delegated work unavailable: ready=%v err=%v", ready, err)
+	}
 	if err := campaignRepo.ValidateCampaignReady(f.ctx, f.campaignID); err != nil {
 		t.Fatalf("read-back delegated rolling queue did not make campaign startable: %v", err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `UPDATE confenge_dispatch_queue SET status='sent' WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+	if ready, err := campaignRepo.HasReadyDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || ready {
+		t.Fatalf("sent delegated work remained ready: ready=%v err=%v", ready, err)
 	}
 }
 

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -50,6 +50,7 @@ type CampaignRepository interface {
 	StartCampaign(ctx context.Context, campaignID uuid.UUID) error
 	StopCampaign(ctx context.Context, campaignID uuid.UUID) error
 	ValidateCampaignReady(ctx context.Context, campaignID uuid.UUID) error
+	HasReadyDelegatedFirstTouch(ctx context.Context, campaignID uuid.UUID) (bool, error)
 	UpdateVerificationStatus(ctx context.Context, campaignID uuid.UUID, status string, summary *models.CampaignVerificationSummary) error
 	GetPendingCampaignTasks(ctx context.Context, campaignID uuid.UUID) ([]Task, error)
 	// ListCampaignScheduleCandidates returns active campaigns that have NO pending
@@ -1429,29 +1430,11 @@ func (r *campaignRepository) ValidateCampaignReady(ctx context.Context, campaign
 		return err
 	}
 	if contactCount == 0 {
-		// CONFENGE rolling campaigns enroll the exact approved draft just in time.
-		var delegatedQueued int
-		err = r.DB.QueryRow(ctx, `
-			SELECT COUNT(*)
-			FROM confenge_dispatch_queue q
-			JOIN outreach_touchpoints t
-			  ON t.organization_id=q.organization_id AND t.draft_id=q.draft_id
-			JOIN confenge_delegated_first_touch_decisions d
-			  ON d.organization_id=q.organization_id AND d.draft_id=q.draft_id
-			 AND d.queue_message_key=q.message_key
-			JOIN confenge_campaign_policy_authorizations a
-			  ON a.id=d.policy_authorization_id AND a.organization_id=d.organization_id
-			WHERE a.campaign_id=$1 AND a.revoked_at IS NULL AND a.effective_at <= now()
-			  AND q.channel='EMAIL' AND q.status IN ('queued','reserved')
-			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL' AND t.state='QUEUED'
-			  AND t.content_hash <> '' AND t.approved_content_hash=t.content_hash
-			  AND d.decision='DELEGATED_POLICY_APPROVE' AND d.state='QUEUED'
-			  AND d.policy_version='CFG-FIRST-TOUCH-ROUTING-v1'
-			  AND d.readback_at IS NOT NULL AND d.due_at=q.due_at`, campaignID).Scan(&delegatedQueued)
+		delegatedQueued, err := r.HasReadyDelegatedFirstTouch(ctx, campaignID)
 		if err != nil {
 			return err
 		}
-		if delegatedQueued == 0 {
+		if !delegatedQueued {
 			return errx.New(errx.BadRequest, "campaign must have at least one contact")
 		}
 	}
@@ -1481,6 +1464,31 @@ func (r *campaignRepository) ValidateCampaignReady(ctx context.Context, campaign
 		return errx.New(errx.BadRequest, "campaign must have at least one active sending mailbox")
 	}
 	return nil
+}
+
+// HasReadyDelegatedFirstTouch reports exact rolling work waiting for just-in-time enrollment.
+func (r *campaignRepository) HasReadyDelegatedFirstTouch(ctx context.Context, campaignID uuid.UUID) (bool, error) {
+	var ready bool
+	err := r.DB.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM confenge_dispatch_queue q
+			JOIN outreach_touchpoints t
+			  ON t.organization_id=q.organization_id AND t.draft_id=q.draft_id
+			JOIN confenge_delegated_first_touch_decisions d
+			  ON d.organization_id=q.organization_id AND d.draft_id=q.draft_id
+			 AND d.queue_message_key=q.message_key
+			JOIN confenge_campaign_policy_authorizations a
+			  ON a.id=d.policy_authorization_id AND a.organization_id=d.organization_id
+			WHERE a.campaign_id=$1 AND a.revoked_at IS NULL AND a.effective_at <= now()
+			  AND q.channel='EMAIL' AND q.status IN ('queued','reserved')
+			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL' AND t.state='QUEUED'
+			  AND t.content_hash <> '' AND t.approved_content_hash=t.content_hash
+			  AND d.decision='DELEGATED_POLICY_APPROVE' AND d.state='QUEUED'
+			  AND d.policy_version='CFG-FIRST-TOUCH-ROUTING-v1'
+			  AND d.readback_at IS NOT NULL AND d.due_at=q.due_at
+		)`, campaignID).Scan(&ready)
+	return ready, err
 }
 
 // GetPendingCampaignTasks returns all pending tasks for a campaign

--- a/internal/tasks/campaign_reconciler.go
+++ b/internal/tasks/campaign_reconciler.go
@@ -68,8 +68,16 @@ func (s *tasksService) ReconcileCampaignSchedules(ctx context.Context, limit int
 		case errors.Is(cerr, scheduler.ErrNoEmailAccounts):
 			// No mailbox to send from — pause rather than spin every pass.
 			s.autoPauseCampaign(ctx, id, uuid.Nil)
-		case errors.Is(cerr, scheduler.ErrCampaignCompleted), errors.Is(cerr, scheduler.ErrCampaignEnded):
-			// Nothing left to send (or past its end date): close it out.
+		case errors.Is(cerr, scheduler.ErrCampaignCompleted):
+			ready, readyErr := s.campaignRepo.HasReadyDelegatedFirstTouch(ctx, id)
+			if readyErr != nil {
+				log.Warn().Err(readyErr).Str("campaign_id", id.String()).Msg("campaign reconcile: rolling queue check failed; will retry")
+				continue
+			}
+			if !ready {
+				s.campaignRepo.UpdateStatus(ctx, id, "completed")
+			}
+		case errors.Is(cerr, scheduler.ErrCampaignEnded):
 			s.campaignRepo.UpdateStatus(ctx, id, "completed")
 		default:
 			// Transient error (DB blip): leave it; the next pass retries.

--- a/internal/tasks/campaign_rolling_test.go
+++ b/internal/tasks/campaign_rolling_test.go
@@ -1,0 +1,136 @@
+package tasks
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+	"github.com/warmbly/warmbly/internal/scheduler"
+	"github.com/warmbly/warmbly/internal/tasks/proto"
+)
+
+type rollingCampaignRepo struct {
+	repository.CampaignRepository
+	campaign *models.Campaign
+	ready    bool
+	statuses []string
+}
+
+func (r *rollingCampaignRepo) ListCampaignScheduleCandidates(context.Context, int) ([]uuid.UUID, error) {
+	return []uuid.UUID{r.campaign.ID}, nil
+}
+
+func (r *rollingCampaignRepo) GetByID(context.Context, uuid.UUID) (*models.Campaign, error) {
+	return r.campaign, nil
+}
+
+func (r *rollingCampaignRepo) HasReadyDelegatedFirstTouch(context.Context, uuid.UUID) (bool, error) {
+	return r.ready, nil
+}
+
+func (r *rollingCampaignRepo) UpdateStatus(_ context.Context, _ uuid.UUID, status string) error {
+	r.statuses = append(r.statuses, status)
+	return nil
+}
+
+type rollingTaskRepo struct {
+	repository.TaskRepository
+	taskID     uuid.UUID
+	campaignID uuid.UUID
+	statuses   []string
+}
+
+func (r *rollingTaskRepo) CancelOverduePendingTasks(context.Context, string, time.Duration) (int64, error) {
+	return 0, nil
+}
+
+func (r *rollingTaskRepo) GetTask(context.Context, uuid.UUID) (*repository.Task, error) {
+	return &repository.Task{ID: r.taskID, Status: "pending"}, nil
+}
+
+func (r *rollingTaskRepo) GetCampaignTask(context.Context, uuid.UUID) (*repository.CampaignTask, error) {
+	return &repository.CampaignTask{TaskID: r.taskID, CampaignID: &r.campaignID}, nil
+}
+
+func (r *rollingTaskRepo) UpdateTaskStatus(_ context.Context, _ uuid.UUID, status string) error {
+	r.statuses = append(r.statuses, status)
+	return nil
+}
+
+func (r *rollingTaskRepo) UpdateTaskStatusWithLock(_ context.Context, _ uuid.UUID, status string) error {
+	r.statuses = append(r.statuses, status)
+	return nil
+}
+
+type rollingProgressRepo struct {
+	repository.CampaignProgressRepository
+}
+
+func (rollingProgressRepo) GetCampaignProgress(context.Context, uuid.UUID) (*repository.CampaignProgress, error) {
+	return &repository.CampaignProgress{}, nil
+}
+
+type rollingCompletedScheduler struct{}
+
+func (rollingCompletedScheduler) CalculateNextWarmupTime(context.Context, uuid.UUID) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (rollingCompletedScheduler) CalculateNextCampaignTime(context.Context, uuid.UUID) (time.Time, *repository.ContactSequencePair, uuid.UUID, error) {
+	return time.Time{}, nil, uuid.Nil, scheduler.ErrCampaignCompleted
+}
+
+func (rollingCompletedScheduler) CalculateNextEmailTime(context.Context, uuid.UUID) (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func TestCampaignReconcilerPreservesReadyRollingQueue(t *testing.T) {
+	campaign := &models.Campaign{ID: uuid.New(), Status: "active"}
+	for _, ready := range []bool{true, false} {
+		repo := &rollingCampaignRepo{campaign: campaign, ready: ready}
+		svc := &tasksService{
+			campaignRepo: repo,
+			taskRepo:     &rollingTaskRepo{},
+			scheduler:    rollingCompletedScheduler{},
+		}
+		if _, err := svc.ReconcileCampaignSchedules(context.Background(), 1); err != nil {
+			t.Fatal(err)
+		}
+		if ready && len(repo.statuses) != 0 {
+			t.Fatalf("ready rolling campaign was completed: %v", repo.statuses)
+		}
+		if !ready && (len(repo.statuses) != 1 || repo.statuses[0] != "completed") {
+			t.Fatalf("ordinary exhausted campaign did not complete: %v", repo.statuses)
+		}
+	}
+}
+
+func TestCampaignTaskPreservesReadyRollingQueue(t *testing.T) {
+	for _, ready := range []bool{true, false} {
+		campaignID, taskID := uuid.New(), uuid.New()
+		repo := &rollingCampaignRepo{campaign: &models.Campaign{ID: campaignID, Status: "active"}, ready: ready}
+		tasks := &rollingTaskRepo{taskID: taskID, campaignID: campaignID}
+		svc := &tasksService{
+			campaignRepo:         repo,
+			taskRepo:             tasks,
+			campaignProgressRepo: rollingProgressRepo{},
+			scheduler:            rollingCompletedScheduler{},
+		}
+		if xerr := svc.HandleCampaignTask(&proto.ProcessTask{TaskId: taskID.String()}); xerr != nil {
+			t.Fatalf("handler failed: %v", xerr)
+		}
+		if ready && len(repo.statuses) != 0 {
+			t.Fatalf("ready rolling campaign was completed: %v", repo.statuses)
+		}
+		if !ready && (len(repo.statuses) != 1 || repo.statuses[0] != "completed") {
+			t.Fatalf("ordinary exhausted campaign did not complete: %v", repo.statuses)
+		}
+		if got := tasks.statuses[len(tasks.statuses)-1]; got != "completed" {
+			t.Fatalf("task did not close cleanly: %v", tasks.statuses)
+		}
+	}
+}

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -201,9 +201,21 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 			executionStatus = "completed"
 			return nil
 		}
-		// Terminal: all emails sent, OR the campaign passed its end date. Both end
-		// the campaign at the "completed" status (the status enum has no separate
-		// "ended"); the reason differs in the activity log.
+		if errors.Is(err, scheduler.ErrCampaignCompleted) {
+			ready, readyErr := s.campaignRepo.HasReadyDelegatedFirstTouch(ctx, campaign.ID)
+			if readyErr != nil {
+				sentry.CaptureException(readyErr)
+				_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "pending")
+				executionStatus = "failed"
+				return errx.InternalError()
+			}
+			if ready {
+				_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "completed")
+				executionStatus = "completed"
+				return nil
+			}
+		}
+		// Terminal campaigns have no remaining rolling work or passed their end date.
 		if errors.Is(err, scheduler.ErrCampaignCompleted) || errors.Is(err, scheduler.ErrCampaignEnded) {
 			reason := "Campaign completed: all emails sent"
 			if errors.Is(err, scheduler.ErrCampaignEnded) {


### PR DESCRIPTION
Fixes the production scheduler gap found during the controlled outbound activation.

- preserves an active campaign only while an exact read-back delegated first touch is queued or reserved
- applies the guard at start, reconciliation, and campaign-task completion
- keeps ordinary exhausted campaigns and end-date completion unchanged
- adds PostgreSQL and focused scheduler regressions

Verification:
- focused campaign/task tests
- PostgreSQL delegated queue test against all migrations
- golangci-lint ./...
- gofmt -l . is empty