### PR TITLE
fix(confenge): reject shared-recipient identity conflicts

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1101,6 +1101,11 @@ func main() {
 			// CAMPAIGN_POLICY stays inert unless the narrow delegated manifest path is enabled.
 			confengeServiceForHandler.WirePolicyAuth(repository.NewConfengePolicyRepository(primaryDB.Pool))
 			confengeServiceForHandler.WireDelegatedFirstTouch(primaryDB.Pool)
+			if reconciled, err := confengeServiceForHandler.ReconcileDelegatedFirstTouchLedger(ctx, confengeCfg.OperatorOrgID); err != nil {
+				log.Printf("confenge delegated first-touch ledger reconciliation failed closed: %v", err)
+			} else if reconciled > 0 {
+				log.Printf("confenge delegated first-touch ledger reconciled cancelled=%d", reconciled)
+			}
 			confengeServiceForHandler.WireOrgRisk(orgRiskService)
 			if primaryDB == nil || primaryDB.Pool == nil {
 				log.Fatalf("confenge: postgres required for bounded cohort authority")

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -196,6 +196,45 @@ func (s *service) WireDelegatedFirstTouch(db *pgxpool.Pool) { s.delegatedDB = db
 
 func (s *service) WireOrgRisk(risk OrgRiskPolicy) { s.orgRisk = risk }
 
+// ReconcileDelegatedFirstTouchLedger repairs an audit projection that can be
+// left behind if an older runtime cancels the canonical touchpoint/queue first.
+// It never creates approval or queue work; it only makes an already-safe
+// cancellation explicit and releases stale one-live-account/root bindings.
+func (s *service) ReconcileDelegatedFirstTouchLedger(ctx context.Context, orgID uuid.UUID) (int64, error) {
+	if s == nil || s.delegatedDB == nil || orgID == uuid.Nil {
+		return 0, fmt.Errorf("delegated first-touch store is not wired")
+	}
+	result, err := s.delegatedDB.Exec(ctx, `
+		WITH invalid AS (
+			SELECT d.id,
+				COALESCE(NULLIF(q.last_error,''),NULLIF(q.cancel_reason,''),'canonical_queue_state_drift') AS reason
+			FROM confenge_delegated_first_touch_decisions d
+			JOIN outreach_touchpoints t
+			  ON t.organization_id=d.organization_id AND t.id=d.touchpoint_id
+			LEFT JOIN confenge_dispatch_queue q
+			  ON q.organization_id=d.organization_id AND q.draft_id=d.draft_id AND q.message_key=d.queue_message_key
+			WHERE d.organization_id=$1
+			  AND d.state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')
+			  AND (
+				(d.state IN ('APPROVED','APPROVED_NOT_SCHEDULED') AND t.state <> 'APPROVED')
+				OR (d.state='QUEUED' AND (t.state <> 'QUEUED' OR q.status IS DISTINCT FROM 'queued'))
+			  )
+		)
+		UPDATE confenge_delegated_first_touch_decisions d
+		SET state='CANCELLED',
+			blocker_codes=CASE
+				WHEN d.blocker_codes @> jsonb_build_array(invalid.reason)
+					THEN d.blocker_codes
+				ELSE d.blocker_codes || jsonb_build_array(invalid.reason)
+			END,
+			updated_at=now()
+		FROM invalid WHERE d.id=invalid.id`, orgID)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected(), nil
+}
+
 func hashText(value string) string {
 	sum := sha256.Sum256([]byte(value))
 	return hex.EncodeToString(sum[:])
@@ -810,6 +849,15 @@ func (s *service) validateDelegatedEntry(ctx context.Context, orgID uuid.UUID, m
 	}
 	if !CandidateControlledEligible(cand) || !ControlledRouteAllowed(cand, nil) || !CandidateEnrollable(cand) {
 		add("recipient_not_controlled_eligible")
+	}
+	// Public application requires delegatedDB before entering this validator.
+	// The nil branch exists only for the pure deterministic gate unit tests.
+	if s.delegatedDB != nil {
+		if conflict, conflictErr := s.delegatedRecipientSharedAcrossCNPJIdentities(ctx, orgID, cand.Email); conflictErr != nil {
+			add("recipient_identity_conflict_check_unavailable")
+		} else if conflict {
+			add("recipient_shared_across_cnpj_identities")
+		}
 	}
 	if strings.EqualFold(strings.TrimSpace(cand.EmailDerivation), "INFERRED") ||
 		!strings.EqualFold(strings.TrimSpace(cand.ChannelEpistemic), "OBSERVED") ||
@@ -1720,6 +1768,11 @@ func (s *service) assertDelegatedFirstTouchDecision(ctx context.Context, orgID u
 	if !strings.EqualFold(cand.Email, got.Recipient) || CandidateRouteClass(cand) != got.RouteClass {
 		return fail("recipient_or_route_class_drift")
 	}
+	if conflict, conflictErr := s.delegatedRecipientSharedAcrossCNPJIdentities(ctx, orgID, cand.Email); conflictErr != nil {
+		return fail("recipient_identity_conflict_check_unavailable")
+	} else if conflict {
+		return fail("recipient_shared_across_cnpj_identities")
+	}
 	now := time.Now().UTC()
 	var webSources []DelegatedWebSource
 	if json.Unmarshal(got.WebSources, &webSources) != nil || !candidateSourceCorroborated(cand, webSources) {
@@ -1778,6 +1831,39 @@ func (s *service) assertDelegatedFirstTouchDecision(ctx context.Context, orgID u
 		return fail("fact_evidence_row_drift")
 	}
 	return nil
+}
+
+// delegatedRecipientSharedAcrossCNPJIdentities rejects a mailbox that the
+// current authoritative feed attributes to more than one legal identity. An
+// exact email/domain match is not evidence of a matrix/branch/group relation;
+// until the producer publishes such a typed relationship, delegated approval
+// must fail closed and leave the ambiguity for human reconciliation.
+func (s *service) delegatedRecipientSharedAcrossCNPJIdentities(ctx context.Context, orgID uuid.UUID, recipient string) (bool, error) {
+	if s == nil || s.delegatedDB == nil || !validExactEmail(recipient) {
+		return false, fmt.Errorf("delegated recipient identity store unavailable")
+	}
+	var identities int
+	err := s.delegatedDB.QueryRow(ctx, `
+		SELECT count(DISTINCT a.cnpj14)::int
+		FROM outreach_contact_candidates c
+		JOIN outreach_accounts a
+		  ON a.organization_id=c.organization_id AND a.id=c.account_id
+		JOIN outreach_import_runs r
+		  ON r.organization_id=c.organization_id AND r.id=c.last_import_run_id
+		JOIN outreach_feed_sync_state feed
+		  ON feed.organization_id=c.organization_id
+		WHERE c.organization_id=$1
+		  AND lower(btrim(c.email))=lower(btrim($2))
+		  AND a.cnpj14 <> ''
+		  AND a.source_run_id=feed.last_run_id
+		  AND r.source_run_id=feed.last_run_id AND r.status='completed'
+		  AND c.blocked=false AND c.do_not_contact=false AND c.bounced=false
+		  AND c.channel_epistemic_class='OBSERVED'
+		  AND c.ownership_status='COMPANY_OWNED'
+		  AND c.route_freshness='FRESH'
+		  AND (c.route_suppression='' OR c.route_suppression='NONE')
+		  AND c.discovery_json @> '{"mailbox_company_evidence":"OBSERVED"}'::jsonb`, orgID, strings.TrimSpace(recipient)).Scan(&identities)
+	return identities > 1, err
 }
 
 func (s *service) cancelDelegatedDecision(ctx context.Context, orgID, touchpointID uuid.UUID, reason string) error {

--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -203,6 +203,38 @@ func newDelegatedPGFixture(t *testing.T) *delegatedPGFixture {
 	return f
 }
 
+func addSharedRecipientIdentityClaim(t *testing.T, f *delegatedPGFixture) {
+	t.Helper()
+	entry := f.manifest.Entries[0]
+	account, err := f.repo.GetAccount(f.ctx, f.orgID, entry.AccountID)
+	if err != nil || account == nil {
+		t.Fatalf("source account unavailable: account=%+v err=%v", account, err)
+	}
+	candidate, err := f.repo.GetCandidate(f.ctx, f.orgID, entry.ContactCandidateID)
+	if err != nil || candidate == nil {
+		t.Fatalf("source candidate unavailable: candidate=%+v err=%v", candidate, err)
+	}
+	sharedAccount := *account
+	sharedAccount.ID = uuid.New()
+	sharedAccount.SourceLeadID = "lead-shared-recipient-conflict"
+	sharedAccount.CNPJ14 = "22333444000155"
+	sharedAccount.CNPJRoot = "22333444"
+	sharedAccount.SupplierCNPJ14 = sharedAccount.CNPJ14
+	sharedAccount.SupplierIdentityRef = "cnpj:" + sharedAccount.CNPJ14
+	if _, err := f.repo.UpsertAccount(f.ctx, &sharedAccount); err != nil {
+		t.Fatal(err)
+	}
+	sharedCandidate := *candidate
+	sharedCandidate.ID = uuid.New()
+	sharedCandidate.AccountID = sharedAccount.ID
+	sharedCandidate.SourceContactID = "route-shared-recipient-conflict"
+	// The exact mailbox and source claim are intentionally copied to a second
+	// CNPJ. Without a typed group/branch relationship this must be ambiguous.
+	if _, err := f.repo.UpsertCandidate(f.ctx, &sharedCandidate); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestDelegatedFirstTouchApprovesQueuesAuditsAndReplaysOncePostgres(t *testing.T) {
 	f := newDelegatedPGFixture(t)
 	first, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
@@ -410,6 +442,119 @@ func TestDelegatedFirstTouchPartialBatchFailureDoesNotBlockEligibleItemPostgres(
 		if item.Decision == "HOLD" && item.ApprovalSource != "POLICY_EVALUATION_HOLD" {
 			t.Fatalf("HOLD was presented as an approval: %+v", item)
 		}
+	}
+}
+
+func TestDelegatedFirstTouchSharedRecipientAcrossCNPJIdentitiesHoldsPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	addSharedRecipientIdentityClaim(t, f)
+
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 0 || report.Held != 1 || len(report.Items) != 1 {
+		t.Fatalf("shared recipient did not fail closed: report=%+v err=%v", report, xerr)
+	}
+	if !containsString(report.Items[0].Blockers, "recipient_shared_across_cnpj_identities") {
+		t.Fatalf("shared recipient blocker missing: %+v", report.Items[0])
+	}
+}
+
+func TestDelegatedFirstTouchSharedRecipientDriftCancelsQueuedDecisionPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+	tp, err := f.repo.GetTouchpoint(f.ctx, f.orgID, report.Items[0].TouchpointID)
+	if err != nil || tp == nil {
+		t.Fatalf("queued touchpoint unavailable: tp=%+v err=%v", tp, err)
+	}
+	addSharedRecipientIdentityClaim(t, f)
+
+	if err := f.svc.AssertTransportable(f.ctx, f.orgID, tp); err == nil ||
+		!strings.Contains(err.Error(), "recipient_shared_across_cnpj_identities") {
+		t.Fatalf("shared recipient drift remained transportable: %v", err)
+	}
+	var decisionState, touchState, queueState, blockerCodes string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT d.state,t.state,q.status,d.blocker_codes::text
+		FROM confenge_delegated_first_touch_decisions d
+		JOIN outreach_touchpoints t ON t.organization_id=d.organization_id AND t.id=d.touchpoint_id
+		JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.draft_id=d.draft_id
+		WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, tp.ID).
+		Scan(&decisionState, &touchState, &queueState, &blockerCodes); err != nil {
+		t.Fatal(err)
+	}
+	if decisionState != "CANCELLED" || touchState != models.TouchpointNeedsReview || queueState != "cancelled" ||
+		!strings.Contains(blockerCodes, "recipient_shared_across_cnpj_identities") {
+		t.Fatalf("shared recipient drift was not cancelled: decision=%s touch=%s queue=%s blockers=%s",
+			decisionState, touchState, queueState, blockerCodes)
+	}
+}
+
+func TestDelegatedFirstTouchContextInvalidationCancelsDecisionLedgerPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+	entry := f.manifest.Entries[0]
+	if err := f.repo.InvalidateAccountApprovalsForContext(
+		f.ctx, f.orgID, entry.AccountID, strings.Repeat("d", 64),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	var decisionState, touchState, queueState, blockerCodes string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT d.state,t.state,q.status,d.blocker_codes::text
+		FROM confenge_delegated_first_touch_decisions d
+		JOIN outreach_touchpoints t ON t.organization_id=d.organization_id AND t.id=d.touchpoint_id
+		JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.draft_id=d.draft_id
+		WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID).
+		Scan(&decisionState, &touchState, &queueState, &blockerCodes); err != nil {
+		t.Fatal(err)
+	}
+	if decisionState != "CANCELLED" || touchState != models.TouchpointNeedsReview || queueState != "cancelled" ||
+		!strings.Contains(blockerCodes, "context_stale") {
+		t.Fatalf("context drift left a false delegated ledger: decision=%s touch=%s queue=%s blockers=%s",
+			decisionState, touchState, queueState, blockerCodes)
+	}
+}
+
+func TestDelegatedFirstTouchLedgerReconciliationRepairsOlderQueueCancellationPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE confenge_dispatch_queue
+		SET status='cancelled',cancel_reason='context_stale',last_error='context_stale'
+		WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_touchpoints SET state='NEEDS_REVIEW',stop_reason='context_stale'
+		WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+
+	reconciled, err := f.svc.ReconcileDelegatedFirstTouchLedger(f.ctx, f.orgID)
+	if err != nil || reconciled != 1 {
+		t.Fatalf("older cancellation was not reconciled: count=%d err=%v", reconciled, err)
+	}
+	var state, blockers string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT state,blocker_codes::text FROM confenge_delegated_first_touch_decisions
+		WHERE organization_id=$1`, f.orgID).Scan(&state, &blockers); err != nil {
+		t.Fatal(err)
+	}
+	if state != "CANCELLED" || !strings.Contains(blockers, "context_stale") {
+		t.Fatalf("delegated ledger remained false: state=%s blockers=%s", state, blockers)
+	}
+	reconciled, err = f.svc.ReconcileDelegatedFirstTouchLedger(f.ctx, f.orgID)
+	if err != nil || reconciled != 0 {
+		t.Fatalf("ledger reconciliation is not idempotent: count=%d err=%v", reconciled, err)
 	}
 }
 

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -112,6 +112,7 @@ type Service interface {
 	ProcessEditorialRecoveryOnce(ctx context.Context) (bool, error)
 	ProcessDraftGenerationOnce(ctx context.Context) (bool, error)
 	ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, error)
+	ReconcileDelegatedFirstTouchLedger(ctx context.Context, orgID uuid.UUID) (int64, error)
 
 	// Per-touchpoint human approval cadence.
 	PreparePilotCohort(ctx context.Context, orgID, userID uuid.UUID, accountIDs []uuid.UUID, operation PilotOperation) (*PilotCohortResult, *errx.Error)

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -158,6 +158,26 @@ func (r *outreachRepository) InvalidateAccountApprovalsForContext(ctx context.Co
 		) AND status IN ('queued','reserved')`, orgID, accountID, currentContextHash); err != nil {
 		return err
 	}
+	// Keep the delegated decision ledger aligned with the canonical queue and
+	// touchpoint invalidation below. A QUEUED decision whose queue row is already
+	// cancelled is operationally safe but auditably false, and can also retain a
+	// stale one-live-account binding.
+	if _, err := tx.Exec(ctx, `
+		UPDATE confenge_delegated_first_touch_decisions d
+		SET state='CANCELLED',
+			blocker_codes=CASE
+				WHEN d.blocker_codes @> '["context_stale"]'::jsonb THEN d.blocker_codes
+				ELSE d.blocker_codes || '["context_stale"]'::jsonb
+			END,
+			updated_at=now()
+		FROM outreach_touchpoints t
+		WHERE d.organization_id=$1 AND d.account_id=$2
+		  AND t.organization_id=d.organization_id AND t.id=d.touchpoint_id
+		  AND t.generated_context_hash IS DISTINCT FROM $3
+		  AND t.state IN ('APPROVED','QUEUED')
+		  AND d.state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')`, orgID, accountID, currentContextHash); err != nil {
+		return err
+	}
 	if _, err := tx.Exec(ctx, `
 		DELETE FROM campaign_leads cl
 		USING outreach_drafts d, outreach_touchpoints t


### PR DESCRIPTION
Adds two fail-closed defenses to `CFG-FIRST-TOUCH-ROUTING-v1`:

- delegated approval queries the fully applied current feed and holds an exact mailbox attributed to multiple distinct CNPJ identities;
- the same check runs again in `AssertTransportable`, so a conflict introduced after approval cancels the decision, touchpoint and canonical queue row before transport.

It also closes an audit-projection gap found live: canonical `context_stale` invalidation now cancels the associated delegated decision ledger in the same transaction. A scoped, idempotent startup reconciliation repairs rows left false-`QUEUED` by older runtimes; it can only cancel and never creates approval or queue work.

This is the consumer-side defense for extra-cli PR #509. It reuses the existing database, decision audit, canonical queue and cancellation path; no parallel scheduler or queue.

Verification:
- attributed DIRECT/ROLE/GENERIC/FREEMAIL deterministic gates pass
- migrated isolated PostgreSQL integration: approval/replay, shared-recipient HOLD, shared-recipient drift cancellation, context-stale decision-ledger cancellation, startup repair/idempotency, and recipient/content/policy drift all pass
- dispatch governor remains paused in the test fixture

Operational follow-up under #155: deploy this SHA while transport remains paused, verify startup repairs the already-cancelled invalid canary ledger, ingest the corrected source run, then create a replacement QUEUED canary with zero provider send.