### PR TITLE
feat: revoke stale delegated first-touch decisions when the authoritative feed or runtime binding advances

### DIFF
--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -409,6 +409,71 @@ func TestDelegatedFirstTouchWorkerSkipsMismatchedDecisionBoundByCurrentIdempoten
 	}
 }
 
+func TestDelegatedFirstTouchFeedRefreshRetiresStaleQueuePostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+
+	newRun := "run-refreshed-" + uuid.NewString()
+	newSnapshot := strings.Repeat("f", 64)
+	if _, err := f.pool.Exec(f.ctx, `UPDATE outreach_accounts SET source_run_id=$3 WHERE organization_id=$1 AND id=$2`,
+		f.orgID, f.manifest.Entries[0].AccountID, newRun); err != nil {
+		t.Fatal(err)
+	}
+	retired, err := f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, newRun, newSnapshot)
+	if err != nil || retired != 1 {
+		t.Fatalf("stale delegated queue retirement: retired=%d err=%v", retired, err)
+	}
+
+	var decisionState, touchpointState, draftState, queueState, reason string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT d.state,t.state,dr.status,q.status,q.cancel_reason
+		FROM confenge_delegated_first_touch_decisions d
+		JOIN outreach_touchpoints t ON t.organization_id=d.organization_id AND t.id=d.touchpoint_id
+		JOIN outreach_drafts dr ON dr.organization_id=d.organization_id AND dr.id=d.draft_id
+		JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.message_key=d.queue_message_key
+		WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID).
+		Scan(&decisionState, &touchpointState, &draftState, &queueState, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if decisionState != "CANCELLED" || touchpointState != models.TouchpointNeedsReview ||
+		draftState != models.OutreachDraftNeedsReview || queueState != "cancelled" || reason != delegatedBindingRefreshReason {
+		t.Fatalf("stale delegated state survived refresh: decision=%s touchpoint=%s draft=%s queue=%s reason=%s",
+			decisionState, touchpointState, draftState, queueState, reason)
+	}
+	if retired, err = f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, newRun, newSnapshot); err != nil || retired != 0 {
+		t.Fatalf("retirement retry was not idempotent: retired=%d err=%v", retired, err)
+	}
+}
+
+func TestDelegatedFirstTouchRuntimeRefreshRetiresStaleQueuePostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+
+	f.svc.cfg.RepositorySHA = "sha-next-runtime"
+	retired, err := f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, f.manifest.SourceRunID, f.manifest.SourceSnapshotHash)
+	if err != nil || retired != 1 {
+		t.Fatalf("stale runtime retirement: retired=%d err=%v", retired, err)
+	}
+	var decisionState, queueState string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT d.state,q.status
+		FROM confenge_delegated_first_touch_decisions d
+		JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.message_key=d.queue_message_key
+		WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID).
+		Scan(&decisionState, &queueState); err != nil {
+		t.Fatal(err)
+	}
+	if decisionState != "CANCELLED" || queueState != "cancelled" {
+		t.Fatalf("stale runtime survived refresh: decision=%s queue=%s", decisionState, queueState)
+	}
+}
+
 func TestDelegatedFirstTouchPartialBatchFailureDoesNotBlockEligibleItemPostgres(t *testing.T) {
 	f := newDelegatedPGFixture(t)
 	invalid := f.manifest.Entries[0]

--- a/internal/app/confenge/delegated_first_touch_refresh.go
+++ b/internal/app/confenge/delegated_first_touch_refresh.go
@@ -1,0 +1,94 @@
+package confenge
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+)
+
+const delegatedBindingRefreshReason = "delegated_authority_or_source_binding_advanced"
+
+// retireStaleDelegatedFirstTouches revokes live approvals bound to an older feed.
+func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uuid.UUID, sourceRunID, snapshotHash string) (int, error) {
+	if s == nil || s.delegatedDB == nil {
+		return 0, nil
+	}
+	tx, err := s.delegatedDB.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx)
+
+	rows, err := tx.Query(ctx, `
+		SELECT d.touchpoint_id
+		FROM confenge_delegated_first_touch_decisions d
+		LEFT JOIN outreach_accounts a
+		  ON a.organization_id=d.organization_id AND a.id=d.account_id
+		WHERE d.organization_id=$1
+		  AND d.state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')
+		  AND d.touchpoint_id IS NOT NULL
+		  AND (d.evidence_source_run_id<>$2 OR d.source_snapshot_hash<>$3
+		    OR a.id IS NULL OR a.source_run_id<>$2 OR d.runtime_release_sha<>$4
+		    OR d.policy_version<>$5 OR d.policy_hash<>$6)
+		FOR UPDATE OF d`, orgID, sourceRunID, snapshotHash, s.cfg.RepositorySHA,
+		DelegatedFirstTouchPolicyV1, DelegatedFirstTouchPolicyHashV1)
+	if err != nil {
+		return 0, err
+	}
+	var touchpointIDs []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err = rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		touchpointIDs = append(touchpointIDs, id)
+	}
+	if err = rows.Err(); err != nil {
+		rows.Close()
+		return 0, err
+	}
+	rows.Close()
+	if len(touchpointIDs) == 0 {
+		return 0, tx.Commit(ctx)
+	}
+
+	if _, err = tx.Exec(ctx, `
+		UPDATE confenge_dispatch_queue q
+		SET status='cancelled',cancel_reason=$3,last_error=$3,updated_at=now()
+		FROM outreach_touchpoints t
+		WHERE t.organization_id=$1 AND t.id=ANY($2::uuid[]) AND t.draft_id=q.draft_id
+		  AND q.organization_id=t.organization_id AND q.status IN ('queued','reserved')`,
+		orgID, touchpointIDs, delegatedBindingRefreshReason); err != nil {
+		return 0, err
+	}
+	if _, err = tx.Exec(ctx, `
+		UPDATE outreach_drafts d
+		SET status='NEEDS_REVIEW',approved_by=NULL,approved_at=NULL,
+			campaign_id=NULL,enrollment_contact_id=NULL,enrolled_at=NULL,updated_at=now()
+		FROM outreach_touchpoints t
+		WHERE t.organization_id=$1 AND t.id=ANY($2::uuid[])
+		  AND t.draft_id=d.id AND d.organization_id=t.organization_id`, orgID, touchpointIDs); err != nil {
+		return 0, err
+	}
+	if _, err = tx.Exec(ctx, `
+		UPDATE outreach_touchpoints
+		SET state='NEEDS_REVIEW',approved_content_hash='',approved_by=NULL,approved_at=NULL,
+			authorization_mode='',campaign_policy_authorization_id=NULL,authorization_policy_hash='',
+			authorization_at=NULL,signature_version='',queued_at=NULL,stop_reason=$3,updated_at=now()
+		WHERE organization_id=$1 AND id=ANY($2::uuid[])`, orgID, touchpointIDs, delegatedBindingRefreshReason); err != nil {
+		return 0, err
+	}
+	if _, err = tx.Exec(ctx, `
+		UPDATE confenge_delegated_first_touch_decisions
+		SET state='CANCELLED',blocker_codes=blocker_codes || jsonb_build_array($3::text),updated_at=now()
+		WHERE organization_id=$1 AND touchpoint_id=ANY($2::uuid[])
+		  AND state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')`,
+		orgID, touchpointIDs, delegatedBindingRefreshReason); err != nil {
+		return 0, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return len(touchpointIDs), nil
+}

--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -72,6 +72,16 @@ func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, err
 		return false, nil
 	}
 	orgID := s.cfg.OperatorOrgID
+	feed, err := s.repo.GetFeedSyncState(ctx, orgID)
+	if err != nil || feed == nil {
+		return false, err
+	}
+	if feed.LastStatus != "completed" {
+		return false, nil
+	}
+	if _, err = s.retireStaleDelegatedFirstTouches(ctx, orgID, feed.LastRunID, feed.LastSnapshotHash); err != nil {
+		return false, err
+	}
 	var queued int
 	if err := s.delegatedDB.QueryRow(ctx, `
 		SELECT count(*) FROM confenge_dispatch_queue
@@ -107,11 +117,6 @@ func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, err
 	if err != nil || cand == nil {
 		return false, err
 	}
-	feed, err := s.repo.GetFeedSyncState(ctx, orgID)
-	if err != nil || feed == nil {
-		return false, err
-	}
-
 	recent, err := s.repo.ListDrafts(ctx, orgID, "", 500, 0)
 	if err != nil {
 		return false, err

--- a/internal/app/confenge/feed_sync.go
+++ b/internal/app/confenge/feed_sync.go
@@ -264,6 +264,14 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 			return result, errx.New(errx.ServiceUnavailable, "feed deactivations failed; snapshot not committed")
 		}
 		result.Deactivations = n
+		delegatedRetired, delegatedErr := s.retireStaleDelegatedFirstTouches(ctx, orgID, man.Source.RunID, man.Source.SnapshotHash)
+		if delegatedErr != nil {
+			result.Status = "partial"
+			result.Errors = append(result.Errors, "stale delegated first-touch retirement: "+delegatedErr.Error())
+			s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "partial", result, false, nil)
+			return result, errx.New(errx.ServiceUnavailable, "feed stale delegated first-touch retirement failed; snapshot not committed")
+		}
+		result.Counts["stale_delegated_first_touches_retired"] = delegatedRetired
 		retired, requeued, staleErr := s.retireStaleReviewBacklog(ctx, orgID)
 		if staleErr != nil {
 			result.Status = "partial"


### PR DESCRIPTION
Cancels stale delegated decisions, dispatch rows, touchpoints, and drafts atomically before a new authoritative feed becomes current.

Also reconciles stale delegated state on worker startup so a legacy queued audit row cannot block rolling replenishment.

Verification:
- targeted delegated first-touch unit and PostgreSQL tests pass
- golangci-lint passes with Go 1.25
- gofmt and git diff check pass