### PR TITLE
feat: make canonical backups read-only for legacy Asaas queues and prove isolated restores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Run structural tests
-        run: python3 -m unittest deploy.confenge-vps.test_vps_pack
+        run: >-
+          python3 -m unittest
+          deploy.confenge-vps.test_vps_pack
+          deploy.confenge-vps.test_backup
+          deploy/confenge-vps/asaas-adapter/test_adapter.py
 
       - name: Validate deployment pack
         run: deploy/confenge-vps/validate.sh

--- a/deploy/confenge-vps/asaas-adapter.env.example
+++ b/deploy/confenge-vps/asaas-adapter.env.example
@@ -14,4 +14,6 @@ ASAAS_ADAPTER_MAX_BACKOFF_SECONDS=900
 ASAAS_ADAPTER_PROCESSING_LEASE_SECONDS=120
 ASAAS_ADAPTER_PROCESSED_RETENTION_DAYS=45
 ASAAS_ADAPTER_BACKUP_MAX_AGE_SECONDS=93600
+# Backup freshness lives in this non-secret sidecar, never in a queue row.
+ASAAS_ADAPTER_BACKUP_RECEIPT=/var/lib/confenge-asaas-adapter/events.sqlite3.backup-receipt.json
 ASAAS_ADAPTER_DRY_RUN=false

--- a/deploy/confenge-vps/asaas-adapter/adapter.py
+++ b/deploy/confenge-vps/asaas-adapter/adapter.py
@@ -38,6 +38,42 @@ RETRYABLE_HTTP = {408, 425, 429, 500, 502, 503, 504}
 MAX_BODY_BYTES = 256 * 1024
 MAX_PROVIDER_TEXT_CHARS = 500
 WARMBLY_PROVIDER_PATH = "/v1/confenge/intel/commercial/provider-events"
+QUEUE_PROOF_VERSION = "confenge.asaas-queue-proof.v1"
+BACKUP_RECEIPT_VERSION = "confenge.asaas-backup-receipt.v1"
+CURRENT_QUEUE_SCHEMA = "confenge.asaas-queue.current-v1"
+LEGACY_QUEUE_SCHEMA = "confenge.asaas-queue.legacy-stateless-v0"
+CURRENT_TABLE_COLUMNS = {
+    "metadata": ("key", "value"),
+    "events": (
+        "provider_event_id",
+        "correlation_id",
+        "event_type",
+        "occurred_at",
+        "received_at",
+        "payload",
+        "payload_sha256",
+        "state",
+        "attempts",
+        "next_attempt_at",
+        "lease_until",
+        "last_http_status",
+        "last_code",
+        "updated_at",
+        "processed_at",
+    ),
+    "occurrences": (
+        "id",
+        "provider_event_id",
+        "correlation_id",
+        "code",
+        "owner",
+        "next_action",
+        "state",
+        "opened_at",
+        "detail",
+    ),
+    "backups": ("path", "created_at", "sha256"),
+}
 
 
 def utc_now() -> str:
@@ -155,6 +191,7 @@ class Config:
     warmbly_bearer_token: str
     warmbly_webhook_secret: str
     warmbly_previous_secret: str
+    backup_receipt_path: Path | None = None
     max_attempts: int = 8
     base_backoff_seconds: int = 5
     max_backoff_seconds: int = 900
@@ -168,8 +205,9 @@ class Config:
         state = Path(
             os.getenv("ASAAS_ADAPTER_STATE_DIR", "/var/lib/confenge-asaas-adapter")
         )
+        db_path = Path(os.getenv("ASAAS_ADAPTER_DB", str(state / "events.sqlite3")))
         return cls(
-            db_path=Path(os.getenv("ASAAS_ADAPTER_DB", str(state / "events.sqlite3"))),
+            db_path=db_path,
             listen_host=os.getenv("ASAAS_ADAPTER_HOST", "127.0.0.1"),
             listen_port=int(os.getenv("ASAAS_ADAPTER_PORT", "8791")),
             asaas_token=os.getenv("ASAAS_WEBHOOK_TOKEN", ""),
@@ -183,6 +221,12 @@ class Config:
             ),
             warmbly_previous_secret=os.getenv(
                 "ASAAS_ADAPTER_WARMBLY_WEBHOOK_SECRET_PREVIOUS", ""
+            ),
+            backup_receipt_path=Path(
+                os.getenv(
+                    "ASAAS_ADAPTER_BACKUP_RECEIPT",
+                    f"{db_path}.backup-receipt.json",
+                )
             ),
             max_attempts=int(os.getenv("ASAAS_ADAPTER_MAX_ATTEMPTS", "8")),
             base_backoff_seconds=int(
@@ -273,9 +317,172 @@ def file_sha256(path: Path) -> str:
     return digest.hexdigest()
 
 
+def _database_path_from_env() -> Path:
+    state = Path(
+        os.getenv("ASAAS_ADAPTER_STATE_DIR", "/var/lib/confenge-asaas-adapter")
+    )
+    return Path(os.getenv("ASAAS_ADAPTER_DB", str(state / "events.sqlite3")))
+
+
+def _read_only_database(path: Path) -> sqlite3.Connection:
+    if not path.is_file():
+        raise ValueError("adapter queue database does not exist")
+    database = sqlite3.connect(
+        f"{path.resolve().as_uri()}?mode=ro", uri=True, timeout=30
+    )
+    database.row_factory = sqlite3.Row
+    database.execute("PRAGMA query_only=ON")
+    return database
+
+
+def _table_columns(database: sqlite3.Connection) -> dict[str, tuple[str, ...]]:
+    tables: dict[str, tuple[str, ...]] = {}
+    rows = database.execute(
+        "SELECT name FROM sqlite_schema "
+        "WHERE type='table' AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    )
+    for row in rows:
+        name = str(row["name"])
+        columns = database.execute(
+            "SELECT name FROM pragma_table_info(?) ORDER BY cid", (name,)
+        )
+        tables[name] = tuple(str(column["name"]) for column in columns)
+    return tables
+
+
+def _stored_schema_version(
+    database: sqlite3.Connection, tables: dict[str, tuple[str, ...]]
+) -> int | None:
+    if tables.get("metadata") != CURRENT_TABLE_COLUMNS["metadata"]:
+        return None
+    row = database.execute(
+        "SELECT value FROM metadata WHERE key='schema_version'"
+    ).fetchone()
+    if row is None:
+        return None
+    try:
+        return int(row["value"])
+    except (TypeError, ValueError) as error:
+        raise ValueError("invalid adapter queue schema version") from error
+
+
+def _classify_queue_schema(
+    database: sqlite3.Connection, tables: dict[str, tuple[str, ...]]
+) -> tuple[str, int | None]:
+    version = _stored_schema_version(database, tables)
+    if tables == CURRENT_TABLE_COLUMNS and version == SCHEMA_VERSION:
+        invalid = database.execute(
+            "SELECT COUNT(*) FROM events WHERE state NOT IN (?,?,?,?,?,?)",
+            QUEUE_STATES,
+        ).fetchone()[0]
+        if invalid:
+            raise ValueError("adapter queue contains an unsupported state")
+        return CURRENT_QUEUE_SCHEMA, version
+
+    event_columns = set(tables.get("events", ()))
+    if (
+        version is None
+        and "state" not in event_columns
+        and {"provider_event_id", "payload"}.issubset(event_columns)
+    ):
+        return LEGACY_QUEUE_SCHEMA, None
+
+    if version is not None and version != SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported adapter queue schema version {version}; "
+            f"backup tooling supports version {SCHEMA_VERSION}"
+        )
+    if "events" not in tables:
+        raise ValueError("unsupported adapter queue schema: events table is missing")
+    raise ValueError(
+        "unsupported adapter queue schema: events columns do not match "
+        "current-v1 or legacy-stateless-v0"
+    )
+
+
+def inspect_queue_database(
+    path: Path, *, full_integrity: bool = False
+) -> dict[str, Any]:
+    database = _read_only_database(path)
+    try:
+        check = "integrity_check" if full_integrity else "quick_check(1)"
+        check_result = [row[0] for row in database.execute(f"PRAGMA {check}")]
+        if check_result != ["ok"]:
+            raise ValueError("adapter queue failed SQLite integrity validation")
+        tables = _table_columns(database)
+        schema, version = _classify_queue_schema(database, tables)
+        counted_tables = tuple(
+            name
+            for name in ("metadata", "events", "occurrences", "backups")
+            if name in tables
+        )
+        table_counts = {
+            name: int(database.execute(f'SELECT COUNT(*) FROM "{name}"').fetchone()[0])
+            for name in counted_tables
+        }
+        queue_counts: dict[str, int] | None = None
+        if schema == CURRENT_QUEUE_SCHEMA:
+            queue_counts = {state: 0 for state in QUEUE_STATES}
+            for row in database.execute(
+                "SELECT state,COUNT(*) AS count FROM events GROUP BY state"
+            ):
+                queue_counts[str(row["state"])] = int(row["count"])
+        return {
+            "proof_version": QUEUE_PROOF_VERSION,
+            "schema": schema,
+            "schema_version": version,
+            "sqlite_version": sqlite3.sqlite_version,
+            "integrity_check": "ok",
+            "table_counts": table_counts,
+            "queue_state_counts": queue_counts,
+        }
+    finally:
+        database.close()
+
+
+def backup_database(source: Path, destination: Path) -> dict[str, Any]:
+    source_proof = inspect_queue_database(source)
+    destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    descriptor, staged_name = tempfile.mkstemp(
+        prefix="asaas-backup.", suffix=".sqlite3", dir=destination.parent
+    )
+    os.close(descriptor)
+    staged = Path(staged_name)
+    try:
+        source_database = _read_only_database(source)
+        target_database = sqlite3.connect(staged)
+        try:
+            source_database.backup(target_database)
+        finally:
+            target_database.close()
+            source_database.close()
+        os.chmod(staged, 0o600)
+        proof = inspect_queue_database(staged, full_integrity=True)
+        if proof["schema"] != source_proof["schema"]:
+            raise ValueError("adapter queue schema changed during backup")
+        os.replace(staged, destination)
+        return {
+            **proof,
+            "sha256": file_sha256(destination),
+            "size_bytes": destination.stat().st_size,
+        }
+    finally:
+        with contextlib.suppress(FileNotFoundError):
+            staged.unlink()
+
+
 class Queue:
-    def __init__(self, path: Path, *, recover_processing: bool = True):
+    def __init__(
+        self,
+        path: Path,
+        *,
+        recover_processing: bool = True,
+        backup_receipt_path: Path | None = None,
+    ):
         self.path = path
+        self.backup_receipt_path = backup_receipt_path or Path(
+            f"{path}.backup-receipt.json"
+        )
         path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         secure_database_permissions(path)
         self.db = sqlite3.connect(path, timeout=30, check_same_thread=False)
@@ -507,10 +714,23 @@ class Queue:
             last_backup = self.db.execute(
                 "SELECT created_at FROM backups ORDER BY created_at DESC LIMIT 1"
             ).fetchone()
+        backup_stamps = [last_backup["created_at"]] if last_backup else []
+        with contextlib.suppress(OSError, json.JSONDecodeError, TypeError, ValueError):
+            if self.backup_receipt_path.stat().st_size > 4096:
+                raise ValueError("backup receipt is oversized")
+            receipt = json.loads(self.backup_receipt_path.read_text(encoding="utf-8"))
+            if receipt.get("format_version") != BACKUP_RECEIPT_VERSION:
+                raise ValueError("unknown backup receipt")
+            created_at = receipt.get("created_at")
+            if not isinstance(created_at, str):
+                raise TypeError("invalid backup receipt")
+            datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+            backup_stamps.append(created_at)
         backup_age: int | None = None
-        if last_backup:
-            stamp = datetime.fromisoformat(
-                last_backup["created_at"].replace("Z", "+00:00")
+        if backup_stamps:
+            stamp = max(
+                datetime.fromisoformat(value.replace("Z", "+00:00"))
+                for value in backup_stamps
             )
             backup_age = max(
                 0, int((datetime.now(timezone.utc) - stamp).total_seconds())
@@ -546,25 +766,8 @@ class Queue:
             return cur.rowcount
 
     def backup(self, destination: Path) -> dict[str, Any]:
-        destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
         with self.lock:
-            target = sqlite3.connect(destination)
-            try:
-                self.db.backup(target)
-            finally:
-                target.close()
-        os.chmod(destination, 0o600)
-        digest = file_sha256(destination)
-        with self.lock, self.db:
-            self.db.execute(
-                "INSERT OR REPLACE INTO backups(path,created_at,sha256) VALUES(?,?,?)",
-                (str(destination), utc_now(), digest),
-            )
-        return {
-            "path": str(destination),
-            "sha256": digest,
-            "counts": self.stats(0)["queue"],
-        }
+            return backup_database(self.path, destination)
 
 
 class Processor:
@@ -713,7 +916,9 @@ class Processor:
 class App:
     def __init__(self, config: Config):
         self.config = config
-        self.queue = Queue(config.db_path)
+        self.queue = Queue(
+            config.db_path, backup_receipt_path=config.backup_receipt_path
+        )
         self.processor = Processor(self.queue, config)
         self.wake = threading.Event()
         self.stop = threading.Event()
@@ -840,24 +1045,8 @@ def handler_for(app: App) -> type[BaseHTTPRequestHandler]:
     return Handler
 
 
-def restore_database(source: Path, destination: Path) -> None:
-    if not source.is_file():
-        raise ValueError("backup does not exist")
-    probe = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
-    try:
-        version = probe.execute(
-            "SELECT value FROM metadata WHERE key='schema_version'"
-        ).fetchone()
-        invalid = probe.execute(
-            "SELECT COUNT(*) FROM events WHERE state NOT IN (?,?,?,?,?,?)", QUEUE_STATES
-        ).fetchone()[0]
-        if version is None or int(version[0]) != SCHEMA_VERSION or invalid:
-            raise ValueError("incompatible adapter backup")
-        integrity = probe.execute("PRAGMA integrity_check").fetchall()
-        if integrity != [("ok",)]:
-            raise ValueError("adapter backup failed integrity_check")
-    finally:
-        probe.close()
+def restore_database(source: Path, destination: Path) -> dict[str, Any]:
+    proof = inspect_queue_database(source, full_integrity=True)
     destination.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
     os.chmod(destination.parent, 0o700)
     fd, staged_name = tempfile.mkstemp(prefix="events.restore.", dir=destination.parent)
@@ -872,6 +1061,11 @@ def restore_database(source: Path, destination: Path) -> None:
     finally:
         with contextlib.suppress(FileNotFoundError):
             staged.unlink()
+    return {
+        **proof,
+        "sha256": file_sha256(destination),
+        "size_bytes": destination.stat().st_size,
+    }
 
 
 def assert_permissions(path: Path) -> None:
@@ -899,6 +1093,7 @@ def main() -> int:
             "serve",
             "drain",
             "health",
+            "preflight",
             "backup",
             "restore",
             "permissions",
@@ -907,6 +1102,19 @@ def main() -> int:
     )
     parser.add_argument("path", nargs="?")
     args = parser.parse_args()
+    if args.command in ("preflight", "backup"):
+        try:
+            source = _database_path_from_env()
+            if args.command == "preflight":
+                proof = inspect_queue_database(source)
+            else:
+                if not args.path:
+                    parser.error("backup requires a destination path")
+                proof = backup_database(source, Path(args.path))
+        except (OSError, sqlite3.Error, ValueError) as error:
+            parser.exit(1, f"ASAAS_QUEUE_BACKUP=FAIL reason={error}\n")
+        print(json.dumps(proof, sort_keys=True))
+        return 0
     try:
         config = Config.from_env()
         config.validate(args.command)
@@ -915,7 +1123,11 @@ def main() -> int:
     if args.command == "restore":
         if not args.path:
             parser.error("restore requires a backup path")
-        restore_database(Path(args.path), config.db_path)
+        try:
+            proof = restore_database(Path(args.path), config.db_path)
+        except (OSError, sqlite3.Error, ValueError) as error:
+            parser.exit(1, f"ASAAS_QUEUE_RESTORE=FAIL reason={error}\n")
+        print(json.dumps(proof, sort_keys=True))
         return 0
     if args.command == "permissions":
         assert_permissions(config.db_path)
@@ -930,10 +1142,6 @@ def main() -> int:
             print(
                 json.dumps(queue.stats(config.backup_max_age_seconds), sort_keys=True)
             )
-        elif args.command == "backup":
-            if not args.path:
-                parser.error("backup requires a destination path")
-            print(json.dumps(queue.backup(Path(args.path)), sort_keys=True))
         elif args.command == "drain":
             processor = Processor(queue, config)
             while processor.process_one():

--- a/deploy/confenge-vps/asaas-adapter/test_adapter.py
+++ b/deploy/confenge-vps/asaas-adapter/test_adapter.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 MODULE = Path(__file__).with_name("adapter.py")
+LEGACY_FIXTURE = Path(__file__).with_name("testdata") / "legacy-stateless-v0.sql"
 SPEC = importlib.util.spec_from_file_location("confenge_asaas_adapter", MODULE)
 assert SPEC and SPEC.loader
 adapter = importlib.util.module_from_spec(SPEC)
@@ -270,10 +271,17 @@ class AdapterTest(unittest.TestCase):
 
     def test_online_backup_restore_and_permissions(self):
         self.queue.persist(event("evt_backup"))
+        before = tuple(self.queue.db.execute("SELECT * FROM events ORDER BY rowid"))
         backup = self.root / "backup" / "events.sqlite3"
         proof = self.queue.backup(backup)
-        self.assertEqual(proof["counts"]["pending"], 1)
+        self.assertEqual(proof["queue_state_counts"]["pending"], 1)
         self.assertEqual(proof["sha256"], adapter.file_sha256(backup))
+        self.assertEqual(
+            tuple(self.queue.db.execute("SELECT * FROM events ORDER BY rowid")), before
+        )
+        self.assertEqual(
+            self.queue.db.execute("SELECT COUNT(*) FROM backups").fetchone()[0], 0
+        )
         restored = self.root / "restore" / "events.sqlite3"
         restored.parent.mkdir()
         Path(f"{restored}-wal").write_bytes(b"stale-wal")
@@ -303,6 +311,108 @@ class AdapterTest(unittest.TestCase):
         ).fetchone()
         self.assertEqual(row["state"], "processing")
         self.assertIsNone(row["last_code"])
+        self.assertEqual(
+            self.queue.db.execute("SELECT COUNT(*) FROM backups").fetchone()[0], 0
+        )
+
+    def test_external_backup_receipt_keeps_health_fresh_without_a_queue_row(self):
+        before = tuple(self.queue.db.execute("SELECT * FROM events ORDER BY rowid"))
+        self.queue.backup_receipt_path.write_text(
+            json.dumps(
+                {
+                    "format_version": adapter.BACKUP_RECEIPT_VERSION,
+                    "created_at": adapter.utc_now(),
+                    "archive_sha256": "a" * 64,
+                    "queue_schema": adapter.CURRENT_QUEUE_SCHEMA,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertEqual(self.queue.stats(60)["backup_status"], "FRESH")
+        self.assertEqual(
+            tuple(self.queue.db.execute("SELECT * FROM events ORDER BY rowid")), before
+        )
+        self.assertEqual(
+            self.queue.db.execute("SELECT COUNT(*) FROM backups").fetchone()[0], 0
+        )
+
+    def test_legacy_fixture_reproduces_initialize_failure_but_backup_is_read_only(self):
+        self.queue.close()
+        fixture_sql = LEGACY_FIXTURE.read_text(encoding="utf-8")
+
+        reproduced = self.root / "reproduced" / "events.sqlite3"
+        reproduced.parent.mkdir()
+        connection = adapter.sqlite3.connect(reproduced)
+        connection.executescript(fixture_sql)
+        connection.close()
+        with self.assertRaisesRegex(
+            adapter.sqlite3.OperationalError, "no such column: state"
+        ):
+            adapter.Queue(reproduced)
+
+        legacy = self.root / "legacy" / "events.sqlite3"
+        legacy.parent.mkdir()
+        connection = adapter.sqlite3.connect(legacy)
+        connection.executescript(fixture_sql)
+        connection.close()
+        before_bytes = legacy.read_bytes()
+        before_stat = legacy.stat()
+        connection = adapter.sqlite3.connect(legacy)
+        before_rows = connection.execute("SELECT * FROM events").fetchall()
+        before_tables = connection.execute(
+            "SELECT name,sql FROM sqlite_schema WHERE type='table' ORDER BY name"
+        ).fetchall()
+        connection.close()
+
+        preflight = adapter.inspect_queue_database(legacy)
+        backup = self.root / "legacy-backup" / "events.sqlite3"
+        proof = adapter.backup_database(legacy, backup)
+
+        self.assertEqual(preflight["schema"], adapter.LEGACY_QUEUE_SCHEMA)
+        self.assertEqual(proof["schema"], adapter.LEGACY_QUEUE_SCHEMA)
+        self.assertEqual(proof["table_counts"], {"events": 1})
+        self.assertEqual(legacy.read_bytes(), before_bytes)
+        self.assertEqual(legacy.stat().st_mtime_ns, before_stat.st_mtime_ns)
+        connection = adapter.sqlite3.connect(legacy)
+        self.assertEqual(
+            connection.execute("SELECT * FROM events").fetchall(), before_rows
+        )
+        self.assertEqual(
+            connection.execute(
+                "SELECT name,sql FROM sqlite_schema WHERE type='table' ORDER BY name"
+            ).fetchall(),
+            before_tables,
+        )
+        connection.close()
+
+        restored = self.root / "legacy-restore" / "events.sqlite3"
+        restore_proof = adapter.restore_database(backup, restored)
+        self.assertEqual(restore_proof["schema"], adapter.LEGACY_QUEUE_SCHEMA)
+        self.assertEqual(adapter.file_sha256(restored), adapter.file_sha256(backup))
+        self.queue = adapter.Queue(self.root / "replacement" / "events.sqlite3")
+
+    def test_backup_preflight_fails_closed_for_future_schema_without_writing(self):
+        self.queue.close()
+        connection = adapter.sqlite3.connect(self.queue.path)
+        connection.execute("UPDATE metadata SET value='2' WHERE key='schema_version'")
+        connection.commit()
+        connection.close()
+        before = self.queue.path.read_bytes()
+
+        with self.assertRaisesRegex(
+            ValueError, "unsupported adapter queue schema version 2"
+        ):
+            adapter.inspect_queue_database(self.queue.path)
+
+        self.assertEqual(self.queue.path.read_bytes(), before)
+        self.queue = adapter.Queue(self.root / "replacement" / "events.sqlite3")
+
+    def test_backup_preflight_does_not_create_a_missing_source(self):
+        missing = self.root / "missing" / "events.sqlite3"
+        with self.assertRaisesRegex(ValueError, "does not exist"):
+            adapter.inspect_queue_database(missing)
+        self.assertFalse(missing.exists())
 
     def test_queue_refuses_to_overwrite_a_different_schema_version(self):
         self.queue.close()

--- a/deploy/confenge-vps/asaas-adapter/testdata/legacy-stateless-v0.sql
+++ b/deploy/confenge-vps/asaas-adapter/testdata/legacy-stateless-v0.sql
@@ -1,0 +1,42 @@
+-- Regression model for the unversioned Asaas queue reported in issue #186.
+-- It deliberately has no events.state column or schema-version metadata.
+CREATE TABLE events (
+    provider_event_id TEXT PRIMARY KEY,
+    correlation_id TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    occurred_at TEXT NOT NULL,
+    received_at TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    payload_sha256 TEXT NOT NULL,
+    attempts INTEGER NOT NULL DEFAULT 0,
+    next_attempt_at REAL NOT NULL DEFAULT 0,
+    lease_until REAL,
+    last_http_status INTEGER,
+    last_code TEXT,
+    updated_at TEXT NOT NULL,
+    processed_at TEXT
+);
+
+INSERT INTO events (
+    provider_event_id,
+    correlation_id,
+    event_type,
+    occurred_at,
+    received_at,
+    payload,
+    payload_sha256,
+    attempts,
+    next_attempt_at,
+    updated_at
+) VALUES (
+    'evt_fixture_legacy',
+    'corr_fixture_legacy',
+    'PAYMENT_CREATED',
+    '2026-08-25T00:00:00Z',
+    '2026-08-25T00:00:00Z',
+    '{}',
+    '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a',
+    0,
+    0,
+    '2026-08-25T00:00:00Z'
+);

--- a/deploy/confenge-vps/backup.sh
+++ b/deploy/confenge-vps/backup.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Backup Warmbly CONFENGE operational data (DB + key material pointers).
+# Backup Warmbly CONFENGE operational data without mutating the Asaas queue.
 # Never includes Hostinger plaintext password. Never prints secret values.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -8,91 +8,243 @@ source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
 load_vps_env
 cd "$ROOT"
 
+umask 077
 TS="$(date -u +%Y%m%dT%H%M%SZ)"
+CREATED_AT="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 OUT_DIR="${CONFENGE_BACKUP_DIR:-$ROOT/data/backups/confenge-vps}"
-mkdir -p "$OUT_DIR"
+SECRETS_DIR="${CONFENGE_SECRETS_BACKUP_DIR:-$OUT_DIR/secrets}"
 STAGE="$OUT_DIR/stage-$TS"
-mkdir -p "$STAGE"
+ARCHIVE="$OUT_DIR/warmbly-confenge-$TS.tar.gz"
+ARCHIVE_TMP="$OUT_DIR/.warmbly-confenge-$TS.tar.gz.tmp"
+MANIFEST_SIDECAR="$ARCHIVE.manifest.json"
+CHECKSUM_SIDECAR="$ARCHIVE.sha256"
+SEC_BUNDLE="$SECRETS_DIR/keys-$TS.env"
+SEC_BUNDLE_TMP=""
+RECEIPT_TMP=""
+COMPLETE=false
+
+if [[ -e "$STAGE" || -e "$ARCHIVE" || -e "$MANIFEST_SIDECAR" || \
+      -e "$CHECKSUM_SIDECAR" || -e "$SEC_BUNDLE" ]]; then
+  echo "BACKUP=FAIL reason=timestamp output collision" >&2
+  exit 1
+fi
+mkdir -p "$OUT_DIR" "$SECRETS_DIR" "$STAGE"
+
+cleanup() {
+  rm -rf -- "$STAGE"
+  rm -f -- "$ARCHIVE_TMP"
+  if [[ -n "$SEC_BUNDLE_TMP" ]]; then
+    rm -f -- "$SEC_BUNDLE_TMP"
+  fi
+  if [[ -n "$RECEIPT_TMP" ]]; then
+    rm -f -- "$RECEIPT_TMP"
+  fi
+  if [[ "$COMPLETE" != "true" ]]; then
+    rm -f -- "$ARCHIVE" "$MANIFEST_SIDECAR" "$CHECKSUM_SIDECAR"
+    rm -f -- "$SEC_BUNDLE" "$SEC_BUNDLE.sha256"
+  fi
+}
+trap cleanup EXIT
+
+# Fail before the heavier pg_dump if a present queue is corrupt or unknown.
+ASAAS_DB="${ASAAS_ADAPTER_DB:-/var/lib/confenge-asaas-adapter/events.sqlite3}"
+if [[ -f "$ASAAS_DB" ]]; then
+  echo "Preflighting Asaas queue schema (read-only)..."
+  ASAAS_ADAPTER_DB="$ASAAS_DB" python3 \
+    "$ROOT/deploy/confenge-vps/asaas-adapter/adapter.py" preflight \
+    >"$STAGE/asaas-preflight.json"
+fi
 
 echo "Backing up postgres (warmbly_dev)..."
-compose_cmd exec -T postgres pg_dump -U warmbly warmbly_dev >"$STAGE/warmbly_dev.sql"
+PG_DUMP_VERSION="$(compose_cmd exec -T postgres pg_dump --version | head -1)"
+compose_cmd exec -T postgres pg_dump \
+  -U warmbly --no-owner --no-privileges warmbly_dev \
+  >"$STAGE/warmbly_dev.sql"
+if ! grep -q '^-- PostgreSQL database dump complete' "$STAGE/warmbly_dev.sql"; then
+  echo "POSTGRES_BACKUP=FAIL reason=pg_dump completion marker missing" >&2
+  exit 1
+fi
 
-# Online SQLite backup uses sqlite3.Connection.backup, so WAL writes can
-# continue without copying a torn db/WAL pair. No payload is printed.
-ASAAS_DB="${ASAAS_ADAPTER_DB:-/var/lib/confenge-asaas-adapter/events.sqlite3}"
+# sqlite3.Connection.backup reads a WAL-consistent snapshot from a mode=ro
+# connection. It never initializes Queue or writes backup metadata to the source.
 if [[ -f "$ASAAS_DB" ]]; then
   ASAAS_ADAPTER_DB="$ASAAS_DB" python3 \
     "$ROOT/deploy/confenge-vps/asaas-adapter/adapter.py" backup \
     "$STAGE/asaas-events.sqlite3" >"$STAGE/asaas-backup-proof.json"
 fi
 
-# Encryption keys: copy env keys into a separate 0600 secrets bundle (not next to public dumps by default)
-SECRETS_DIR="${CONFENGE_SECRETS_BACKUP_DIR:-$OUT_DIR/secrets}"
-mkdir -p "$SECRETS_DIR"
-SEC_BUNDLE="$SECRETS_DIR/keys-$TS.env"
-umask 077
+# Copy encryption roots into a separate 0600 bundle, never into the archive.
+SEC_BUNDLE_TMP="$(mktemp "$SECRETS_DIR/.keys-$TS.XXXXXX")"
 {
   echo "# CONFENGE VPS key material backup $TS"
-  echo "# Store offline / encrypted separately from SQL dumps."
+  echo "# Store offline and encrypted, separately from SQL dumps."
   for k in KMS_LOCAL_MASTER_KEY CREDENTIALS_ENCRYPTION_KEY AUTH_SECRET INTERNAL_API_TOKEN CONFENGE_OUTCOME_WEBHOOK_SECRET; do
     v="${!k:-}"
     if [[ -n "$v" ]]; then
       printf '%s=%s\n' "$k" "$v"
     fi
   done
-} >"$SEC_BUNDLE"
-chmod 600 "$SEC_BUNDLE"
+} >"$SEC_BUNDLE_TMP"
+chmod 600 "$SEC_BUNDLE_TMP"
 
-# Config snapshot without secrets
-python3 - "$ROOT/deploy/confenge-vps/.env" "$STAGE/env.redacted" <<'PY'
-import re, sys
-src, dst = sys.argv[1], sys.argv[2]
-secret_keys = re.compile(
-    r"(PASSWORD|SECRET|TOKEN|KEY|AUTH_SECRET|CREDENTIALS|KMS_|WEBHOOK_SECRET)",
+# Snapshot configuration while removing secrets, credentials, and operator PII.
+CONFIG_SOURCE="${CONFENGE_VPS_ENV:-$ROOT/deploy/confenge-vps/.env}"
+python3 - "$CONFIG_SOURCE" "$STAGE/env.redacted" <<'PY'
+import re
+import sys
+
+source, destination = sys.argv[1], sys.argv[2]
+sensitive_keys = re.compile(
+    r"(PASS|SECRET|TOKEN|KEY|CREDENTIAL|KMS_|AUTH|BEARER|PRIVATE|"
+    r"DATABASE_URL|PRIMARY_DB|DSN|COOKIE|SESSION)",
     re.I,
 )
+pii_keys = re.compile(r"(EMAIL|MAILBOX_NAME|USER_ID|ORG_ID|USERNAME)", re.I)
+userinfo = re.compile(r"([a-z][a-z0-9+.-]*://)[^/@\s]+@", re.I)
+url_query = re.compile(r"[a-z][a-z0-9+.-]*://[^\s?]+\?", re.I)
+email_value = re.compile(r"[^\s@=]+@[^\s@]+")
+
 try:
-    lines = open(src, encoding="utf-8").read().splitlines()
+    lines = open(source, encoding="utf-8").read().splitlines()
 except FileNotFoundError:
-    open(dst, "w", encoding="utf-8").write("# no .env present\n")
+    open(destination, "w", encoding="utf-8").write("# no .env present\n")
     raise SystemExit(0)
-out = []
+
+output = ["# CONFENGE configuration snapshot with secrets and PII redacted"]
 for line in lines:
-    if not line.strip() or line.strip().startswith("#"):
-        out.append(line)
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
         continue
     if "=" not in line:
-        out.append(line)
         continue
-    k, _, _ = line.partition("=")
-    if secret_keys.search(k):
-        out.append(f"{k}=***REDACTED***")
-    else:
-        out.append(line)
-open(dst, "w", encoding="utf-8").write("\n".join(out) + "\n")
+    key, _, value = line.partition("=")
+    if (
+        sensitive_keys.search(key)
+        or pii_keys.search(key)
+        or email_value.search(value)
+        or url_query.search(value)
+    ):
+        output.append(f"{key}=***REDACTED***")
+        continue
+    redacted_value = userinfo.sub(r"\1***REDACTED***@", value)
+    output.append(f"{key}={redacted_value}")
+open(destination, "w", encoding="utf-8").write("\n".join(output) + "\n")
 PY
 
-# Manifest
-{
-  echo "ts=$TS"
-  echo "project=${COMPOSE_PROJECT_NAME:-warmbly-confenge}"
-  echo "git_sha=$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
-  echo "host=$(hostname 2>/dev/null || echo unknown)"
-  echo "sql=warmbly_dev.sql"
-  if [[ -f "$STAGE/asaas-events.sqlite3" ]]; then
-    echo "asaas_queue=asaas-events.sqlite3"
-  else
-    echo "asaas_queue=absent"
-  fi
-  echo "secrets_bundle=$(basename "$SEC_BUNDLE")"
-  echo "note=Keep SQL and secrets_bundle offline and separate; both needed for full restore."
-} >"$STAGE/MANIFEST.txt"
+GIT_SHA="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null || echo unknown)"
+python3 - "$STAGE" "$CREATED_AT" "$GIT_SHA" "$PG_DUMP_VERSION" <<'PY'
+import hashlib
+import json
+import sys
+from pathlib import Path
 
-ARCHIVE="$OUT_DIR/warmbly-confenge-$TS.tar.gz"
-tar -C "$STAGE" -czf "$ARCHIVE" .
-rm -rf "$STAGE"
-chmod 600 "$ARCHIVE" 2>/dev/null || true
+stage = Path(sys.argv[1])
+created_at, git_sha, pg_dump_version = sys.argv[2:5]
+
+def component(name):
+    path = stage / name
+    return {
+        "file": name,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+        "size_bytes": path.stat().st_size,
+    }
+
+components = {
+    "postgres": component("warmbly_dev.sql"),
+    "redacted_config": component("env.redacted"),
+    "encryption_roots": {
+        "included_in_archive": False,
+        "separate_bundle_required": True,
+    },
+}
+component_files = ["env.redacted", "warmbly_dev.sql"]
+proof_path = stage / "asaas-backup-proof.json"
+if proof_path.is_file():
+    proof = json.loads(proof_path.read_text(encoding="utf-8"))
+    components["asaas_queue"] = {
+        **component("asaas-events.sqlite3"),
+        "included": True,
+        "schema": proof["schema"],
+        "schema_version": proof["schema_version"],
+        "sqlite_version": proof["sqlite_version"],
+        "table_counts": proof["table_counts"],
+        "queue_state_counts": proof["queue_state_counts"],
+    }
+    components["asaas_backup_proof"] = component("asaas-backup-proof.json")
+    components["asaas_preflight"] = component("asaas-preflight.json")
+    component_files.extend(
+        ["asaas-backup-proof.json", "asaas-events.sqlite3", "asaas-preflight.json"]
+    )
+else:
+    components["asaas_queue"] = {"included": False, "reason": "source_absent"}
+
+manifest = {
+    "format_version": "confenge.backup-manifest.v2",
+    "created_at": created_at,
+    "git_sha": git_sha,
+    "versions": {"pg_dump": pg_dump_version},
+    "components": components,
+    "excluded": [
+        "plaintext_mailbox_password",
+        "node_modules",
+        "build_cache",
+        "unbounded_logs",
+        "extra_cli_datalake",
+    ],
+}
+(stage / "MANIFEST.json").write_text(
+    json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+)
+component_files.append("MANIFEST.json")
+checksums = [
+    f"{hashlib.sha256((stage / name).read_bytes()).hexdigest()}  {name}"
+    for name in sorted(component_files)
+]
+(stage / "SHA256SUMS").write_text("\n".join(checksums) + "\n", encoding="utf-8")
+PY
+
+tar -C "$STAGE" -czf "$ARCHIVE_TMP" .
+chmod 600 "$ARCHIVE_TMP"
+install -m 600 "$STAGE/MANIFEST.json" "$MANIFEST_SIDECAR"
+ARCHIVE_SHA256="$(sha256sum "$ARCHIVE_TMP" | awk '{print $1}')"
+printf '%s  %s\n' "$ARCHIVE_SHA256" "$(basename "$ARCHIVE")" >"$CHECKSUM_SIDECAR"
+chmod 600 "$CHECKSUM_SIDECAR"
+
+mv "$SEC_BUNDLE_TMP" "$SEC_BUNDLE"
+SEC_BUNDLE_TMP=""
+SEC_SHA256="$(sha256sum "$SEC_BUNDLE" | awk '{print $1}')"
+printf '%s  %s\n' "$SEC_SHA256" "$(basename "$SEC_BUNDLE")" >"$SEC_BUNDLE.sha256"
+chmod 600 "$SEC_BUNDLE" "$SEC_BUNDLE.sha256"
+mv "$ARCHIVE_TMP" "$ARCHIVE"
+
+# Keep health freshness outside SQLite so the queue database stays unchanged.
+if [[ -f "$ASAAS_DB" ]]; then
+  RECEIPT_PATH="${ASAAS_ADAPTER_BACKUP_RECEIPT:-$ASAAS_DB.backup-receipt.json}"
+  RECEIPT_TMP="$(mktemp "$(dirname "$RECEIPT_PATH")/.asaas-backup-receipt.XXXXXX")"
+  python3 - "$RECEIPT_TMP" "$CREATED_AT" "$ARCHIVE_SHA256" "$STAGE/asaas-backup-proof.json" <<'PY'
+import json
+import sys
+
+destination, created_at, archive_sha256, proof_path = sys.argv[1:5]
+proof = json.load(open(proof_path, encoding="utf-8"))
+receipt = {
+    "format_version": "confenge.asaas-backup-receipt.v1",
+    "created_at": created_at,
+    "archive_sha256": archive_sha256,
+    "queue_schema": proof["schema"],
+}
+open(destination, "w", encoding="utf-8").write(
+    json.dumps(receipt, sort_keys=True) + "\n"
+)
+PY
+  chmod 644 "$RECEIPT_TMP"
+  mv "$RECEIPT_TMP" "$RECEIPT_PATH"
+  RECEIPT_TMP=""
+fi
+COMPLETE=true
 
 echo "Backup archive: $ARCHIVE"
+echo "Manifest: $MANIFEST_SIDECAR"
+echo "Archive checksum: $CHECKSUM_SIDECAR"
 echo "Secrets bundle: $SEC_BUNDLE (0600; store separately)"
 echo "Excluded: node_modules, build cache, unlimited logs, extra-cli datalake, plaintext mailbox password"

--- a/deploy/confenge-vps/restore.sh
+++ b/deploy/confenge-vps/restore.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
-# Restore Warmbly CONFENGE DB from backup.sh SQL dump.
-# Requires keys already present in deploy/confenge-vps/.env (from secrets bundle).
-# DESTRUCTIVE to current warmbly_dev contents.
+# Restore a Warmbly CONFENGE backup. Use isolated targets for restore proofs.
+# Requires keys already present in deploy/confenge-vps/.env for live recovery.
 set -euo pipefail
 ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 # shellcheck source=lib.sh
@@ -11,49 +10,113 @@ cd "$ROOT"
 
 FILE="${1:-${FILE:-}}"
 ADAPTER_FILE=""
+TMP=""
 if [[ -z "$FILE" ]]; then
-  echo "Usage: deploy/confenge-vps/restore.sh /path/to/warmbly_dev.sql" >&2
+  echo "Usage: deploy/confenge-vps/restore.sh /path/to/backup.tar.gz" >&2
   echo "   or: FILE=... deploy/confenge-vps/restore.sh" >&2
   exit 2
 fi
 if [[ ! -f "$FILE" ]]; then
-  echo "missing SQL file: $FILE" >&2
+  echo "missing backup file" >&2
   exit 2
 fi
 
-# If archive given, extract SQL
+cleanup() {
+  if [[ -n "$TMP" ]]; then
+    rm -rf -- "$TMP"
+  fi
+}
+trap cleanup EXIT
+
 if [[ "$FILE" == *.tar.gz ]]; then
   TMP="$(mktemp -d)"
+  while IFS= read -r entry; do
+    case "$entry" in
+      /*|../*|*/../*)
+        echo "archive contains an unsafe path" >&2
+        exit 1
+        ;;
+    esac
+  done < <(tar -tzf "$FILE")
   tar -xzf "$FILE" -C "$TMP"
-  if [[ -f "$TMP/warmbly_dev.sql" ]]; then
-    FILE="$TMP/warmbly_dev.sql"
-    if [[ -f "$TMP/asaas-events.sqlite3" ]]; then
-      ADAPTER_FILE="$TMP/asaas-events.sqlite3"
-    fi
-  else
-    echo "archive missing warmbly_dev.sql" >&2
+  if [[ ! -f "$TMP/warmbly_dev.sql" || ! -f "$TMP/MANIFEST.json" || ! -f "$TMP/SHA256SUMS" ]]; then
+    echo "archive is missing SQL, manifest, or checksums" >&2
     exit 1
+  fi
+  (cd "$TMP" && sha256sum -c SHA256SUMS)
+  python3 - "$TMP/MANIFEST.json" <<'PY'
+import json
+import sys
+
+manifest = json.load(open(sys.argv[1], encoding="utf-8"))
+if manifest.get("format_version") != "confenge.backup-manifest.v2":
+    raise SystemExit("unsupported backup manifest version")
+postgres = manifest.get("components", {}).get("postgres", {})
+if postgres.get("file") != "warmbly_dev.sql":
+    raise SystemExit("backup manifest does not identify the PostgreSQL dump")
+PY
+  FILE="$TMP/warmbly_dev.sql"
+  if [[ -f "$TMP/asaas-events.sqlite3" ]]; then
+    ADAPTER_FILE="$TMP/asaas-events.sqlite3"
   fi
 fi
 
-echo "Restoring $FILE into warmbly_dev (destructive)..."
+if ! grep -q '^-- PostgreSQL database dump complete' "$FILE"; then
+  echo "restore refused: pg_dump completion marker missing" >&2
+  exit 1
+fi
+
+TARGET_DATABASE="${CONFENGE_RESTORE_DATABASE:-warmbly_dev}"
+if [[ ! "$TARGET_DATABASE" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+  echo "restore refused: invalid PostgreSQL target name" >&2
+  exit 2
+fi
+if [[ "$TARGET_DATABASE" == "warmbly_dev" ]]; then
+  echo "Restoring into warmbly_dev (destructive to current database contents)..."
+else
+  echo "Restoring into isolated PostgreSQL database $TARGET_DATABASE..."
+fi
 compose_cmd exec -T postgres pg_isready -U warmbly >/dev/null
-# Drop connections and recreate schema content via psql
-compose_cmd exec -T postgres psql -U warmbly -d warmbly_dev -v ON_ERROR_STOP=1 < "$FILE"
-echo "Restore complete. Restart backend/worker if needed: deploy/confenge-vps/up.sh"
-echo "Verify encryption keys match the dump era or sealed credentials will not decrypt."
+TARGET_TABLES="$(
+  compose_cmd exec -T postgres psql \
+    -U warmbly -d "$TARGET_DATABASE" -Atqc \
+    "SELECT count(*) FROM pg_tables WHERE schemaname NOT IN ('pg_catalog','information_schema')"
+)"
+if [[ "$TARGET_TABLES" != "0" ]]; then
+  echo "restore refused: PostgreSQL target is not empty" >&2
+  exit 1
+fi
+compose_cmd exec -T postgres psql \
+  -U warmbly -d "$TARGET_DATABASE" -v ON_ERROR_STOP=1 <"$FILE"
+RESTORED_DATABASE="$(
+  compose_cmd exec -T postgres psql \
+    -U warmbly -d "$TARGET_DATABASE" -Atqc 'SELECT current_database()'
+)"
+if [[ "$RESTORED_DATABASE" != "$TARGET_DATABASE" ]]; then
+  echo "restore verification failed: PostgreSQL target did not reopen" >&2
+  exit 1
+fi
 
 if [[ -n "$ADAPTER_FILE" ]]; then
-  echo "Restoring durable Asaas transport queue..."
+  LIVE_ADAPTER_DB="${ASAAS_ADAPTER_DB:-/var/lib/confenge-asaas-adapter/events.sqlite3}"
+  TARGET_ADAPTER_DB="${CONFENGE_RESTORE_ASAAS_DB:-$LIVE_ADAPTER_DB}"
   ASAAS_WAS_ACTIVE=false
-  if systemctl is-active --quiet confenge-asaas-adapter.service 2>/dev/null; then
+  if [[ "$TARGET_ADAPTER_DB" == "$LIVE_ADAPTER_DB" ]] && \
+     systemctl is-active --quiet confenge-asaas-adapter.service 2>/dev/null; then
     systemctl stop confenge-asaas-adapter.service
     ASAAS_WAS_ACTIVE=true
   fi
-  python3 "$ROOT/deploy/confenge-vps/asaas-adapter/adapter.py" restore "$ADAPTER_FILE"
-  python3 "$ROOT/deploy/confenge-vps/asaas-adapter/adapter.py" permissions
+  ASAAS_ADAPTER_DB="$TARGET_ADAPTER_DB" python3 \
+    "$ROOT/deploy/confenge-vps/asaas-adapter/adapter.py" restore "$ADAPTER_FILE" \
+    >"${TMP:-$(dirname "$TARGET_ADAPTER_DB")}/asaas-restore-proof.json"
+  ASAAS_ADAPTER_DB="$TARGET_ADAPTER_DB" python3 \
+    "$ROOT/deploy/confenge-vps/asaas-adapter/adapter.py" permissions
+  ASAAS_ADAPTER_DB="$TARGET_ADAPTER_DB" python3 \
+    "$ROOT/deploy/confenge-vps/asaas-adapter/adapter.py" preflight >/dev/null
   if [[ "$ASAAS_WAS_ACTIVE" == "true" ]]; then
     systemctl start confenge-asaas-adapter.service
   fi
-  echo "Asaas queue restore complete; counts are available from its health endpoint."
 fi
+
+echo "RESTORE_PROOF=PASS postgres_database=$TARGET_DATABASE"
+echo "Verify that encryption roots match the backup era before reopening sealed credentials."

--- a/deploy/confenge-vps/test_backup.py
+++ b/deploy/confenge-vps/test_backup.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import stat
+import subprocess
+import tarfile
+import tempfile
+import unittest
+from pathlib import Path
+
+PACK = Path(__file__).resolve().parent
+ROOT = PACK.parent.parent
+ADAPTER = PACK / "asaas-adapter" / "adapter.py"
+LEGACY_FIXTURE = PACK / "asaas-adapter" / "testdata" / "legacy-stateless-v0.sql"
+
+
+class BackupScriptTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory(prefix="warmbly-backup-test-")
+        self.root = Path(self.temporary.name)
+        self.bin = self.root / "bin"
+        self.bin.mkdir()
+        self.docker_log = self.root / "docker.log"
+        docker = self.bin / "docker"
+        docker.write_text(
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >>"$FAKE_DOCKER_LOG"
+case " $* " in
+  *" pg_dump --version "*)
+    echo "pg_dump (PostgreSQL) 16.10"
+    ;;
+  *" pg_dump "*)
+    printf '%s\\n' \
+      '-- fixture PostgreSQL dump' \
+      'CREATE TABLE backup_restore_marker (value text PRIMARY KEY);' \
+      "INSERT INTO backup_restore_marker VALUES ('fixture-186');" \
+      '-- PostgreSQL database dump complete'
+    ;;
+  *" pg_isready "*)
+    ;;
+  *" -Atqc SELECT count(*) FROM pg_tables "*)
+    echo "0"
+    ;;
+  *" -Atqc SELECT current_database() "*)
+    previous=""
+    for argument in "$@"; do
+      if [[ "$previous" == "-d" ]]; then
+        echo "$argument"
+        break
+      fi
+      previous="$argument"
+    done
+    ;;
+  *" psql "*)
+    grep -q 'backup_restore_marker'
+    ;;
+  *)
+    echo "unexpected fake docker invocation" >&2
+    exit 1
+    ;;
+esac
+""",
+            encoding="utf-8",
+        )
+        docker.chmod(0o755)
+        self.environment_file = self.root / "vps.env"
+        self.environment_file.write_text(
+            """COMPOSE_PROJECT_NAME=warmbly-confenge-test
+AUTH_SECRET=fixture-secret-never-archive
+INTERNAL_API_TOKEN=fixture-token-never-archive
+KMS_LOCAL_MASTER_KEY=fixture-kms-never-archive
+CREDENTIALS_ENCRYPTION_KEY=fixture-credentials-never-archive
+CONFENGE_OUTCOME_WEBHOOK_SECRET=fixture-webhook-never-archive
+PRIMARY_DB=postgres://fixture:fixture-password@postgres/db
+CONFENGE_MAILBOX_EMAIL=operator-fixture@example.invalid
+CONFENGE_OPERATOR_USER_ID=11111111-0000-0000-0000-000000000001
+PUBLIC_HOST=127.0.0.1
+PUBLIC_CALLBACK_URL=https://example.invalid/callback?token=fixture-query-never-archive
+""",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def environment(self, database: Path, backup_dir: Path) -> dict[str, str]:
+        environment = os.environ.copy()
+        environment.update(
+            {
+                "PATH": f"{self.bin}:{environment['PATH']}",
+                "FAKE_DOCKER_LOG": str(self.docker_log),
+                "CONFENGE_VPS_ENV": str(self.environment_file),
+                "CONFENGE_BACKUP_DIR": str(backup_dir),
+                "CONFENGE_SECRETS_BACKUP_DIR": str(backup_dir / "secrets"),
+                "ASAAS_ADAPTER_DB": str(database),
+            }
+        )
+        return environment
+
+    @staticmethod
+    def create_legacy_database(path: Path) -> None:
+        path.parent.mkdir(parents=True)
+        database = sqlite3.connect(path)
+        database.executescript(LEGACY_FIXTURE.read_text(encoding="utf-8"))
+        database.close()
+
+    def test_canonical_backup_and_isolated_restore_preserve_legacy_queue(self) -> None:
+        database = self.root / "live-copy" / "events.sqlite3"
+        backup_dir = self.root / "backups"
+        self.create_legacy_database(database)
+        before_bytes = database.read_bytes()
+        before_stat = database.stat()
+        connection = sqlite3.connect(database)
+        before_rows = connection.execute("SELECT * FROM events").fetchall()
+        connection.close()
+
+        result = subprocess.run(
+            ["bash", str(PACK / "backup.sh")],
+            cwd=ROOT,
+            env=self.environment(database, backup_dir),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Preflighting Asaas queue schema (read-only)", result.stdout)
+        self.assertEqual(database.read_bytes(), before_bytes)
+        self.assertEqual(database.stat().st_mtime_ns, before_stat.st_mtime_ns)
+        connection = sqlite3.connect(database)
+        self.assertEqual(
+            connection.execute("SELECT * FROM events").fetchall(), before_rows
+        )
+        self.assertEqual(
+            [
+                row[0]
+                for row in connection.execute(
+                    "SELECT name FROM sqlite_schema WHERE type='table' ORDER BY name"
+                )
+            ],
+            ["events"],
+        )
+        connection.close()
+        receipt = Path(f"{database}.backup-receipt.json")
+        self.assertTrue(receipt.is_file())
+        receipt_data = json.loads(receipt.read_text(encoding="utf-8"))
+        self.assertEqual(
+            receipt_data["format_version"], "confenge.asaas-backup-receipt.v1"
+        )
+        self.assertNotIn(str(database), receipt.read_text(encoding="utf-8"))
+
+        archives = list(backup_dir.glob("warmbly-confenge-*.tar.gz"))
+        self.assertEqual(len(archives), 1)
+        archive = archives[0]
+        self.assertTrue(Path(f"{archive}.manifest.json").is_file())
+        self.assertTrue(Path(f"{archive}.sha256").is_file())
+        expected_archive_hash = Path(f"{archive}.sha256").read_text().split()[0]
+        self.assertEqual(
+            expected_archive_hash, hashlib.sha256(archive.read_bytes()).hexdigest()
+        )
+
+        with tarfile.open(archive, "r:gz") as bundle:
+            members = {
+                member.name.removeprefix("./"): bundle.extractfile(member).read()
+                for member in bundle.getmembers()
+                if member.isfile()
+            }
+        self.assertIn("MANIFEST.json", members)
+        self.assertIn("SHA256SUMS", members)
+        self.assertIn("asaas-events.sqlite3", members)
+        manifest = json.loads(members["MANIFEST.json"])
+        self.assertEqual(manifest["format_version"], "confenge.backup-manifest.v2")
+        self.assertEqual(
+            manifest["components"]["asaas_queue"]["schema"],
+            "confenge.asaas-queue.legacy-stateless-v0",
+        )
+        self.assertEqual(
+            manifest["components"]["asaas_queue"]["table_counts"], {"events": 1}
+        )
+        for checksum_line in members["SHA256SUMS"].decode().splitlines():
+            digest, name = checksum_line.split("  ", 1)
+            self.assertEqual(hashlib.sha256(members[name]).hexdigest(), digest)
+
+        forbidden = (
+            b"fixture-secret-never-archive",
+            b"fixture-token-never-archive",
+            b"fixture-password",
+            b"fixture-query-never-archive",
+            b"operator-fixture@example.invalid",
+        )
+        public_metadata = members["MANIFEST.json"] + members["env.redacted"]
+        for value in forbidden:
+            self.assertNotIn(value, public_metadata)
+        self.assertIn(b"PRIMARY_DB=***REDACTED***", members["env.redacted"])
+        self.assertIn(b"CONFENGE_MAILBOX_EMAIL=***REDACTED***", members["env.redacted"])
+        self.assertIn(b"PUBLIC_CALLBACK_URL=***REDACTED***", members["env.redacted"])
+
+        secret_bundles = list((backup_dir / "secrets").glob("keys-*.env"))
+        self.assertEqual(len(secret_bundles), 1)
+        self.assertEqual(stat.S_IMODE(secret_bundles[0].stat().st_mode), 0o600)
+        self.assertIn("fixture-secret-never-archive", secret_bundles[0].read_text())
+
+        restored = self.root / "isolated" / "asaas-events.sqlite3"
+        restore_environment = self.environment(database, backup_dir)
+        restore_environment.update(
+            {
+                "CONFENGE_RESTORE_DATABASE": "warmbly_restore_verify_186",
+                "CONFENGE_RESTORE_ASAAS_DB": str(restored),
+            }
+        )
+        restored_result = subprocess.run(
+            ["bash", str(PACK / "restore.sh"), str(archive)],
+            cwd=ROOT,
+            env=restore_environment,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        self.assertEqual(restored_result.returncode, 0, restored_result.stderr)
+        self.assertIn(
+            "RESTORE_PROOF=PASS postgres_database=warmbly_restore_verify_186",
+            restored_result.stdout,
+        )
+        self.assertEqual(
+            hashlib.sha256(restored.read_bytes()).hexdigest(),
+            hashlib.sha256(members["asaas-events.sqlite3"]).hexdigest(),
+        )
+        connection = sqlite3.connect(restored)
+        self.assertEqual(
+            connection.execute("SELECT COUNT(*) FROM events").fetchone()[0], 1
+        )
+        connection.close()
+        self.assertEqual(database.read_bytes(), before_bytes)
+
+    def test_unknown_schema_fails_before_postgres_dump(self) -> None:
+        database = self.root / "future" / "events.sqlite3"
+        database.parent.mkdir()
+        connection = sqlite3.connect(database)
+        connection.executescript(
+            """
+            CREATE TABLE metadata (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+            INSERT INTO metadata VALUES ('schema_version', '2');
+            CREATE TABLE events (
+                provider_event_id TEXT PRIMARY KEY,
+                payload TEXT NOT NULL,
+                state TEXT NOT NULL
+            );
+            """
+        )
+        connection.close()
+        before = database.read_bytes()
+
+        result = subprocess.run(
+            ["bash", str(PACK / "backup.sh")],
+            cwd=ROOT,
+            env=self.environment(database, self.root / "future-backups"),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("unsupported adapter queue schema version 2", result.stderr)
+        self.assertFalse(self.docker_log.exists())
+        self.assertEqual(database.read_bytes(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/confenge/vps-disaster-recovery.md
+++ b/docs/confenge/vps-disaster-recovery.md
@@ -7,8 +7,9 @@
 | Postgres | `deploy/confenge-vps/backup.sh` → `warmbly_dev.sql` | Approvals, queues, sealed creds, outcomes |
 | Encryption roots | secrets bundle `keys-*.env` (0600) | `KMS_LOCAL_MASTER_KEY`, `CREDENTIALS_ENCRYPTION_KEY`, `AUTH_SECRET`, tokens |
 | Redacted env | `env.redacted` inside archive | Non-secret config snapshot |
+| Backup inventory | `MANIFEST.json` and `SHA256SUMS` inside archive | Hashes, sizes, versions, schema class, and structural counts only |
 | confenge_ops volume | included indirectly via kill-switch host mirror | Prefer DB governor state |
-| Asaas transport queue | `asaas-events.sqlite3` inside the archive | Online SQLite backup; payload minimized, blocked/dead retained |
+| Asaas transport queue | `asaas-events.sqlite3` inside the archive | Online read-only SQLite backup; payload minimized, blocked/dead retained |
 
 **Do not back up:** plaintext Hostinger password, extra-cli datalake, unlimited logs, `node_modules`.
 
@@ -20,32 +21,114 @@
 # on VPS, repo at /opt/warmbly-confenge
 deploy/confenge-vps/backup.sh
 # → data/backups/confenge-vps/warmbly-confenge-<ts>.tar.gz
+# → data/backups/confenge-vps/warmbly-confenge-<ts>.tar.gz.manifest.json
+# → data/backups/confenge-vps/warmbly-confenge-<ts>.tar.gz.sha256
 # → data/backups/confenge-vps/secrets/keys-<ts>.env
+# → data/backups/confenge-vps/secrets/keys-<ts>.env.sha256
 ```
 
-Schedule (example): daily cron under root, after business window.
+The script preflights a present Asaas SQLite schema before starting `pg_dump`.
+It accepts the current versioned schema and the known unversioned legacy schema
+without initializing `Queue`. An unknown version, unknown column layout, missing
+`events` table, or SQLite integrity error fails early with no PostgreSQL dump.
+
+The PostgreSQL dump uses one `pg_dump` MVCC snapshot. The SQLite copy uses
+`sqlite3.Connection.backup` with the source opened in `mode=ro`, so WAL writers
+can continue. The backup path does not run DDL, recover leases, insert a backup
+row, or change queue states and timestamps. `MANIFEST.json` contains no payload,
+secret, hostname, email address, or operator identity.
+
+Validate both checksum layers before moving an archive:
+
+```bash
+ARCHIVE=data/backups/confenge-vps/warmbly-confenge-<ts>.tar.gz
+(cd "$(dirname "$ARCHIVE")" && sha256sum -c "$(basename "$ARCHIVE").sha256")
+
+PROOF_DIR="$(mktemp -d)"
+tar -xzf "$ARCHIVE" -C "$PROOF_DIR"
+(cd "$PROOF_DIR" && sha256sum -c SHA256SUMS)
+ASAAS_ADAPTER_DB="$PROOF_DIR/asaas-events.sqlite3" \
+  python3 deploy/confenge-vps/asaas-adapter/adapter.py preflight
+```
+
+Never point a schema test at the live file first. The tracked regression fixture is
+`deploy/confenge-vps/asaas-adapter/testdata/legacy-stateless-v0.sql`.
+
+Schedule the backup daily under root after the business window. A backup does
+not pause a campaign, call Asaas, send mail, or resume any commercial flow.
 
 ## Restore
 
 1. Install Docker stack (`install.sh`, `gen-secrets.sh` **or** restore keys from secrets bundle into `deploy/confenge-vps/.env` mode 0600).
-2. `deploy/confenge-vps/up.sh` until postgres healthy.
-3. `deploy/confenge-vps/restore.sh /path/to/archive.tar.gz` (destructive to current DB and adapter queue). The script validates the adapter schema and restores it with mode 0600 under a 0700 state directory.
+2. Start PostgreSQL only, then create or recreate an empty `warmbly_dev`. The
+   restore script refuses a non-empty target before applying any SQL.
+3. `deploy/confenge-vps/restore.sh /path/to/archive.tar.gz` (destructive to the selected empty database and adapter target). The script verifies the manifest and checksums, validates either supported adapter schema, and restores it with mode 0600 under a 0700 state directory.
 4. Restart backend/worker: `docker compose ... restart backend worker`.
 5. `deploy/confenge-vps/status.sh`
 6. Confirm mailbox still decrypts (list accounts / trigger IMAP). Do **not** re-enter password unless keys were wrong era.
 
 ## Controlled restore proof
 
+Run every proof against a disposable Compose project or a separate proof host.
+Do not use the production project name, PostgreSQL database, adapter path, or
+secrets file. The proof database must be empty.
+
 ```bash
-# With stack up and non-production data:
-deploy/confenge-vps/backup.sh
-# Note archive path and secrets path (do not commit)
-# Insert probe: deploy/confenge-vps/prove-restart.sh already writes a probe table
-deploy/confenge-vps/restore.sh data/backups/confenge-vps/.../warmbly_dev.sql
-# Expect probe row or known approval still present
+export COMPOSE_PROJECT_NAME=warmbly-restore-proof-186
+export CONFENGE_VPS_ENV=/path/to/proof-only.env
+export CONFENGE_RESTORE_DATABASE=warmbly_restore_proof_186
+export CONFENGE_RESTORE_ASAAS_DB=/tmp/warmbly-restore-proof-186/events.sqlite3
+
+# proof-only.env must set the same unique COMPOSE_PROJECT_NAME value.
+# Start only the disposable PostgreSQL service, then create an empty target.
+docker compose -p "$COMPOSE_PROJECT_NAME" \
+  -f docker-compose.yml -f deploy/confenge-vps/docker-compose.override.yml \
+  --env-file "$CONFENGE_VPS_ENV" up -d postgres
+docker compose -p "$COMPOSE_PROJECT_NAME" \
+  -f docker-compose.yml -f deploy/confenge-vps/docker-compose.override.yml \
+  --env-file "$CONFENGE_VPS_ENV" exec -T postgres \
+  createdb -U warmbly "$CONFENGE_RESTORE_DATABASE"
+
+deploy/confenge-vps/restore.sh /path/to/warmbly-confenge-<ts>.tar.gz
+# RESTORE_PROOF=PASS postgres_database=warmbly_restore_proof_186
+
+# PostgreSQL opens and carries the migration marker from the dump.
+docker compose -p "$COMPOSE_PROJECT_NAME" \
+  -f docker-compose.yml -f deploy/confenge-vps/docker-compose.override.yml \
+  --env-file "$CONFENGE_VPS_ENV" exec -T postgres \
+  psql -U warmbly -d "$CONFENGE_RESTORE_DATABASE" -Atqc \
+  'SELECT version,dirty FROM schema_migrations ORDER BY version DESC LIMIT 1'
+
+# SQLite opens, passes integrity/schema validation, and keeps structural counts.
+ASAAS_ADAPTER_DB="$CONFENGE_RESTORE_ASAAS_DB" \
+  python3 deploy/confenge-vps/asaas-adapter/adapter.py preflight
 ```
 
-If restore cannot be run on the live VPS safely, run against a disposable compose project name and document the result; live VPS restore remains operator-scheduled.
+Compare the SQLite `schema`, `table_counts`, and `queue_state_counts` output to
+`MANIFEST.json`. Compare the restored file hash to the archived
+`asaas-events.sqlite3` hash. Inspect `env.redacted` for `***REDACTED***`, and
+keep the key bundle outside the extracted archive. The key bundle is required
+for a future live restore, but no proof should attempt to decrypt a real
+mailbox.
+
+After recording the proof, remove only the disposable project and proof
+directory. A live restore remains operator-scheduled and requires a commercial
+reconciliation window.
+
+## Failure and rollback
+
+- A preflight failure happens before `pg_dump`. Keep the current release, copy
+  the SQLite file with an approved online mechanism, and update the fixture and
+  classifier in code. Do not migrate the live file to make the backup pass.
+- A PostgreSQL or packaging failure removes the private stage and incomplete
+  archive outputs. The Asaas source remains read-only.
+- A restore-proof failure affects only the disposable targets. Delete those
+  targets, retain the last known-good archive, and investigate the manifest or
+  component named in the error.
+- Never pause or resume a campaign as part of backup recovery. Never call an
+  Asaas mutation endpoint. Restoring the production queue requires an explicit
+  operator window, adapter stop, post-restore financial reconciliation, and
+  rollback to the prior application SHA if the restored schema cannot start.
 
 ## After VPS reboot
 


### PR DESCRIPTION
Closes #186

## Causa

O comando `adapter.py backup` construía `Queue` antes de copiar o SQLite. `Queue._initialize()` executava `PRAGMA journal_mode=WAL`, DDL, criação de metadata/índices e, no schema atual, recuperação operacional. Depois da cópia, `Queue.backup()` também inseria uma row em `backups`. No SQLite legado sem `events.state`, a criação de `events_ready_idx` falhava após já ter alterado o arquivo fonte.

## Correção

- adiciona preflight read-only antes do `pg_dump`, com classificação explícita do schema atual e do legado sem estado;
- recusa versão/estrutura desconhecida e corrupção SQLite antes do dump pesado;
- abre a origem SQLite com `mode=ro` e usa `sqlite3.Connection.backup` para uma cópia online consistente com WAL;
- remove a inicialização operacional e qualquer INSERT no SQLite do caminho de backup;
- preserva a frescura do health em um receipt externo não secreto, sem row/status/timestamp na fila;
- valida o marcador final do `pg_dump` e publica archive, `MANIFEST.json`, `SHA256SUMS`, manifest/checksum sidecars e bundle de chaves separado;
- redige segredos, credenciais, PII, userinfo e query strings do snapshot de configuração;
- valida checksums e manifest no restore, exige alvo PostgreSQL vazio e aceita restore isolado do schema legado sem migrá-lo;
- inclui fixture legado, regressões de imutabilidade/fail-closed/restore e o runbook completo.

## Verificação local

```bash
ruff format --check deploy/confenge-vps/asaas-adapter/adapter.py deploy/confenge-vps/asaas-adapter/test_adapter.py deploy/confenge-vps/test_backup.py
ruff check deploy/confenge-vps/asaas-adapter/adapter.py deploy/confenge-vps/asaas-adapter/test_adapter.py deploy/confenge-vps/test_backup.py
shellcheck -x --severity=error deploy/confenge-vps/backup.sh deploy/confenge-vps/restore.sh
python3 -m unittest deploy.confenge-vps.test_vps_pack deploy.confenge-vps.test_backup deploy/confenge-vps/asaas-adapter/test_adapter.py
deploy/confenge-vps/validate.sh
```

Resultado: 36 testes passaram; `VALIDATE=PASS`.

## Prova de backup e restore isolados

Executada no SHA `d28d2992b2b45ff9fe87f08aecff61cc2cd52f64`, em projeto descartável `warmbly-186-proof-d28d2992`, com PostgreSQL 16.15 real, base sintética com marcador e fixture SQLite legado. O projeto não era `warmbly-confenge` e foi removido com seu volume após a prova.

- `backup.sh`: exit 0
- `restore.sh`: exit 0 e `RESTORE_PROOF=PASS postgres_database=warmbly_restore_proof_186`
- archive SHA-256: `925bd6e4190b5bebe0a44cd464d99c8b94928e86041f069fc122b26c7afe07c9`
- checksum sidecar e todos os checksums internos: reconciliados
- manifest: `confenge.backup-manifest.v2`, ligado ao SHA do commit
- PostgreSQL restaurado abriu e retornou o marcador `fixture-186-final`
- schema SQLite: `confenge.asaas-queue.legacy-stateless-v0`
- fonte SQLite antes/depois: `29bcfa8908ec13b376fdd2ffce5844da4328fdb229461ea99f2b5d7cc678455e` em ambos
- archive SQLite/restaurado: `72e77e71d5751b7a929eb459b936eebd50f65850ef9a111a06519357b111935a` em ambos
- SQLite restaurado: `integrity_check=ok`, `events=1`
- segredos sintéticos ausentes de `env.redacted` e do manifest

Nenhum arquivo, banco, container, campanha ou serviço live foi usado. Nenhuma chamada ao provider Asaas ou fluxo de dinheiro foi executado. Nenhum pause/resume ou envio foi acionado.

## Rollback

A alteração é restrita ao tooling e ao adaptador. Reverter o commit restaura o comportamento anterior do código, mas não deve ser usado contra o SQLite legado porque reintroduz a mutação e a falha da #186. Em falha operacional, manter o último archive conhecido, não migrar o SQLite live para fazer o backup passar e investigar em uma cópia com o preflight/fixture documentados no runbook.
