### PR TITLE
feat: preserve CONFENGE delegated campaign continuity while current feed first touches await replacement queue readback

### DIFF
--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -21,6 +21,8 @@ The CONFENGE first-touch campaign has one narrow exception. `CONFENGE_DELEGATED_
 
 `CONFENGE_DELEGATED_FIRST_TOUCH_AUTORUN_ENABLED=true` starts the rolling evaluator for that same narrow policy. It keeps at most one first touch in the canonical dispatch queue, converts ordinary QA failures into exceptions, and replenishes the next eligible item after dispatch. It does not enable legacy auto-send or GREEN autorun, create another queue, or bypass any send-time gate. The flag defaults to `false`.
 
+The canonical campaign remains active while the current completed feed has prepared first touches that the delegated worker has not decided. This covers the short interval after a feed refresh cancels a stale queue and before the worker writes the replacement queue. Only a current `NEEDS_REVIEW` first touch under the active founder policy keeps the campaign alive. An exhausted ordinary campaign still completes, and pending work still needs the full delegated checks before it can become `QUEUED` or transportable.
+
 For a manual batch, the agent first writes a research manifest containing candidate IDs, public evidence and copy, but no mailbox address. `confenge first-touch seal` reads the selected mailbox from the operational database, derives its route class, binds the subject and body hashes, and creates a new mode `0600` manifest without printing the address. `confenge first-touch apply --dry-run` validates that sealed artifact before the confirmed write path records approval and canonical queue readback. Autorun constructs the same manifest from current persisted supplier, recipient, feed, and evidence records, then sends it through the same validator and apply path.
 
 Optional feed source:

--- a/internal/app/campaign/handlers.go
+++ b/internal/app/campaign/handlers.go
@@ -151,6 +151,19 @@ func (s *campaignService) StartCampaign(ctx context.Context, orgID uuid.UUID, ca
 	startable := map[string]bool{
 		"draft": true, "paused": true, "paused_no_accounts": true, "paused_guardrail": true,
 	}
+	if campaign.Status == "completed" {
+		ready, readyErr := s.campaignRepository.HasReadyDelegatedFirstTouch(ctx, cID)
+		if readyErr != nil {
+			return errx.InternalError()
+		}
+		if !ready {
+			ready, readyErr = s.campaignRepository.HasPendingDelegatedFirstTouch(ctx, cID)
+			if readyErr != nil {
+				return errx.InternalError()
+			}
+		}
+		startable[campaign.Status] = ready
+	}
 	if !startable[campaign.Status] {
 		return errx.New(errx.BadRequest, "campaign must be in draft, paused, paused_no_accounts, or paused_guardrail status to start")
 	}
@@ -293,6 +306,13 @@ func (s *campaignService) enqueueCampaignWakeup(ctx context.Context, campaignID 
 			if readyErr != nil {
 				sentry.CaptureException(readyErr)
 				return errx.InternalError()
+			}
+			if !ready {
+				ready, readyErr = s.campaignRepository.HasPendingDelegatedFirstTouch(ctx, campaignID)
+				if readyErr != nil {
+					sentry.CaptureException(readyErr)
+					return errx.InternalError()
+				}
 			}
 			if ready {
 				return nil

--- a/internal/app/campaign/rolling_wakeup_test.go
+++ b/internal/app/campaign/rolling_wakeup_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 
+	"github.com/warmbly/warmbly/internal/models"
 	"github.com/warmbly/warmbly/internal/repository"
 	"github.com/warmbly/warmbly/internal/scheduler"
 	"github.com/warmbly/warmbly/internal/tasks/proto"
@@ -15,13 +16,41 @@ import (
 
 type rollingWakeupCampaignRepo struct {
 	repository.CampaignRepository
-	ready    bool
-	readyErr error
-	statuses []string
+	campaign   *models.Campaign
+	ready      bool
+	pending    bool
+	readyErr   error
+	pendingErr error
+	statuses   []string
+}
+
+func (r *rollingWakeupCampaignRepo) GetByID(context.Context, uuid.UUID) (*models.Campaign, error) {
+	return r.campaign, nil
 }
 
 func (r *rollingWakeupCampaignRepo) HasReadyDelegatedFirstTouch(context.Context, uuid.UUID) (bool, error) {
 	return r.ready, r.readyErr
+}
+
+func (r *rollingWakeupCampaignRepo) HasPendingDelegatedFirstTouch(context.Context, uuid.UUID) (bool, error) {
+	return r.pending, r.pendingErr
+}
+
+func (r *rollingWakeupCampaignRepo) ValidateCampaignReady(context.Context, uuid.UUID) error {
+	return nil
+}
+
+func (r *rollingWakeupCampaignRepo) GetSequencesByCampaignID(context.Context, uuid.UUID) ([]models.Sequence, error) {
+	return nil, nil
+}
+
+func (r *rollingWakeupCampaignRepo) CountActiveForOrganization(context.Context, uuid.UUID) (int, error) {
+	return 0, nil
+}
+
+func (r *rollingWakeupCampaignRepo) StartCampaign(_ context.Context, _ uuid.UUID) error {
+	r.statuses = append(r.statuses, "active")
+	return nil
 }
 
 func (r *rollingWakeupCampaignRepo) UpdateStatusWithLock(_ context.Context, _ uuid.UUID, status string) error {
@@ -57,17 +86,21 @@ func TestEnqueueCampaignWakeupPreservesActiveRollingCampaign(t *testing.T) {
 	tests := []struct {
 		name       string
 		ready      bool
+		pending    bool
 		readyErr   error
+		pendingErr error
 		wantErr    bool
 		wantStatus string
 	}{
 		{name: "ready delegated queue", ready: true},
+		{name: "pending current delegated backlog", pending: true},
 		{name: "ordinary completed campaign", wantErr: true, wantStatus: "completed"},
 		{name: "queue lookup failure", readyErr: errors.New("db unavailable"), wantErr: true},
+		{name: "backlog lookup failure", pendingErr: errors.New("db unavailable"), wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			repo := &rollingWakeupCampaignRepo{ready: tt.ready, readyErr: tt.readyErr}
+			repo := &rollingWakeupCampaignRepo{ready: tt.ready, pending: tt.pending, readyErr: tt.readyErr, pendingErr: tt.pendingErr}
 			svc := &campaignService{
 				campaignRepository: repo,
 				taskRepo:           &rollingWakeupTaskRepo{},
@@ -83,6 +116,37 @@ func TestEnqueueCampaignWakeupPreservesActiveRollingCampaign(t *testing.T) {
 			}
 			if len(repo.statuses) > 0 && repo.statuses[0] != tt.wantStatus {
 				t.Fatalf("unexpected status update: %v", repo.statuses)
+			}
+		})
+	}
+}
+
+func TestCompletedCampaignCanRestartOnlyForDelegatedRollingWork(t *testing.T) {
+	orgID, campaignID := uuid.New(), uuid.New()
+	for _, tt := range []struct {
+		name, status            string
+		ready, pending, wantErr bool
+	}{
+		{name: "read-back queue", status: "completed", ready: true},
+		{name: "pending current backlog", status: "completed", pending: true},
+		{name: "ordinary completed", status: "completed", wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			repo := &rollingWakeupCampaignRepo{
+				campaign: &models.Campaign{ID: campaignID, OrganizationID: &orgID, Status: tt.status},
+				ready:    tt.ready, pending: tt.pending,
+			}
+			svc := &campaignService{
+				campaignRepository: repo,
+				taskRepo:           &rollingWakeupTaskRepo{}, scheduler: rollingWakeupScheduler{},
+				tasksClient: rollingWakeupTaskScheduler{},
+			}
+			xerr := svc.StartCampaign(context.Background(), orgID, campaignID.String())
+			if (xerr != nil) != tt.wantErr {
+				t.Fatalf("start error mismatch: got=%v wantErr=%v", xerr, tt.wantErr)
+			}
+			if !tt.wantErr && (len(repo.statuses) != 1 || repo.statuses[0] != "active") {
+				t.Fatalf("rolling campaign did not restart: %v", repo.statuses)
 			}
 		})
 	}

--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -302,8 +302,29 @@ func TestCampaignReadyAcceptsReadBackDelegatedQueueWithoutContact(t *testing.T) 
 	if ready, err := campaignRepo.HasReadyDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || ready {
 		t.Fatalf("ordinary empty campaign unexpectedly has delegated work: ready=%v err=%v", ready, err)
 	}
+	if pending, err := campaignRepo.HasPendingDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || pending {
+		t.Fatalf("ordinary empty campaign unexpectedly has pending delegated work: pending=%v err=%v", pending, err)
+	}
 	if err := campaignRepo.ValidateCampaignReady(f.ctx, f.campaignID); err == nil || !strings.Contains(err.Error(), "at least one contact") {
 		t.Fatalf("ordinary empty campaign unexpectedly ready: %v", err)
+	}
+	entry := f.manifest.Entries[0]
+	account, err := f.repo.GetAccount(f.ctx, f.orgID, entry.AccountID)
+	if err != nil || account == nil {
+		t.Fatalf("account unavailable: account=%+v err=%v", account, err)
+	}
+	candidate, err := f.repo.GetCandidate(f.ctx, f.orgID, entry.ContactCandidateID)
+	if err != nil || candidate == nil {
+		t.Fatalf("candidate unavailable: candidate=%+v err=%v", candidate, err)
+	}
+	if _, _, err := f.svc.prepareDelegatedTouchpoint(f.ctx, f.orgID, account, candidate, f.manifest, entry); err != nil {
+		t.Fatal(err)
+	}
+	if pending, err := campaignRepo.HasPendingDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || !pending {
+		t.Fatalf("current undecided backlog unavailable: pending=%v err=%v", pending, err)
+	}
+	if err := campaignRepo.ValidateCampaignReady(f.ctx, f.campaignID); err != nil {
+		t.Fatalf("current delegated backlog did not keep rolling campaign startable: %v", err)
 	}
 	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
 	if xerr != nil || report == nil || report.Queued != 1 || len(report.Items) != 1 || report.Items[0].State != "QUEUED" {
@@ -318,6 +339,9 @@ func TestCampaignReadyAcceptsReadBackDelegatedQueueWithoutContact(t *testing.T) 
 	}
 	if ready, err := campaignRepo.HasReadyDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || !ready {
 		t.Fatalf("read-back delegated work unavailable: ready=%v err=%v", ready, err)
+	}
+	if pending, err := campaignRepo.HasPendingDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || pending {
+		t.Fatalf("decided delegated work remained pending: pending=%v err=%v", pending, err)
 	}
 	if err := campaignRepo.ValidateCampaignReady(f.ctx, f.campaignID); err != nil {
 		t.Fatalf("read-back delegated rolling queue did not make campaign startable: %v", err)

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -51,6 +51,7 @@ type CampaignRepository interface {
 	StopCampaign(ctx context.Context, campaignID uuid.UUID) error
 	ValidateCampaignReady(ctx context.Context, campaignID uuid.UUID) error
 	HasReadyDelegatedFirstTouch(ctx context.Context, campaignID uuid.UUID) (bool, error)
+	HasPendingDelegatedFirstTouch(ctx context.Context, campaignID uuid.UUID) (bool, error)
 	UpdateVerificationStatus(ctx context.Context, campaignID uuid.UUID, status string, summary *models.CampaignVerificationSummary) error
 	GetPendingCampaignTasks(ctx context.Context, campaignID uuid.UUID) ([]Task, error)
 	// ListCampaignScheduleCandidates returns active campaigns that have NO pending
@@ -1430,11 +1431,17 @@ func (r *campaignRepository) ValidateCampaignReady(ctx context.Context, campaign
 		return err
 	}
 	if contactCount == 0 {
-		delegatedQueued, err := r.HasReadyDelegatedFirstTouch(ctx, campaignID)
+		delegatedWork, err := r.HasReadyDelegatedFirstTouch(ctx, campaignID)
 		if err != nil {
 			return err
 		}
-		if !delegatedQueued {
+		if !delegatedWork {
+			delegatedWork, err = r.HasPendingDelegatedFirstTouch(ctx, campaignID)
+			if err != nil {
+				return err
+			}
+		}
+		if !delegatedWork {
 			return errx.New(errx.BadRequest, "campaign must have at least one contact")
 		}
 	}
@@ -1489,6 +1496,42 @@ func (r *campaignRepository) HasReadyDelegatedFirstTouch(ctx context.Context, ca
 			  AND d.readback_at IS NOT NULL AND d.due_at=q.due_at
 		)`, campaignID).Scan(&ready)
 	return ready, err
+}
+
+// HasPendingDelegatedFirstTouch keeps current undecided work alive without granting transport authority.
+func (r *campaignRepository) HasPendingDelegatedFirstTouch(ctx context.Context, campaignID uuid.UUID) (bool, error) {
+	var pending bool
+	err := r.DB.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1
+			FROM outreach_touchpoints t
+			JOIN outreach_accounts account
+			  ON account.organization_id=t.organization_id AND account.id=t.account_id
+			JOIN outreach_feed_sync_state feed
+			  ON feed.organization_id=t.organization_id
+			JOIN outreach_org_settings settings
+			  ON settings.organization_id=t.organization_id AND settings.campaign_id=$1
+			JOIN confenge_campaign_policy_authorizations auth
+			  ON auth.organization_id=t.organization_id AND auth.campaign_id=$1
+			WHERE t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+			  AND t.state='NEEDS_REVIEW' AND t.contact_candidate_id IS NOT NULL
+			  AND feed.last_status='completed' AND account.source_run_id=feed.last_run_id
+			  AND auth.revoked_at IS NULL AND auth.effective_at <= now()
+			  AND auth.prompt_policy_version='CFG-FIRST-TOUCH-ROUTING-v1'
+			  AND auth.authorized_by_label='founder-approved-first-touch-policy'
+			  AND auth.channel='EMAIL'
+			  AND NOT EXISTS (
+				SELECT 1
+				FROM confenge_delegated_first_touch_decisions decision
+				WHERE decision.organization_id=t.organization_id
+				  AND decision.account_id=t.account_id
+				  AND (
+					decision.evidence_source_run_id=account.source_run_id
+					OR decision.idempotency_key='delegated-first-touch:' || account.source_run_id || ':' || account.id::text
+				  )
+			  )
+		)`, campaignID).Scan(&pending)
+	return pending, err
 }
 
 // GetPendingCampaignTasks returns all pending tasks for a campaign

--- a/internal/tasks/campaign_reconciler.go
+++ b/internal/tasks/campaign_reconciler.go
@@ -75,6 +75,13 @@ func (s *tasksService) ReconcileCampaignSchedules(ctx context.Context, limit int
 				continue
 			}
 			if !ready {
+				ready, readyErr = s.campaignRepo.HasPendingDelegatedFirstTouch(ctx, id)
+				if readyErr != nil {
+					log.Warn().Err(readyErr).Str("campaign_id", id.String()).Msg("campaign reconcile: rolling backlog check failed; will retry")
+					continue
+				}
+			}
+			if !ready {
 				s.campaignRepo.UpdateStatus(ctx, id, "completed")
 			}
 		case errors.Is(cerr, scheduler.ErrCampaignEnded):

--- a/internal/tasks/campaign_rolling_test.go
+++ b/internal/tasks/campaign_rolling_test.go
@@ -17,6 +17,7 @@ type rollingCampaignRepo struct {
 	repository.CampaignRepository
 	campaign *models.Campaign
 	ready    bool
+	pending  bool
 	statuses []string
 }
 
@@ -30,6 +31,10 @@ func (r *rollingCampaignRepo) GetByID(context.Context, uuid.UUID) (*models.Campa
 
 func (r *rollingCampaignRepo) HasReadyDelegatedFirstTouch(context.Context, uuid.UUID) (bool, error) {
 	return r.ready, nil
+}
+
+func (r *rollingCampaignRepo) HasPendingDelegatedFirstTouch(context.Context, uuid.UUID) (bool, error) {
+	return r.pending, nil
 }
 
 func (r *rollingCampaignRepo) UpdateStatus(_ context.Context, _ uuid.UUID, status string) error {
@@ -90,8 +95,15 @@ func (rollingCompletedScheduler) CalculateNextEmailTime(context.Context, uuid.UU
 
 func TestCampaignReconcilerPreservesReadyRollingQueue(t *testing.T) {
 	campaign := &models.Campaign{ID: uuid.New(), Status: "active"}
-	for _, ready := range []bool{true, false} {
-		repo := &rollingCampaignRepo{campaign: campaign, ready: ready}
+	for _, tt := range []struct {
+		name, wantStatus string
+		ready, pending   bool
+	}{
+		{name: "read-back queue", ready: true},
+		{name: "current pending backlog", pending: true},
+		{name: "exhausted", wantStatus: "completed"},
+	} {
+		repo := &rollingCampaignRepo{campaign: campaign, ready: tt.ready, pending: tt.pending}
 		svc := &tasksService{
 			campaignRepo: repo,
 			taskRepo:     &rollingTaskRepo{},
@@ -100,19 +112,26 @@ func TestCampaignReconcilerPreservesReadyRollingQueue(t *testing.T) {
 		if _, err := svc.ReconcileCampaignSchedules(context.Background(), 1); err != nil {
 			t.Fatal(err)
 		}
-		if ready && len(repo.statuses) != 0 {
-			t.Fatalf("ready rolling campaign was completed: %v", repo.statuses)
+		if (tt.ready || tt.pending) && len(repo.statuses) != 0 {
+			t.Fatalf("rolling campaign with work was completed: %v", repo.statuses)
 		}
-		if !ready && (len(repo.statuses) != 1 || repo.statuses[0] != "completed") {
+		if tt.wantStatus != "" && (len(repo.statuses) != 1 || repo.statuses[0] != tt.wantStatus) {
 			t.Fatalf("ordinary exhausted campaign did not complete: %v", repo.statuses)
 		}
 	}
 }
 
 func TestCampaignTaskPreservesReadyRollingQueue(t *testing.T) {
-	for _, ready := range []bool{true, false} {
+	for _, tt := range []struct {
+		name, wantStatus string
+		ready, pending   bool
+	}{
+		{name: "read-back queue", ready: true},
+		{name: "current pending backlog", pending: true},
+		{name: "exhausted", wantStatus: "completed"},
+	} {
 		campaignID, taskID := uuid.New(), uuid.New()
-		repo := &rollingCampaignRepo{campaign: &models.Campaign{ID: campaignID, Status: "active"}, ready: ready}
+		repo := &rollingCampaignRepo{campaign: &models.Campaign{ID: campaignID, Status: "active"}, ready: tt.ready, pending: tt.pending}
 		tasks := &rollingTaskRepo{taskID: taskID, campaignID: campaignID}
 		svc := &tasksService{
 			campaignRepo:         repo,
@@ -123,10 +142,10 @@ func TestCampaignTaskPreservesReadyRollingQueue(t *testing.T) {
 		if xerr := svc.HandleCampaignTask(&proto.ProcessTask{TaskId: taskID.String()}); xerr != nil {
 			t.Fatalf("handler failed: %v", xerr)
 		}
-		if ready && len(repo.statuses) != 0 {
-			t.Fatalf("ready rolling campaign was completed: %v", repo.statuses)
+		if (tt.ready || tt.pending) && len(repo.statuses) != 0 {
+			t.Fatalf("rolling campaign with work was completed: %v", repo.statuses)
 		}
-		if !ready && (len(repo.statuses) != 1 || repo.statuses[0] != "completed") {
+		if tt.wantStatus != "" && (len(repo.statuses) != 1 || repo.statuses[0] != tt.wantStatus) {
 			t.Fatalf("ordinary exhausted campaign did not complete: %v", repo.statuses)
 		}
 		if got := tasks.statuses[len(tasks.statuses)-1]; got != "completed" {

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -209,6 +209,15 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 				executionStatus = "failed"
 				return errx.InternalError()
 			}
+			if !ready {
+				ready, readyErr = s.campaignRepo.HasPendingDelegatedFirstTouch(ctx, campaign.ID)
+				if readyErr != nil {
+					sentry.CaptureException(readyErr)
+					_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "pending")
+					executionStatus = "failed"
+					return errx.InternalError()
+				}
+			}
 			if ready {
 				_ = s.taskRepo.UpdateTaskStatus(ctx, taskID, "completed")
 				executionStatus = "completed"


### PR DESCRIPTION
P0 production fix for the feed-refresh continuity gap observed on the live CONFENGE runtime.

When a new authoritative source run atomically cancels the stale delegated queue, the campaign scheduler can observe the brief zero-queue interval and mark the canonical campaign completed before the rolling evaluator creates the replacement. The evaluator then fails closed with canonical_campaign_not_schedulable.

This change keeps only the canonical CONFENGE campaign alive while the completed current feed contains undecided INITIAL EMAIL touchpoints under the active CFG-FIRST-TOUCH-ROUTING-v1 founder policy. It grants no approval or transport authority. Ordinary exhausted campaigns still complete. A completed canonical campaign can be restarted only when an exact queue readback or current pending delegated backlog exists.

Verification:
- gofmt clean
- golangci-lint passed
- focused campaign/task tests passed
- migrated Postgres delegated queue/backlog test passed
- docs types:check passed
- docs lint passed with two pre-existing warnings