### PR TITLE
feat: recognize the live CONFENGE persist-first legacy Asaas queue in read-only canonical backup preflight

### DIFF
--- a/deploy/confenge-vps/asaas-adapter/adapter.py
+++ b/deploy/confenge-vps/asaas-adapter/adapter.py
@@ -42,6 +42,7 @@ QUEUE_PROOF_VERSION = "confenge.asaas-queue-proof.v1"
 BACKUP_RECEIPT_VERSION = "confenge.asaas-backup-receipt.v1"
 CURRENT_QUEUE_SCHEMA = "confenge.asaas-queue.current-v1"
 LEGACY_QUEUE_SCHEMA = "confenge.asaas-queue.legacy-stateless-v0"
+LEGACY_PERSIST_FIRST_QUEUE_SCHEMA = "confenge.asaas-queue.legacy-persist-first-v0"
 CURRENT_TABLE_COLUMNS = {
     "metadata": ("key", "value"),
     "events": (
@@ -73,6 +74,21 @@ CURRENT_TABLE_COLUMNS = {
         "detail",
     ),
     "backups": ("path", "created_at", "sha256"),
+}
+LEGACY_PERSIST_FIRST_TABLE_COLUMNS = {
+    "events": (
+        "provider_event_id",
+        "received_at",
+        "raw_type",
+        "payload_json",
+        "payload_sha256",
+        "status",
+        "attempts",
+        "next_attempt_at",
+        "last_error",
+        "canonical_json",
+    ),
+    "metadata": ("key", "value"),
 }
 
 
@@ -379,6 +395,9 @@ def _classify_queue_schema(
             raise ValueError("adapter queue contains an unsupported state")
         return CURRENT_QUEUE_SCHEMA, version
 
+    if tables == LEGACY_PERSIST_FIRST_TABLE_COLUMNS and version is None:
+        return LEGACY_PERSIST_FIRST_QUEUE_SCHEMA, None
+
     event_columns = set(tables.get("events", ()))
     if (
         version is None
@@ -396,7 +415,7 @@ def _classify_queue_schema(
         raise ValueError("unsupported adapter queue schema: events table is missing")
     raise ValueError(
         "unsupported adapter queue schema: events columns do not match "
-        "current-v1 or legacy-stateless-v0"
+        "current-v1 or a recognized legacy schema"
     )
 
 

--- a/deploy/confenge-vps/asaas-adapter/test_adapter.py
+++ b/deploy/confenge-vps/asaas-adapter/test_adapter.py
@@ -16,6 +16,9 @@ from unittest.mock import patch
 
 MODULE = Path(__file__).with_name("adapter.py")
 LEGACY_FIXTURE = Path(__file__).with_name("testdata") / "legacy-stateless-v0.sql"
+LEGACY_PERSIST_FIRST_FIXTURE = (
+    Path(__file__).with_name("testdata") / "legacy-persist-first-v0.sql"
+)
 SPEC = importlib.util.spec_from_file_location("confenge_asaas_adapter", MODULE)
 assert SPEC and SPEC.loader
 adapter = importlib.util.module_from_spec(SPEC)
@@ -391,6 +394,27 @@ class AdapterTest(unittest.TestCase):
         self.assertEqual(restore_proof["schema"], adapter.LEGACY_QUEUE_SCHEMA)
         self.assertEqual(adapter.file_sha256(restored), adapter.file_sha256(backup))
         self.queue = adapter.Queue(self.root / "replacement" / "events.sqlite3")
+
+    def test_live_legacy_persist_first_fixture_backup_is_read_only(self):
+        legacy = self.root / "legacy-persist-first" / "events.sqlite3"
+        legacy.parent.mkdir()
+        connection = adapter.sqlite3.connect(legacy)
+        connection.executescript(
+            LEGACY_PERSIST_FIRST_FIXTURE.read_text(encoding="utf-8")
+        )
+        connection.close()
+        before_bytes = legacy.read_bytes()
+        before_stat = legacy.stat()
+
+        preflight = adapter.inspect_queue_database(legacy)
+        backup = self.root / "legacy-persist-first-backup" / "events.sqlite3"
+        proof = adapter.backup_database(legacy, backup)
+
+        self.assertEqual(preflight["schema"], adapter.LEGACY_PERSIST_FIRST_QUEUE_SCHEMA)
+        self.assertEqual(proof["schema"], adapter.LEGACY_PERSIST_FIRST_QUEUE_SCHEMA)
+        self.assertEqual(proof["table_counts"], {"metadata": 0, "events": 1})
+        self.assertEqual(legacy.read_bytes(), before_bytes)
+        self.assertEqual(legacy.stat().st_mtime_ns, before_stat.st_mtime_ns)
 
     def test_backup_preflight_fails_closed_for_future_schema_without_writing(self):
         self.queue.close()

--- a/deploy/confenge-vps/asaas-adapter/testdata/legacy-persist-first-v0.sql
+++ b/deploy/confenge-vps/asaas-adapter/testdata/legacy-persist-first-v0.sql
@@ -1,0 +1,43 @@
+-- Regression model for the persist-first Asaas queue observed live in issue #186.
+-- The metadata table is present but empty, so the schema remains unversioned.
+CREATE TABLE metadata (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+CREATE TABLE events (
+    provider_event_id TEXT PRIMARY KEY,
+    received_at INTEGER NOT NULL,
+    raw_type TEXT NOT NULL,
+    payload_json TEXT NOT NULL,
+    payload_sha256 TEXT NOT NULL,
+    status TEXT NOT NULL,
+    attempts INTEGER NOT NULL,
+    next_attempt_at INTEGER NOT NULL,
+    last_error TEXT NOT NULL,
+    canonical_json TEXT NOT NULL
+);
+
+INSERT INTO events (
+    provider_event_id,
+    received_at,
+    raw_type,
+    payload_json,
+    payload_sha256,
+    status,
+    attempts,
+    next_attempt_at,
+    last_error,
+    canonical_json
+) VALUES (
+    'evt_fixture_persist_first',
+    1787745600,
+    'PAYMENT_CREATED',
+    '{}',
+    '44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a',
+    'pending',
+    0,
+    0,
+    '',
+    '{}'
+);

--- a/deploy/confenge-vps/test_backup.py
+++ b/deploy/confenge-vps/test_backup.py
@@ -15,6 +15,9 @@ PACK = Path(__file__).resolve().parent
 ROOT = PACK.parent.parent
 ADAPTER = PACK / "asaas-adapter" / "adapter.py"
 LEGACY_FIXTURE = PACK / "asaas-adapter" / "testdata" / "legacy-stateless-v0.sql"
+LEGACY_PERSIST_FIRST_FIXTURE = (
+    PACK / "asaas-adapter" / "testdata" / "legacy-persist-first-v0.sql"
+)
 
 
 class BackupScriptTest(unittest.TestCase):
@@ -269,6 +272,37 @@ PUBLIC_CALLBACK_URL=https://example.invalid/callback?token=fixture-query-never-a
         self.assertIn("unsupported adapter queue schema version 2", result.stderr)
         self.assertFalse(self.docker_log.exists())
         self.assertEqual(database.read_bytes(), before)
+
+    def test_canonical_backup_accepts_live_legacy_persist_first_queue(self) -> None:
+        database = self.root / "live-legacy" / "events.sqlite3"
+        database.parent.mkdir()
+        connection = sqlite3.connect(database)
+        connection.executescript(
+            LEGACY_PERSIST_FIRST_FIXTURE.read_text(encoding="utf-8")
+        )
+        connection.close()
+        before = database.read_bytes()
+        backup_dir = self.root / "live-legacy-backups"
+
+        result = subprocess.run(
+            ["bash", str(PACK / "backup.sh")],
+            cwd=ROOT,
+            env=self.environment(database, backup_dir),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(database.read_bytes(), before)
+        archive = next(backup_dir.glob("warmbly-confenge-*.tar.gz"))
+        with tarfile.open(archive, "r:gz") as bundle:
+            manifest = json.load(bundle.extractfile("./MANIFEST.json"))
+        self.assertEqual(
+            manifest["components"]["asaas_queue"]["schema"],
+            "confenge.asaas-queue.legacy-persist-first-v0",
+        )
 
 
 if __name__ == "__main__":

--- a/docs/confenge/vps-disaster-recovery.md
+++ b/docs/confenge/vps-disaster-recovery.md
@@ -28,7 +28,7 @@ deploy/confenge-vps/backup.sh
 ```
 
 The script preflights a present Asaas SQLite schema before starting `pg_dump`.
-It accepts the current versioned schema and the known unversioned legacy schema
+It accepts the current versioned schema and the known unversioned legacy schemas
 without initializing `Queue`. An unknown version, unknown column layout, missing
 `events` table, or SQLite integrity error fails early with no PostgreSQL dump.
 


### PR DESCRIPTION
Extends the fail-closed canonical backup preflight from #195 for the exact unversioned persist-first SQLite signature observed live during the P0 pre-deploy backup.

- matches the complete metadata/events column topology, not a permissive subset
- preserves mode=ro source access and refuses unknown schemas
- adds a sanitized fixture for the observed topology
- proves source-byte immutability through adapter and canonical backup tests
- keeps future/unknown schema rejection unchanged

Verification: ruff format/check, 38 unit tests, and deploy/confenge-vps/validate.sh all pass.

Follow-up to #186.