### PR TITLE
feat: keep mailbox-purpose suppression dominant over delegated controlled-route first-touch approval

### DIFF
--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -23,6 +23,8 @@ The CONFENGE first-touch campaign has one narrow exception. `CONFENGE_DELEGATED_
 
 The canonical campaign remains active while the current completed feed has prepared first touches that the delegated worker has not decided. This covers the short interval after a feed refresh cancels a stale queue and before the worker writes the replacement queue. Only a current `NEEDS_REVIEW` first touch under the active founder policy keeps the campaign alive. An exhausted ordinary campaign still completes, and pending work still needs the full delegated checks before it can become `QUEUED` or transportable.
 
+An upstream controlled route never overrides mailbox-purpose suppression. Addresses classified as blocked for sending or as an unsuitable mailbox stay out of delegated approval even when their route class is otherwise allowed.
+
 For a manual batch, the agent first writes a research manifest containing candidate IDs, public evidence and copy, but no mailbox address. `confenge first-touch seal` reads the selected mailbox from the operational database, derives its route class, binds the subject and body hashes, and creates a new mode `0600` manifest without printing the address. `confenge first-touch apply --dry-run` validates that sealed artifact before the confirmed write path records approval and canonical queue readback. Autorun constructs the same manifest from current persisted supplier, recipient, feed, and evidence records, then sends it through the same validator and apply path.
 
 Optional feed source:

--- a/internal/app/confenge/contact_tier_test.go
+++ b/internal/app/confenge/contact_tier_test.go
@@ -31,7 +31,7 @@ func loadContactTierFeed(t *testing.T) *Feed {
 	return feed
 }
 
-func TestPublishedExhaustedTierDoesNotBlockExplicitControlledRoute(t *testing.T) {
+func TestPublishedExhaustedTierCannotOverrideMailboxPurposeSuppression(t *testing.T) {
 	controlled := true
 	purposeBlocked := true
 	provenanceValid := false
@@ -57,8 +57,11 @@ func TestPublishedExhaustedTierDoesNotBlockExplicitControlledRoute(t *testing.T)
 		RouteSuppression:               "NONE",
 		ContactTier:                    ContactTierE,
 	})
-	if c.Blocked || c.BlockReason != "" || !CandidateControlledEligible(c) || !CandidateEnrollable(c) {
-		t.Fatalf("explicit controlled route was collapsed into strict EXHAUSTED lane: %+v", c)
+	if c.Blocked || c.BlockReason != "" {
+		t.Fatalf("mailbox-purpose suppression became a sticky account block: %+v", c)
+	}
+	if CandidateControlledEligible(c) || CandidateEnrollable(c) {
+		t.Fatalf("explicit controlled route overrode mailbox-purpose suppression: %+v", c)
 	}
 	if !c.MailboxPurposeSendBlocked || c.EmailSendReady {
 		t.Fatalf("strict autorun guards were weakened: %+v", c)

--- a/internal/app/confenge/controlled_email_adversarial_test.go
+++ b/internal/app/confenge/controlled_email_adversarial_test.go
@@ -200,6 +200,31 @@ func TestLegacyControlledFallbackRemainsFailClosed(t *testing.T) {
 	}
 }
 
+func TestExplicitControlledRouteCannotOverrideMailboxPurposeSuppression(t *testing.T) {
+	eligible := true
+	base := models.OutreachContactCandidate{
+		Email: "contato@empresa.com.br", MailboxPurpose: "GENERIC_CONTACT",
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+		OwnershipStatus:    "COMPANY_OWNED",
+		DiscoveryJSON: discoveryJSON(t, controlledDiscovery{
+			RouteClass: RouteClassGenericCompany, ControlledEmailEligible: &eligible,
+		}),
+	}
+
+	blockedPurpose := base
+	blockedPurpose.MailboxPurpose = "ORCAMENTO"
+	blockedPurpose.MailboxPurposeSendBlocked = true
+	if CandidateControlledEligible(&blockedPurpose) {
+		t.Fatal("explicit controlled route overrode mailbox purpose suppression")
+	}
+
+	unsuitableMailbox := base
+	unsuitableMailbox.RecipientCommercialSuitability = "UNSUITABLE_MAILBOX"
+	if CandidateControlledEligible(&unsuitableMailbox) {
+		t.Fatal("explicit controlled route overrode unsuitable mailbox classification")
+	}
+}
+
 func TestCopyQARejectsInventionAndGmailCorporateClaim(t *testing.T) {
 	c := &models.OutreachContactCandidate{Email: "contato@empresa.com.br"}
 	errs := ValidateCopyForRouteClass(RouteClassGenericCompany, "Olá, Ana, você é o gerente.", "Oi Ana", c)

--- a/internal/app/confenge/controlled_route.go
+++ b/internal/app/confenge/controlled_route.go
@@ -116,7 +116,7 @@ func CandidateControlledEligible(c *models.OutreachContactCandidate) bool {
 	if c == nil {
 		return false
 	}
-	if c.DoNotContact || c.Bounced || c.Blocked {
+	if c.DoNotContact || c.Bounced || c.Blocked || candidateMailboxPurposeSuppressed(c) {
 		return false
 	}
 	d := parseControlledDiscovery(c)
@@ -179,6 +179,9 @@ func legacyControlledPublicRoute(c *models.OutreachContactCandidate, class strin
 // suppression, provenance and fixture guards still apply. Legacy nominal paths
 // keep using CanEnroll directly.
 func CandidateEnrollable(c *models.OutreachContactCandidate) bool {
+	if candidateMailboxPurposeSuppressed(c) {
+		return false
+	}
 	if c.CanEnroll() {
 		return true
 	}
@@ -186,6 +189,11 @@ func CandidateEnrollable(c *models.OutreachContactCandidate) bool {
 		return false
 	}
 	return c.EnrollableIgnoringVerification()
+}
+
+func candidateMailboxPurposeSuppressed(c *models.OutreachContactCandidate) bool {
+	return c == nil || c.MailboxPurposeSendBlocked ||
+		strings.EqualFold(strings.TrimSpace(c.RecipientCommercialSuitability), "UNSUITABLE_MAILBOX")
 }
 
 func CandidatePreferredInitial(c *models.OutreachContactCandidate) bool {

--- a/internal/app/confenge/delegated_first_touch_adversarial_test.go
+++ b/internal/app/confenge/delegated_first_touch_adversarial_test.go
@@ -182,6 +182,15 @@ func TestDelegatedFirstTouchFailsClosedOnRecipientComplianceAndSourceDrift(t *te
 		{"suppression", func(f *delegatedValidationFixture) { f.account.DoNotContact = true }, "account_suppressed_or_interacted"},
 		{"opt_out", func(f *delegatedValidationFixture) { f.candidate.DoNotContact = true; f.storeCandidate() }, "recipient_not_controlled_eligible"},
 		{"hard_bounce", func(f *delegatedValidationFixture) { f.candidate.Bounced = true; f.storeCandidate() }, "recipient_not_controlled_eligible"},
+		{"mailbox_purpose_blocked", func(f *delegatedValidationFixture) {
+			f.candidate.MailboxPurpose = "ORCAMENTO"
+			f.candidate.MailboxPurposeSendBlocked = true
+			f.storeCandidate()
+		}, "recipient_not_controlled_eligible"},
+		{"mailbox_commercially_unsuitable", func(f *delegatedValidationFixture) {
+			f.candidate.RecipientCommercialSuitability = "UNSUITABLE_MAILBOX"
+			f.storeCandidate()
+		}, "recipient_not_controlled_eligible"},
 		{"copy_editorial", func(f *delegatedValidationFixture) {
 			f.entry.BodyText += " Espero que este e-mail o encontre bem."
 			f.entry.BodyHash = hashText(f.entry.BodyText)


### PR DESCRIPTION
## Live defect

The paused P0 canary produced a current delegated QUEUED readback whose recipient was simultaneously classified `mailbox_purpose_send_blocked=true` and `UNSUITABLE_MAILBOX`. No SMTP attempt occurred.

## Cause and correction

An explicit upstream `controlled_email_eligible=true` route bypassed mailbox-purpose suppression in `CandidateControlledEligible`, which also affected the final transport assertion. This change makes mailbox-purpose blocking and the exact unsuitable-mailbox classification dominant for explicit and legacy routes. It does not widen eligibility or alter rate, scheduling, DNC, bounce, kill switch, or follow-up behavior.

## Verification

- targeted controlled-route and delegated first-touch adversarial tests pass
- `make lint` passes
- `gofmt -l ./cmd ./internal` is empty
- docs typecheck and lint pass (two existing warnings)

The live queue remains paused with attempts=0 pending this fix.