### PR TITLE
feat: make delegated first touches evidence-specific and verify deterministic quality across 10k-message corpora

### DIFF
--- a/docs/confenge/delegated-first-touch-corpus-v1.md
+++ b/docs/confenge/delegated-first-touch-corpus-v1.md
@@ -1,0 +1,105 @@
+# Delegated first-touch corpus report v1
+
+Date: 2026-08-26
+
+Rules: `confenge.first-touch-copy-rules.v1`
+
+Composer: `confenge.composer.v7`
+
+## Decision
+
+The delegated composer no longer rotates a bank of interchangeable subjects,
+openings, purpose sentences and questions. It builds one typed brief from the
+current company, confirmed supplier role, supported public fact, service code,
+route class and recipient purpose. A missing specific fact produces a shorter
+supplier-role message. It never causes an invented detail.
+
+The v1 corpus rules make the following editorial distinctions:
+
+- Exact subject and body reuse is a hard failure after the first occurrence.
+  This rule has the same meaning for 10 or 10,000 messages: two evidence briefs
+  must not produce the same complete reader-facing message.
+- A near duplicate is the same factual focus, service practice, route class and
+  recipient purpose after removing company and person identity. It is measured
+  as a semantic group. It is not failed against an unexplained percentage.
+- Subject, opening, practice-line and CTA concentration are reported with the
+  evidence dimension that supports each repetition. Practice follows
+  `service_code`; CTA follows route class plus recipient purpose. Concentration
+  alone does not trigger synonym rotation.
+- Unsupported claims, buyer/supplier confusion, guessed people, internal
+  metadata, offensive or manipulative language, empty content, wrong-route CTA
+  and missing contact exit have a required count of zero.
+- The complete body remains inside the existing 45 to 150 word hard band.
+
+This preserves the decision in issue #152. A practice line covering 47% of a
+feed is legitimate when exactly 47% of the feed has the supporting service. It
+would be a defect if the line crossed service boundaries or if cosmetic wording
+were used to hide the concentration.
+
+## Corpus construction
+
+Both corpora are deterministic and generated in the Go regression suite.
+
+- The sanitized replay contributes 200 structural seeds from
+  `data/confenge-feeds/full_national/chunk_*.json`, the same 200-lead source used
+  by issue #152. Sanitization keeps only service code, moment code and contract
+  object shape. Company, contact, agency, value and record identifiers are
+  discarded.
+- The remaining records are structured synthetic briefs with unique companies
+  and confirmed contract objects. The service distribution is the measured
+  #152 distribution: 47% budget/spreadsheet audit, 32% contract monitoring, 11%
+  backoffice, 9% diagnostic and 1% addenda.
+- Routes are balanced across `DIRECT_PERSON`, `ROLE_OR_DEPARTMENT`,
+  `GENERIC_COMPANY` and `PUBLIC_COMPANY_FREEMAIL`. Only direct routes with
+  person evidence use a first name.
+- Every specific fact is present in a `CONFIRMED_FACT` evidence row. Replay
+  objects that are numeric, truncated, metadata-shaped or not supportable fall
+  back to the simple supplier-role copy.
+
+## Results
+
+| Metric | 1,000 | 10,000 |
+| --- | ---: | ---: |
+| Exact duplicate groups / messages | 0 / 0 | 0 / 0 |
+| Near-duplicate groups / messages | 13 / 111 | 13 / 111 |
+| Largest near-duplicate group | 19 | 19 |
+| Largest exact subject concentration | 1 (0.10%) | 1 (0.01%) |
+| Specific-fact opening | 887 (88.70%) | 9,887 (98.87%) |
+| Simple supplier-role fallback | 113 (11.30%) | 113 (1.13%) |
+| Largest practice line | 470 (47.00%) | 4,700 (47.00%) |
+| Generic/freemail forwarding CTA | 500 (50.00%) | 5,000 (50.00%) |
+| Direct-person ownership CTA | 250 (25.00%) | 2,500 (25.00%) |
+| Role/purpose area CTA | 250 (25.00%) | 2,500 (25.00%) |
+| Unsupported claims | 0 | 0 |
+| Buyer/supplier confusion | 0 | 0 |
+| Guessed people | 0 | 0 |
+| Internal metadata leakage | 0 | 0 |
+| Offensive or manipulative language | 0 | 0 |
+| Empty subject or body | 0 | 0 |
+| Route-inappropriate CTA | 0 | 0 |
+| Missing contact exit | 0 | 0 |
+| Word length min / average / p50 | 49 / 56.51 / 56 | 49 / 56.21 / 56 |
+| Word length p90 / p95 / p99 / max | 60 / 60 / 65 / 69 | 58 / 60 / 60 / 69 |
+
+The 111 near-duplicate messages all come from 13 sanitized replay groups whose
+specific object could not safely enter copy. They use the explicit simple
+fallback and remain visible in the report. The 9,800 synthetic briefs add
+supported factual focus without increasing those groups.
+
+The local 10,000-message regression completed composition, a second canonical
+projection check, aggregation, sorting and JSON serialization in 31.04 seconds.
+This is a corpus-test measurement, not a production latency threshold. The
+worker composes one item through the O(1) path, while the audit is O(n log n) and
+performs no all-pairs comparison. No model call is present in either path.
+
+## Reproduction
+
+```bash
+go test ./internal/app/confenge \
+  -run '^TestDelegatedFirstTouchCorpusAtScale$' -count=1 -v
+```
+
+The test prints the complete JSON report for both sizes. Adversarial regressions
+also prove deterministic failures for unsupported claims, contracting-authority
+inversion, exact content reuse, empty content, hallucinated people, internal
+metadata, offensive or manipulative wording and route-inappropriate CTAs.

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -23,6 +23,28 @@ The CONFENGE first-touch campaign has one narrow exception. `CONFENGE_DELEGATED_
 
 For a manual batch, the agent first writes a research manifest containing candidate IDs, public evidence and copy, but no mailbox address. `confenge first-touch seal` reads the selected mailbox from the operational database, derives its route class, binds the subject and body hashes, and creates a new mode `0600` manifest without printing the address. `confenge first-touch apply --dry-run` validates that sealed artifact before the confirmed write path records approval and canonical queue readback. Autorun constructs the same manifest from current persisted supplier, recipient, feed, and evidence records, then sends it through the same validator and apply path.
 
+Delegated copy uses `confenge.composer.v7` and the versioned
+`confenge.first-touch-copy-rules.v1` contract. It does not rotate synonyms or
+choose prose from a UUID. The deterministic brief may use only the company,
+confirmed supplier role, a public fact bound to current `CONFIRMED_FACT`
+evidence, service code, route class and recipient purpose. If a specific fact
+cannot be supported, the composer uses a short supplier-role message instead of
+inventing detail. `DIRECT_PERSON` uses a first name only when the selected route
+has person evidence. Role, generic and company-attributed freemail routes ask
+for the appropriate internal routing without pretending to reach a decision
+maker. Every message includes a plain request to say if further contact is not
+wanted.
+
+Corpus QA measures exact and semantic near duplicates, subject, opening,
+practice-line and CTA concentration, evidence support, metadata leakage,
+route-class fit and length. Exact content reuse, unsupported claims,
+buyer/supplier inversion, guessed people, empty copy, internal metadata,
+offensive or manipulative language and route-inappropriate CTAs fail closed.
+Concentration is attributed to its factual dimension instead of compared with
+a hidden percentage. A repeated practice line is valid when it follows the
+actual `service_code` distribution; the composer never creates cosmetic
+variants to disguise it.
+
 Optional feed source:
 
 ```env

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -120,6 +120,12 @@ type DelegatedFirstTouchEntry struct {
 	Recipient                 string                `json:"recipient"`
 	Subject                   string                `json:"subject"`
 	BodyText                  string                `json:"body_text"`
+	CopyRulesVersion          string                `json:"copy_rules_version"`
+	FactUsed                  string                `json:"fact_used"`
+	FactEvidenceIDs           []string              `json:"fact_evidence_ids"`
+	Practice                  string                `json:"practice"`
+	CTA                       string                `json:"cta"`
+	SemanticSignature         string                `json:"semantic_signature"`
 	SubjectHash               string                `json:"subject_hash"`
 	BodyHash                  string                `json:"body_hash"`
 	EvidenceIDs               []string              `json:"evidence_ids"`
@@ -889,53 +895,59 @@ func (s *service) validateDelegatedDeterministicQA(ctx context.Context, orgID uu
 	if err != nil {
 		return []string{"evidence_bundle_unavailable"}
 	}
-	if len(entry.EvidenceIDs) == 0 || !stringSetContainsAll(entry.ContractEvidenceIDs, entry.EvidenceIDs) {
-		return []string{"fact_evidence_binding_mismatch"}
+	var blockers []string
+	add := func(code string) { blockers = appendUnique(blockers, code) }
+	if entry.CopyRulesVersion != DelegatedFirstTouchCopyRulesV1 {
+		add("copy_rules_version_mismatch")
+	}
+	expected := buildDelegatedRoutingCopy(acc, cand, evidence)
+	if expected.Subject == "" || expected.Body == "" {
+		add("deterministic_copy_unavailable")
+	} else {
+		if entry.Subject != expected.Subject || entry.BodyText != expected.Body ||
+			entry.FactUsed != expected.FactUsed || entry.Practice != expected.Practice ||
+			entry.CTA != expected.CTA || entry.SemanticSignature != expected.SemanticSignature {
+			add("deterministic_copy_projection_mismatch")
+		}
+		if canonicalStringSet(entry.FactEvidenceIDs) != canonicalStringSet(expected.FactEvidenceIDs) {
+			add("fact_evidence_binding_mismatch")
+		}
+	}
+	wantEvidence := uniqueStrings(append(append([]string{}, entry.ContractEvidenceIDs...), entry.FactEvidenceIDs...))
+	if len(entry.ContractEvidenceIDs) == 0 || canonicalStringSet(entry.EvidenceIDs) != canonicalStringSet(wantEvidence) {
+		add("fact_evidence_binding_mismatch")
 	}
 	if !delegatedEvidenceRowsCurrent(evidence, entry.EvidenceIDs, acc.LastImportRunID, time.Now().UTC()) {
-		return []string{"fact_evidence_not_current_confirmed"}
+		add("fact_evidence_not_current_confirmed")
 	}
 	out := &DraftOutput{
 		Channel: ChannelEmailInitial, Subject: entry.Subject, BodyText: entry.BodyText,
-		FactUsed: "Atuação como contratada em contrato público confirmada.", EvidenceIDs: entry.EvidenceIDs,
-		Claims:      []DraftClaim{{Phrase: "Atuação como contratada em contrato público confirmada.", EvidenceIDs: entry.EvidenceIDs}},
+		FactUsed: entry.FactUsed, EvidenceIDs: entry.EvidenceIDs,
+		Claims:      []DraftClaim{{Phrase: "Atuação como contratada no setor público confirmada.", EvidenceIDs: entry.ContractEvidenceIDs}},
 		ServiceCode: acc.ServiceCode, Question: "Quem é o responsável interno por contratos públicos?",
-		CTA: "Indicar o responsável ou encaminhar a mensagem.", Followups: []DraftFollowup{}, RiskFlags: []string{},
+		CTA: expected.CTA, Followups: []DraftFollowup{}, RiskFlags: []string{},
 	}
-	comparisonBodies := make([]string, 0, len(recentBodies))
+	if len(entry.FactEvidenceIDs) > 0 {
+		out.Claims = append(out.Claims, DraftClaim{Phrase: entry.FactUsed, EvidenceIDs: entry.FactEvidenceIDs})
+	}
 	for i := range recentBodies {
-		if recentBodies[i].AccountID != acc.ID {
-			comparisonBodies = append(comparisonBodies, recentBodies[i].Body)
+		if recentBodies[i].AccountID != acc.ID && normalizeForCorpus(recentBodies[i].Body) == normalizeForCorpus(entry.BodyText) {
+			add("corpus_exact_content_limit")
+			break
 		}
 	}
 	qa := ValidateDraft(out, acc, cand, ValidateOpts{
 		MaxWords: s.cfg.MaxInitialEmailWords, Evidence: evidence, Channel: ChannelEmailInitial,
-		RecentBodies: comparisonBodies, PromptVersion: PromptVersion,
+		PromptVersion: PromptVersion,
 	})
-	blockers := make([]string, 0, len(qa.Errors))
 	for _, item := range qa.Errors {
 		code := "deterministic_qa:" + reasonCode(item)
-		blockers = appendUnique(blockers, code)
+		add(code)
 	}
 	if risk, _ := ClassifyRisk(acc, cand, out, qa); risk != "GREEN" {
-		blockers = appendUnique(blockers, "deterministic_qa:risk_class_not_green")
+		add("deterministic_qa:risk_class_not_green")
 	}
 	return blockers
-}
-
-func stringSetContainsAll(superset, subset []string) bool {
-	seen := map[string]bool{}
-	for _, value := range superset {
-		if value = strings.TrimSpace(value); value != "" {
-			seen[value] = true
-		}
-	}
-	for _, value := range subset {
-		if !seen[strings.TrimSpace(value)] {
-			return false
-		}
-	}
-	return len(subset) > 0
 }
 
 func delegatedEvidenceRowsCurrent(evidence []models.OutreachEvidence, required []string, importID *uuid.UUID, now time.Time) bool {
@@ -1115,8 +1127,17 @@ func validateDelegatedCopy(entry DelegatedFirstTouchEntry, acc *models.OutreachA
 		add("copy_hash_mismatch")
 	}
 	words := len(strings.Fields(body))
-	if subject == "" || len([]rune(subject)) > 100 || words < 45 || words > 150 {
+	if subject == "" {
+		add("subject_empty")
+	}
+	if body == "" {
+		add("body_empty")
+	}
+	if len([]rune(subject)) > 100 || words < 45 || words > 150 {
 		add("copy_length_invalid")
+	}
+	if entry.CopyRulesVersion != DelegatedFirstTouchCopyRulesV1 {
+		add("copy_rules_version_mismatch")
 	}
 	low := strings.ToLower(subject + "\n" + body)
 	if !strings.Contains(low, "tiago sasaki") || !strings.Contains(low, "confenge") || !strings.Contains(low, "confenge.com.br") {
@@ -1129,8 +1150,27 @@ func validateDelegatedCopy(entry DelegatedFirstTouchEntry, acc *models.OutreachA
 		delegatedContainsAny(low, "como contratante", "figura como contratante", "aparece como contratante", "órgão contratante", "orgao contratante") {
 		add("target_role_claim_mismatch")
 	}
-	if !delegatedContainsAny(low, "responsável", "responsavel", "quem cuida") || !delegatedContainsAny(low, "indicar", "encaminhar", "direcionar") {
-		add("routing_cta_missing")
+	class := CandidateRouteClass(cand)
+	switch class {
+	case RouteClassDirectPerson:
+		if !delegatedContainsAny(low, "essa frente passa por você", "essa frente passa por voce") ||
+			delegatedContainsAny(low, "encaminhar esta mensagem", "indicar a pessoa", "indicar quem") {
+			add("route_cta_mismatch")
+		}
+	case RouteClassRoleOrDepartment:
+		if !delegatedContainsAny(low, "essa frente fica com a", "essa frente fica com a sua área", "essa frente fica com a sua area") ||
+			!delegatedContainsAny(low, "devo procurar outra", "devo procurar outra área", "devo procurar outra area") {
+			add("route_cta_mismatch")
+		}
+	case RouteClassGenericCompany, RouteClassPublicCompanyFreemail:
+		if !delegatedContainsAny(low, "encaminhar esta mensagem") || !delegatedContainsAny(low, "quem cuida dessa frente") {
+			add("route_cta_mismatch")
+		}
+	default:
+		add("route_cta_mismatch")
+	}
+	if !strings.Contains(low, strings.ToLower(delegatedContactExit)) {
+		add("contact_exit_missing")
 	}
 	if delegatedContainsAny(low, "marcar uma reunião", "agendar uma reunião", "agendar uma reuniao", "proposta comercial", "diagnóstico", "diagnostico", "r$", "contrato nº", "processo nº", "pregão nº", "pregao nº") {
 		add("copy_exceeds_first_touch_scope")
@@ -1139,28 +1179,43 @@ func validateDelegatedCopy(entry DelegatedFirstTouchEntry, acc *models.OutreachA
 		"grande volume", "alto volume", "muitos contratos", "diversos contratos", "vários contratos", "varios contratos",
 		"dezenas de", "centenas de", "milhares de", "ampla atuação", "ampla atuacao", "líder", "lider",
 		"faturamento", "receita", "lucro", "margem", "crédito", "credito", "dívida", "divida",
-		"reequilíbrio", "reequilibrio", "reajuste", "medição", "medicao", "pagamento em atraso",
-		"irregularidade", "ilegalidade", "litígio", "litigio", "condenação", "condenacao", "sanção", "sancao",
+		"pagamento em atraso", "irregularidade", "ilegalidade", "litígio", "litigio", "condenação", "condenacao", "sanção", "sancao",
 		"penalidade", "inadimplência", "inadimplencia", "rescisão", "rescisao") {
 		add("unsupported_factual_claim")
 	}
-	// v1 copy is intentionally routing-only. A numeric amount, date, quantity,
-	// process or contract identifier would require phrase-level fact extraction;
-	// hold it instead of trusting an agent's factual-PASS assertion.
+	// Numeric amounts, dates, quantities and identifiers require a separate
+	// typed projection. Hold them instead of trusting a factual-PASS assertion.
 	if delegatedDigitPattern.MatchString(subject + "\n" + body) {
 		add("unsupported_specific_fact")
 	}
 	if delegatedContainsAny(low, "soluções inovadoras", "solucoes inovadoras", "potencializar resultados", "sinergia", "transformar desafios") {
 		add("marketing_template_language")
 	}
+	if delegatedContainsAny(low,
+		"idiota", "incompetente", "burro", "preguiçoso", "preguicoso",
+		"responda agora", "última chance", "ultima chance", "não perca", "nao perca", "você precisa", "voce precisa") {
+		add("offensive_or_manipulative_language")
+	}
 	if strings.Contains(low, "—") || LooksLikeInternalReasoning(subject+"\n"+body) {
 		add("copy_artifact")
 	}
-	company := strings.ToLower(firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial))
+	if looksLikeMetadataDump(subject+"\n"+body) || qaKeyValueRe.MatchString(subject+"\n"+body) ||
+		qaScoreRe.MatchString(subject+"\n"+body) || qaEnumRe.MatchString(subject+"\n"+body) {
+		add("internal_metadata_leak")
+	}
+	company := strings.ToLower(editorialCompanyName(acc))
 	if company != "" && !strings.Contains(low, company) {
 		add("company_name_missing")
 	}
-	class := CandidateRouteClass(cand)
+	personProven := class == RouteClassDirectPerson && composerMaySeePersonName(cand)
+	if personProven {
+		first := strings.ToLower(titleFirstName(firstName(cand.Name)))
+		if first == "" || !strings.HasPrefix(strings.ToLower(strings.TrimSpace(body)), "olá, "+first) {
+			add("hallucinated_person")
+		}
+	} else if looksInventedPersonGreeting(strings.SplitN(body, "\n", 2)[0]) {
+		add("hallucinated_person")
+	}
 	if class != RouteClassDirectPerson && delegatedContainsAny(low, "como responsável", "como responsavel", "sei que você cuida", "sei que voce cuida", "seus contratos") {
 		add("generic_recipient_false_role")
 	}
@@ -1240,7 +1295,7 @@ func (s *service) prepareDelegatedTouchpoint(ctx context.Context, orgID uuid.UUI
 		tp.PolicyVersion = models.CadencePolicyVersionV1
 	}
 	tp.ServiceCode = acc.ServiceCode
-	tp.FactUsed = "Atuação como contratada em contrato público confirmada."
+	tp.FactUsed = entry.FactUsed
 	tp.EvidenceIDs = append([]string{}, entry.EvidenceIDs...)
 	tp.GeneratedContextHash = acc.MessageContextHash
 	tp.StopReason = ""
@@ -1262,8 +1317,8 @@ func (s *service) prepareDelegatedTouchpoint(ctx context.Context, orgID uuid.UUI
 		Subject: tp.Subject, BodyText: tp.BodyText, FollowupsJSON: []byte("[]"),
 		ServiceCode: acc.ServiceCode, StrategyCode: "FIRST_TOUCH_ROUTING",
 		FactUsed: tp.FactUsed, EvidenceIDs: tp.EvidenceIDs,
-		Question: "Quem é o responsável interno por contratos públicos?",
-		CTA:      "Indicar o responsável ou encaminhar a mensagem.",
+		Question: entry.CTA,
+		CTA:      entry.CTA,
 		Provider: "agent_cli", Model: manifest.AgentID, PromptVersion: PromptVersion,
 		Generation: entry.QA.Attempts, ValidationJSON: qaJSON, ValidationOK: &ok,
 		RiskClass: "GREEN", RiskFlags: []string{}, RedTeamResult: "PASS",

--- a/internal/app/confenge/delegated_first_touch_adversarial_test.go
+++ b/internal/app/confenge/delegated_first_touch_adversarial_test.go
@@ -62,6 +62,17 @@ func newDelegatedValidationFixture(t *testing.T, routeClass, email string) deleg
 		RecipientCommercialSuitability: "SUITABLE", LastImportRunID: &importID, DiscoveryJSON: discovery,
 		ChannelEpistemic: "OBSERVED", RouteFreshness: "FRESH", RouteSuppression: "NONE", EmailDerivation: "OBSERVED",
 	}
+	if routeClass == RouteClassDirectPerson {
+		candidate.Name = "Ana Souza"
+		candidate.Role = "Gerente de Contratos"
+		candidate.MailboxPurpose = "PERSONAL_WORK"
+	} else if routeClass == RouteClassRoleOrDepartment {
+		candidate.Name = "Equipe"
+		candidate.Role = "Licitações"
+		candidate.MailboxPurpose = "LICITACOES"
+	} else {
+		candidate.MailboxPurpose = "GENERIC_CONTACT"
+	}
 	repo.accounts[accKey(orgID, account.CNPJ14)] = account
 	repo.byID[accountID] = account
 	repo.cands[accountID] = []models.OutreachContactCandidate{candidate}
@@ -71,22 +82,15 @@ func newDelegatedValidationFixture(t *testing.T, routeClass, email string) deleg
 		Synthesis: "Empresa Alfa figura como contratada.", ConsultedAt: &now, LastImportRunID: &importID,
 	}}
 	svc := NewService(Config{Enabled: true, FeedMaxAge: 24 * time.Hour, MaxInitialEmailWords: 120}, repo, nil).(*service)
-	body := "Olá, equipe da Empresa Alfa. Meu nome é Tiago Sasaki, da CONFENGE. A Empresa Alfa aparece como contratada em contratos públicos confirmados em fonte pública. Trabalhamos com organização técnica de rotinas ligadas à administração pública. Quem é a pessoa responsável por esse tema na empresa? Você poderia indicar o contato correto ou encaminhar esta mensagem, por favor? Obrigado, Tiago Sasaki, confenge.com.br."
-	entry := DelegatedFirstTouchEntry{
-		IdempotencyKey: "first-touch:lead-1:v1", CorrelationID: "corr-1", AccountID: accountID,
-		ContactCandidateID: candidateID, CNPJ14: account.CNPJ14, SupplierCNPJ14: account.SupplierCNPJ14,
-		BuyerCNPJ14: account.BuyerCNPJ14, ContractorRoleStatus: ContractorRoleConfirmed, TargetPartyRole: "SUPPLIER",
-		ContractRoleSource: account.ContractorRoleSource, ContractEvidenceIDs: account.ContractorRoleEvidenceIDs,
-		ContractEvidenceHash: evidenceHash, ContractEvidenceReference: account.ContractorRoleEvidenceReference,
-		SupplierIdentityRef: account.SupplierIdentityRef, BuyerIdentityRef: account.BuyerIdentityRef,
-		RoleMatchMethod: account.ContractorRoleMatchMethod, RoleConfidence: account.ContractorRoleConfidence,
-		ContractRoleReasonCodes: account.ContractorRoleReasonCodes, EvidenceObservedAt: now,
-		ReconciliationStatus: ReconciliationCorroborated,
-		WebSources:           []DelegatedWebSource{{URL: candidate.SourceURL, Kind: "OFFICIAL_COMPANY_PAGE", Supports: "COMPANY_IDENTITY_AND_MAILBOX", ObservedAt: now}},
-		RouteClass:           routeClass, Recipient: email, Subject: "Responsável por contratos públicos na Empresa Alfa", BodyText: body,
-		EvidenceIDs: []string{"contract-1"}, QA: DelegatedFirstTouchQA{Result: "PASS", Attempts: 1, IdentityPassed: true,
-			FactualPassed: true, CopyPassed: true, OperationalPassed: true, Reviewer: "agent:codex"},
-	}
+	copy := buildDelegatedRoutingCopy(account, &candidate, repo.evidence[accountID])
+	entry := delegatedEntryFromCurrentState(account, &candidate, uuid.New(), copy)
+	entry.IdempotencyKey = "first-touch:lead-1:v1"
+	entry.CorrelationID = "corr-1"
+	entry.ReconciliationStatus = ReconciliationCorroborated
+	entry.WebSources = []DelegatedWebSource{{URL: candidate.SourceURL, Kind: "OFFICIAL_COMPANY_PAGE", Supports: "COMPANY_IDENTITY_AND_MAILBOX", ObservedAt: now}}
+	entry.RouteClass = routeClass
+	entry.Recipient = email
+	entry.QA.Reviewer = "agent:codex"
 	entry.SubjectHash, entry.BodyHash = hashText(entry.Subject), hashText(entry.BodyText)
 	manifest := DelegatedFirstTouchManifest{
 		SchemaVersion: DelegatedFirstTouchManifestV1, BatchID: "batch-1", AgentID: "agent:codex",
@@ -127,6 +131,33 @@ func TestDelegatedFirstTouchAttributedFreemailPasses(t *testing.T) {
 	f := newDelegatedValidationFixture(t, RouteClassPublicCompanyFreemail, "empresa.alfa@gmail.com")
 	if blockers := f.validate(); len(blockers) != 0 {
 		t.Fatalf("attributed company freemail blocked: %v", blockers)
+	}
+}
+
+func TestDelegatedFirstTouchSupportedSpecificFactPassesAllDeterministicGates(t *testing.T) {
+	f := newDelegatedValidationFixture(t, RouteClassGenericCompany, "contato@empresa.example")
+	factID := "fact-pavimentacao"
+	f.account.FactToMention = "Contratação de empresa para pavimentação asfáltica na Avenida Ipê"
+	f.account.MomentEvidenceIDs = []string{factID}
+	now := time.Now().UTC().Truncate(time.Second)
+	f.repo.evidence[f.account.ID] = append(f.repo.evidence[f.account.ID], models.OutreachEvidence{
+		ID: uuid.New(), OrganizationID: f.orgID, AccountID: f.account.ID, SourceEvidenceID: factID,
+		EpistemicClass: models.OutreachEpistemicConfirmedFact, Reliability: "HIGH",
+		URL: "https://pncp.gov.br/contratos/2", Synthesis: f.account.FactToMention,
+		ConsultedAt: &now, LastImportRunID: &f.importID,
+	})
+	copy := buildDelegatedRoutingCopy(f.account, &f.candidate, f.repo.evidence[f.account.ID])
+	if len(copy.FactEvidenceIDs) != 1 {
+		t.Fatalf("specific fact was not bound to evidence: %+v", copy)
+	}
+	f.entry.Subject, f.entry.BodyText = copy.Subject, copy.Body
+	f.entry.CopyRulesVersion, f.entry.FactUsed = DelegatedFirstTouchCopyRulesV1, copy.FactUsed
+	f.entry.FactEvidenceIDs = append([]string{}, copy.FactEvidenceIDs...)
+	f.entry.Practice, f.entry.CTA, f.entry.SemanticSignature = copy.Practice, copy.CTA, copy.SemanticSignature
+	f.entry.EvidenceIDs = uniqueStrings(append(append([]string{}, f.entry.ContractEvidenceIDs...), copy.FactEvidenceIDs...))
+	f.entry.SubjectHash, f.entry.BodyHash = hashText(f.entry.Subject), hashText(f.entry.BodyText)
+	if blockers := f.validate(); len(blockers) != 0 {
+		t.Fatalf("supported specific fact blocked: %v", blockers)
 	}
 }
 
@@ -186,13 +217,37 @@ func TestDelegatedFirstTouchFailsClosedOnRecipientComplianceAndSourceDrift(t *te
 			f.entry.BodyText += " Espero que este e-mail o encontre bem."
 			f.entry.BodyHash = hashText(f.entry.BodyText)
 		}, "deterministic_qa:banned_phrase_espero_que_este_e_mail_o_encontre_bem"},
+		{"empty_subject", func(f *delegatedValidationFixture) {
+			f.entry.Subject = ""
+			f.entry.SubjectHash = hashText(f.entry.Subject)
+		}, "subject_empty"},
+		{"empty_body", func(f *delegatedValidationFixture) {
+			f.entry.BodyText = ""
+			f.entry.BodyHash = hashText(f.entry.BodyText)
+		}, "body_empty"},
+		{"hallucinated_person", func(f *delegatedValidationFixture) {
+			f.entry.BodyText = strings.Replace(f.entry.BodyText, "Olá,", "Olá, Roberto,", 1)
+			f.entry.BodyHash = hashText(f.entry.BodyText)
+		}, "hallucinated_person"},
+		{"internal_metadata", func(f *delegatedValidationFixture) {
+			f.entry.BodyText += " route_class=GENERIC_COMPANY"
+			f.entry.BodyHash = hashText(f.entry.BodyText)
+		}, "internal_metadata_leak"},
+		{"offensive_or_manipulative", func(f *delegatedValidationFixture) {
+			f.entry.BodyText += " Você precisa responder agora."
+			f.entry.BodyHash = hashText(f.entry.BodyText)
+		}, "offensive_or_manipulative_language"},
+		{"route_cta_mismatch", func(f *delegatedValidationFixture) {
+			f.entry.BodyText = strings.Replace(f.entry.BodyText, f.entry.CTA, "Faz sentido marcarmos uma reunião?", 1)
+			f.entry.BodyHash = hashText(f.entry.BodyText)
+		}, "route_cta_mismatch"},
 		{"fact_evidence_mismatch", func(f *delegatedValidationFixture) { f.entry.EvidenceIDs = []string{"other"} }, "fact_evidence_binding_mismatch"},
 		{"buyer_claim_in_copy", func(f *delegatedValidationFixture) {
 			f.entry.BodyText = strings.Replace(f.entry.BodyText, "aparece como contratada", "aparece como contratante", 1)
 			f.entry.BodyHash = hashText(f.entry.BodyText)
 		}, "target_role_claim_mismatch"},
 		{"unsupported_numeric_fact", func(f *delegatedValidationFixture) {
-			f.entry.BodyText = strings.Replace(f.entry.BodyText, "contratos públicos confirmados", "3 contratos públicos confirmados", 1)
+			f.entry.BodyText += " Há 3 contratos."
 			f.entry.BodyHash = hashText(f.entry.BodyText)
 		}, "unsupported_specific_fact"},
 		{"unsupported_qualitative_fact", func(f *delegatedValidationFixture) {
@@ -208,6 +263,17 @@ func TestDelegatedFirstTouchFailsClosedOnRecipientComplianceAndSourceDrift(t *te
 				t.Fatalf("missing blocker %q: %v", tc.want, got)
 			}
 		})
+	}
+}
+
+func TestDelegatedFirstTouchRejectsExactContentReuse(t *testing.T) {
+	f := newDelegatedValidationFixture(t, RouteClassGenericCompany, "contato@empresa.example")
+	_, _, blockers := f.service.validateDelegatedEntry(
+		context.Background(), f.orgID, f.manifest, f.entry, map[string]bool{},
+		[]delegatedRecentBody{{AccountID: uuid.New(), Body: f.entry.BodyText}}, true,
+	)
+	if !delegatedTestContains(blockers, "corpus_exact_content_limit") {
+		t.Fatalf("identical reader-facing content passed: %v", blockers)
 	}
 }
 

--- a/internal/app/confenge/delegated_first_touch_copy.go
+++ b/internal/app/confenge/delegated_first_touch_copy.go
@@ -1,0 +1,258 @@
+package confenge
+
+import (
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// DelegatedFirstTouchCopyRulesV1 names the editorial contract used both by the
+// runway worker and by corpus QA. Concentration is interpreted through these
+// factual dimensions, never through a target percentage of cosmetic variety.
+const DelegatedFirstTouchCopyRulesV1 = "confenge.first-touch-copy-rules.v1"
+
+const delegatedContactExit = "Se preferir não receber meus contatos, é só me avisar."
+
+type delegatedRoutingCopy struct {
+	Subject             string
+	Body                string
+	Opening             string
+	OpeningKey          string
+	Practice            string
+	PracticeKey         string
+	CTA                 string
+	CTAKey              string
+	SubjectKey          string
+	FactUsed            string
+	FactKey             string
+	FactEvidenceIDs     []string
+	RouteClass          string
+	RecipientPurposeKey string
+	PersonUsed          string
+	SemanticSignature   string
+}
+
+type delegatedFactProjection struct {
+	Phrase      string
+	Subject     string
+	Key         string
+	EvidenceIDs []string
+}
+
+// composeDelegatedRoutingCopy keeps the legacy two-string boundary used by the
+// worker while the typed projection remains available to QA and corpus tests.
+func composeDelegatedRoutingCopy(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) (string, string) {
+	copy := buildDelegatedRoutingCopy(acc, cand, evidence)
+	return copy.Subject, copy.Body
+}
+
+func buildDelegatedRoutingCopy(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) delegatedRoutingCopy {
+	if acc == nil || cand == nil {
+		return delegatedRoutingCopy{}
+	}
+	company := editorialCompanyName(acc)
+	if company == "" {
+		return delegatedRoutingCopy{}
+	}
+
+	routeClass := CandidateRouteClass(cand)
+	purposeKey, purposeLabel := delegatedRecipientPurpose(cand)
+	person := ""
+	greeting := "Olá"
+	if routeClass == RouteClassDirectPerson && composerMaySeePersonName(cand) {
+		person = titleFirstName(firstName(cand.Name))
+		if person != "" {
+			greeting += ", " + person
+		}
+	}
+
+	fact := delegatedSupportedFact(acc, evidence)
+	opening := "Vi em registro público que a " + company + " aparece como contratada no setor público."
+	openingKey := "SUPPLIER_ROLE"
+	subject := company + " no setor público"
+	subjectKey := normalizeForCorpus(subject)
+	factUsed := "Atuação como contratada no setor público confirmada."
+	factKey := "SUPPLIER_ROLE"
+	if fact.Phrase != "" {
+		opening = "Vi a " + company + " como contratada em " + fact.Phrase + "."
+		openingKey = "CONTRACT_FACT"
+		subject = delegatedFactSubject(company, fact.Subject)
+		subjectKey = normalizeForCorpus(subject)
+		factUsed = "Atuação como contratada em " + fact.Phrase + "."
+		factKey = fact.Key
+	}
+
+	practice := practiceForAccount(acc)
+	cta, ctaKey := delegatedCTA(routeClass, purposeKey, purposeLabel)
+	if cta == "" {
+		return delegatedRoutingCopy{}
+	}
+	body := greeting + ",\n\n" +
+		"Sou Tiago Sasaki, da CONFENGE. " + opening + "\n\n" +
+		practice + ". " + cta + "\n\n" +
+		delegatedContactExit + "\n\n" +
+		"Obrigado,\nTiago Sasaki\nCONFENGE\ntiago.sasaki@confenge.com.br"
+
+	semantic := strings.Join([]string{
+		DelegatedFirstTouchCopyRulesV1,
+		factKey,
+		normalizeForCorpus(practice),
+		routeClass,
+		purposeKey,
+	}, "|")
+	return delegatedRoutingCopy{
+		Subject: subject, Body: body,
+		Opening: opening, OpeningKey: openingKey,
+		Practice: practice, PracticeKey: normalizeForCorpus(practice),
+		CTA: cta, CTAKey: ctaKey,
+		SubjectKey: subjectKey,
+		FactUsed:   factUsed, FactKey: factKey, FactEvidenceIDs: append([]string{}, fact.EvidenceIDs...),
+		RouteClass: routeClass, RecipientPurposeKey: purposeKey, PersonUsed: person,
+		SemanticSignature: hashText(semantic),
+	}
+}
+
+func delegatedFactSubject(company, factSubject string) string {
+	detail := strings.TrimSpace(factSubject)
+	detail = strings.TrimSpace(strings.TrimPrefix(strings.TrimPrefix(detail, "Sobre "), "sobre "))
+	candidate := strings.TrimSpace(company + " e " + detail)
+	if detail == "" || len([]rune(candidate)) > 100 {
+		return company + " no setor público"
+	}
+	return candidate
+}
+
+func delegatedRecipientPurpose(cand *models.OutreachContactCandidate) (string, string) {
+	if cand == nil {
+		return "UNKNOWN", ""
+	}
+	purpose := strings.ToUpper(strings.TrimSpace(cand.MailboxPurpose))
+	role := foldASCII(strings.ToLower(strings.TrimSpace(cand.Role)))
+	switch {
+	case strings.Contains(purpose, "LICIT") || strings.Contains(role, "licit"):
+		return "LICITACOES", "licitações"
+	case strings.Contains(purpose, "CONTRAT") || strings.Contains(role, "contrat"):
+		return "CONTRATOS", "contratos"
+	case strings.Contains(purpose, "COMERCIAL") || strings.Contains(role, "comercial"):
+		return "COMERCIAL", "comercial"
+	case purpose == "ROLE_MAILBOX":
+		return "ROLE_MAILBOX", ""
+	case purpose == "PERSONAL_WORK":
+		return "PERSONAL_WORK", ""
+	case purpose == "GENERIC_CONTACT" || purpose == "GENERIC":
+		return "GENERIC_CONTACT", ""
+	case purpose != "":
+		return purpose, ""
+	default:
+		return "UNKNOWN", ""
+	}
+}
+
+func delegatedCTA(routeClass, purposeKey, purposeLabel string) (string, string) {
+	switch routeClass {
+	case RouteClassDirectPerson:
+		return "Essa frente passa por você?", "DIRECT_OWNER_CHECK"
+	case RouteClassRoleOrDepartment:
+		if purposeLabel != "" {
+			return "Essa frente fica com a área de " + purposeLabel + " ou devo procurar outra?", "ROLE_PURPOSE_CHECK:" + purposeKey
+		}
+		return "Essa frente fica com a sua área ou devo procurar outra?", "ROLE_AREA_CHECK"
+	case RouteClassGenericCompany, RouteClassPublicCompanyFreemail:
+		return "Você consegue encaminhar esta mensagem a quem cuida dessa frente?", "GENERIC_FORWARD"
+	default:
+		return "", ""
+	}
+}
+
+// delegatedSupportedFact uses only a fact already projected by extra-cli and
+// bound to a current CONFIRMED_FACT row. Raw contracts are deliberately not
+// parsed here: buyer/supplier interpretation remains upstream authority.
+func delegatedSupportedFact(acc *models.OutreachAccount, evidence []models.OutreachEvidence) delegatedFactProjection {
+	if acc == nil {
+		return delegatedFactProjection{}
+	}
+	raw := strings.TrimSpace(acc.FactToMention)
+	low := foldASCII(strings.ToLower(raw))
+	if raw == "" || delegatedDigitPattern.MatchString(raw) || delegatedContainsAny(low,
+		"atuacao como contratada", "empresa contratada", "fornecedora", "portfolio publico observado",
+		"sem prova", "hipotese", "pode haver", "lead", "score") {
+		return delegatedFactProjection{}
+	}
+	if looksLikeMetadataDump(raw) || containsDumpLabel(raw) || qaEnumRe.MatchString(raw) ||
+		qaKeyValueRe.MatchString(raw) || qaScoreRe.MatchString(raw) {
+		return delegatedFactProjection{}
+	}
+	digest := DigestPublicFact(raw)
+	if digest.Phrase == "" || digest.Relation == FactRelationCompanyContext || len(strings.Fields(digest.Phrase)) > 16 {
+		return delegatedFactProjection{}
+	}
+	if len(factPhraseDefects(digest.Phrase)) > 0 || delegatedContainsAny(foldASCII(strings.ToLower(digest.Phrase)),
+		"credito", "reequilibrio", "irregular", "inadimpl", "litig", "sancao", "conden") {
+		return delegatedFactProjection{}
+	}
+
+	candidateIDs := append([]string{}, acc.MomentEvidenceIDs...)
+	candidateIDs = append(candidateIDs, acc.ContractorRoleEvidenceIDs...)
+	ids := delegatedEvidenceSupportingFact(raw, digest.Phrase, candidateIDs, evidence)
+	if len(ids) == 0 {
+		return delegatedFactProjection{}
+	}
+	return delegatedFactProjection{
+		Phrase: digest.Phrase, Subject: digest.Subject,
+		Key: "FACT:" + normalizeForCorpus(digest.Phrase), EvidenceIDs: ids,
+	}
+}
+
+func delegatedEvidenceSupportingFact(raw, phrase string, candidateIDs []string, evidence []models.OutreachEvidence) []string {
+	wanted := map[string]bool{}
+	for _, id := range candidateIDs {
+		if id = strings.TrimSpace(id); id != "" {
+			wanted[id] = true
+		}
+	}
+	if len(wanted) == 0 {
+		return nil
+	}
+	var supported []string
+	for i := range evidence {
+		e := evidence[i]
+		id := strings.TrimSpace(e.SourceEvidenceID)
+		if !wanted[id] || !strings.EqualFold(strings.TrimSpace(e.EpistemicClass), models.OutreachEpistemicConfirmedFact) {
+			continue
+		}
+		blob := strings.Join([]string{e.Title, e.Excerpt, e.Synthesis}, " ")
+		if delegatedEvidenceTextSupports(blob, raw, phrase) {
+			supported = appendUnique(supported, id)
+		}
+	}
+	return supported
+}
+
+var delegatedFactStopWords = map[string]bool{
+	"para": true, "pela": true, "pelo": true, "como": true, "empresa": true,
+	"contratacao": true, "contratada": true, "servico": true, "servicos": true,
+	"obra": true, "obras": true, "publico": true, "publica": true, "publicos": true,
+}
+
+func delegatedEvidenceTextSupports(blob, raw, phrase string) bool {
+	blob = normalizeForCorpus(blob)
+	if blob == "" {
+		return false
+	}
+	if normalizedRaw := normalizeForCorpus(raw); len([]rune(normalizedRaw)) >= 12 && strings.Contains(blob, normalizedRaw) {
+		return true
+	}
+	hits := 0
+	seen := map[string]bool{}
+	for _, word := range strings.Fields(normalizeForCorpus(phrase)) {
+		word = strings.Trim(word, ".,;:!?()[]\"'")
+		if len([]rune(word)) < 5 || delegatedFactStopWords[word] || seen[word] {
+			continue
+		}
+		seen[word] = true
+		if strings.Contains(" "+blob+" ", " "+word+" ") {
+			hits++
+		}
+	}
+	return hits >= 2
+}

--- a/internal/app/confenge/delegated_first_touch_corpus.go
+++ b/internal/app/confenge/delegated_first_touch_corpus.go
@@ -1,0 +1,249 @@
+package confenge
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// DelegatedCorpusMessage keeps the evidence beside the rendered projection so
+// corpus QA can distinguish factual repetition from cosmetic template spin.
+type DelegatedCorpusMessage struct {
+	ID        string
+	Source    string
+	Account   *models.OutreachAccount
+	Candidate *models.OutreachContactCandidate
+	Evidence  []models.OutreachEvidence
+	Copy      delegatedRoutingCopy
+}
+
+// ComposeDelegatedCorpusMessage is the reproducible corpus entrypoint. It does
+// no network or model work and has the same O(1) composer path as the worker.
+func ComposeDelegatedCorpusMessage(id, source string, acc *models.OutreachAccount, cand *models.OutreachContactCandidate, evidence []models.OutreachEvidence) DelegatedCorpusMessage {
+	return DelegatedCorpusMessage{
+		ID: id, Source: source, Account: acc, Candidate: cand,
+		Evidence: append([]models.OutreachEvidence{}, evidence...),
+		Copy:     buildDelegatedRoutingCopy(acc, cand, evidence),
+	}
+}
+
+type CorpusConcentration struct {
+	Value             string  `json:"value"`
+	Count             int     `json:"count"`
+	Share             float64 `json:"share"`
+	EvidenceDimension string  `json:"evidence_dimension"`
+}
+
+type CorpusLengthStats struct {
+	Minimum int     `json:"minimum"`
+	Average float64 `json:"average"`
+	P50     int     `json:"p50"`
+	P90     int     `json:"p90"`
+	P95     int     `json:"p95"`
+	P99     int     `json:"p99"`
+	Maximum int     `json:"maximum"`
+}
+
+// DelegatedCorpusReport is intentionally descriptive for concentration. The
+// hard failures below protect truth and usability; service/practice and
+// route/CTA repetition are reported against their supporting dimensions rather
+// than failed against an unexplained percentage.
+type DelegatedCorpusReport struct {
+	RulesVersion              string                `json:"rules_version"`
+	Messages                  int                   `json:"messages"`
+	SourceMix                 map[string]int        `json:"source_mix"`
+	ExactDuplicateGroups      int                   `json:"exact_duplicate_groups"`
+	ExactDuplicateMessages    int                   `json:"exact_duplicate_messages"`
+	LargestExactGroup         int                   `json:"largest_exact_group"`
+	NearDuplicateGroups       int                   `json:"near_duplicate_groups"`
+	NearDuplicateMessages     int                   `json:"near_duplicate_messages"`
+	LargestNearGroup          int                   `json:"largest_near_group"`
+	NearDuplicateDefinition   string                `json:"near_duplicate_definition"`
+	SubjectConcentration      []CorpusConcentration `json:"subject_concentration"`
+	OpeningConcentration      []CorpusConcentration `json:"opening_concentration"`
+	PracticeLineConcentration []CorpusConcentration `json:"practice_line_concentration"`
+	CTAConcentration          []CorpusConcentration `json:"cta_concentration"`
+	UnsupportedClaims         int                   `json:"unsupported_claims"`
+	BuyerSupplierConfusions   int                   `json:"buyer_supplier_confusions"`
+	GuessedPeople             int                   `json:"guessed_people"`
+	InternalMetadataLeaks     int                   `json:"internal_metadata_leaks"`
+	OffensiveOrManipulative   int                   `json:"offensive_or_manipulative"`
+	EmptySubjectOrBody        int                   `json:"empty_subject_or_body"`
+	RouteInappropriate        int                   `json:"route_inappropriate"`
+	ContactExitMissing        int                   `json:"contact_exit_missing"`
+	LengthWords               CorpusLengthStats     `json:"length_words"`
+	Violations                map[string]int        `json:"violations,omitempty"`
+}
+
+// AuditDelegatedFirstTouchCorpus runs in O(n log n): every duplication and
+// concentration measure is map-backed, with sorting only for deterministic
+// output and percentiles. It never does an all-pairs 10k comparison.
+func AuditDelegatedFirstTouchCorpus(messages []DelegatedCorpusMessage) DelegatedCorpusReport {
+	report := DelegatedCorpusReport{
+		RulesVersion: DelegatedFirstTouchCopyRulesV1,
+		Messages:     len(messages), SourceMix: map[string]int{}, Violations: map[string]int{},
+		NearDuplicateDefinition: "same factual focus + service practice + route class + recipient purpose after removing company and person identity",
+	}
+	exact := map[string]int{}
+	near := map[string]int{}
+	subjects := map[string]int{}
+	openings := map[string]int{}
+	practices := map[string]int{}
+	ctas := map[string]int{}
+	lengths := make([]int, 0, len(messages))
+
+	for i := range messages {
+		message := messages[i]
+		copy := message.Copy
+		report.SourceMix[firstNonEmpty(strings.TrimSpace(message.Source), "unknown")]++
+		exact[normalizeForCorpus(copy.Subject)+"\x00"+normalizeForCorpus(copy.Body)]++
+		near[copy.SemanticSignature]++
+		subjects[copy.SubjectKey]++
+		openings[copy.OpeningKey]++
+		practices[copy.PracticeKey]++
+		ctas[copy.CTAKey]++
+		lengths = append(lengths, len(strings.Fields(copy.Body)))
+
+		expected := buildDelegatedRoutingCopy(message.Account, message.Candidate, message.Evidence)
+		blob := copy.Subject + "\n" + copy.Body
+		folded := foldASCII(strings.ToLower(blob))
+		if strings.TrimSpace(copy.Subject) == "" || strings.TrimSpace(copy.Body) == "" {
+			report.EmptySubjectOrBody++
+		}
+		if copy.Subject != expected.Subject || copy.Body != expected.Body || copy.FactUsed != expected.FactUsed {
+			report.UnsupportedClaims++
+		}
+		if delegatedContainsAny(folded, "como contratante", "figura como contratante", "orgao contratante", "órgão contratante") {
+			report.BuyerSupplierConfusions++
+		}
+		if delegatedCorpusGuessedPerson(copy, expected, message.Candidate) {
+			report.GuessedPeople++
+		}
+		if LooksLikeInternalReasoning(blob) || looksLikeMetadataDump(blob) || containsDumpLabel(blob) ||
+			qaEnumRe.MatchString(blob) || qaKeyValueRe.MatchString(blob) || qaScoreRe.MatchString(blob) {
+			report.InternalMetadataLeaks++
+		}
+		if delegatedContainsAny(folded,
+			"idiota", "incompetente", "burro", "preguicoso", "responda agora", "ultima chance", "nao perca", "voce precisa") {
+			report.OffensiveOrManipulative++
+		}
+		if copy.RouteClass != expected.RouteClass || copy.CTAKey != expected.CTAKey || copy.CTA != expected.CTA ||
+			!strings.Contains(copy.Body, expected.CTA) {
+			report.RouteInappropriate++
+		}
+		if !strings.Contains(copy.Body, delegatedContactExit) {
+			report.ContactExitMissing++
+		}
+	}
+
+	report.ExactDuplicateGroups, report.ExactDuplicateMessages, report.LargestExactGroup = duplicateSummary(exact)
+	report.NearDuplicateGroups, report.NearDuplicateMessages, report.LargestNearGroup = duplicateSummary(near)
+	report.SubjectConcentration = topCorpusConcentrations(subjects, len(messages), "fact_focus")
+	report.OpeningConcentration = topCorpusConcentrations(openings, len(messages), "fact_support")
+	report.PracticeLineConcentration = topCorpusConcentrations(practices, len(messages), "service_code")
+	report.CTAConcentration = topCorpusConcentrations(ctas, len(messages), "route_class+recipient_purpose")
+	report.LengthWords = corpusLengthStats(lengths)
+
+	// Exact reader-facing content may occur once. Unlike a percentage cap, this
+	// has an editorial meaning at every corpus size: two recipients must never
+	// receive the same complete subject and body from distinct evidence briefs.
+	if report.ExactDuplicateMessages > 0 {
+		report.Violations["exact_content_reused"] = report.ExactDuplicateMessages
+	}
+	for code, count := range map[string]int{
+		"unsupported_claim":                  report.UnsupportedClaims,
+		"buyer_supplier_confusion":           report.BuyerSupplierConfusions,
+		"guessed_person":                     report.GuessedPeople,
+		"internal_metadata_leak":             report.InternalMetadataLeaks,
+		"offensive_or_manipulative_language": report.OffensiveOrManipulative,
+		"subject_or_body_empty":              report.EmptySubjectOrBody,
+		"route_inappropriate":                report.RouteInappropriate,
+		"contact_exit_missing":               report.ContactExitMissing,
+	} {
+		if count > 0 {
+			report.Violations[code] = count
+		}
+	}
+	return report
+}
+
+func delegatedCorpusGuessedPerson(copy, expected delegatedRoutingCopy, cand *models.OutreachContactCandidate) bool {
+	if copy.PersonUsed != expected.PersonUsed {
+		return true
+	}
+	if expected.PersonUsed != "" {
+		return !strings.HasPrefix(copy.Body, "Olá, "+expected.PersonUsed+",")
+	}
+	return looksInventedPersonGreeting(strings.SplitN(copy.Body, "\n", 2)[0]) ||
+		(cand != nil && CandidateRouteClass(cand) != RouteClassDirectPerson && copy.PersonUsed != "")
+}
+
+func duplicateSummary(groups map[string]int) (groupCount, messageCount, largest int) {
+	for key, count := range groups {
+		if key == "" || count < 2 {
+			continue
+		}
+		groupCount++
+		messageCount += count
+		if count > largest {
+			largest = count
+		}
+	}
+	return groupCount, messageCount, largest
+}
+
+func topCorpusConcentrations(counts map[string]int, total int, dimension string) []CorpusConcentration {
+	out := make([]CorpusConcentration, 0, len(counts))
+	for value, count := range counts {
+		if value == "" || count == 0 {
+			continue
+		}
+		share := 0.0
+		if total > 0 {
+			share = float64(count) / float64(total)
+		}
+		out = append(out, CorpusConcentration{Value: value, Count: count, Share: share, EvidenceDimension: dimension})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Value < out[j].Value
+	})
+	if len(out) > 10 {
+		out = out[:10]
+	}
+	return out
+}
+
+func corpusLengthStats(lengths []int) CorpusLengthStats {
+	if len(lengths) == 0 {
+		return CorpusLengthStats{}
+	}
+	sort.Ints(lengths)
+	total := 0
+	for _, n := range lengths {
+		total += n
+	}
+	return CorpusLengthStats{
+		Minimum: lengths[0], Average: float64(total) / float64(len(lengths)),
+		P50: corpusPercentile(lengths, 50), P90: corpusPercentile(lengths, 90),
+		P95: corpusPercentile(lengths, 95), P99: corpusPercentile(lengths, 99),
+		Maximum: lengths[len(lengths)-1],
+	}
+}
+
+func corpusPercentile(sorted []int, percent int) int {
+	if len(sorted) == 0 {
+		return 0
+	}
+	index := (percent*len(sorted) + 99) / 100
+	if index < 1 {
+		index = 1
+	}
+	if index > len(sorted) {
+		index = len(sorted)
+	}
+	return sorted[index-1]
+}

--- a/internal/app/confenge/delegated_first_touch_corpus_test.go
+++ b/internal/app/confenge/delegated_first_touch_corpus_test.go
@@ -1,0 +1,211 @@
+package confenge
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+type sanitizedReplaySeed struct {
+	ServiceCode string
+	MomentCode  string
+	Fact        string
+}
+
+func TestDelegatedFirstTouchCorpusAtScale(t *testing.T) {
+	replay := loadSanitizedReplaySeeds(t)
+	if len(replay) != 200 {
+		t.Fatalf("sanitized replay seeds=%d want 200 from the #152 feed", len(replay))
+	}
+	for _, size := range []int{1000, 10000} {
+		t.Run(fmt.Sprintf("corpus_%d", size), func(t *testing.T) {
+			started := time.Now()
+			messages := syntheticDelegatedCorpus(size, replay)
+			report := AuditDelegatedFirstTouchCorpus(messages)
+			if report.Messages != size {
+				t.Fatalf("messages=%d want %d", report.Messages, size)
+			}
+			if report.SourceMix["sanitized_replay"] != len(replay) {
+				t.Fatalf("sanitized replay mix=%v", report.SourceMix)
+			}
+			if len(report.Violations) != 0 {
+				for i := range messages {
+					expected := buildDelegatedRoutingCopy(messages[i].Account, messages[i].Candidate, messages[i].Evidence)
+					if delegatedCorpusGuessedPerson(messages[i].Copy, expected, messages[i].Candidate) {
+						t.Logf("guessed-person diagnostic id=%s route=%s used=%q expected=%q body=%q", messages[i].ID, messages[i].Copy.RouteClass, messages[i].Copy.PersonUsed, expected.PersonUsed, strings.SplitN(messages[i].Copy.Body, "\n", 2)[0])
+					}
+					blob := messages[i].Copy.Subject + "\n" + messages[i].Copy.Body
+					if LooksLikeInternalReasoning(blob) || looksLikeMetadataDump(blob) || containsDumpLabel(blob) || qaEnumRe.MatchString(blob) || qaKeyValueRe.MatchString(blob) || qaScoreRe.MatchString(blob) {
+						t.Logf("metadata diagnostic id=%s subject=%q body=%q", messages[i].ID, messages[i].Copy.Subject, messages[i].Copy.Body)
+					}
+				}
+				t.Fatalf("corpus hard violations: %+v", report.Violations)
+			}
+			if report.UnsupportedClaims != 0 || report.GuessedPeople != 0 || report.RouteInappropriate != 0 {
+				t.Fatalf("truth or routing regression: %+v", report)
+			}
+			if report.LengthWords.Minimum < 45 || report.LengthWords.Maximum > 150 {
+				t.Fatalf("length policy drift: %+v", report.LengthWords)
+			}
+			if report.NearDuplicateDefinition == "" {
+				t.Fatal("near-duplicate control became unmeasurable")
+			}
+			encoded, err := json.Marshal(report)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Logf("processed=%d elapsed=%s report=%s", size, time.Since(started), encoded)
+		})
+	}
+}
+
+func TestDelegatedCorpusAuditDetectsHardFailures(t *testing.T) {
+	messages := syntheticDelegatedCorpus(8, nil)
+	messages[1].Copy = messages[0].Copy
+	messages[2].Copy.Body += " route_class=GENERIC_COMPANY"
+	messages[3].Copy.Body = strings.Replace(messages[3].Copy.Body, "Olá,", "Olá, Roberto,", 1)
+	messages[3].Copy.PersonUsed = "Roberto"
+	messages[4].Copy.Body = strings.Replace(messages[4].Copy.Body, messages[4].Copy.CTA, "Você precisa responder agora.", 1)
+	messages[4].Copy.CTA = "Você precisa responder agora."
+	messages[5].Copy.Subject = ""
+	messages[6].Copy.Body = strings.Replace(messages[6].Copy.Body, "como contratada", "como contratante", 1)
+	messages[7].Copy.Body = strings.Replace(messages[7].Copy.Body, messages[7].Copy.CTA, "Podemos marcar uma reunião?", 1)
+	messages[7].Copy.CTA = "Podemos marcar uma reunião?"
+
+	report := AuditDelegatedFirstTouchCorpus(messages)
+	for _, code := range []string{
+		"exact_content_reused", "unsupported_claim", "guessed_person", "internal_metadata_leak",
+		"offensive_or_manipulative_language", "subject_or_body_empty", "buyer_supplier_confusion", "route_inappropriate",
+	} {
+		if report.Violations[code] == 0 {
+			t.Errorf("hard defect %s was not detected: %+v", code, report.Violations)
+		}
+	}
+}
+
+func syntheticDelegatedCorpus(size int, replay []sanitizedReplaySeed) []DelegatedCorpusMessage {
+	messages := make([]DelegatedCorpusMessage, 0, size)
+	for i := 0; i < size; i++ {
+		seed := sanitizedReplaySeed{}
+		source := "synthetic_structured"
+		if i < len(replay) {
+			seed = replay[i]
+			source = "sanitized_replay"
+		}
+		acc, cand, evidence := syntheticDelegatedBrief(i, seed)
+		messages = append(messages, ComposeDelegatedCorpusMessage(fmt.Sprintf("message-%d", i), source, acc, cand, evidence))
+	}
+	return messages
+}
+
+func syntheticDelegatedBrief(i int, seed sanitizedReplaySeed) (*models.OutreachAccount, *models.OutreachContactCandidate, []models.OutreachEvidence) {
+	label := corpusAlphaLabel(i)
+	service := seed.ServiceCode
+	if service == "" {
+		switch i % 100 {
+		case 0:
+			service = "aditivos_extracontratuais"
+		case 1, 2, 3, 4, 5, 6, 7, 8, 9:
+			service = "diagnostico_contratual_b2g"
+		case 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20:
+			service = "reforco_temporario_backoffice"
+		case 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52:
+			service = "gestao_monitoramento_contratual"
+		default:
+			service = "auditoria_orcamento_bdi"
+		}
+	}
+	fact := strings.TrimSpace(seed.Fact)
+	if fact == "" {
+		fact = "Contratação de empresa para execução de pavimentação asfáltica na Avenida " + label
+	}
+	factID := "fact-" + label
+	roleID := "role-" + label
+	accountID := uuid.NewSHA1(uuid.NameSpaceOID, []byte("corpus-account:"+label))
+	acc := &models.OutreachAccount{
+		ID: accountID, NomeFantasia: "Construtora Aurora " + label,
+		ServiceCode: service, MomentCode: firstNonEmpty(seed.MomentCode, "PORTFOLIO_REVIEW"),
+		FactToMention: fact, MomentEvidenceIDs: []string{factID},
+		ContractorRoleEvidenceIDs: []string{roleID}, ContractorRoleStatus: ContractorRoleConfirmed,
+		TargetPartyRole: "SUPPLIER", SupplierCNPJ14: "11222333000144", BuyerCNPJ14: "99888777000166",
+	}
+	route := []string{RouteClassDirectPerson, RouteClassRoleOrDepartment, RouteClassGenericCompany, RouteClassPublicCompanyFreemail}[i%4]
+	personUnknown := route != RouteClassDirectPerson
+	discovery := []byte(fmt.Sprintf(`{"route_class":%q,"person_unknown":%t}`, route, personUnknown))
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.NewSHA1(uuid.NameSpaceOID, []byte("corpus-candidate:"+label)), AccountID: accountID,
+		Name: "Contato", Role: "Atendimento", Email: "contato." + strings.ToLower(label) + "@empresa.example",
+		VerificationStatus: models.OutreachVerifyOfficialSource, EmailSendReady: true,
+		OwnershipStatus: "COMPANY_OWNED", DiscoveryJSON: discovery, MailboxPurpose: "GENERIC_CONTACT",
+	}
+	switch route {
+	case RouteClassDirectPerson:
+		cand.Name, cand.Role, cand.MailboxPurpose = "Ana Souza", "Gerente de Contratos", "PERSONAL_WORK"
+	case RouteClassRoleOrDepartment:
+		cand.Name, cand.Role, cand.MailboxPurpose = "Equipe", "Licitações", "LICITACOES"
+	case RouteClassPublicCompanyFreemail:
+		cand.Email = "empresa." + strings.ToLower(label) + "@gmail.com"
+	}
+	evidence := []models.OutreachEvidence{
+		{SourceEvidenceID: roleID, EpistemicClass: models.OutreachEpistemicConfirmedFact, Synthesis: "A empresa aparece como contratada no setor público."},
+		{SourceEvidenceID: factID, EpistemicClass: models.OutreachEpistemicConfirmedFact, Synthesis: fact},
+	}
+	return acc, cand, evidence
+}
+
+func corpusAlphaLabel(i int) string {
+	// Fixed-width alphabetic identity keeps synthetic facts unique without
+	// leaking test counters into copy, which the delegated policy forbids.
+	i++
+	letters := make([]byte, 5)
+	for pos := len(letters) - 1; pos >= 0; pos-- {
+		letters[pos] = byte('A' + i%26)
+		i /= 26
+	}
+	return string(letters)
+}
+
+func loadSanitizedReplaySeeds(t *testing.T) []sanitizedReplaySeed {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join("..", "..", "..", "data", "confenge-feeds", "full_national", "chunk_*.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var seeds []sanitizedReplaySeed
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var feed Feed
+		if err := json.Unmarshal(raw, &feed); err != nil {
+			t.Fatalf("decode %s: %v", path, err)
+		}
+		for i := range feed.Leads {
+			lead := feed.Leads[i]
+			seed := sanitizedReplaySeed{ServiceCode: lead.Offer.ServiceCode, MomentCode: lead.Moment.Code}
+			if len(lead.Contracts) > 0 {
+				var contract struct {
+					Object string `json:"object"`
+				}
+				_ = json.Unmarshal(lead.Contracts[0], &contract)
+				seed.Fact = strings.TrimSpace(contract.Object)
+			}
+			if seed.Fact == "" {
+				seed.Fact = strings.TrimSpace(lead.MessagingContext.FactToMention)
+			}
+			// Company, contact, agency, values and identifiers are deliberately
+			// discarded. Only service, moment and contract-object shape replay.
+			seeds = append(seeds, seed)
+		}
+	}
+	return seeds
+}

--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -117,18 +117,12 @@ func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, err
 	if err != nil || cand == nil {
 		return false, err
 	}
-	recent, err := s.repo.ListDrafts(ctx, orgID, "", 500, 0)
+	evidence, err := s.repo.ListEvidence(ctx, orgID, acc.ID)
 	if err != nil {
 		return false, err
 	}
-	recentBodies := make([]string, 0, len(recent))
-	for i := range recent {
-		if recent[i].AccountID != accountID {
-			recentBodies = append(recentBodies, recent[i].BodyText)
-		}
-	}
-	subject, body := composeDelegatedRoutingCopy(acc, recentBodies)
-	entry := delegatedEntryFromCurrentState(acc, cand, touchpointID, subject, body)
+	copy := buildDelegatedRoutingCopy(acc, cand, evidence)
+	entry := delegatedEntryFromCurrentState(acc, cand, touchpointID, copy)
 	sealed, err := SealDelegatedFirstTouchEntry(entry, cand)
 	if err != nil {
 		sealed = entry
@@ -177,7 +171,7 @@ func (s *service) nextDelegatedFirstTouchCandidate(ctx context.Context, orgID uu
 	return touchpointID, accountID, candidateID, err
 }
 
-func delegatedEntryFromCurrentState(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, touchpointID uuid.UUID, subject, body string) DelegatedFirstTouchEntry {
+func delegatedEntryFromCurrentState(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, touchpointID uuid.UUID, copy delegatedRoutingCopy) DelegatedFirstTouchEntry {
 	observedAt := time.Time{}
 	if acc.ContractorRoleObservedAt != nil {
 		observedAt = acc.ContractorRoleObservedAt.UTC()
@@ -203,65 +197,13 @@ func delegatedEntryFromCurrentState(acc *models.OutreachAccount, cand *models.Ou
 		ContractRoleReasonCodes: append([]string{}, acc.ContractorRoleReasonCodes...), EvidenceObservedAt: observedAt,
 		ReconciliationStatus: ReconciliationWebContact,
 		WebSources:           []DelegatedWebSource{{URL: cand.SourceURL, Kind: "PUBLIC_COMPANY_SOURCE", Supports: "COMPANY_MAILBOX", ObservedAt: webObservedAt}},
-		Subject:              subject, BodyText: body, EvidenceIDs: append([]string{}, acc.ContractorRoleEvidenceIDs...),
+		Subject:              copy.Subject, BodyText: copy.Body, CopyRulesVersion: DelegatedFirstTouchCopyRulesV1,
+		FactUsed: copy.FactUsed, FactEvidenceIDs: append([]string{}, copy.FactEvidenceIDs...),
+		Practice: copy.Practice, CTA: copy.CTA,
+		SemanticSignature: copy.SemanticSignature,
+		EvidenceIDs:       uniqueStrings(append(append([]string{}, acc.ContractorRoleEvidenceIDs...), copy.FactEvidenceIDs...)),
 		QA: DelegatedFirstTouchQA{Result: "PASS", Attempts: 1, IdentityPassed: true, FactualPassed: true,
 			CopyPassed: true, OperationalPassed: true, Reviewer: DelegatedFirstTouchValidatorV1,
-			ReasonCodes: []string{"deterministic_routing_copy", "current_supplier_evidence", "current_attributed_recipient"}},
+			ReasonCodes: []string{"deterministic_factual_copy", "current_supplier_evidence", "current_attributed_recipient"}},
 	}
-}
-
-func composeDelegatedRoutingCopy(acc *models.OutreachAccount, recent []string) (string, string) {
-	company := strings.TrimSpace(firstNonEmpty(acc.NomeFantasia, acc.RazaoSocial))
-	subjects := []string{
-		"Responsável por contratos públicos", "Contato sobre contratos públicos",
-		"Área responsável por licitações", "Encaminhamento sobre contratos públicos",
-		"Quem cuida de contratos públicos?", "Direcionamento para contratos públicos",
-		"Contato com a área de licitações", "Setor de contratos públicos",
-	}
-	openings := []string{
-		"Sou Tiago Sasaki, da CONFENGE. Em fonte pública, a %s consta como empresa contratada em contratos públicos.",
-		"Meu nome é Tiago Sasaki e falo pela CONFENGE. Uma fonte pública registra a %s como fornecedora em contratos públicos.",
-		"Aqui é Tiago Sasaki, da CONFENGE. Consultamos fonte pública que identifica a %s como contratada no setor público.",
-		"Tiago Sasaki falando, pela CONFENGE. A atuação da %s como empresa contratada aparece em fonte pública.",
-		"Sou o Tiago Sasaki, da CONFENGE. Encontramos em fonte pública a %s no papel de fornecedora em contrato público.",
-		"Meu nome é Tiago Sasaki, da CONFENGE. O registro público consultado mostra a %s como empresa contratada.",
-		"Falo em nome da CONFENGE, sou Tiago Sasaki. A %s foi identificada em fonte pública como fornecedora do setor público.",
-		"Sou Tiago Sasaki e escrevo pela CONFENGE. Há registro público da %s como contratada em contratos públicos.",
-	}
-	purposes := []string{
-		"Este contato inicial serve apenas para localizar a pessoa ou área que acompanha esse assunto dentro da empresa.",
-		"Escrevo somente para encontrar o setor interno que trata desse tema na empresa.",
-		"O objetivo desta primeira mensagem é chegar à equipe responsável por esse tema dentro da empresa.",
-		"Busco apenas direcionar este primeiro contato à área interna que acompanha contratos públicos.",
-		"Minha intenção neste contato inicial é identificar quem recebe assuntos ligados a contratos públicos.",
-		"Esta mensagem tem apenas o propósito de localizar a área adequada para tratar desse assunto.",
-		"Quero somente confirmar qual equipe interna acompanha contratos públicos e licitações.",
-		"O motivo deste contato é encontrar o canal correto para assuntos de contratos públicos na empresa.",
-	}
-	questions := []string{
-		"Você poderia indicar quem é responsável por contratos públicos e licitações, ou encaminhar esta mensagem ao setor correto?",
-		"Poderia indicar a pessoa responsável por contratos públicos, ou encaminhar o contato à área de licitações?",
-		"Quem é responsável por contratos públicos na empresa, e seria possível encaminhar esta mensagem a essa área?",
-		"Seria possível indicar quem cuida de contratos públicos e direcionar esta mensagem ao setor responsável?",
-		"Você poderia encaminhar esta mensagem à área responsável por licitações, ou indicar quem cuida desse tema?",
-		"Qual pessoa ou setor é responsável por contratos públicos, e você poderia indicar esse contato?",
-		"Poderia direcionar esta mensagem a quem cuida de licitações e contratos públicos dentro da empresa?",
-		"Você consegue indicar o responsável por contratos públicos ou encaminhar esta mensagem à equipe adequada?",
-	}
-	seed := int(acc.ID.ID())
-	for attempt := 0; attempt < len(subjects)*len(openings)*len(purposes)*len(questions); attempt++ {
-		n := seed + attempt
-		subject := subjects[n%len(subjects)]
-		n /= len(subjects)
-		opening := fmt.Sprintf(openings[n%len(openings)], company)
-		n /= len(openings)
-		purpose := purposes[n%len(purposes)]
-		n /= len(purposes)
-		question := questions[n%len(questions)]
-		body := strings.Join([]string{opening, purpose, question, "Atenciosamente,\nEng. Tiago Sasaki\nCONFENGE\ntiago.sasaki@confenge.com.br"}, "\n\n")
-		if _, duplicate := NearDuplicate(body, recent); !duplicate {
-			return subject, body
-		}
-	}
-	return subjects[seed%len(subjects)], ""
 }

--- a/internal/app/confenge/delegated_first_touch_worker_test.go
+++ b/internal/app/confenge/delegated_first_touch_worker_test.go
@@ -3,6 +3,7 @@ package confenge
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -45,18 +46,82 @@ func TestDelegatedFirstTouchWorkerDrainsHoldsUntilQueuedOrIdle(t *testing.T) {
 	}
 }
 
-func TestComposeDelegatedRoutingCopyAvoidsRecentBody(t *testing.T) {
-	acc := &models.OutreachAccount{ID: uuid.MustParse("21982eb9-878a-4c67-8a80-25ff6ca4d1f7"), NomeFantasia: "Empresa Alfa"}
-	subject, first := composeDelegatedRoutingCopy(acc, nil)
+func TestComposeDelegatedRoutingCopyVariesOnlyWithEvidence(t *testing.T) {
+	acc := &models.OutreachAccount{ID: uuid.MustParse("21982eb9-878a-4c67-8a80-25ff6ca4d1f7"), NomeFantasia: "Empresa Alfa", ServiceCode: "MONITORAMENTO_CONTRATUAL"}
+	cand := &models.OutreachContactCandidate{
+		Name: "Contato", Role: "Atendimento", MailboxPurpose: "GENERIC_CONTACT",
+		DiscoveryJSON: []byte(`{"route_class":"GENERIC_COMPANY","person_unknown":true}`),
+	}
+	subject, first := composeDelegatedRoutingCopy(acc, cand, nil)
 	if subject == "" || first == "" || !strings.Contains(first, "Empresa Alfa") {
 		t.Fatalf("incomplete first copy: subject=%q body=%q", subject, first)
 	}
-	_, second := composeDelegatedRoutingCopy(acc, []string{first})
-	if second == "" || second == first {
-		t.Fatalf("composer did not avoid recent body")
+	secondSubject, second := composeDelegatedRoutingCopy(acc, cand, nil)
+	if secondSubject != subject || second != first {
+		t.Fatal("identical evidence produced cosmetic variation")
 	}
-	if _, duplicate := NearDuplicate(second, []string{first}); duplicate {
-		t.Fatal("composer returned a near-duplicate body")
+	if !strings.Contains(first, delegatedContactExit) {
+		t.Fatal("copy omitted the natural contact exit")
+	}
+}
+
+func TestComposeDelegatedRoutingCopyUsesOnlyBoundFactsAndRouteIdentity(t *testing.T) {
+	factID := "fact-pavimentacao"
+	acc := &models.OutreachAccount{
+		ID: uuid.New(), NomeFantasia: "Empresa Alfa", ServiceCode: "auditoria_orcamento_bdi",
+		FactToMention:     "Contratação de empresa para pavimentação asfáltica na Avenida Ipê",
+		MomentEvidenceIDs: []string{factID}, ContractorRoleEvidenceIDs: []string{"role-alfa"},
+	}
+	evidence := []models.OutreachEvidence{{
+		SourceEvidenceID: factID, EpistemicClass: models.OutreachEpistemicConfirmedFact,
+		Synthesis: "Contratação de empresa para pavimentação asfáltica na Avenida Ipê",
+	}}
+	tests := []struct {
+		name, route, purpose, person, wantCTA string
+		wantName                              bool
+	}{
+		{"direct", RouteClassDirectPerson, "PERSONAL_WORK", "Ana Souza", "Essa frente passa por você?", true},
+		{"direct_without_identity", RouteClassDirectPerson, "PERSONAL_WORK", "Contato", "Essa frente passa por você?", false},
+		{"role", RouteClassRoleOrDepartment, "LICITACOES", "Equipe", "Essa frente fica com a área de licitações ou devo procurar outra?", false},
+		{"generic", RouteClassGenericCompany, "GENERIC_CONTACT", "Contato", "Você consegue encaminhar esta mensagem a quem cuida dessa frente?", false},
+		{"freemail", RouteClassPublicCompanyFreemail, "GENERIC_CONTACT", "Contato", "Você consegue encaminhar esta mensagem a quem cuida dessa frente?", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			personUnknown := tc.route != RouteClassDirectPerson
+			cand := &models.OutreachContactCandidate{
+				Name: tc.person, Role: "Atendimento", MailboxPurpose: tc.purpose,
+				Email: "rota@empresa.example", VerificationStatus: models.OutreachVerifyOfficialSource,
+				DiscoveryJSON: []byte(fmt.Sprintf(`{"route_class":%q,"person_unknown":%t}`, tc.route, personUnknown)),
+			}
+			copy := buildDelegatedRoutingCopy(acc, cand, evidence)
+			if !strings.Contains(normalizeForCorpus(copy.Body), "pavimentacao asfaltica na avenida ipe") || len(copy.FactEvidenceIDs) != 1 {
+				t.Fatalf("supported fact was not projected: %+v", copy)
+			}
+			if copy.CTA != tc.wantCTA {
+				t.Fatalf("cta=%q want %q", copy.CTA, tc.wantCTA)
+			}
+			hasName := strings.HasPrefix(copy.Body, "Olá, Ana,")
+			if hasName != tc.wantName {
+				t.Fatalf("identity use=%v want %v body=%q", hasName, tc.wantName, copy.Body)
+			}
+		})
+	}
+
+	unsupported := buildDelegatedRoutingCopy(acc, testsCandidate(RouteClassGenericCompany), []models.OutreachEvidence{{
+		SourceEvidenceID: factID, EpistemicClass: models.OutreachEpistemicStrongInference,
+		Synthesis: "Possível pavimentação asfáltica na Avenida Ipê",
+	}})
+	if len(unsupported.FactEvidenceIDs) != 0 || !strings.Contains(unsupported.Body, "aparece como contratada no setor público") {
+		t.Fatalf("unsupported detail did not fall back to simple copy: %+v", unsupported)
+	}
+}
+
+func testsCandidate(route string) *models.OutreachContactCandidate {
+	return &models.OutreachContactCandidate{
+		Name: "Contato", Role: "Atendimento", Email: "contato@empresa.example", MailboxPurpose: "GENERIC_CONTACT",
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+		DiscoveryJSON:      []byte(fmt.Sprintf(`{"route_class":%q,"person_unknown":true}`, route)),
 	}
 }
 
@@ -87,13 +152,13 @@ func TestDelegatedEntryUsesSourceObservationDateNotImportTimestamp(t *testing.T)
 		SourceDate: &sourceDate, UpdatedAt: importedAt,
 	}
 
-	entry := delegatedEntryFromCurrentState(acc, cand, uuid.New(), "Assunto", "Corpo")
+	entry := delegatedEntryFromCurrentState(acc, cand, uuid.New(), delegatedRoutingCopy{Subject: "Assunto", Body: "Corpo"})
 	if got := entry.WebSources[0].ObservedAt; !got.Equal(sourceDate) {
 		t.Fatalf("web observation=%s want source date %s; import timestamp must not refresh evidence", got, sourceDate)
 	}
 
 	cand.SourceDate = nil
-	entry = delegatedEntryFromCurrentState(acc, cand, uuid.New(), "Assunto", "Corpo")
+	entry = delegatedEntryFromCurrentState(acc, cand, uuid.New(), delegatedRoutingCopy{Subject: "Assunto", Body: "Corpo"})
 	if got := entry.WebSources[0].ObservedAt; !got.IsZero() {
 		t.Fatalf("missing source date must fail closed, got observation %s", got)
 	}

--- a/internal/app/confenge/generate_test.go
+++ b/internal/app/confenge/generate_test.go
@@ -386,13 +386,12 @@ func TestPromptVersionV6(t *testing.T) {
 	if OutreachDoctrineVersion != "confenge-outreach-v2" {
 		t.Fatalf("doctrine=%s", OutreachDoctrineVersion)
 	}
-	// v6 (2026-08-24) reads the sentence saying what the sender does from the
-	// lead's own service playbook instead of collapsing every lead to one
-	// string, and lets the closing ask follow the route class. Two v5 messages
-	// to different services were byte-identical below the fact; two v6 messages
-	// are not. The bump is deliberate: a v5 grant must not authorize v6 output.
+	// v7 (2026-08-26) keeps v6 service and route variation, then removes the
+	// delegated phrase bank. The delegated brief now varies only with bound fact,
+	// company, service, route and recipient purpose, and includes a contact exit.
+	// The bump is deliberate: a v6 grant must not authorize v7 output.
 	// Bump this pin only with that reasoning.
-	if ComposerVersion != "confenge.composer.v6" {
+	if ComposerVersion != "confenge.composer.v7" {
 		t.Fatalf("composer=%s", ComposerVersion)
 	}
 }

--- a/internal/app/confenge/messageability.go
+++ b/internal/app/confenge/messageability.go
@@ -34,7 +34,12 @@ const (
 // the closing ask follows the route class. Two v5 messages to different services
 // were byte-identical below the fact; two v6 messages are not. A v5 grant must
 // not authorize v6 copy; release_manifest.go already fails closed on drift.
-const ComposerVersion = "confenge.composer.v6"
+// Bumped to v7 on 2026-08-26: delegated first touches no longer rotate a
+// combinatorial phrase bank. A typed deterministic brief uses only supplier
+// role, supported public fact, service, route and recipient purpose; it also
+// carries the corpus-rules stamp and a natural contact exit. Existing frozen
+// copy must be regenerated before delegated authorization.
+const ComposerVersion = "confenge.composer.v7"
 
 // Outbound hook classes from the service playbook.
 const (


### PR DESCRIPTION
## Summary

- replace delegated UUID/phrase-bank rotation with one typed deterministic copy brief based only on company, confirmed supplier role, supported public fact, service, route class and recipient purpose
- bind projected facts to current `CONFIRMED_FACT` evidence, use names only for evidenced `DIRECT_PERSON` routes, add route-specific CTAs and a plain contact exit
- add versioned `confenge.first-touch-copy-rules.v1` QA that fails closed on unsupported or inverted claims, guessed people, exact content reuse, empty copy, metadata leakage and offensive or manipulative language
- add deterministic 1,000 and 10,000 message corpus regressions using 200 sanitized #152 replay seeds plus structured synthetic briefs, with an O(n log n) audit and no model calls
- document the editorial rules and measured corpus in `docs/confenge/delegated-first-touch-corpus-v1.md`

## Corpus results

| Metric | 1,000 | 10,000 |
| --- | ---: | ---: |
| Exact duplicate groups / messages | 0 / 0 | 0 / 0 |
| Near-duplicate groups / messages | 13 / 111 | 13 / 111 |
| Largest near-duplicate group | 19 | 19 |
| Unsupported claims | 0 | 0 |
| Buyer/supplier confusion | 0 | 0 |
| Guessed people | 0 | 0 |
| Internal metadata leakage | 0 | 0 |
| Route-inappropriate CTA | 0 | 0 |
| Word count min / average / p99 / max | 49 / 56.51 / 65 / 69 | 49 / 56.21 / 60 / 69 |

The 111 semantic near duplicates are 13 visible fallback groups from sanitized replay facts that could not safely enter copy. Practice-line concentration remains the actual #152 service distribution (47%, 32%, 11%, 9%, 1%) instead of being disguised by synonym rotation.

## Validation

- `make lint`
- targeted delegated composer, deterministic QA, adversarial, 1k and 10k corpus tests
- `go test ./cmd/confenge -count=1`
- `go test ./internal/app/confenge -run '^TestPromptVersionV6$' -count=1`
- `pnpm types:check` in `docs/`
- `pnpm lint` in `docs/` (0 errors; 2 existing warnings)

The broader CONFENGE package acceptance run was not used as a gate because `TestProductAcceptanceMultichannelSum` requires the local Mailpit service, which was not running. All changed and directly related tests pass.

Relates to #152 and #155.
