### PR TITLE
feat: reconcile outbound outcomes with exact-recipient auto-protection

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1371,14 +1371,13 @@ func main() {
 		// notification (in-app + email per the user's channels).
 		tokenService.WireSignInAlerter(notification.NewSignInAlerter(notificationService))
 		advancedService.WireRealtime(streamingPublisher)
+		if hook, ok := confengeServiceForHandler.(advanced.ConfengeSuppressionHook); ok {
+			advancedService.WireConfengeSuppression(hook)
+		}
 		// Inbox agent (M10): the draft repo the review endpoints read, plus the
 		// agent wired onto the advanced service so any reply processed here also
 		// drafts. Paid + opt-in checked inside; nil provider leaves it inert.
 		aiDraftRepo = repository.NewAIDraftRepository(primaryDB.Pool)
-		// CONFENGE reply attribution (outbox + CRM) when outreach feature is on.
-		if confengeServiceForHandler != nil && confengeServiceForHandler.Enabled() {
-			advancedService.WireConfengeReply(confengeServiceForHandler)
-		}
 		advancedService.WireInboxAgent(inboxagent.NewService(
 			aiProvider, creditService, featureGateService,
 			organizationRepository, uniboxRepository, skillsService,

--- a/cmd/consumer/confenge_wire_test.go
+++ b/cmd/consumer/confenge_wire_test.go
@@ -6,10 +6,7 @@ import (
 	"testing"
 )
 
-// TestConfengeReplyPathWiresCRM guards the production email handoff path:
-// ProcessIncomingReply runs in the consumer and calls OnClassifiedReply →
-// ProcessInboundHandoff → applyReplyCRM. Without WireCRM, CRM tasks/deals
-// never create on real inbound email.
+// TestConfengeReplyPathWiresCRM keeps one reconciler for each IMAP reply.
 func TestConfengeReplyPathWiresCRM(t *testing.T) {
 	b, err := os.ReadFile("main.go")
 	if err != nil {
@@ -19,26 +16,25 @@ func TestConfengeReplyPathWiresCRM(t *testing.T) {
 	newIdx := strings.Index(s, "confenge.NewService")
 	wireIntel := strings.Index(s, "WireIntel")
 	wireCRM := strings.Index(s, "WireCRM")
-	wireReply := strings.Index(s, "WireConfengeReply")
 	if newIdx < 0 {
 		t.Fatal("consumer must construct confenge.Service when enabled")
 	}
 	if wireCRM < 0 {
 		t.Fatal("consumer must WireCRM on confenge so email reply handoff creates CRM tasks/deals")
 	}
-	if wireIntel < 0 || !(newIdx < wireIntel && wireIntel < wireReply) {
-		t.Fatalf("consumer must WireIntel(Postgres) before reply/DSN handling; new=%d intel=%d reply=%d", newIdx, wireIntel, wireReply)
+	if wireIntel < 0 || !(newIdx < wireIntel && wireIntel < wireCRM) {
+		t.Fatalf("consumer must WireIntel(Postgres) before reply/DSN handling; new=%d intel=%d crm=%d", newIdx, wireIntel, wireCRM)
 	}
-	if wireReply < 0 {
-		t.Fatal("consumer must WireConfengeReply for email handoff")
+	if !(newIdx < wireCRM) {
+		t.Fatalf("WireCRM must follow confenge.NewService (at %d); WireCRM at %d", newIdx, wireCRM)
 	}
-	if !(newIdx < wireCRM && wireCRM < wireReply) {
-		t.Fatalf("WireCRM must sit between confenge.NewService (at %d) and WireConfengeReply (at %d); WireCRM at %d", newIdx, wireReply, wireCRM)
+	if strings.Contains(s, "advancedService.WireConfengeReply") {
+		t.Fatal("consumer must not wire a second CONFENGE reply reconciler")
 	}
 	// Reject the old "CRM not wired on consumer" posture if reintroduced near the wire site.
 	snippet := s
-	if wireReply > 0 && wireReply+200 < len(s) {
-		snippet = s[newIdx : wireReply+80]
+	if wireCRM > 0 && wireCRM+200 < len(s) {
+		snippet = s[newIdx : wireCRM+80]
 	}
 	if strings.Contains(snippet, "CRM not wired on consumer") {
 		t.Fatal("stale comment: CRM must be wired on consumer for reply handoff")

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -368,7 +368,6 @@ func main() {
 		// email handoff path; without it s.crm is nil and handoff is a silent no-op
 		// for CRM side effects. Same rationale as WireNotifier / WireRealtime.
 		confengeSvc.WireCRM(crm.NewService(crmRepo))
-		advancedService.WireConfengeReply(confengeSvc)
 	}
 
 	advancedService.WireInboxAgent(inboxAgentServiceC)

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -280,6 +280,8 @@ Registering and managing the OAuth apps your workspace owns. The flow itself (au
 | PATCH | `/automations/:id/layout` | `INTEGRATIONS` |
 | GET/POST/PATCH/DELETE | `/warmup/routing[/:id]` | `WARMUP_ROUTING` |
 
+`POST /deliverability/events` accepts explicit `delivered` and `soft_bounce` facts in addition to hard `bounce`, complaint, unsubscribe, open, click, and reply events. Its permission scope is unchanged.
+
 ### Retry safety
 
 Mutating API requests may include an `Idempotency-Key` header. Warmbly stores the completed response for 24 hours per organization and key. Reusing the same key with the same method, route, query, and body replays the original response with `X-Idempotent-Replayed: true`; reusing the key with a different request returns `409 Conflict`.

--- a/docs/content/docs/api/reference/deliverability-ops.mdx
+++ b/docs/content/docs/api/reference/deliverability-ops.mdx
@@ -127,7 +127,7 @@ Auth: **Scope** `WRITE_CAMPAIGNS` · **Org permission** `manage_settings`
 
 `POST /deliverability/events`
 
-Posts a single deliverability signal (bounce, complaint, unsubscribe, open, click, or reply) into the platform. This is API-key callable so downstream pipelines (for example an SES bounce processor) can report events without a human in the loop. Depending on the org's bounce-pipeline settings, a bounce, complaint, or unsubscribe may auto-suppress the recipient. Supply an `idempotency_key` to make retries safe.
+Posts a single deliverability signal into the platform. This is API-key callable so downstream pipelines (for example an SES bounce processor) can report events without a human in the loop. A `bounce` is a hard or permanent bounce and may suppress the recipient according to the organization's settings. A `soft_bounce` stays transient and is never promoted to permanent suppression by this endpoint. `delivered` requires an explicit provider delivery fact. Supply an `idempotency_key` to make retries safe.
 
 Auth: **Scope** `WRITE_CAMPAIGNS` · **Org permission** `send_campaigns`
 
@@ -135,7 +135,7 @@ Auth: **Scope** `WRITE_CAMPAIGNS` · **Org permission** `send_campaigns`
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `event_type` | string | Yes | One of `bounce`, `complaint`, `unsubscribe`, `open`, `click`, `reply`. |
+| `event_type` | string | Yes | One of `bounce`, `soft_bounce`, `delivered`, `complaint`, `unsubscribe`, `open`, `click`, `reply`. |
 | `recipient_email` | string | Yes | The recipient address the event is about. |
 | `campaign_id` | uuid | No | Campaign the event is attributed to. |
 | `task_id` | uuid | No | Send task the event is attributed to. |

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -84,6 +84,18 @@ Dominant stops: `DO_NOT_CONTACT`, opt-out, bounce, and human reply cancel open f
 
 Approval is also bounded in time, not only in scope. Frozen copy can be approved, authorized, queued and sent only while the composer that wrote it is the one the platform ships. Copy from an earlier composer becomes `LEGACY_SUPERSEDED`: readable for audit, refused by every operational path, and moved forward by recomposing the cohort into a new version. See [CONFENGE editorial lifecycle](/guides/confenge-editorial-lifecycle/).
 
+## Delivery and reply reconciliation
+
+The commercial chain is the authoritative record for outbound transport outcomes. An `attempted` fact is recorded at the worker transport boundary. A provider acceptance is recorded as `accepted`, not as delivery. `delivered` is recorded only when a provider or delivery-status notification reports it explicitly. If transport reaches an ambiguous final state, the chain preserves `delivery_unknown` as UNKNOWN until stronger evidence arrives.
+
+Hard bounces and complaints suppress the exact recipient address in the canonical suppression store. They cancel queued work for that address without invalidating the whole company or another mailbox at the same company. Soft bounces remain soft and do not become permanent suppression without later evidence. A missing reply is not evidence of a bad mailbox.
+
+Unsubscribe and opt-out events record their reason, source, and timestamp against the exact recipient scope. The final `AssertTransportable` database read checks that canonical suppression immediately before provider transport, including for an item that was approved and queued before the suppression arrived.
+
+A human reply marks the correlated touchpoint, stops incompatible future attempts for the account, and enters the existing human triage flow. It never triggers an automatic reply in the CONFENGE flow. Positive, routed, and ordinary replies remain distinct commercial facts. Duplicate or replayed provider events reuse stable receipts, while out-of-order or impossible transitions retain the observed fact and enter the existing exception queue for reconciliation.
+
+Operational outcome metrics contain only opaque dimensions: `route_class`, `source`, `source_run`, `cohort`, and sender `mailbox`. Recipient addresses and company names are not metric dimensions.
+
 ## Import
 
 `POST /api/v1/confenge/import` accepts:

--- a/internal/app/advanced/confenge_reply_safety_test.go
+++ b/internal/app/advanced/confenge_reply_safety_test.go
@@ -1,0 +1,14 @@
+package advanced
+
+import "testing"
+
+func TestConfengeReplyNeverLaunchesInstantFollowUp(t *testing.T) {
+	for _, name := range []string{"CONFENGE | Outreach consultivo inicial", " confenge pilot"} {
+		if allowsInstantReplyActions(name) {
+			t.Fatalf("CONFENGE reply allowed instant follow-up for %q", name)
+		}
+	}
+	if !allowsInstantReplyActions("Customer onboarding") {
+		t.Fatal("unrelated campaign behavior changed")
+	}
+}

--- a/internal/app/advanced/events.go
+++ b/internal/app/advanced/events.go
@@ -104,6 +104,10 @@ func (s *service) WireConfengeReply(h ConfengeReplyHook) {
 	s.confengeReply = h
 }
 
+func (s *service) WireConfengeSuppression(h ConfengeSuppressionHook) {
+	s.confengeSuppression = h
+}
+
 // notify raises an in-app notification off the hot path. It detaches from the
 // request context (the ingest call may return first) and is best-effort.
 func (s *service) notify(userID uuid.UUID, orgID *uuid.UUID, category models.NotificationCategory, title, body, link string, meta map[string]any) {

--- a/internal/app/advanced/outbound_bounce_test.go
+++ b/internal/app/advanced/outbound_bounce_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -82,6 +83,24 @@ type outboundContactRepo struct {
 	contact *models.Contact
 }
 
+type confengeDeliverabilityRecorder struct {
+	calls int
+	req   *models.IngestDeliverabilityEventRequest
+	idem  string
+}
+
+func (r *confengeDeliverabilityRecorder) OnRecipientSuppressed(context.Context, uuid.UUID, string, string, string, *uuid.UUID, time.Time) error {
+	return nil
+}
+
+func (r *confengeDeliverabilityRecorder) OnDeliverabilityEvent(_ context.Context, _ uuid.UUID, req *models.IngestDeliverabilityEventRequest, _, idem string, _ uuid.UUID, _ time.Time) error {
+	r.calls++
+	copy := *req
+	r.req = &copy
+	r.idem = idem
+	return nil
+}
+
 func (r outboundContactRepo) GetByID(context.Context, uuid.UUID) (*models.Contact, *errx.Error) {
 	return r.contact, nil
 }
@@ -140,4 +159,32 @@ func TestIngestDeliverabilityEventLoadsSettingsBeforeClaim(t *testing.T) {
 
 	require.NotNil(t, xerr)
 	require.Zero(t, repo.createCalls)
+}
+
+func TestIngestDeliverabilityEventReplaysProviderProjectionIdempotently(t *testing.T) {
+	repo := &outboundAdvancedRepo{autoSuppress: true}
+	hook := &confengeDeliverabilityRecorder{}
+	svc := &service{repo: repo, confengeSuppression: hook}
+	req := &models.IngestDeliverabilityEventRequest{
+		EventType: models.DeliverabilityEventDelivered, RecipientEmail: "lead@example.com",
+		Provider: "ses", IdempotencyKey: "ses:delivered:47",
+	}
+
+	orgID := uuid.New()
+	require.Nil(t, svc.IngestDeliverabilityEvent(context.Background(), orgID, req))
+	require.Nil(t, svc.IngestDeliverabilityEvent(context.Background(), orgID, req))
+	require.Equal(t, 2, hook.calls)
+	require.Equal(t, models.DeliverabilityEventDelivered, hook.req.EventType)
+	require.Equal(t, "ses:delivered:47", hook.idem)
+	require.Zero(t, repo.suppressCalls)
+}
+
+func TestIngestDeliverabilityEventNeverSuppressesSoftBounce(t *testing.T) {
+	repo := &outboundAdvancedRepo{autoSuppress: true}
+	svc := &service{repo: repo}
+	require.Nil(t, svc.IngestDeliverabilityEvent(context.Background(), uuid.New(), &models.IngestDeliverabilityEventRequest{
+		EventType: models.DeliverabilityEventSoftBounce, RecipientEmail: "lead@example.com",
+		IdempotencyKey: "ses:soft:47",
+	}))
+	require.Zero(t, repo.suppressCalls)
 }

--- a/internal/app/advanced/service.go
+++ b/internal/app/advanced/service.go
@@ -124,6 +124,7 @@ type Service interface {
 	// WireConfengeReply attributes classified replies to CONFENGE staging
 	// (outcome outbox + CRM tasks/deals). Best-effort; nil = feature off.
 	WireConfengeReply(h ConfengeReplyHook)
+	WireConfengeSuppression(h ConfengeSuppressionHook)
 
 	// EmitCampaignEvent dispatches a campaign event (e.g. from a sequence
 	// "notify" action node) to customer webhooks and wired integrations.
@@ -167,6 +168,7 @@ type service struct {
 	automationRunner     AutomationRunner
 	inboxAgent           InboxAgent
 	confengeReply        ConfengeReplyHook
+	confengeSuppression  ConfengeSuppressionHook
 }
 
 // ConfengeReplyHook is implemented by the CONFENGE outreach service. Kept as a
@@ -175,6 +177,16 @@ type service struct {
 // and CRM tasks run on the real email path (not only PreClass).
 type ConfengeReplyHook interface {
 	OnClassifiedReply(ctx context.Context, orgID uuid.UUID, contactEmail, replyClass string, contactID *uuid.UUID, subject, bodyText string, actorID uuid.UUID) error
+}
+
+// ConfengeSuppressionHook projects canonical suppression into CONFENGE.
+type ConfengeSuppressionHook interface {
+	OnRecipientSuppressed(ctx context.Context, orgID uuid.UUID, email, reason, source string, campaignID *uuid.UUID, occurredAt time.Time) error
+}
+
+// ConfengeDeliverabilityHook reconciles provider facts through the existing CONFENGE ledger.
+type ConfengeDeliverabilityHook interface {
+	OnDeliverabilityEvent(context.Context, uuid.UUID, *models.IngestDeliverabilityEventRequest, string, string, uuid.UUID, time.Time) error
 }
 
 func NewService(
@@ -545,6 +557,12 @@ func (s *service) Unsubscribe(ctx context.Context, campaignID, contactID uuid.UU
 		CampaignID:     &campaignID,
 	}); err != nil {
 		return toErrx(err)
+	}
+	if s.confengeSuppression != nil {
+		if err := s.confengeSuppression.OnRecipientSuppressed(ctx, *campaign.OrganizationID, contact.Email,
+			"one-click unsubscribe", string(models.DeliverabilityEventUnsubscribe), &campaignID, time.Now().UTC()); err != nil {
+			return toErrx(err)
+		}
 	}
 
 	s.emit(ctx, *campaign.OrganizationID, models.WebhookEventCampaignUnsubscribed, map[string]any{
@@ -982,7 +1000,14 @@ func (s *service) ProcessIncomingReply(ctx context.Context, emailAccountID uuid.
 		// and exactly once per reply event via the instant_fired["reply"] gate. The
 		// just-classified reply_class and (human-only) replied_at have already been
 		// persisted above, so the matcher reads them off the loaded progress row.
-		s.fireInstantActions(ctx, cID, ctID, sID, "reply")
+		// CONFENGE replies enter human triage without launching instant follow-ups.
+		campaignName := ""
+		if campaign, campaignErr := s.campaignRepo.GetByID(ctx, cID); campaignErr == nil && campaign != nil {
+			campaignName = campaign.Name
+		}
+		if allowsInstantReplyActions(campaignName) {
+			s.fireInstantActions(ctx, cID, ctID, sID, "reply")
+		}
 	}
 
 	actionTaken := ""
@@ -1091,6 +1116,10 @@ func (s *service) ProcessIncomingReply(ctx context.Context, emailAccountID uuid.
 	return nil
 }
 
+func allowsInstantReplyActions(campaignName string) bool {
+	return !strings.HasPrefix(strings.ToUpper(strings.TrimSpace(campaignName)), "CONFENGE")
+}
+
 func ptrTime(t time.Time) *time.Time {
 	return &t
 }
@@ -1106,6 +1135,8 @@ func (s *service) IngestDeliverabilityEvent(ctx context.Context, organizationID 
 	eventType := req.EventType
 	switch eventType {
 	case models.DeliverabilityEventBounce,
+		models.DeliverabilityEventSoftBounce,
+		models.DeliverabilityEventDelivered,
 		models.DeliverabilityEventComplaint,
 		models.DeliverabilityEventUnsubscribe,
 		models.DeliverabilityEventOpen,
@@ -1124,6 +1155,7 @@ func (s *service) IngestDeliverabilityEvent(ctx context.Context, organizationID 
 	if provider == "" {
 		provider = "manual"
 	}
+	observedAt := time.Now().UTC()
 
 	settings, err := s.repo.GetOutreachSettings(ctx, organizationID)
 	if err != nil {
@@ -1165,6 +1197,25 @@ func (s *service) IngestDeliverabilityEvent(ctx context.Context, organizationID 
 
 	if req.CampaignID != nil && req.ContactID != nil {
 		if err := s.repo.MarkVariantEvent(ctx, *req.CampaignID, *req.ContactID, string(eventType)); err != nil {
+			return toErrx(err)
+		}
+	}
+
+	if hook, ok := s.confengeSuppression.(ConfengeDeliverabilityHook); ok {
+		mailboxID := uuid.Nil
+		if req.TaskID != nil && s.taskRepo != nil {
+			task, taskErr := s.taskRepo.GetTask(ctx, *req.TaskID)
+			if taskErr != nil {
+				return toErrx(taskErr)
+			}
+			if task != nil {
+				mailboxID = task.EmailAccountID
+			}
+		}
+		projection := *req
+		projection.Provider = provider
+		projection.IdempotencyKey = idempotencyKey
+		if err := hook.OnDeliverabilityEvent(ctx, organizationID, &projection, provider, idempotencyKey, mailboxID, observedAt); err != nil {
 			return toErrx(err)
 		}
 	}

--- a/internal/app/confenge/cohort_operator_flow_test.go
+++ b/internal/app/confenge/cohort_operator_flow_test.go
@@ -425,6 +425,11 @@ func TestObservePathPopulatesRouteClassWithoutHandBuiltEvent(t *testing.T) {
 	if err := svc.transitionCompletedTouchpoint(ctx, org, tp, now, "prov-1"); err != nil {
 		t.Fatal(err)
 	}
+	if err := svc.observeControlledEmail(ctx, org, intel.EventProviderAccepted, tp, cand, ControlledEmailContext{
+		OccurredAt: now, ProviderName: "smtp", StableEventRef: "prov-1",
+	}); err != nil {
+		t.Fatal(err)
+	}
 	_ = repo.UpdateTouchpoint(ctx, tp)
 	if err := svc.NoteReply(ctx, org, cand.Email, map[string]any{"reply_class": "POSITIVE"}); err != nil {
 		t.Fatal(err)

--- a/internal/app/confenge/cohort_store_pg_test.go
+++ b/internal/app/confenge/cohort_store_pg_test.go
@@ -398,10 +398,10 @@ func TestPostgresGateThenCompleteLastSlot(t *testing.T) {
 	if gate.Kind != GateProceed {
 		t.Fatalf("first gate must reserve last slot: %+v err=%v", gate, gate.Err)
 	}
-	if err := svc.ObserveCampaignEmailAttempt(ctx, org, campaignID, enrollContactID, sequenceID, clock.Now()); err != nil {
+	if err := svc.ObserveCampaignEmailAttempt(ctx, org, campaignID, enrollContactID, sequenceID, uuid.New(), uuid.New(), "smtp", clock.Now()); err != nil {
 		t.Fatalf("observe provider attempt: %v", err)
 	}
-	if err := svc.CompleteCampaignEmail(ctx, org, campaignID, enrollContactID, sequenceID, "prov-1", time.Now().UTC()); err != nil {
+	if err := svc.CompleteCampaignEmail(ctx, org, campaignID, enrollContactID, sequenceID, uuid.New(), uuid.New(), "prov-1", "smtp", time.Now().UTC()); err != nil {
 		t.Fatalf("complete last reserved slot must succeed: %v", err)
 	}
 	st, err := store.HeldSlot(ctx, auth.ID, MessageKeyCampaignEmail(campaignID, enrollContactID, sequenceID))

--- a/internal/app/confenge/controlled_email_observe.go
+++ b/internal/app/confenge/controlled_email_observe.go
@@ -2,7 +2,9 @@ package confenge
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -21,6 +23,9 @@ type ControlledEmailContext struct {
 	PolicyVersion  string
 	ProviderName   string
 	Source         string
+	SourceRunID    string
+	MailboxID      string
+	StableEventRef string
 	BounceClass    string
 	ReplyClass     string
 	AccountRef     string
@@ -41,6 +46,9 @@ func SnapshotControlledEmailContext(tp *models.OutreachTouchpoint, cand *models.
 	if cand != nil {
 		if class := CandidateRouteClass(cand); class != "" {
 			ctx.RouteClass = class
+		}
+		if cand.AccountID != uuid.Nil {
+			ctx.AccountRef = cand.AccountID.String()
 		}
 	}
 	if auth != nil {
@@ -86,6 +94,12 @@ func applyControlledEmailContext(ev *intel.CommercialEvent, c ControlledEmailCon
 	}
 	if ev.Source == "" {
 		ev.Source = c.Source
+	}
+	if ev.SourceRunID == "" {
+		ev.SourceRunID = c.SourceRunID
+	}
+	if ev.MailboxID == "" {
+		ev.MailboxID = c.MailboxID
 	}
 	if ev.BounceClass == "" {
 		ev.BounceClass = c.BounceClass
@@ -137,6 +151,22 @@ func (s *service) liveControlledEmailContext(ctx context.Context, orgID uuid.UUI
 		auth, _ = s.cohortStore.GetGrant(ctx, *tp.CampaignPolicyAuthorizationID)
 	}
 	result := SnapshotControlledEmailContext(tp, cand, auth, provider)
+	if s != nil && s.repo != nil {
+		var accountID uuid.UUID
+		if tp != nil {
+			accountID = tp.AccountID
+		} else if cand != nil {
+			accountID = cand.AccountID
+		}
+		if accountID != uuid.Nil {
+			if account, err := s.repo.GetAccount(ctx, orgID, accountID); err == nil && account != nil {
+				result.SourceRunID = strings.TrimSpace(account.SourceRunID)
+				if result.Source == "" || result.Source == intel.Unknown {
+					result.Source = firstNonEmpty(strings.TrimSpace(account.SourceSystem), intel.Unknown)
+				}
+			}
+		}
+	}
 	if result.ProviderName == "" || result.ProviderName == intel.Unknown {
 		result.ProviderName = s.observedControlledProvider(orgID, result.AccountRef, result.TouchpointID)
 	}
@@ -173,9 +203,9 @@ func (s *service) observedControlledProvider(orgID uuid.UUID, accountRef, touchp
 	return firstNonEmpty(provider, intel.Unknown)
 }
 
-func (s *service) observeControlledEmail(ctx context.Context, orgID uuid.UUID, typ string, tp *models.OutreachTouchpoint, cand *models.OutreachContactCandidate, extra ControlledEmailContext) {
+func (s *service) observeControlledEmail(ctx context.Context, orgID uuid.UUID, typ string, tp *models.OutreachTouchpoint, cand *models.OutreachContactCandidate, extra ControlledEmailContext) error {
 	if s == nil {
-		return
+		return nil
 	}
 	now := extra.OccurredAt.UTC()
 	if now.IsZero() {
@@ -191,17 +221,25 @@ func (s *service) observeControlledEmail(ctx context.Context, orgID uuid.UUID, t
 	if extra.Source != "" && (c.Source == "" || c.Source == intel.Unknown) {
 		c.Source = extra.Source
 	}
+	if extra.SourceRunID != "" {
+		c.SourceRunID = extra.SourceRunID
+	}
+	if extra.MailboxID != "" {
+		c.MailboxID = extra.MailboxID
+	}
 	c.SMTPStatus = extra.SMTPStatus
 	c.EnhancedStatus = extra.EnhancedStatus
 	c.Diagnostic = extra.Diagnostic
+	stableRef := firstNonEmpty(strings.TrimSpace(extra.StableEventRef), c.TouchpointID, c.AccountRef)
+	stableID := controlledEmailEventID(typ, orgID.String(), stableRef)
 	ev := intel.CommercialEvent{
-		EventID:        uuid.NewString(),
+		EventID:        stableID,
 		Version:        intel.EventSchemaV1,
 		Type:           typ,
 		OccurredAt:     now,
 		IngestedAt:     now,
 		OrganizationID: orgID.String(),
-		IdempotencyKey: typ + ":" + orgID.String() + ":" + c.TouchpointID + ":" + c.AccountRef,
+		IdempotencyKey: "controlled-email:" + stableID,
 		// This path is invoked by real cohort transport/IMAP/DSN handling.
 		// Fixtures and canaries set Synthetic at their own construction sites.
 		Synthetic: false,
@@ -212,8 +250,17 @@ func (s *service) observeControlledEmail(ctx context.Context, orgID uuid.UUID, t
 	}
 	recordObservedControlledEmail(s, ev)
 	if s.intel != nil || s.intelStore() != nil {
-		_ = intel.IngestEvent(s.intelStore(), ev)
+		res := intel.IngestEvent(s.intelStore(), ev)
+		if intel.JoinUnavailable(res) {
+			return fmt.Errorf("controlled email ledger unavailable for %s", typ)
+		}
 	}
+	return nil
+}
+
+func controlledEmailEventID(parts ...string) string {
+	h := sha256.Sum256([]byte(strings.Join(parts, "\x00")))
+	return fmt.Sprintf("email-%x", h[:16])
 }
 
 var observedMu sync.Mutex
@@ -246,6 +293,9 @@ func mergeOutcomeControlledEmail(meta map[string]any, c ControlledEmailContext) 
 	putIfMissing(meta, "cohort_id", c.CohortID)
 	putIfMissing(meta, "policy_version", c.PolicyVersion)
 	putIfMissing(meta, "provider_name", c.ProviderName)
+	putIfMissing(meta, "source", c.Source)
+	putIfMissing(meta, "source_run_id", c.SourceRunID)
+	putIfMissing(meta, "mailbox_id", c.MailboxID)
 	putIfMissing(meta, "bounce_class", c.BounceClass)
 	putIfMissing(meta, "reply_class", c.ReplyClass)
 }
@@ -273,6 +323,8 @@ func CommercialEventFromOutcome(ev models.OutreachOutcome) intel.CommercialEvent
 		EnhancedStatus:  metaString(meta, "enhanced_status"),
 		Diagnostic:      metaString(meta, "diagnostic"),
 		Source:          metaString(meta, "source"),
+		SourceRunID:     metaString(meta, "source_run_id"),
+		MailboxID:       metaString(meta, "mailbox_id"),
 	}
 	if out.EmailRouteClass == "" {
 		out.EmailRouteClass = intel.Unknown

--- a/internal/app/confenge/crm_test.go
+++ b/internal/app/confenge/crm_test.go
@@ -128,8 +128,12 @@ func TestHandleClassifiedReplyDNC(t *testing.T) {
 		VerificationStatus: models.OutreachVerifyOfficialSource,
 	})
 	_ = svc.HandleClassifiedReply(context.Background(), org, uuid.Nil, "x@example.com", replyclassify.ClassUnsubscribe, nil)
+	cand, _, _ := r.FindCandidateByEmail(context.Background(), org, "x@example.com")
+	if cand == nil || !cand.DoNotContact {
+		t.Fatalf("exact recipient DNC not set: %+v", cand)
+	}
 	acc, _ := r.GetAccountByCNPJ(context.Background(), org, "11222333000181")
-	if acc == nil || !acc.DoNotContact {
-		t.Fatalf("DNC not set: %+v", acc)
+	if acc == nil || acc.DoNotContact || acc.Blocked {
+		t.Fatalf("recipient opt-out must preserve company identity: %+v", acc)
 	}
 }

--- a/internal/app/confenge/e2e_flow_test.go
+++ b/internal/app/confenge/e2e_flow_test.go
@@ -199,8 +199,8 @@ func TestSoftBounceIsObservableWithoutSuppression(t *testing.T) {
 	if len(events) != 1 || events[0].Type != "soft_bounce" || events[0].BounceClass != "SOFT" {
 		t.Fatalf("soft bounce missing from commercial ledger: %+v", events)
 	}
-	if len(outcomes) != 1 || !strings.Contains(string(outcomes[0].Payload), `"enhanced_status":"4.4.1"`) {
-		t.Fatalf("soft provenance missing from outcome: %+v", outcomes)
+	if len(outcomes) != 0 {
+		t.Fatalf("soft bounce must not emit a permanent BOUNCED outcome: %+v", outcomes)
 	}
 }
 

--- a/internal/app/confenge/hooks.go
+++ b/internal/app/confenge/hooks.go
@@ -29,6 +29,10 @@ type OutcomeSink interface {
 // raw message body.
 type BounceObservation struct {
 	Class             string
+	DeliveryUnknown   bool
+	EventID           string
+	MailboxID         string
+	OccurredAt        time.Time
 	ProviderName      string
 	OriginalMessageID string
 	EnhancedStatus    string
@@ -41,6 +45,92 @@ type BounceObservation struct {
 // implement OutcomeSink continue to compile. New DSN consumers must prefer it.
 type StructuredBounceOutcomeSink interface {
 	NoteBounceObservation(ctx context.Context, orgID uuid.UUID, contactEmail string, observation BounceObservation) error
+}
+
+type DeliveryObservation struct {
+	EventID, MailboxID, ProviderName, OriginalMessageID string
+	EnhancedStatus, SMTPStatus, Diagnostic              string
+	OccurredAt                                          time.Time
+}
+
+type ComplaintObservation struct {
+	EventID, MailboxID, ProviderName, OriginalMessageID string
+	FeedbackType                                        string
+	OccurredAt                                          time.Time
+}
+
+// StructuredEmailOutcomeSink receives observable post-acceptance facts.
+type StructuredEmailOutcomeSink interface {
+	NoteDeliveryObservation(context.Context, uuid.UUID, string, DeliveryObservation) error
+	NoteComplaintObservation(context.Context, uuid.UUID, string, ComplaintObservation) error
+}
+
+// OnRecipientSuppressed implements advanced.ConfengeSuppressionHook.
+func (s *service) OnRecipientSuppressed(ctx context.Context, orgID uuid.UUID, email, reason, source string, campaignID *uuid.UUID, occurredAt time.Time) error {
+	if !strings.EqualFold(strings.TrimSpace(source), string(models.DeliverabilityEventUnsubscribe)) {
+		return fmt.Errorf("unsupported recipient suppression source %q", source)
+	}
+	stableRef := "one-click:" + email
+	if campaignID != nil {
+		stableRef += ":" + campaignID.String()
+	}
+	return s.noteDNCObserved(ctx, orgID, email, reason, "one_click", stableRef, occurredAt)
+}
+
+// OnDeliverabilityEvent implements advanced.ConfengeDeliverabilityHook.
+func (s *service) OnDeliverabilityEvent(ctx context.Context, orgID uuid.UUID, req *models.IngestDeliverabilityEventRequest, provider, idempotencyKey string, mailboxID uuid.UUID, occurredAt time.Time) error {
+	if req == nil {
+		return nil
+	}
+	originalMessageID := metaString(req.Metadata, "original_message_id")
+	stableRef := firstNonEmpty(idempotencyKey, originalMessageID)
+	mailboxRef := opaqueUUID(mailboxID)
+	switch req.EventType {
+	case models.DeliverabilityEventBounce:
+		return s.NoteBounceObservation(ctx, orgID, req.RecipientEmail, BounceObservation{
+			Class: "HARD", EventID: "webhook:" + stableRef, MailboxID: mailboxRef,
+			OccurredAt: occurredAt, ProviderName: provider, OriginalMessageID: originalMessageID,
+			EnhancedStatus: metaString(req.Metadata, "enhanced_status"), SMTPStatus: metaString(req.Metadata, "smtp_status"),
+			Diagnostic: metaString(req.Metadata, "diagnostic"), Reason: req.Reason,
+		})
+	case models.DeliverabilityEventSoftBounce:
+		return s.NoteBounceObservation(ctx, orgID, req.RecipientEmail, BounceObservation{
+			Class: "SOFT", EventID: "webhook:" + stableRef, MailboxID: mailboxRef,
+			OccurredAt: occurredAt, ProviderName: provider, OriginalMessageID: originalMessageID,
+			EnhancedStatus: metaString(req.Metadata, "enhanced_status"), SMTPStatus: metaString(req.Metadata, "smtp_status"),
+			Diagnostic: metaString(req.Metadata, "diagnostic"), Reason: req.Reason,
+		})
+	case models.DeliverabilityEventDelivered:
+		return s.NoteDeliveryObservation(ctx, orgID, req.RecipientEmail, DeliveryObservation{
+			EventID: "webhook:" + stableRef, MailboxID: mailboxRef, ProviderName: provider,
+			OriginalMessageID: originalMessageID, OccurredAt: occurredAt,
+			EnhancedStatus: metaString(req.Metadata, "enhanced_status"), SMTPStatus: metaString(req.Metadata, "smtp_status"),
+			Diagnostic: metaString(req.Metadata, "diagnostic"),
+		})
+	case models.DeliverabilityEventComplaint:
+		return s.NoteComplaintObservation(ctx, orgID, req.RecipientEmail, ComplaintObservation{
+			EventID: "webhook:" + stableRef, MailboxID: mailboxRef, ProviderName: provider,
+			OriginalMessageID: originalMessageID, FeedbackType: firstNonEmpty(metaString(req.Metadata, "feedback_type"), req.Reason),
+			OccurredAt: occurredAt,
+		})
+	case models.DeliverabilityEventUnsubscribe:
+		return s.noteDNCObserved(ctx, orgID, req.RecipientEmail, req.Reason, provider, "webhook:"+stableRef, occurredAt)
+	case models.DeliverabilityEventReply:
+		meta := map[string]any{
+			"message_id": stableRef, "provider_name": provider, "mailbox_id": mailboxRef,
+			"occurred_at": occurredAt.UTC().Format(time.RFC3339Nano), "reply_class": metaString(req.Metadata, "reply_class"),
+			"subject": metaString(req.Metadata, "subject"), "body_text": metaString(req.Metadata, "body_text"),
+		}
+		if req.CampaignID != nil {
+			meta["campaign_id"] = req.CampaignID.String()
+		}
+		if req.ContactID != nil {
+			meta["contact_id"] = req.ContactID.String()
+		}
+		return s.NoteReply(ctx, orgID, req.RecipientEmail, meta)
+	default:
+		return nil
+	}
 }
 
 func (s *service) enqueueErr(ctx context.Context, orgID uuid.UUID, ev models.OutreachOutcome) error {
@@ -85,16 +175,6 @@ func (s *service) NoteReply(ctx context.Context, orgID uuid.UUID, contactEmail s
 		correlatedTP = nil
 		exactCorrelationRequested = true
 	}
-	_, _ = s.repo.CancelOpenTouchpoints(ctx, orgID, acc.ID, models.TouchpointReplied, "REPLY")
-	payload, _ := jsonMarshalMap(meta)
-	phone := ""
-	if cand != nil {
-		phone = cand.PhoneE164
-		if phone == "" {
-			phone = cand.Phone
-		}
-	}
-	s.cancelQueuedForRecipient(ctx, orgID, email, phone, "reply")
 	replyClass := ""
 	if meta != nil {
 		if v, ok := meta["reply_class"].(string); ok {
@@ -115,16 +195,39 @@ func (s *service) NoteReply(ctx context.Context, orgID uuid.UUID, contactEmail s
 		observeCandidate = nil
 		extra.AccountRef = acc.ID.String()
 	}
-	s.observeControlledEmail(ctx, orgID, "reply", correlatedTP, observeCandidate, extra)
-	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
-		IdempotencyKey: fmt.Sprintf("replied:%s:%s:%d", orgID, email, time.Now().UTC().Truncate(time.Minute).Unix()),
-		SourceLeadID:   acc.SourceLeadID,
-		CNPJ14:         acc.CNPJ14,
-		ContactEmail:   email,
-		EventType:      OutcomeReplied,
-		OccurredAt:     time.Now().UTC(),
-		Payload:        payload,
+	stableRef := firstNonEmpty(metaString(meta, "message_id"), metaString(meta, "external_message_id"), metaString(meta, "original_message_id"))
+	extra.StableEventRef = firstNonEmpty(stableRef, email+":"+replyClass)
+	extra.MailboxID = metaString(meta, "mailbox_id")
+	if err := s.observeControlledEmail(ctx, orgID, intel.EventReply, correlatedTP, observeCandidate, extra); err != nil {
+		return err
+	}
+	var touchpointID uuid.UUID
+	if correlatedTP != nil {
+		touchpointID = correlatedTP.ID
+	}
+	actorID, _ := uuid.Parse(metaString(meta, "actor_id"))
+	contactID, _ := uuid.Parse(metaString(meta, "contact_id"))
+	var warmblyContactID *uuid.UUID
+	if contactID != uuid.Nil {
+		warmblyContactID = &contactID
+	}
+	occurredAt := time.Now().UTC()
+	if raw := metaString(meta, "occurred_at"); raw != "" {
+		if parsed, parseErr := time.Parse(time.RFC3339Nano, raw); parseErr == nil {
+			occurredAt = parsed.UTC()
+		}
+	}
+	_, xerr := s.ProcessInboundHandoff(ctx, orgID, InboundHandoff{
+		Channel: models.OutreachChannelEmail, ContactEmail: email,
+		Subject: metaString(meta, "subject"), BodyText: metaString(meta, "body_text"),
+		PreClass: replyClass, ExternalMessageID: stableRef, OccurredAt: occurredAt,
+		WarmblyContactID: warmblyContactID, ActorID: actorID, AccountID: acc.ID,
+		TouchpointID: touchpointID,
 	})
+	if xerr != nil {
+		return fmt.Errorf("%s", xerr.Message)
+	}
+	return nil
 }
 
 // NoteBounce implements OutcomeSink.
@@ -160,10 +263,6 @@ func (s *service) NoteBounceObservation(ctx context.Context, orgID uuid.UUID, co
 	if acc != nil {
 		cnpj, lead = acc.CNPJ14, acc.SourceLeadID
 	}
-	if acc != nil && definitiveHard {
-		_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, acc.Blocked, acc.DoNotContact, "bounce", models.OutreachQueueBounced)
-		_, _ = s.repo.CancelOpenTouchpoints(ctx, orgID, acc.ID, models.TouchpointBounced, "BOUNCE")
-	}
 	phone := ""
 	if cand != nil {
 		phone = cand.PhoneE164
@@ -172,10 +271,29 @@ func (s *service) NoteBounceObservation(ctx context.Context, orgID uuid.UUID, co
 		}
 	}
 	if definitiveHard {
+		if suppressions, ok := s.repo.(interface {
+			UpsertOutreachRecipientSuppression(context.Context, *models.SuppressedRecipient) error
+			CancelSuppressedOutreachRecipient(context.Context, uuid.UUID, string, string, string) (int, error)
+		}); ok {
+			if err := suppressions.UpsertOutreachRecipientSuppression(ctx, &models.SuppressedRecipient{
+				OrganizationID: orgID, Email: email, Reason: firstNonEmpty(observation.Reason, "hard bounce"),
+				Source: models.DeliverabilityEventBounce, Metadata: map[string]interface{}{
+					"bounce_class": bounceClass, "provider": observation.ProviderName,
+					"enhanced_status": observation.EnhancedStatus,
+				},
+			}); err != nil {
+				return err
+			}
+			if _, err := suppressions.CancelSuppressedOutreachRecipient(ctx, orgID, email, models.TouchpointBounced, "hard_bounce"); err != nil {
+				return err
+			}
+		}
 		s.cancelQueuedForRecipient(ctx, orgID, email, phone, "bounce")
 	}
 	typ := intel.EventUnknownState
-	if bounceClass == "HARD" {
+	if observation.DeliveryUnknown {
+		typ = intel.EventDeliveryUnknown
+	} else if bounceClass == "HARD" {
 		typ = "hard_bounce"
 	} else if bounceClass == "SOFT" {
 		typ = "soft_bounce"
@@ -186,10 +304,17 @@ func (s *service) NoteBounceObservation(ctx context.Context, orgID uuid.UUID, co
 	}); ok && strings.TrimSpace(observation.OriginalMessageID) != "" {
 		correlatedTP, _ = finder.GetTouchpointByProviderMessageID(ctx, orgID, observation.OriginalMessageID)
 	}
-	s.observeControlledEmail(ctx, orgID, typ, correlatedTP, cand, ControlledEmailContext{
+	if err := s.observeControlledEmail(ctx, orgID, typ, correlatedTP, cand, ControlledEmailContext{
+		OccurredAt: observation.OccurredAt, StableEventRef: firstNonEmpty(observation.EventID, observation.OriginalMessageID, email+":"+bounceClass),
+		MailboxID:   observation.MailboxID,
 		BounceClass: bounceClass, ProviderName: observation.ProviderName, SMTPStatus: observation.SMTPStatus,
 		EnhancedStatus: observation.EnhancedStatus, Diagnostic: observation.Diagnostic,
-	})
+	}); err != nil {
+		return err
+	}
+	if !definitiveHard {
+		return nil
+	}
 	idemRef := firstNonEmpty(strings.TrimSpace(observation.OriginalMessageID), email)
 	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
 		IdempotencyKey: fmt.Sprintf("bounced:%s:%s:%s", orgID, bounceClass, idemRef),
@@ -197,7 +322,7 @@ func (s *service) NoteBounceObservation(ctx context.Context, orgID uuid.UUID, co
 		CNPJ14:         cnpj,
 		ContactEmail:   email,
 		EventType:      OutcomeBounced,
-		OccurredAt:     time.Now().UTC(),
+		OccurredAt:     firstNonZeroTime(nil, observation.OccurredAt),
 		Payload: mustJSON(map[string]any{
 			"reason": observation.Reason, "bounce_class": bounceClass,
 			"original_message_id": observation.OriginalMessageID,
@@ -208,12 +333,85 @@ func (s *service) NoteBounceObservation(ctx context.Context, orgID uuid.UUID, co
 	})
 }
 
+func (s *service) NoteDeliveryObservation(ctx context.Context, orgID uuid.UUID, contactEmail string, observation DeliveryObservation) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	var cand *models.OutreachContactCandidate
+	if email := strings.TrimSpace(strings.ToLower(contactEmail)); email != "" {
+		cand, _, _ = s.repo.FindCandidateByEmail(ctx, orgID, email)
+	}
+	var touchpoint *models.OutreachTouchpoint
+	if finder, ok := s.repo.(interface {
+		GetTouchpointByProviderMessageID(context.Context, uuid.UUID, string) (*models.OutreachTouchpoint, error)
+	}); ok {
+		var err error
+		touchpoint, err = finder.GetTouchpointByProviderMessageID(ctx, orgID, observation.OriginalMessageID)
+		if err != nil {
+			return err
+		}
+	}
+	if touchpoint == nil && cand == nil {
+		return nil
+	}
+	return s.observeControlledEmail(ctx, orgID, intel.EventDelivered, touchpoint, cand, ControlledEmailContext{
+		OccurredAt: observation.OccurredAt, ProviderName: observation.ProviderName,
+		MailboxID: observation.MailboxID, StableEventRef: firstNonEmpty(observation.EventID, observation.OriginalMessageID),
+		SMTPStatus: observation.SMTPStatus, EnhancedStatus: observation.EnhancedStatus, Diagnostic: observation.Diagnostic,
+	})
+}
+
+func (s *service) NoteComplaintObservation(ctx context.Context, orgID uuid.UUID, contactEmail string, observation ComplaintObservation) error {
+	if !s.cfg.Enabled {
+		return nil
+	}
+	email := strings.TrimSpace(strings.ToLower(contactEmail))
+	if email == "" {
+		return nil
+	}
+	cand, _, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil {
+		return err
+	}
+	if suppressions, ok := s.repo.(interface {
+		UpsertOutreachRecipientSuppression(context.Context, *models.SuppressedRecipient) error
+		CancelSuppressedOutreachRecipient(context.Context, uuid.UUID, string, string, string) (int, error)
+	}); ok {
+		if err := suppressions.UpsertOutreachRecipientSuppression(ctx, &models.SuppressedRecipient{
+			OrganizationID: orgID, Email: email, Reason: firstNonEmpty(observation.FeedbackType, "provider complaint"),
+			Source: models.DeliverabilityEventComplaint,
+		}); err != nil {
+			return err
+		}
+		if _, err := suppressions.CancelSuppressedOutreachRecipient(ctx, orgID, email, models.TouchpointCancelled, "spam_complaint"); err != nil {
+			return err
+		}
+	}
+	var touchpoint *models.OutreachTouchpoint
+	if finder, ok := s.repo.(interface {
+		GetTouchpointByProviderMessageID(context.Context, uuid.UUID, string) (*models.OutreachTouchpoint, error)
+	}); ok {
+		touchpoint, err = finder.GetTouchpointByProviderMessageID(ctx, orgID, observation.OriginalMessageID)
+		if err != nil {
+			return err
+		}
+	}
+	return s.observeControlledEmail(ctx, orgID, intel.EventSpamComplaint, touchpoint, cand, ControlledEmailContext{
+		OccurredAt: observation.OccurredAt, ProviderName: observation.ProviderName,
+		MailboxID: observation.MailboxID, StableEventRef: firstNonEmpty(observation.EventID, observation.OriginalMessageID, email),
+	})
+}
+
 // NoteDNC implements OutcomeSink.
 func (s *service) NoteDNC(ctx context.Context, orgID uuid.UUID, contactEmail, reason string) error {
 	return s.noteDNC(ctx, orgID, contactEmail, reason, "")
 }
 
 func (s *service) noteDNC(ctx context.Context, orgID uuid.UUID, contactEmail, reason, provider string) error {
+	return s.noteDNCObserved(ctx, orgID, contactEmail, reason, provider, "", time.Time{})
+}
+
+func (s *service) noteDNCObserved(ctx context.Context, orgID uuid.UUID, contactEmail, reason, provider, stableRef string, occurredAt time.Time) error {
 	if !s.cfg.Enabled {
 		return nil
 	}
@@ -233,8 +431,27 @@ func (s *service) noteDNC(ctx context.Context, orgID uuid.UUID, contactEmail, re
 	cnpj, lead := "", ""
 	if acc != nil {
 		cnpj, lead = acc.CNPJ14, acc.SourceLeadID
-		_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, true, true, reason, models.OutreachQueueDoNotContact)
-		_, _ = s.repo.CancelOpenTouchpoints(ctx, orgID, acc.ID, models.TouchpointDNC, "DNC")
+	}
+	if suppressions, ok := s.repo.(interface {
+		UpsertOutreachRecipientSuppression(context.Context, *models.SuppressedRecipient) error
+		CancelSuppressedOutreachRecipient(context.Context, uuid.UUID, string, string, string) (int, error)
+	}); ok {
+		metadata := map[string]interface{}{}
+		if !occurredAt.IsZero() {
+			metadata["observed_at"] = occurredAt.UTC().Format(time.RFC3339Nano)
+		}
+		if stableRef != "" {
+			metadata["event_ref"] = stableRef
+		}
+		if err := suppressions.UpsertOutreachRecipientSuppression(ctx, &models.SuppressedRecipient{
+			OrganizationID: orgID, Email: email, Reason: firstNonEmpty(reason, "recipient opt-out"),
+			Source: models.DeliverabilityEventUnsubscribe, Metadata: metadata,
+		}); err != nil {
+			return err
+		}
+		if _, err := suppressions.CancelSuppressedOutreachRecipient(ctx, orgID, email, models.TouchpointDNC, "opt_out"); err != nil {
+			return err
+		}
 	}
 	// Dominant block: drop queued email AND WhatsApp outbound for this recipient.
 	phone := ""
@@ -245,14 +462,19 @@ func (s *service) noteDNC(ctx context.Context, orgID uuid.UUID, contactEmail, re
 		}
 	}
 	s.cancelQueuedForRecipient(ctx, orgID, email, phone, "DO_NOT_CONTACT")
-	s.observeControlledEmail(ctx, orgID, "opt_out", nil, cand, ControlledEmailContext{ReplyClass: "OPT_OUT", ProviderName: provider})
+	if err := s.observeControlledEmail(ctx, orgID, "opt_out", nil, cand, ControlledEmailContext{
+		OccurredAt: occurredAt, ReplyClass: "OPT_OUT", ProviderName: provider,
+		StableEventRef: firstNonEmpty(stableRef, "opt-out:"+email),
+	}); err != nil {
+		return err
+	}
 	return s.enqueueErr(ctx, orgID, models.OutreachOutcome{
 		IdempotencyKey: fmt.Sprintf("dnc:%s:%s", orgID, email),
 		SourceLeadID:   lead,
 		CNPJ14:         cnpj,
 		ContactEmail:   email,
 		EventType:      OutcomeDoNotContact,
-		OccurredAt:     time.Now().UTC(),
+		OccurredAt:     firstNonZeroTime(nil, occurredAt),
 		Payload:        mustJSON(map[string]any{"reason": reason}),
 	})
 }

--- a/internal/app/confenge/human_gate_scheduling_pg_test.go
+++ b/internal/app/confenge/human_gate_scheduling_pg_test.go
@@ -300,6 +300,49 @@ func TestHumanGateApproveAfterSourceRunAdvancedStillRefusesLateSuppressionPostgr
 	}
 }
 
+func TestAssertTransportableSeesCanonicalSuppressionMinutesBeforeDuePostgres(t *testing.T) {
+	f := newSchedulingPGFixture(t)
+	cohort := f.review("APPROVE", "approve-before-canonical-suppression")
+	scheduling := cohort.Candidates[0].Scheduling
+	if scheduling == nil {
+		t.Fatal("approved candidate was not queued")
+	}
+	touchpoint, err := f.svc.repo.GetTouchpoint(f.ctx, f.org, scheduling.TouchpointID)
+	if err != nil || touchpoint == nil {
+		t.Fatalf("load touchpoint: %v", err)
+	}
+	dueAt := time.Now().UTC().Add(5 * time.Minute)
+	if _, err := f.pool.Exec(f.ctx, `UPDATE outreach_touchpoints SET due_at=$3 WHERE organization_id=$1 AND id=$2`, f.org, touchpoint.ID, dueAt); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `
+		INSERT INTO suppressed_recipients (organization_id,email,reason,source,metadata,created_at,updated_at)
+		VALUES ($1,$2,'one-click unsubscribe','unsubscribe','{}'::jsonb,$3,$3)
+		ON CONFLICT (organization_id,email) DO UPDATE SET reason=excluded.reason,source=excluded.source,updated_at=excluded.updated_at`,
+		f.org, touchpoint.Recipient, dueAt.Add(-2*time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv(EnvKillSwitchPath, t.TempDir()+"/not-engaged")
+	if err := f.svc.AssertTransportable(f.ctx, f.org, touchpoint); err == nil {
+		t.Fatal("canonical suppression inserted before due_at must stop transport")
+	}
+	var touchpointState, queueState string
+	if err := f.pool.QueryRow(f.ctx, `SELECT t.state,q.status FROM outreach_touchpoints t
+		JOIN confenge_dispatch_queue q ON q.draft_id=t.draft_id WHERE t.id=$1`, touchpoint.ID).Scan(&touchpointState, &queueState); err != nil {
+		t.Fatal(err)
+	}
+	if touchpointState != models.TouchpointDNC || queueState != dispatch.QueueCancelled {
+		t.Fatalf("suppressed due item survived: touchpoint=%s queue=%s", touchpointState, queueState)
+	}
+	var accountBlocked, accountDNC bool
+	if err := f.pool.QueryRow(f.ctx, `SELECT blocked,do_not_contact FROM outreach_accounts WHERE organization_id=$1 AND id=$2`, f.org, touchpoint.AccountID).Scan(&accountBlocked, &accountDNC); err != nil {
+		t.Fatal(err)
+	}
+	if accountBlocked || accountDNC {
+		t.Fatal("exact mailbox suppression invalidated the company account")
+	}
+}
+
 func TestHumanGateHoldCancelsQueuedMessageAndLaterApproveGetsNewQueueKeyPostgres(t *testing.T) {
 	f := newSchedulingPGFixture(t)
 	f.review("APPROVE", "approve-before-hold")

--- a/internal/app/confenge/intel/commercial.go
+++ b/internal/app/confenge/intel/commercial.go
@@ -354,12 +354,31 @@ func ApplyCommercialTransition(existing *Chain, ev CommercialEvent) TransitionRe
 		res.Held = true
 		res.Reason = "conflicting_external_reference"
 	}
+	if isEmailOutcomeType(typ) && typ != EventEmailAttempted && st.Email.AttemptedAt == nil {
+		add(ExceptionOutOfOrder, "email outcome arrived before attempted evidence", "review provider ordering; preserve the observed fact", false)
+	}
+	if st.Email.HardBouncedAt != nil && ev.OccurredAt.After(st.Email.HardBouncedAt.UTC()) &&
+		(typ == EventEmailAttempted || typ == EventProviderAccepted) {
+		add(ExceptionImpossibleCommercial, "transport evidence occurred after exact recipient hard-bounce suppression", "hold and verify the pre-send suppression gate", true)
+	}
 
 	st.Timeline = appendReceipt(st.Timeline, ev, canonical)
+	st.Email = reduceEmailOutcomeState(st.Email, ev, canonical)
 	st.Delivery.OnboardingDecision = decideOnboardingState(st, res.Held)
 	res.Facts.Commercial = st
 	copyCommercialKeys(&res.Facts, st)
 	return res
+}
+
+func isEmailOutcomeType(typ string) bool {
+	switch typ {
+	case EventEmailAttempted, EventProviderAccepted, EventDelivered, EventDeliveryUnknown,
+		EventHardBounce, EventSoftBounce, EventReply, EventOptOut,
+		EventSpamComplaint, EventNoReply:
+		return true
+	default:
+		return false
+	}
 }
 
 func stateFromEvent(ev CommercialEvent, existing *Chain) CommercialState {
@@ -972,6 +991,8 @@ func appendReceipt(tl []CommercialReceipt, ev CommercialEvent, typ string) []Com
 		ActorRef:        ev.ActorRef,
 		EmailRouteClass: ev.EmailRouteClass,
 		Source:          ev.Source,
+		SourceRunID:     ev.SourceRunID,
+		MailboxID:       ev.MailboxID,
 		ProviderName:    ev.ProviderName,
 		CohortID:        ev.CohortID,
 		PolicyVersion:   ev.PolicyVersion,
@@ -983,6 +1004,52 @@ func appendReceipt(tl []CommercialReceipt, ev CommercialEvent, typ string) []Com
 		EnhancedStatus:  ev.EnhancedStatus,
 		Diagnostic:      ev.Diagnostic,
 	})
+}
+
+func reduceEmailOutcomeState(st EmailOutcomeState, ev CommercialEvent, typ string) EmailOutcomeState {
+	setEarliest := func(dst **time.Time) {
+		t := ev.OccurredAt.UTC()
+		if *dst == nil || t.Before(**dst) {
+			*dst = &t
+		}
+	}
+	switch typ {
+	case EventEmailAttempted:
+		setEarliest(&st.AttemptedAt)
+	case EventProviderAccepted:
+		setEarliest(&st.ProviderAcceptedAt)
+	case EventDelivered:
+		setEarliest(&st.DeliveredAt)
+	case EventDeliveryUnknown:
+		setEarliest(&st.DeliveryUnknownAt)
+	case EventHardBounce:
+		setEarliest(&st.HardBouncedAt)
+	case EventSoftBounce:
+		setEarliest(&st.SoftBouncedAt)
+	case EventReply:
+		setEarliest(&st.RepliedAt)
+		if strings.TrimSpace(ev.ReplyClass) != "" {
+			st.ReplyClass = ev.ReplyClass
+		}
+	case EventOptOut:
+		setEarliest(&st.OptedOutAt)
+	case EventSpamComplaint:
+		setEarliest(&st.ComplainedAt)
+	}
+	// Terminal negative evidence dominates while stronger positive evidence resolves UNKNOWN.
+	switch {
+	case st.HardBouncedAt != nil:
+		st.DeliveryStatus = EventHardBounce
+	case st.DeliveredAt != nil:
+		st.DeliveryStatus = EventDelivered
+	case st.ProviderAcceptedAt != nil:
+		st.DeliveryStatus = EventProviderAccepted
+	case st.DeliveryUnknownAt != nil:
+		st.DeliveryStatus = EventDeliveryUnknown
+	case st.AttemptedAt != nil:
+		st.DeliveryStatus = EventEmailAttempted
+	}
+	return st
 }
 
 func evidenceRefs(ev CommercialEvent) []string {
@@ -1010,7 +1077,7 @@ func NormalizeEventType(t string) (canonical, raw string, unknown bool) {
 		EventWon, EventLost, EventUnknownState, EventRevenueEvidenced,
 		EventLearningCandidate, EventXRayCompleted, EventPageView,
 		EventCitation, EventCorrection,
-		EventEmailAttempted, EventProviderAccepted, EventDelivered,
+		EventEmailAttempted, EventProviderAccepted, EventDelivered, EventDeliveryUnknown,
 		EventHardBounce, EventSoftBounce, EventOptOut, EventSpamComplaint, EventNoReply,
 		EventOfferViewed, EventOfferSelected, EventEligibilitySubmitted,
 		EventCapacityApproved, EventCapacityRejected, EventCapacityWaitlisted,
@@ -1120,7 +1187,7 @@ func isCommercialEvent(t string) bool {
 		EventServiceEnded, EventRenewalDue, EventRenewed,
 		EventCommercialExceptionOpen, EventCommercialExceptionRes,
 		EventCommercialException, EventUnknownProvider,
-		EventEmailAttempted, EventProviderAccepted, EventDelivered,
+		EventEmailAttempted, EventProviderAccepted, EventDelivered, EventDeliveryUnknown,
 		EventHardBounce, EventSoftBounce, EventReply, EventOptOut,
 		EventSpamComplaint, EventNoReply:
 		return true

--- a/internal/app/confenge/intel/commercial_types.go
+++ b/internal/app/confenge/intel/commercial_types.go
@@ -283,6 +283,8 @@ type CommercialReceipt struct {
 	ActorRef        string    `json:"actor_ref,omitempty"`
 	EmailRouteClass string    `json:"email_route_class,omitempty"`
 	Source          string    `json:"source,omitempty"`
+	SourceRunID     string    `json:"source_run_id,omitempty"`
+	MailboxID       string    `json:"mailbox_id,omitempty"`
 	ProviderName    string    `json:"provider_name,omitempty"`
 	CohortID        string    `json:"cohort_id,omitempty"`
 	PolicyVersion   string    `json:"policy_version,omitempty"`
@@ -295,6 +297,21 @@ type CommercialReceipt struct {
 	Diagnostic      string    `json:"diagnostic,omitempty"`
 }
 
+// EmailOutcomeState projects immutable transport facts monotonically.
+type EmailOutcomeState struct {
+	DeliveryStatus     string     `json:"delivery_status,omitempty"`
+	AttemptedAt        *time.Time `json:"attempted_at,omitempty"`
+	ProviderAcceptedAt *time.Time `json:"provider_accepted_at,omitempty"`
+	DeliveredAt        *time.Time `json:"delivered_at,omitempty"`
+	DeliveryUnknownAt  *time.Time `json:"delivery_unknown_at,omitempty"`
+	HardBouncedAt      *time.Time `json:"hard_bounced_at,omitempty"`
+	SoftBouncedAt      *time.Time `json:"soft_bounced_at,omitempty"`
+	RepliedAt          *time.Time `json:"replied_at,omitempty"`
+	ReplyClass         string     `json:"reply_class,omitempty"`
+	OptedOutAt         *time.Time `json:"opted_out_at,omitempty"`
+	ComplainedAt       *time.Time `json:"complained_at,omitempty"`
+}
+
 // CommercialState is derived canonical commercial state on the existing chain.
 type CommercialState struct {
 	Offer          OfferSnapshot          `json:"offer,omitempty"`
@@ -303,6 +320,7 @@ type CommercialState struct {
 	Payment        PaymentState           `json:"payment,omitempty"`
 	Subscription   SubscriptionState      `json:"subscription,omitempty"`
 	Delivery       DeliveryState          `json:"delivery,omitempty"`
+	Email          EmailOutcomeState      `json:"email,omitempty"`
 	Control        CommercialControlState `json:"control,omitempty"`
 	Gates          GateStates             `json:"gates,omitempty"`
 	Timeline       []CommercialReceipt    `json:"timeline,omitempty"`

--- a/internal/app/confenge/intel/controlled_email_outcomes.go
+++ b/internal/app/confenge/intel/controlled_email_outcomes.go
@@ -7,10 +7,12 @@ import (
 	"strings"
 )
 
-// ControlledEmailOutcomeSlice is one (route class, source, provider, cohort, policy) bucket.
+// ControlledEmailOutcomeSlice is one non-PII operational outcome bucket.
 type ControlledEmailOutcomeSlice struct {
 	RouteClass    string `json:"route_class"`
 	Source        string `json:"source"`
+	SourceRunID   string `json:"source_run_id"`
+	MailboxID     string `json:"mailbox_id"`
 	Provider      string `json:"provider"`
 	CohortID      string `json:"cohort_id"`
 	PolicyVersion string `json:"policy_version"`
@@ -19,6 +21,7 @@ type ControlledEmailOutcomeSlice struct {
 	Attempted         *int `json:"attempted"`
 	ProviderAccepted  *int `json:"provider_accepted"`
 	Delivered         *int `json:"delivered"`
+	DeliveryUnknown   *int `json:"delivery_unknown"`
 	HardBounce        *int `json:"hard_bounce"`
 	SoftBounce        *int `json:"soft_bounce"`
 	Reply             *int `json:"reply"`
@@ -61,6 +64,8 @@ func SliceControlledEmailOutcomes(events []CommercialEvent) []ControlledEmailOut
 		return strings.Join([]string{
 			orUnknown(ev.EmailRouteClass),
 			orUnknown(ev.Source),
+			orUnknown(ev.SourceRunID),
+			orUnknown(ev.MailboxID),
 			normalizeControlledProvider(ev.ProviderName),
 			orUnknown(ev.CohortID),
 			orUnknown(ev.PolicyVersion),
@@ -74,6 +79,8 @@ func SliceControlledEmailOutcomes(events []CommercialEvent) []ControlledEmailOut
 		out = append(out, ControlledEmailOutcomeSlice{
 			RouteClass:    orUnknown(ev.EmailRouteClass),
 			Source:        orUnknown(ev.Source),
+			SourceRunID:   orUnknown(ev.SourceRunID),
+			MailboxID:     orUnknown(ev.MailboxID),
 			Provider:      normalizeControlledProvider(ev.ProviderName),
 			CohortID:      orUnknown(ev.CohortID),
 			PolicyVersion: orUnknown(ev.PolicyVersion),
@@ -102,6 +109,8 @@ func SliceControlledEmailOutcomes(events []CommercialEvent) []ControlledEmailOut
 			incrementObserved(&row.ProviderAccepted)
 		case typ == "delivered":
 			incrementObserved(&row.Delivered)
+		case typ == EventDeliveryUnknown:
+			incrementObserved(&row.DeliveryUnknown)
 		case typ == "hard_bounce" || strings.EqualFold(ev.BounceClass, "HARD"):
 			incrementObserved(&row.HardBounce)
 		case typ == "soft_bounce" || strings.EqualFold(ev.BounceClass, "SOFT"):
@@ -234,6 +243,7 @@ func ControlledEmailEventsFromChains(chains []Chain, includeSynthetic bool) []Co
 				OccurredAt: receipt.OccurredAt, IngestedAt: receipt.IngestedAt,
 				OrganizationID: chain.Keys.OrganizationID, Synthetic: chain.Synthetic,
 				EmailRouteClass: receipt.EmailRouteClass, Source: receipt.Source,
+				SourceRunID: receipt.SourceRunID, MailboxID: receipt.MailboxID,
 				ProviderName: receipt.ProviderName, CohortID: receipt.CohortID,
 				PolicyVersion: receipt.PolicyVersion, BounceClass: receipt.BounceClass,
 				ReplyClass: receipt.ReplyClass, AccountPublicID: receipt.AccountPublicID,
@@ -247,7 +257,7 @@ func ControlledEmailEventsFromChains(chains []Chain, includeSynthetic bool) []Co
 
 func isControlledEmailReceipt(receipt CommercialReceipt) bool {
 	switch strings.ToLower(strings.TrimSpace(receipt.Type)) {
-	case EventEmailAttempted, EventProviderAccepted, EventDelivered, EventHardBounce,
+	case EventEmailAttempted, EventProviderAccepted, EventDelivered, EventDeliveryUnknown, EventHardBounce,
 		EventSoftBounce, EventReply, EventOptOut, EventSpamComplaint, EventNoReply:
 		return true
 	default:
@@ -257,12 +267,12 @@ func isControlledEmailReceipt(receipt CommercialReceipt) bool {
 
 func FormatControlledEmailReport(rep ControlledEmailExecutiveReport) string {
 	var b bytes.Buffer
-	fmt.Fprintf(&b, "route_class\tcohort_id\tattempted\tprovider_accepted\tdelivered\thard_bounce\tsoft_bounce\treply\tpositive_reply\trouted_or_forwarded\topt_out\tspam_complaint\tmeeting\tproposal\tqualified_pipeline\tobserved_revenue\tunknown\n")
+	fmt.Fprintf(&b, "route_class\tsource\tsource_run_id\tmailbox_id\tcohort_id\tattempted\tprovider_accepted\tdelivered\tdelivery_unknown\thard_bounce\tsoft_bounce\treply\tpositive_reply\trouted_or_forwarded\topt_out\tspam_complaint\tmeeting\tproposal\tqualified_pipeline\tobserved_revenue\tunknown\n")
 	rows := append([]ControlledEmailOutcomeSlice{}, rep.Rows...)
 	sort.Slice(rows, func(i, j int) bool { return rows[i].RouteClass < rows[j].RouteClass })
 	for _, r := range rows {
-		fmt.Fprintf(&b, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			orUnknown(r.RouteClass), orUnknown(r.CohortID), metric(r.Attempted), metric(r.ProviderAccepted), metric(r.Delivered),
+		fmt.Fprintf(&b, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			orUnknown(r.RouteClass), orUnknown(r.Source), orUnknown(r.SourceRunID), orUnknown(r.MailboxID), orUnknown(r.CohortID), metric(r.Attempted), metric(r.ProviderAccepted), metric(r.Delivered), metric(r.DeliveryUnknown),
 			metric(r.HardBounce), metric(r.SoftBounce), metric(r.Reply), metric(r.PositiveReply), metric(r.RoutedForwarded),
 			metric(r.OptOut), metric(r.SpamComplaint), metric(r.Meeting), metric(r.Proposal), metric(r.QualifiedPipeline), metric(r.ObservedRevenue), metric(r.Unknown))
 	}

--- a/internal/app/confenge/intel/email_reconciliation_test.go
+++ b/internal/app/confenge/intel/email_reconciliation_test.go
@@ -1,0 +1,97 @@
+package intel
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEmailOutcomeReplayRestartAndOutOfOrderRemainHonest(t *testing.T) {
+	orgID := "00000000-0000-0000-0000-000000000047"
+	base := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+	event := func(id, typ string, at time.Time) CommercialEvent {
+		return CommercialEvent{
+			EventID: id, Version: EventSchemaV1, Type: typ,
+			OccurredAt: at, IngestedAt: base.Add(time.Hour), OrganizationID: orgID,
+			CorrelationID: "touchpoint-47:account-47", IdempotencyKey: "event:" + id,
+			EmailRouteClass: "R1_DIRECT", Source: "extra-cli", SourceRunID: "run-47",
+			MailboxID: "00000000-0000-0000-0000-000000000047", ProviderName: "smtp",
+		}
+	}
+
+	store := NewMemoryStore()
+	accepted := IngestEvent(store, event("accepted-47", EventProviderAccepted, base.Add(time.Minute)))
+	if !hasCode(accepted.Exceptions, ExceptionOutOfOrder) {
+		t.Fatal("accepted before attempted must enter the existing exception queue")
+	}
+	if accepted.Chain.Commercial.Email.DeliveryStatus != EventProviderAccepted {
+		t.Fatalf("status=%s", accepted.Chain.Commercial.Email.DeliveryStatus)
+	}
+	IngestEvent(store, event("attempted-47", EventEmailAttempted, base))
+	unknown := IngestEvent(store, event("unknown-47", EventDeliveryUnknown, base.Add(2*time.Minute)))
+	if unknown.Chain.Commercial.Email.DeliveryStatus != EventProviderAccepted {
+		t.Fatalf("UNKNOWN must not regress accepted, got %s", unknown.Chain.Commercial.Email.DeliveryStatus)
+	}
+	if unknown.Chain.Commercial.Email.DeliveryUnknownAt == nil {
+		t.Fatal("UNKNOWN evidence must remain preserved")
+	}
+	delivered := IngestEvent(store, event("delivered-47", EventDelivered, base.Add(3*time.Minute)))
+	if delivered.Chain.Commercial.Email.DeliveryStatus != EventDelivered {
+		t.Fatalf("explicit delivery must resolve UNKNOWN, got %s", delivered.Chain.Commercial.Email.DeliveryStatus)
+	}
+
+	// Simulate process restart by restoring the durable chain into a fresh store.
+	restarted := NewMemoryStore()
+	if _, _, err := restarted.PutChain(delivered.Chain); err != nil {
+		t.Fatal(err)
+	}
+	replay := IngestEvent(restarted, event("delivered-47", EventDelivered, base.Add(3*time.Minute)))
+	if !replay.Replay {
+		t.Fatal("provider/event replay after restart must be idempotent")
+	}
+	if got, want := len(replay.Chain.Commercial.Timeline), len(delivered.Chain.Commercial.Timeline); got != want {
+		t.Fatalf("timeline duplicated after restart replay: got=%d want=%d", got, want)
+	}
+}
+
+func TestEmailOutcomeSlicesIncludeOperationalDimensionsWithoutPII(t *testing.T) {
+	events := []CommercialEvent{{
+		EventID: "soft-47", Type: EventSoftBounce, EmailRouteClass: "R4_ROLE_ROUTE",
+		Source: "extra-cli", SourceRunID: "run-47", MailboxID: "mailbox-47",
+		ProviderName: "smtp", CohortID: "cohort-47", PolicyVersion: "policy-47",
+	}, {
+		EventID: "unknown-47", Type: EventDeliveryUnknown, EmailRouteClass: "R4_ROLE_ROUTE",
+		Source: "extra-cli", SourceRunID: "run-47", MailboxID: "mailbox-47",
+		ProviderName: "smtp", CohortID: "cohort-47", PolicyVersion: "policy-47",
+	}}
+	rows := SliceControlledEmailOutcomes(events)
+	if len(rows) != 1 || rows[0].SoftBounce == nil || *rows[0].SoftBounce != 1 {
+		t.Fatalf("soft bounce slice=%+v", rows)
+	}
+	if rows[0].HardBounce != nil {
+		t.Fatal("soft bounce must never be promoted to hard bounce")
+	}
+	if rows[0].DeliveryUnknown == nil || *rows[0].DeliveryUnknown != 1 {
+		t.Fatalf("delivery_unknown slice=%+v", rows[0])
+	}
+	report := FormatControlledEmailReport(BuildControlledEmailExecutiveReport(events))
+	for _, want := range []string{"source_run_id", "mailbox_id", "run-47", "mailbox-47", "delivery_unknown"} {
+		if !strings.Contains(report, want) {
+			t.Fatalf("report missing %q: %s", want, report)
+		}
+	}
+	if strings.Contains(report, "@") || MetricKeyContainsPII(report) {
+		t.Fatal("operational outcome report must not contain recipient PII")
+	}
+}
+
+func TestNoReplyDoesNotInvalidateMailbox(t *testing.T) {
+	ev := CommercialEvent{Type: EventNoReply}
+	if !NonReplyDoesNotInvalidateMailbox(ev) {
+		t.Fatal("no reply is UNKNOWN, never bad mailbox evidence")
+	}
+	rows := SliceControlledEmailOutcomes([]CommercialEvent{{EventID: "no-reply-47", Type: EventNoReply}})
+	if len(rows) != 1 || rows[0].Unknown == nil || *rows[0].Unknown != 1 || rows[0].HardBounce != nil {
+		t.Fatalf("no-reply projection=%+v", rows)
+	}
+}

--- a/internal/app/confenge/intel/event.go
+++ b/internal/app/confenge/intel/event.go
@@ -71,6 +71,8 @@ func validateCommercialIdentityFields(ev CommercialEvent) error {
 		{name: "provider_event_id", value: ev.ProviderEventID},
 		{name: "provider.provider_event_id", value: ev.Provider.ProviderEventID},
 		{name: "provider_external_reference", value: ev.Provider.ExternalRef},
+		{name: "source_run_id", value: ev.SourceRunID},
+		{name: "mailbox_id", value: ev.MailboxID},
 		{name: "deliverable_id", value: ev.DeliverableID},
 		{name: "responsible", value: ev.Responsible},
 	}
@@ -110,7 +112,7 @@ func knownEventType(t string) bool {
 		EventCitation, EventCorrection, EventSearchObservation,
 		EventOperatorAlertCreated, EventOperatorAlertEmitted, EventOperatorAlertFailed,
 		EventOperatorAlertAcknowledged, EventFirstHumanActionRecorded, EventInboundResolvedNoAction,
-		EventEmailAttempted, EventProviderAccepted, EventDelivered,
+		EventEmailAttempted, EventProviderAccepted, EventDelivered, EventDeliveryUnknown,
 		EventHardBounce, EventSoftBounce, EventOptOut, EventSpamComplaint, EventNoReply:
 		return true
 	default:

--- a/internal/app/confenge/intel/types.go
+++ b/internal/app/confenge/intel/types.go
@@ -94,6 +94,7 @@ const (
 	EventEmailAttempted            = "email_attempted"
 	EventProviderAccepted          = "provider_accepted"
 	EventDelivered                 = "delivered"
+	EventDeliveryUnknown           = "delivery_unknown"
 	EventHardBounce                = "hard_bounce"
 	EventSoftBounce                = "soft_bounce"
 	EventOptOut                    = "opt_out"
@@ -826,6 +827,8 @@ type CommercialEvent struct {
 
 	// Controlled email observability slices. UNKNOWN stays UNKNOWN.
 	EmailRouteClass string `json:"email_route_class,omitempty"`
+	SourceRunID     string `json:"source_run_id,omitempty"`
+	MailboxID       string `json:"mailbox_id,omitempty"`
 	CohortID        string `json:"cohort_id,omitempty"`
 	PolicyVersion   string `json:"policy_version,omitempty"`
 	ProviderName    string `json:"provider_name,omitempty"`

--- a/internal/app/confenge/outbound_gate.go
+++ b/internal/app/confenge/outbound_gate.go
@@ -296,7 +296,6 @@ func (s *service) GateCampaignEmail(ctx context.Context, orgID uuid.UUID, campai
 	if cohortAuthID != uuid.Nil && res.Reservation != nil {
 		_ = s.cohortStore.BindLeaseToken(ctx, cohortAuthID, cohortKey, res.Reservation.ID.String())
 	}
-	s.observeControlledEmail(ctx, orgID, intel.EventEmailAttempted, enrolledTouchpoint, cand, ControlledEmailContext{})
 	return CampaignGateResult{
 		Kind:          GateProceed,
 		ReservationID: res.Reservation.ID,
@@ -442,6 +441,31 @@ func (s *service) AssertTransportable(ctx context.Context, orgID uuid.UUID, tp *
 			cand, _ = s.repo.GetCandidate(ctx, orgID, *draft.ContactCandidateID)
 		}
 	}
+	if tp.Channel != models.OutreachChannelWhatsApp {
+		if suppressions, ok := s.repo.(interface {
+			GetOutreachRecipientSuppression(context.Context, uuid.UUID, string) (*models.SuppressedRecipient, error)
+			CancelSuppressedOutreachRecipient(context.Context, uuid.UUID, string, string, string) (int, error)
+		}); ok {
+			suppression, suppressionErr := suppressions.GetOutreachRecipientSuppression(ctx, orgID, tp.Recipient)
+			if suppressionErr != nil {
+				return fmt.Errorf("recipient suppression lookup failed: %w", suppressionErr)
+			}
+			if suppression != nil {
+				terminal := models.TouchpointCancelled
+				switch suppression.Source {
+				case models.DeliverabilityEventBounce:
+					terminal = models.TouchpointBounced
+				case models.DeliverabilityEventUnsubscribe:
+					terminal = models.TouchpointDNC
+				}
+				reason := "recipient_suppressed:" + string(suppression.Source)
+				if _, cancelErr := suppressions.CancelSuppressedOutreachRecipient(ctx, orgID, tp.Recipient, terminal, reason); cancelErr != nil {
+					return fmt.Errorf("recipient suppression projection failed: %w", cancelErr)
+				}
+				return fmt.Errorf("recipient is suppressed: %s", suppression.Source)
+			}
+		}
+	}
 	linkedHumanGate, humanGateReason := s.humanGateDispatchInvalidation(ctx, orgID, tp)
 	if mode == AuthorizationModeCampaignPolicy {
 		if linkedHumanGate {
@@ -583,7 +607,7 @@ func (s *service) assertAuthoritativeFeedForTransport(ctx context.Context, orgID
 	return nil
 }
 
-func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, providerMessageID string, acceptedAt time.Time) error {
+func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, contactID, sequenceID, taskID, mailboxID uuid.UUID, providerMessageID, provider string, acceptedAt time.Time) error {
 	touchpoint, err := s.repo.GetTouchpointByEnrollment(ctx, orgID, campaignID, contactID)
 	if err != nil {
 		return err
@@ -597,6 +621,16 @@ func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, 
 		}
 		return s.governor.CommitByMessageKey(ctx, MessageKeyCampaignEmail(campaignID, contactID, sequenceID))
 	}
+	observeAccepted := func() error {
+		var cand *models.OutreachContactCandidate
+		if touchpoint.ContactCandidateID != nil {
+			cand, _ = s.repo.GetCandidate(ctx, orgID, *touchpoint.ContactCandidateID)
+		}
+		return s.observeControlledEmail(ctx, orgID, intel.EventProviderAccepted, touchpoint, cand, ControlledEmailContext{
+			OccurredAt: acceptedAt, ProviderName: firstNonEmpty(provider, "smtp"),
+			MailboxID: opaqueUUID(mailboxID), StableEventRef: firstNonEmpty(opaqueUUID(taskID), providerMessageID),
+		})
+	}
 	if touchpoint.State == models.TouchpointSent {
 		if existing := strings.TrimSpace(touchpoint.ProviderMessageID); existing != "" &&
 			strings.TrimSpace(providerMessageID) != "" && existing != strings.TrimSpace(providerMessageID) {
@@ -608,7 +642,16 @@ func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, 
 		if err := s.markDelegatedFirstTouchSent(ctx, orgID, touchpoint.ID, firstNonZeroTime(touchpoint.SentAt, acceptedAt)); err != nil {
 			return err
 		}
+		if err := observeAccepted(); err != nil {
+			return err
+		}
 		return s.releaseNextTouch(ctx, orgID, touchpoint)
+	}
+	if models.TouchpointTerminalStates[touchpoint.State] {
+		if err := commitProviderSend(); err != nil {
+			return err
+		}
+		return observeAccepted()
 	}
 	now := acceptedAt.UTC()
 	if now.IsZero() {
@@ -626,6 +669,9 @@ func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, 
 	if err := commitProviderSend(); err != nil {
 		return err
 	}
+	if err := observeAccepted(); err != nil {
+		return err
+	}
 	return s.releaseNextTouch(ctx, orgID, touchpoint)
 }
 
@@ -641,7 +687,7 @@ func firstNonZeroTime(value *time.Time, fallback time.Time) time.Time {
 
 // ObserveCampaignEmailAttempt records that the worker reached the provider
 // transport call. It does not claim acceptance or delivery.
-func (s *service) ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, attemptedAt time.Time) error {
+func (s *service) ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID, taskID, mailboxID uuid.UUID, provider string, attemptedAt time.Time) error {
 	touchpoint, err := s.repo.GetTouchpointByEnrollment(ctx, orgID, campaignID, contactID)
 	if err != nil {
 		return err
@@ -649,21 +695,21 @@ func (s *service) ObserveCampaignEmailAttempt(ctx context.Context, orgID, campai
 	if touchpoint == nil {
 		return ErrCampaignTouchpointNotFound
 	}
-	if !isBoundedCohortTouch(touchpoint) {
-		return nil
-	}
 	var cand *models.OutreachContactCandidate
 	if touchpoint.ContactCandidateID != nil {
 		cand, _ = s.repo.GetCandidate(ctx, orgID, *touchpoint.ContactCandidateID)
 	}
-	messageKey := MessageKeyCampaignEmail(campaignID, contactID, sequenceID)
-	if err := s.assertBoundedCohortTransport(ctx, touchpoint, cand, messageKey); err != nil {
-		return err
-	}
-	s.observeControlledEmail(ctx, orgID, intel.EventEmailAttempted, touchpoint, cand, ControlledEmailContext{
-		OccurredAt: attemptedAt, ProviderName: "smtp",
+	return s.observeControlledEmail(ctx, orgID, intel.EventEmailAttempted, touchpoint, cand, ControlledEmailContext{
+		OccurredAt: attemptedAt, ProviderName: firstNonEmpty(provider, "smtp"),
+		MailboxID: opaqueUUID(mailboxID), StableEventRef: firstNonEmpty(opaqueUUID(taskID), MessageKeyCampaignEmail(campaignID, contactID, sequenceID)),
 	})
-	return nil
+}
+
+func opaqueUUID(id uuid.UUID) string {
+	if id == uuid.Nil {
+		return ""
+	}
+	return id.String()
 }
 
 func (s *service) transitionCompletedTouchpoint(ctx context.Context, orgID uuid.UUID, tp *models.OutreachTouchpoint, now time.Time, providerMessageID string) error {
@@ -690,9 +736,6 @@ func (s *service) transitionCompletedTouchpointKeyed(ctx context.Context, orgID 
 		if err := s.commitCohortSlot(ctx, tp, now, messageKey); err != nil {
 			return err
 		}
-		s.observeControlledEmail(ctx, orgID, intel.EventProviderAccepted, tp, cand, ControlledEmailContext{
-			OccurredAt: now, ProviderName: "smtp",
-		})
 		return nil
 	}
 	return TransitionToSent(tp, now, providerMessageID)

--- a/internal/app/confenge/outbound_gate_test.go
+++ b/internal/app/confenge/outbound_gate_test.go
@@ -120,6 +120,80 @@ func TestGateCampaignEmailHardBlockAccountDNC(t *testing.T) {
 	}
 }
 
+func TestAssertTransportableCancelsQueuedSendSuppressedMinutesBeforeDue(t *testing.T) {
+	allowConfengeSendingForTest(t)
+	ctx := context.Background()
+	repo := newMemRepoWithSettings()
+	orgID, accountID, candidateID := uuid.New(), uuid.New(), uuid.New()
+	_, _ = repo.UpsertAccount(ctx, &models.OutreachAccount{ID: accountID, OrganizationID: orgID, CNPJ14: "12345678000176"})
+	_, _ = repo.UpsertCandidate(ctx, &models.OutreachContactCandidate{
+		ID: candidateID, OrganizationID: orgID, AccountID: accountID, Email: "exact@example.com",
+	})
+	otherCandidateID := uuid.New()
+	_, _ = repo.UpsertCandidate(ctx, &models.OutreachContactCandidate{
+		ID: otherCandidateID, OrganizationID: orgID, AccountID: accountID, Email: "other@example.com",
+	})
+	campaignID, contactID := bindTransportableEnrollment(t, repo.memRepo, orgID, accountID, candidateID, "exact@example.com")
+	touchpoint, _ := repo.GetTouchpointByEnrollment(ctx, orgID, campaignID, contactID)
+	dueAt := time.Now().UTC().Add(5 * time.Minute)
+	touchpoint.DueAt = dueAt
+	if err := repo.UpdateTouchpoint(ctx, touchpoint); err != nil {
+		t.Fatal(err)
+	}
+	if err := repo.UpsertOutreachRecipientSuppression(ctx, &models.SuppressedRecipient{
+		OrganizationID: orgID, Email: "exact@example.com", Reason: "one-click unsubscribe",
+		Source: models.DeliverabilityEventUnsubscribe, CreatedAt: dueAt.Add(-2 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	svc := &service{cfg: Config{Enabled: true}, repo: repo}
+	if err := svc.AssertTransportable(ctx, orgID, touchpoint); err == nil {
+		t.Fatal("suppression inserted before due_at must cancel transport")
+	}
+	cancelled, _ := repo.GetTouchpoint(ctx, orgID, touchpoint.ID)
+	if cancelled.State != models.TouchpointDNC {
+		t.Fatalf("touchpoint state=%s want %s", cancelled.State, models.TouchpointDNC)
+	}
+	account, _ := repo.GetAccount(ctx, orgID, accountID)
+	if account.Blocked || account.DoNotContact {
+		t.Fatal("exact recipient suppression must not invalidate the company account")
+	}
+	other, _ := repo.GetCandidate(ctx, orgID, otherCandidateID)
+	if other.Blocked || other.Bounced || other.DoNotContact {
+		t.Fatal("exact recipient suppression must preserve another mailbox at the same company")
+	}
+}
+
+func TestObserveCampaignEmailAttemptIncludesNonCohortControlledTouch(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepoWithSettings()
+	orgID, accountID, candidateID := uuid.New(), uuid.New(), uuid.New()
+	_, _ = repo.UpsertAccount(ctx, &models.OutreachAccount{
+		ID: accountID, OrganizationID: orgID, CNPJ14: "12345678000148",
+		SourceSystem: "extra-cli", SourceRunID: "source-run-47",
+	})
+	_, _ = repo.UpsertCandidate(ctx, &models.OutreachContactCandidate{
+		ID: candidateID, OrganizationID: orgID, AccountID: accountID, Email: "attempt@example.com",
+	})
+	campaignID, contactID := bindTransportableEnrollment(t, repo.memRepo, orgID, accountID, candidateID, "attempt@example.com")
+	account, _ := repo.GetAccount(ctx, orgID, accountID)
+	account.SourceRunID = "source-run-47"
+	_, _ = repo.UpsertAccount(ctx, account)
+	svc := &service{cfg: Config{Enabled: true}, repo: repo}
+	taskID, mailboxID := uuid.New(), uuid.New()
+	if err := svc.ObserveCampaignEmailAttempt(ctx, orgID, campaignID, contactID, uuid.New(), taskID, mailboxID, "smtp", time.Now().UTC()); err != nil {
+		t.Fatal(err)
+	}
+	events := svc.ObservedControlledEmailEvents()
+	if len(events) != 1 || events[0].Type != "email_attempted" {
+		t.Fatalf("attempt projection=%+v", events)
+	}
+	if events[0].SourceRunID != "source-run-47" || events[0].MailboxID != mailboxID.String() {
+		t.Fatalf("operational dimensions missing: %+v", events[0])
+	}
+}
+
 func TestGateCampaignEmailTransientOnGovernorError(t *testing.T) {
 	allowConfengeSendingForTest(t)
 	// errStore fails TryReserveAtomic (simulates DB blip).

--- a/internal/app/confenge/product_acceptance_e2e_test.go
+++ b/internal/app/confenge/product_acceptance_e2e_test.go
@@ -475,9 +475,12 @@ func TestProductAcceptanceMultichannelSum(t *testing.T) {
 			}
 		}
 	}
-	accDNC, _ := rf.GetAccount(context.Background(), org, acme.ID)
-	if !accDNC.DoNotContact {
-		t.Fatal("bullet16 account must be DNC after NoteDNC")
+	candDNC, accDNC, _ := rf.FindCandidateByEmail(context.Background(), org, draft1.RecipientEmail)
+	if candDNC == nil || !candDNC.DoNotContact {
+		t.Fatalf("bullet16 exact recipient must be DNC after NoteDNC: %+v", candDNC)
+	}
+	if accDNC == nil || accDNC.DoNotContact || accDNC.Blocked {
+		t.Fatalf("bullet16 recipient DNC must preserve company identity: %+v", accDNC)
 	}
 
 	// 18. reply draft not sent without new approval

--- a/internal/app/confenge/recipient_outcome_scope_test.go
+++ b/internal/app/confenge/recipient_outcome_scope_test.go
@@ -1,0 +1,111 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestHardBounceSuppressesExactMailboxWithoutInvalidatingCompany(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10}, repo, nil).(*service)
+	orgID, accountID := uuid.New(), uuid.New()
+	_, _ = repo.UpsertAccount(ctx, &models.OutreachAccount{
+		ID: accountID, OrganizationID: orgID, CNPJ14: "12345678000147", QueueState: models.OutreachQueueSent,
+	})
+	exactID, otherID := uuid.New(), uuid.New()
+	_, _ = repo.UpsertCandidate(ctx, &models.OutreachContactCandidate{ID: exactID, OrganizationID: orgID, AccountID: accountID, Email: "bounced@example.com"})
+	_, _ = repo.UpsertCandidate(ctx, &models.OutreachContactCandidate{ID: otherID, OrganizationID: orgID, AccountID: accountID, Email: "healthy@example.com"})
+	for i, recipient := range []string{"bounced@example.com", "healthy@example.com"} {
+		if err := repo.InsertTouchpoint(ctx, &models.OutreachTouchpoint{
+			ID: uuid.New(), OrganizationID: orgID, AccountID: accountID, Ordinal: i + 1,
+			Channel: models.OutreachChannelEmail, State: models.TouchpointPlanned,
+			Recipient: recipient, DueAt: time.Now().UTC().Add(time.Hour),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := svc.NoteBounceObservation(ctx, orgID, "bounced@example.com", BounceObservation{
+		Class: "HARD", EventID: "provider-bounce-47", OriginalMessageID: "message-47",
+		Reason: "550 5.1.1 mailbox unavailable", EnhancedStatus: "5.1.1",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	exact, _ := repo.GetCandidate(ctx, orgID, exactID)
+	other, _ := repo.GetCandidate(ctx, orgID, otherID)
+	if exact == nil || !exact.Bounced || exact.VerificationStatus != models.OutreachVerifyBounced {
+		t.Fatalf("exact mailbox was not bounced: %+v", exact)
+	}
+	if other == nil || other.Bounced || other.Blocked || other.DoNotContact {
+		t.Fatalf("healthy company route was invalidated: %+v", other)
+	}
+	account, _ := repo.GetAccount(ctx, orgID, accountID)
+	if account.Blocked || account.DoNotContact || account.QueueState != models.OutreachQueueSent {
+		t.Fatalf("company identity was invalidated: %+v", account)
+	}
+	touchpoints, _ := repo.ListTouchpoints(ctx, orgID, accountID, "", 10, 0)
+	for _, touchpoint := range touchpoints {
+		if touchpoint.Recipient == "bounced@example.com" && touchpoint.State != models.TouchpointBounced {
+			t.Fatalf("bounced route state=%s", touchpoint.State)
+		}
+		if touchpoint.Recipient == "healthy@example.com" && touchpoint.State != models.TouchpointPlanned {
+			t.Fatalf("healthy route state=%s", touchpoint.State)
+		}
+	}
+	if suppression, _ := repo.GetOutreachRecipientSuppression(ctx, orgID, "bounced@example.com"); suppression == nil || suppression.Source != models.DeliverabilityEventBounce {
+		t.Fatalf("canonical exact suppression missing: %+v", suppression)
+	}
+}
+
+func TestProviderWebhookSoftBounceAndDeliveryShareAuthoritativeLedger(t *testing.T) {
+	ctx := context.Background()
+	repo := newMemRepoWithSettings()
+	svc := NewService(Config{Enabled: true, DefaultDailyLimit: 10}, repo, nil).(*service)
+	orgID, accountID := uuid.New(), uuid.New()
+	_, _ = repo.UpsertAccount(ctx, &models.OutreachAccount{
+		ID: accountID, OrganizationID: orgID, SourceRunID: "run-47", SourceSystem: "provider-webhook",
+	})
+	_, _ = repo.UpsertCandidate(ctx, &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: orgID, AccountID: accountID, Email: "route@example.com",
+	})
+	soft := &models.IngestDeliverabilityEventRequest{
+		EventType: models.DeliverabilityEventSoftBounce, RecipientEmail: "route@example.com",
+		IdempotencyKey: "provider-soft-47", Metadata: map[string]interface{}{"enhanced_status": "4.2.0"},
+	}
+	when := time.Date(2026, 8, 26, 15, 0, 0, 0, time.UTC)
+	mailboxID := uuid.New()
+	if err := svc.OnDeliverabilityEvent(ctx, orgID, soft, "ses", soft.IdempotencyKey, mailboxID, when); err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.OnDeliverabilityEvent(ctx, orgID, soft, "ses", soft.IdempotencyKey, mailboxID, when); err != nil {
+		t.Fatal(err)
+	}
+	if suppression, _ := repo.GetOutreachRecipientSuppression(ctx, orgID, soft.RecipientEmail); suppression != nil {
+		t.Fatalf("soft bounce created permanent suppression: %+v", suppression)
+	}
+	delivered := &models.IngestDeliverabilityEventRequest{
+		EventType: models.DeliverabilityEventDelivered, RecipientEmail: soft.RecipientEmail,
+		IdempotencyKey: "provider-delivered-47", Metadata: map[string]interface{}{"enhanced_status": "2.0.0"},
+	}
+	if err := svc.OnDeliverabilityEvent(ctx, orgID, delivered, "ses", delivered.IdempotencyKey, mailboxID, when.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+
+	chains, err := svc.intelStore().ListChains(orgID.String())
+	if err != nil || len(chains) != 1 {
+		t.Fatalf("authoritative chains=%d err=%v", len(chains), err)
+	}
+	counts := map[string]int{}
+	for _, receipt := range chains[0].Commercial.Timeline {
+		counts[receipt.Type]++
+	}
+	if counts[intel.EventSoftBounce] != 1 || counts[intel.EventDelivered] != 1 {
+		t.Fatalf("provider replay duplicated or lost facts: %+v", counts)
+	}
+}

--- a/internal/app/confenge/reply_handoff.go
+++ b/internal/app/confenge/reply_handoff.go
@@ -21,7 +21,7 @@ type InboundHandoff struct {
 	PreSource, IdempotencyKey, ExternalMessageID           string
 	OccurredAt                                             time.Time
 	WarmblyContactID                                       *uuid.UUID
-	ActorID, AccountID                                     uuid.UUID
+	ActorID, AccountID, TouchpointID, MailboxID            uuid.UUID
 }
 
 type HandoffResult struct {
@@ -87,22 +87,42 @@ func (s *service) ProcessInboundHandoff(ctx context.Context, orgID uuid.UUID, in
 		ooo := ExtractOOODate(in.Subject + "\n" + in.BodyText)
 		intent = CommercialIntent{Intent: IntentOutOfOffice, Confidence: 0.8, Source: "lexicon", OOOReturnDate: ooo, SuggestedAction: SuggestNextAction(IntentOutOfOffice, ooo, "")}
 	}
-	cancelled := s.cancelPendingOutbound(ctx, orgID, acc.ID)
+	if intent.Intent == IntentDoNotContact {
+		if err := s.noteDNC(ctx, orgID, email, "reply_class:opt_out", "imap"); err != nil {
+			return nil, errx.New(errx.Internal, "apply exact recipient opt-out: "+err.Error())
+		}
+		return &HandoffResult{AccountID: acc.ID, QueueState: acc.QueueState, Intent: intent, StoppedCadence: true, IdempotencyKey: idem}, nil
+	}
+	if cand != nil && cand.DoNotContact {
+		// Exact recipient opt-out is sticky without invalidating other company routes.
+		return &HandoffResult{AccountID: acc.ID, QueueState: acc.QueueState, Intent: intent, StoppedCadence: true, IdempotencyKey: idem}, nil
+	}
+	stopsCadence := intent.Intent != IntentOutOfOffice
+	cancelled := 0
+	if stopsCadence {
+		cancelled = s.cancelPendingOutbound(ctx, orgID, acc.ID)
+	}
 	queueState, blocked, dnc := queueStateForIntent(intent.Intent, acc)
 	reason := fmt.Sprintf("reply:%s:%s", channel, intent.Intent)
 	// Pause/cancel open touchpoint cadence (dominant with draft stop).
-	term, stop := models.TouchpointReplied, "REPLY"
-	if intent.Intent == IntentDoNotContact {
-		reason = "reply:DO_NOT_CONTACT"
-		term, stop = models.TouchpointDNC, "DNC"
-		if cand != nil {
-			cand.DoNotContact = true
-			cand.VerificationStatus = models.OutreachVerifyDoNotContact
-			_, _ = s.repo.UpsertCandidate(ctx, cand)
+	stop := "REPLY"
+	if stopsCadence {
+		nTP, cancelErr := s.repo.CancelOpenTouchpoints(ctx, orgID, acc.ID, models.TouchpointReplied, stop)
+		if cancelErr != nil {
+			return nil, errx.New(errx.Internal, "stop reply cadence: "+cancelErr.Error())
 		}
-	}
-	if nTP, err := s.repo.CancelOpenTouchpoints(ctx, orgID, acc.ID, term, stop); err == nil {
 		cancelled += nTP
+		if in.TouchpointID != uuid.Nil {
+			if replied, touchErr := s.repo.GetTouchpoint(ctx, orgID, in.TouchpointID); touchErr != nil {
+				return nil, errx.New(errx.Internal, "load replied touchpoint: "+touchErr.Error())
+			} else if replied != nil && replied.AccountID == acc.ID && replied.State == models.TouchpointSent {
+				replied.State = models.TouchpointReplied
+				replied.StopReason = stop
+				if touchErr := s.repo.UpdateTouchpoint(ctx, replied); touchErr != nil {
+					return nil, errx.New(errx.Internal, "mark replied touchpoint: "+touchErr.Error())
+				}
+			}
+		}
 	}
 	// Drop governor-queued outbound for this recipient (email + phone).
 	phoneRef := phone
@@ -112,21 +132,27 @@ func (s *service) ProcessInboundHandoff(ctx context.Context, orgID uuid.UUID, in
 			phoneRef = cand.Phone
 		}
 	}
-	s.cancelQueuedForRecipient(ctx, orgID, email, phoneRef, stop)
+	if stopsCadence {
+		s.cancelQueuedForRecipient(ctx, orgID, email, phoneRef, stop)
+	}
 	if intent.Intent == IntentOutOfOffice && queueState == "" {
 		queueState = acc.QueueState
 		if queueState == "" {
 			queueState = models.OutreachQueueSent
 		}
 	}
-	_ = s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, blocked, dnc, reason, queueState)
+	if err := s.repo.SetAccountHumanFlags(ctx, orgID, acc.ID, blocked, dnc, reason, queueState); err != nil {
+		return nil, errx.New(errx.Internal, "mark replied account: "+err.Error())
+	}
 	if fresh, gerr := s.repo.GetAccount(ctx, orgID, acc.ID); gerr == nil && fresh != nil {
 		fresh.CommercialState = intent.Intent
 		fresh.QueueState = queueState
 		fresh.Blocked = blocked
 		fresh.DoNotContact = dnc
 		fresh.BlockReason = reason
-		_, _ = s.repo.UpsertAccount(ctx, fresh)
+		if _, updateErr := s.repo.UpsertAccount(ctx, fresh); updateErr != nil {
+			return nil, errx.New(errx.Internal, "persist replied account: "+updateErr.Error())
+		}
 		acc = fresh
 	}
 	contactEmail := email
@@ -143,10 +169,14 @@ func (s *service) ProcessInboundHandoff(ctx context.Context, orgID uuid.UUID, in
 	}
 	controlledReply := controlledReplyClass(intent.Intent)
 	payload["reply_class"] = controlledReply
-	_ = s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{IdempotencyKey: idem, SourceLeadID: acc.SourceLeadID, CNPJ14: acc.CNPJ14, ContactEmail: contactEmail, EventType: eventType, OccurredAt: in.OccurredAt, Payload: mustJSON(payload)})
+	if xerr := s.EnqueueOutcome(ctx, orgID, models.OutreachOutcome{IdempotencyKey: idem, SourceLeadID: acc.SourceLeadID, CNPJ14: acc.CNPJ14, ContactEmail: contactEmail, EventType: eventType, OccurredAt: in.OccurredAt, Payload: mustJSON(payload)}); xerr != nil {
+		return nil, xerr
+	}
 	s.applyReplyCRM(ctx, orgID, in.ActorID, contactEmail, intentToCRMClass(intent.Intent), in.WarmblyContactID, cand, acc)
-	s.markAccountDraftsReplied(ctx, orgID, acc.ID)
-	return &HandoffResult{AccountID: acc.ID, QueueState: queueState, Intent: intent, CancelledDrafts: cancelled, StoppedCadence: true, IdempotencyKey: idem}, nil
+	if stopsCadence {
+		s.markAccountDraftsReplied(ctx, orgID, acc.ID)
+	}
+	return &HandoffResult{AccountID: acc.ID, QueueState: queueState, Intent: intent, CancelledDrafts: cancelled, StoppedCadence: stopsCadence, IdempotencyKey: idem}, nil
 }
 
 // ClassifyControlledReply is the offline, bounded projection used at IMAP

--- a/internal/app/confenge/reply_handoff_test.go
+++ b/internal/app/confenge/reply_handoff_test.go
@@ -221,9 +221,13 @@ func TestProcessInboundHandoffDNCSticky(t *testing.T) {
 	if xerr != nil {
 		t.Fatal(xerr)
 	}
+	cand, _, _ := r.FindCandidateByEmail(context.Background(), org, "dnc@example.com")
+	if cand == nil || !cand.DoNotContact {
+		t.Fatalf("exact recipient DNC not set: %+v", cand)
+	}
 	acc, _ := r.GetAccount(context.Background(), org, accID)
-	if !acc.DoNotContact || acc.QueueState != models.OutreachQueueDoNotContact {
-		t.Fatalf("DNC not set: %+v", acc)
+	if acc.DoNotContact || acc.Blocked {
+		t.Fatalf("recipient DNC must not invalidate company: %+v", acc)
 	}
 	// Later positive reply must not clear sticky DNC.
 	_, xerr = svc.ProcessInboundHandoff(context.Background(), org, InboundHandoff{
@@ -233,9 +237,9 @@ func TestProcessInboundHandoffDNCSticky(t *testing.T) {
 	if xerr != nil {
 		t.Fatal(xerr)
 	}
-	acc, _ = r.GetAccount(context.Background(), org, accID)
-	if !acc.DoNotContact || acc.QueueState != models.OutreachQueueDoNotContact {
-		t.Fatalf("sticky DNC broken: %+v", acc)
+	cand, _, _ = r.FindCandidateByEmail(context.Background(), org, "dnc@example.com")
+	if cand == nil || !cand.DoNotContact {
+		t.Fatalf("sticky exact DNC broken: %+v", cand)
 	}
 }
 

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -106,8 +106,8 @@ type Service interface {
 	DispatchStatus(ctx context.Context, orgID uuid.UUID) (dispatch.Status, *errx.Error)
 	PauseDispatch(ctx context.Context, orgID, userID uuid.UUID, reason string) *errx.Error
 	ResumeDispatch(ctx context.Context, orgID, userID uuid.UUID) *errx.Error
-	CompleteCampaignEmail(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, providerMessageID string, acceptedAt time.Time) error
-	ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, attemptedAt time.Time) error
+	CompleteCampaignEmail(ctx context.Context, orgID, campaignID, contactID, sequenceID, taskID, mailboxID uuid.UUID, providerMessageID, provider string, acceptedAt time.Time) error
+	ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID, taskID, mailboxID uuid.UUID, provider string, attemptedAt time.Time) error
 	ProcessDispatchQueueOnce(ctx context.Context) (bool, error)
 	ProcessEditorialRecoveryOnce(ctx context.Context) (bool, error)
 	ProcessDraftGenerationOnce(ctx context.Context) (bool, error)

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -44,6 +44,7 @@ type memRepo struct {
 	actionByIdem       map[string]*models.OutreachCommercialAction
 	inbound            map[string]*models.OutreachInboundLead
 	alerts             map[string]*models.OutreachOperatorAlert
+	suppressions       map[string]*models.SuppressedRecipient
 }
 
 func newMemRepo() *memRepo {
@@ -61,7 +62,74 @@ func newMemRepo() *memRepo {
 		actionByIdem:     map[string]*models.OutreachCommercialAction{},
 		inbound:          map[string]*models.OutreachInboundLead{},
 		alerts:           map[string]*models.OutreachOperatorAlert{},
+		suppressions:     map[string]*models.SuppressedRecipient{},
 	}
+}
+
+func suppressionKey(orgID uuid.UUID, email string) string {
+	return orgID.String() + "|" + strings.ToLower(strings.TrimSpace(email))
+}
+
+func (m *memRepo) GetOutreachRecipientSuppression(_ context.Context, orgID uuid.UUID, email string) (*models.SuppressedRecipient, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	value := m.suppressions[suppressionKey(orgID, email)]
+	if value == nil || (value.ExpiresAt != nil && !value.ExpiresAt.After(time.Now().UTC())) {
+		return nil, nil
+	}
+	copy := *value
+	return &copy, nil
+}
+
+func (m *memRepo) UpsertOutreachRecipientSuppression(_ context.Context, value *models.SuppressedRecipient) error {
+	if value == nil {
+		return fmt.Errorf("suppression required")
+	}
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	copy := *value
+	copy.Email = strings.ToLower(strings.TrimSpace(copy.Email))
+	if copy.CreatedAt.IsZero() {
+		copy.CreatedAt = time.Now().UTC()
+	}
+	copy.UpdatedAt = time.Now().UTC()
+	m.suppressions[suppressionKey(copy.OrganizationID, copy.Email)] = &copy
+	return nil
+}
+
+func (m *memRepo) CancelSuppressedOutreachRecipient(_ context.Context, orgID uuid.UUID, email, terminalState, reason string) (int, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	email = strings.ToLower(strings.TrimSpace(email))
+	n := 0
+	for _, touchpoint := range m.touchpoints {
+		if touchpoint.OrganizationID == orgID && strings.EqualFold(touchpoint.Recipient, email) && models.TouchpointOpenStates[touchpoint.State] {
+			touchpoint.State = terminalState
+			touchpoint.StopReason = reason
+			touchpoint.ApprovedBy = nil
+			touchpoint.ApprovedContentHash = ""
+			n++
+		}
+	}
+	for accountID, candidates := range m.cands {
+		for i := range candidates {
+			if candidates[i].OrganizationID != orgID || !strings.EqualFold(candidates[i].Email, email) {
+				continue
+			}
+			switch terminalState {
+			case models.TouchpointBounced:
+				candidates[i].Bounced = true
+				candidates[i].VerificationStatus = models.OutreachVerifyBounced
+			case models.TouchpointDNC:
+				candidates[i].DoNotContact = true
+				candidates[i].VerificationStatus = models.OutreachVerifyDoNotContact
+			default:
+				candidates[i].Blocked = true
+			}
+			m.cands[accountID] = candidates
+		}
+	}
+	return n, nil
 }
 
 func accKey(org uuid.UUID, cnpj string) string { return org.String() + "|" + cnpj }

--- a/internal/app/consumer/event_email_attempted.go
+++ b/internal/app/consumer/event_email_attempted.go
@@ -37,12 +37,31 @@ func (s *JobsService) HandleEmailAttempted(ctx context.Context, event *models.Se
 	if campaign == nil || campaign.OrganizationID == nil {
 		return nil
 	}
+	task, err := s.TaskRepo.GetTask(ctx, event.TaskID)
+	if err != nil {
+		return fmt.Errorf("load send task: %w", err)
+	}
+	var mailboxID uuid.UUID
+	provider := "smtp"
+	if task != nil {
+		mailboxID = task.EmailAccountID
+		if s.EmailRepository != nil {
+			if mailbox, xerr := s.EmailRepository.GetByID(ctx, mailboxID); xerr != nil {
+				return fmt.Errorf("load sender mailbox: %w", xerr)
+			} else if mailbox != nil {
+				provider = mailbox.Provider
+			}
+		}
+	}
 	observeErr := s.ConfengeSends.ObserveCampaignEmailAttempt(
 		ctx,
 		*campaign.OrganizationID,
 		*campaignTask.CampaignID,
 		*campaignTask.ContactID,
 		valueOrNilUUID(campaignTask.SequenceID),
+		event.TaskID,
+		mailboxID,
+		provider,
 		event.SentAt,
 	)
 	if errors.Is(observeErr, confenge.ErrCampaignTouchpointNotFound) && !confenge.IsConfengeCampaign(campaign.Name) {

--- a/internal/app/consumer/event_email_failed.go
+++ b/internal/app/consumer/event_email_failed.go
@@ -6,23 +6,71 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
-// HandleEmailFailed records permanent SMTP recipient rejections as bounces.
+// HandleEmailFailed reconciles SMTP outcomes without promoting ambiguity to hard bounce.
 func (s *JobsService) HandleEmailFailed(ctx context.Context, event *models.SendEmailResult) error {
 	if event == nil || event.TaskID == uuid.Nil {
 		return fmt.Errorf("invalid EMAIL_FAILED result")
 	}
-	if event.Error == nil || !strings.EqualFold(event.Error.Code, string(errx.MailErrorCodeRecipientRejected)) {
+	if event.Error == nil {
 		return nil
 	}
-	if s.AdvancedService == nil {
-		return fmt.Errorf("deliverability service is not configured")
+	code := errx.MailErrorCode(strings.ToUpper(strings.TrimSpace(event.Error.Code)))
+	if code != errx.MailErrorCodeRecipientRejected && code != errx.MailErrorCodeRecipientTemporaryRejected && code != errx.MailErrorCodeDeliveryUnknown {
+		return nil
 	}
-	if xerr := s.AdvancedService.RecordOutboundBounce(ctx, event.TaskID, event.Error.Message); xerr != nil {
-		return fmt.Errorf("record outbound SMTP rejection: %w", xerr)
+	if code == errx.MailErrorCodeRecipientRejected {
+		if s.AdvancedService == nil {
+			return fmt.Errorf("deliverability service is not configured")
+		}
+		if xerr := s.AdvancedService.RecordOutboundBounce(ctx, event.TaskID, event.Error.Message); xerr != nil {
+			return fmt.Errorf("record outbound SMTP rejection: %w", xerr)
+		}
+	}
+	if s.ConfengeOutcomes == nil || !s.ConfengeOutcomes.Enabled() || s.TaskRepo == nil || s.EmailRepository == nil {
+		return nil
+	}
+	task, err := s.TaskRepo.GetTask(ctx, event.TaskID)
+	if err != nil {
+		return fmt.Errorf("load failed send task: %w", err)
+	}
+	if task == nil {
+		return nil
+	}
+	mailbox, xerr := s.EmailRepository.GetByID(ctx, task.EmailAccountID)
+	if xerr != nil {
+		return fmt.Errorf("load failed send mailbox: %w", xerr)
+	}
+	if mailbox == nil || mailbox.OrganizationID == nil {
+		return nil
+	}
+	emailTask, err := s.TaskRepo.GetEmailTask(ctx, event.TaskID)
+	if err != nil {
+		return fmt.Errorf("load failed email task: %w", err)
+	}
+	if emailTask == nil || len(emailTask.To) == 0 {
+		return nil
+	}
+	bounceClass := "SOFT"
+	unknown := code == errx.MailErrorCodeDeliveryUnknown
+	if code == errx.MailErrorCodeRecipientRejected {
+		bounceClass = "HARD"
+	} else if unknown {
+		bounceClass = "UNKNOWN"
+	}
+	if structured, ok := s.ConfengeOutcomes.(confenge.StructuredBounceOutcomeSink); ok {
+		if err := structured.NoteBounceObservation(ctx, *mailbox.OrganizationID, emailTask.To[0], confenge.BounceObservation{
+			Class: bounceClass, DeliveryUnknown: unknown,
+			EventID:   "smtp:" + strings.ToLower(string(code)) + ":" + event.TaskID.String(),
+			MailboxID: task.EmailAccountID.String(), OccurredAt: event.SentAt,
+			ProviderName: mailbox.Provider, Reason: event.Error.Message,
+		}); err != nil {
+			return fmt.Errorf("reconcile outbound SMTP outcome: %w", err)
+		}
 	}
 	return nil
 }

--- a/internal/app/consumer/event_email_sent.go
+++ b/internal/app/consumer/event_email_sent.go
@@ -39,6 +39,22 @@ func (s *JobsService) HandleEmailSent(ctx context.Context, event *models.SendEma
 	if campaign == nil || campaign.OrganizationID == nil {
 		return nil
 	}
+	task, err := s.TaskRepo.GetTask(ctx, event.TaskID)
+	if err != nil {
+		return fmt.Errorf("load send task: %w", err)
+	}
+	var mailboxID uuid.UUID
+	provider := "smtp"
+	if task != nil {
+		mailboxID = task.EmailAccountID
+		if s.EmailRepository != nil {
+			if mailbox, xerr := s.EmailRepository.GetByID(ctx, mailboxID); xerr != nil {
+				return fmt.Errorf("load sender mailbox: %w", xerr)
+			} else if mailbox != nil {
+				provider = mailbox.Provider
+			}
+		}
+	}
 
 	providerMessageID := strings.TrimSpace(event.ProviderMsgID)
 	if providerMessageID == "" {
@@ -50,7 +66,10 @@ func (s *JobsService) HandleEmailSent(ctx context.Context, event *models.SendEma
 		*campaignTask.CampaignID,
 		*campaignTask.ContactID,
 		valueOrNilUUID(campaignTask.SequenceID),
+		event.TaskID,
+		mailboxID,
 		providerMessageID,
+		provider,
 		event.SentAt,
 	)
 	if errors.Is(completionErr, confenge.ErrCampaignTouchpointNotFound) && !confenge.IsConfengeCampaign(campaign.Name) {

--- a/internal/app/consumer/event_email_sent_test.go
+++ b/internal/app/consumer/event_email_sent_test.go
@@ -22,6 +22,10 @@ func (r emailSentTaskRepo) GetCampaignTask(context.Context, uuid.UUID) (*reposit
 	return r.task, nil
 }
 
+func (r emailSentTaskRepo) GetTask(_ context.Context, id uuid.UUID) (*repository.Task, error) {
+	return &repository.Task{ID: id}, nil
+}
+
 type emailSentCampaignRepo struct {
 	repository.CampaignRepository
 	campaign *models.Campaign
@@ -42,7 +46,7 @@ type emailSentCompletion struct {
 	err        error
 }
 
-func (c *emailSentCompletion) ObserveCampaignEmailAttempt(_ context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, _ time.Time) error {
+func (c *emailSentCompletion) ObserveCampaignEmailAttempt(_ context.Context, orgID, campaignID, contactID, sequenceID, _, _ uuid.UUID, _ string, _ time.Time) error {
 	c.attempted++
 	c.orgID = orgID
 	c.campaignID = campaignID
@@ -51,7 +55,7 @@ func (c *emailSentCompletion) ObserveCampaignEmailAttempt(_ context.Context, org
 	return c.err
 }
 
-func (c *emailSentCompletion) CompleteCampaignEmail(_ context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, providerMessageID string, _ time.Time) error {
+func (c *emailSentCompletion) CompleteCampaignEmail(_ context.Context, orgID, campaignID, contactID, sequenceID, _, _ uuid.UUID, providerMessageID, _ string, _ time.Time) error {
 	c.called++
 	c.orgID = orgID
 	c.campaignID = campaignID

--- a/internal/app/consumer/event_inbound_bounce.go
+++ b/internal/app/consumer/event_inbound_bounce.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/models"
@@ -31,6 +32,8 @@ func (s *JobsService) HandleInboundBounce(ctx context.Context, e *models.JobEven
 		}
 		if account != nil && account.OrganizationID != nil {
 			observation := confenge.BounceObservation{
+				EventID:   "dsn:" + e.BounceClass + ":" + e.OriginalMessageID,
+				MailboxID: e.EmailID.String(), OccurredAt: time.Now().UTC(),
 				Class: e.BounceClass, ProviderName: account.Provider, OriginalMessageID: e.OriginalMessageID,
 				EnhancedStatus: e.EnhancedStatus, SMTPStatus: e.SMTPStatus,
 				Diagnostic: e.Diagnostic, Reason: e.Reason,

--- a/internal/app/consumer/event_inbound_complaint.go
+++ b/internal/app/consumer/event_inbound_complaint.go
@@ -3,7 +3,9 @@ package jobs
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -16,6 +18,23 @@ func (s *JobsService) HandleInboundComplaint(ctx context.Context, event *models.
 	}
 	if xerr := s.AdvancedService.RecordInboundComplaint(ctx, event.EmailID, event.OriginalMessageID, event.Recipient, event.FeedbackType); xerr != nil {
 		return fmt.Errorf("record inbound complaint: %w", xerr)
+	}
+	if s.ConfengeOutcomes != nil && s.ConfengeOutcomes.Enabled() && s.EmailRepository != nil {
+		account, xerr := s.EmailRepository.GetByID(ctx, event.EmailID)
+		if xerr != nil {
+			return fmt.Errorf("load mailbox for inbound complaint: %w", xerr)
+		}
+		if account != nil && account.OrganizationID != nil {
+			if sink, ok := s.ConfengeOutcomes.(confenge.StructuredEmailOutcomeSink); ok {
+				if err := sink.NoteComplaintObservation(ctx, *account.OrganizationID, event.Recipient, confenge.ComplaintObservation{
+					EventID: "fbl:" + event.OriginalMessageID, MailboxID: event.EmailID.String(),
+					ProviderName: account.Provider, OriginalMessageID: event.OriginalMessageID,
+					FeedbackType: event.FeedbackType, OccurredAt: time.Now().UTC(),
+				}); err != nil {
+					return fmt.Errorf("reconcile complaint: %w", err)
+				}
+			}
+		}
 	}
 	return nil
 }

--- a/internal/app/consumer/event_inbound_deliverability_test.go
+++ b/internal/app/consumer/event_inbound_deliverability_test.go
@@ -40,4 +40,5 @@ func TestInboundDeliverabilityHandlersRejectMissingPayloads(t *testing.T) {
 
 	require.Error(t, svc.HandleInboundBounce(context.Background(), nil))
 	require.Error(t, svc.HandleInboundComplaint(context.Background(), nil))
+	require.Error(t, svc.HandleInboundDelivery(context.Background(), nil))
 }

--- a/internal/app/consumer/event_inbound_delivery.go
+++ b/internal/app/consumer/event_inbound_delivery.go
@@ -1,0 +1,37 @@
+package jobs
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/confenge"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func (s *JobsService) HandleInboundDelivery(ctx context.Context, event *models.JobEventInboundDelivery) error {
+	if event == nil {
+		return fmt.Errorf("invalid INBOUND_DELIVERY event")
+	}
+	if s.ConfengeOutcomes == nil || !s.ConfengeOutcomes.Enabled() || s.EmailRepository == nil {
+		return nil
+	}
+	account, xerr := s.EmailRepository.GetByID(ctx, event.EmailID)
+	if xerr != nil {
+		return fmt.Errorf("load mailbox for inbound delivery: %w", xerr)
+	}
+	if account == nil || account.OrganizationID == nil {
+		return nil
+	}
+	if sink, ok := s.ConfengeOutcomes.(confenge.StructuredEmailOutcomeSink); ok {
+		if err := sink.NoteDeliveryObservation(ctx, *account.OrganizationID, event.Recipient, confenge.DeliveryObservation{
+			EventID:   "dsn:delivered:" + event.OriginalMessageID,
+			MailboxID: event.EmailID.String(), ProviderName: account.Provider,
+			OriginalMessageID: event.OriginalMessageID, EnhancedStatus: event.EnhancedStatus,
+			SMTPStatus: event.SMTPStatus, Diagnostic: event.Diagnostic, OccurredAt: time.Now().UTC(),
+		}); err != nil {
+			return fmt.Errorf("reconcile delivery: %w", err)
+		}
+	}
+	return nil
+}

--- a/internal/app/consumer/event_new_email.go
+++ b/internal/app/consumer/event_new_email.go
@@ -83,7 +83,10 @@ func (s *JobsService) HandleNewEmail(ctx context.Context, e *models.JobEventNewE
 			from := emailaddr.ExtractFirst(e.Message.FromAddr)
 			meta := map[string]any{
 				"subject":       e.Message.Subject,
+				"body_text":     e.Message.Snippet,
 				"message_id":    e.Message.ID.String(),
+				"mailbox_id":    e.Message.EmailID.String(),
+				"occurred_at":   time.Now().UTC().Format(time.RFC3339Nano),
 				"provider_name": account.Provider,
 				"reply_class": confenge.ClassifyControlledReply(
 					e.Message.Subject,
@@ -92,7 +95,9 @@ func (s *JobsService) HandleNewEmail(ctx context.Context, e *models.JobEventNewE
 				),
 			}
 			s.attachReplyCorrelation(ctx, e.Message, meta)
-			_ = s.ConfengeOutcomes.NoteReply(ctx, *account.OrganizationID, from, meta)
+			if err := s.ConfengeOutcomes.NoteReply(ctx, *account.OrganizationID, from, meta); err != nil {
+				return fmt.Errorf("reconcile CONFENGE reply: %w", err)
+			}
 		}
 	}
 

--- a/internal/app/consumer/events.go
+++ b/internal/app/consumer/events.go
@@ -28,6 +28,7 @@ func (w *JobsService) InitEvents() {
 	w.eventHandlers = make(map[models.JobEventType]func(ctx context.Context, body any) error)
 	Register(w, models.JobEventTypeNewEmail, w.HandleNewEmail)
 	Register(w, models.JobEventTypeInboundBounce, w.HandleInboundBounce)
+	Register(w, models.JobEventTypeInboundDelivery, w.HandleInboundDelivery)
 	Register(w, models.JobEventTypeInboundComplaint, w.HandleInboundComplaint)
 	Register(w, models.JobEventTypeEmailUpdate, w.HandleUpdateEmail)
 	Register(w, models.JobEventTypeRemoveEmail, w.HandleRemoveEmail)

--- a/internal/app/consumer/service.go
+++ b/internal/app/consumer/service.go
@@ -50,8 +50,8 @@ type JobsService struct {
 	// ConfengeOutcomes attributes reply/bounce/DNC back to staged leads (optional).
 	ConfengeOutcomes confenge.OutcomeSink
 	ConfengeSends    interface {
-		ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, attemptedAt time.Time) error
-		CompleteCampaignEmail(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, providerMessageID string, acceptedAt time.Time) error
+		ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID, taskID, mailboxID uuid.UUID, provider string, attemptedAt time.Time) error
+		CompleteCampaignEmail(ctx context.Context, orgID, campaignID, contactID, sequenceID, taskID, mailboxID uuid.UUID, providerMessageID, provider string, acceptedAt time.Time) error
 	}
 
 	// Cache for dead worker detection

--- a/internal/app/worker/health_record.go
+++ b/internal/app/worker/health_record.go
@@ -47,8 +47,11 @@ func (s *WorkerService) recordSendOutcome(result *wmail.SendResult) {
 		errx.MailErrorCodeAccountSuspended:
 		s.RecordBounceHard()
 	case errx.MailErrorCodeServerUnreachable,
-		errx.MailErrorCodeConnectionLost:
+		errx.MailErrorCodeConnectionLost,
+		errx.MailErrorCodeRecipientTemporaryRejected:
 		s.RecordBounceSoft()
+	case errx.MailErrorCodeDeliveryUnknown:
+		// UNKNOWN is not evidence against the recipient or mailbox.
 	default:
 		// Best-effort classification on free-text — keeps the signal
 		// useful even when the error code is generic.

--- a/internal/app/worker/wmail/bounce.go
+++ b/internal/app/worker/wmail/bounce.go
@@ -26,7 +26,7 @@ func (w *WMail) maybeEmitBounce(msg *models.EmailMessageData) error {
 	}
 
 	report := dsn.Parse(msg.BodyPlain + "\n" + msg.BodyHTML)
-	if !report.IsBounce {
+	if !report.IsBounce && !report.IsDelivery {
 		return nil
 	}
 
@@ -38,6 +38,13 @@ func (w *WMail) maybeEmitBounce(msg *models.EmailMessageData) error {
 	}
 	if originalID == "" {
 		return nil
+	}
+	if report.IsDelivery {
+		return w.onEvent(models.JobEventTypeInboundDelivery, &models.JobEventInboundDelivery{
+			UserID: w.UserID, EmailID: w.ID,
+			OriginalMessageID: strings.Trim(originalID, "<>"), Recipient: report.FailedRecipient,
+			EnhancedStatus: report.EnhancedStatus, SMTPStatus: report.SMTPStatus, Diagnostic: report.Diagnostic,
+		})
 	}
 
 	return w.onEvent(models.JobEventTypeInboundBounce, &models.JobEventInboundBounce{

--- a/internal/app/worker/wmail/bounce_test.go
+++ b/internal/app/worker/wmail/bounce_test.go
@@ -51,3 +51,23 @@ func TestMaybeEmitBounceReturnsPublishFailure(t *testing.T) {
 		t.Fatal("publish failure was discarded")
 	}
 }
+
+func TestMaybeEmitBouncePublishesExplicitDeliveryDSN(t *testing.T) {
+	var got *models.JobEventInboundDelivery
+	w := &WMail{onEvent: func(kind models.JobEventType, body any) error {
+		if kind != models.JobEventTypeInboundDelivery {
+			t.Fatalf("kind=%s", kind)
+		}
+		got, _ = body.(*models.JobEventInboundDelivery)
+		return nil
+	}}
+	if err := w.maybeEmitBounce(&models.EmailMessageData{
+		From: []string{"Mailer-Daemon <mailer-daemon@example.com>"}, Subject: "Delivery status notification",
+		BodyPlain: "Final-Recipient: rfc822; delivered@example.com\nAction: delivered\nStatus: 2.0.0\nDiagnostic-Code: smtp; 250 queued\nMessage-ID: <delivered-message@example.com>\n",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if got == nil || got.OriginalMessageID != "delivered-message@example.com" {
+		t.Fatalf("delivery DSN not emitted: %+v", got)
+	}
+}

--- a/internal/app/worker/wmail/send.go
+++ b/internal/app/worker/wmail/send.go
@@ -423,6 +423,8 @@ func DetermineErrorEventType(err *errx.MailError) models.JobEventType {
 
 	case errx.MailErrorCodeServerUnreachable, errx.MailErrorCodeConnectionLost:
 		return models.JobEventTypeEmailServerError
+	case errx.MailErrorCodeRecipientRejected, errx.MailErrorCodeRecipientTemporaryRejected, errx.MailErrorCodeDeliveryUnknown:
+		return models.JobEventTypeEmailFailed
 
 	default:
 		return models.JobEventTypeEmailFailed

--- a/internal/client/smtpimap/smtp/client.go
+++ b/internal/client/smtpimap/smtp/client.go
@@ -324,7 +324,7 @@ func (c *Client) sendRaw(ctx context.Context, from string, to []string, data []b
 		return classifySMTPFailure(err, false)
 	}
 	if err := w.Close(); err != nil {
-		return classifySMTPFailure(err, false)
+		return errx.ErrMailDeliveryUnknown
 	}
 
 	return nil
@@ -337,8 +337,13 @@ func classifySMTPFailure(err error, recipientStage bool) *errx.MailError {
 	}
 	if recipientStage {
 		var smtpErr *textproto.Error
-		if errors.As(err, &smtpErr) && smtpErr.Code >= 500 && smtpErr.Code < 600 {
-			return errx.ErrMailRecipientRejected
+		if errors.As(err, &smtpErr) {
+			if smtpErr.Code >= 500 && smtpErr.Code < 600 {
+				return errx.ErrMailRecipientRejected
+			}
+			if smtpErr.Code >= 400 && smtpErr.Code < 500 {
+				return errx.ErrMailRecipientTemporaryRejected
+			}
 		}
 	}
 	return errx.ErrMailServerUnreachable

--- a/internal/client/smtpimap/smtp/client_test.go
+++ b/internal/client/smtpimap/smtp/client_test.go
@@ -19,7 +19,7 @@ func TestClassifySMTPFailureRecordsOnlyPermanentRecipientFailures(t *testing.T) 
 	transient := classifySMTPFailure(&textproto.Error{Code: 450, Msg: "4.2.0 mailbox busy"}, true)
 
 	require.Equal(t, errx.MailErrorCodeRecipientRejected, permanent.Code)
-	require.Equal(t, errx.MailErrorCodeServerUnreachable, transient.Code)
+	require.Equal(t, errx.MailErrorCodeRecipientTemporaryRejected, transient.Code)
 }
 
 func TestClassifySMTPFailureDoesNotTreatSenderStageAsRecipientBounce(t *testing.T) {

--- a/internal/errx/email.go
+++ b/internal/errx/email.go
@@ -45,11 +45,13 @@ const (
 	MailErrorCodeImapUnknown          MailErrorCode = "IMAP_UNKNOWN"
 
 	// Rate limiting and abuse detection
-	MailErrorCodeRateLimitExceeded MailErrorCode = "RATE_LIMIT_EXCEEDED"
-	MailErrorCodeSendingTooFast    MailErrorCode = "SENDING_TOO_FAST"
-	MailErrorCodeRecipientRejected MailErrorCode = "RECIPIENT_REJECTED"
-	MailErrorCodeQuotaExceeded     MailErrorCode = "QUOTA_EXCEEDED"
-	MailErrorCodeAccountSuspended  MailErrorCode = "ACCOUNT_SUSPENDED"
+	MailErrorCodeRateLimitExceeded          MailErrorCode = "RATE_LIMIT_EXCEEDED"
+	MailErrorCodeSendingTooFast             MailErrorCode = "SENDING_TOO_FAST"
+	MailErrorCodeRecipientRejected          MailErrorCode = "RECIPIENT_REJECTED"
+	MailErrorCodeRecipientTemporaryRejected MailErrorCode = "RECIPIENT_TEMPORARY_REJECTED"
+	MailErrorCodeDeliveryUnknown            MailErrorCode = "DELIVERY_UNKNOWN"
+	MailErrorCodeQuotaExceeded              MailErrorCode = "QUOTA_EXCEEDED"
+	MailErrorCodeAccountSuspended           MailErrorCode = "ACCOUNT_SUSPENDED"
 )
 
 var MailErrorCodeGoogleUnknown = func(code int) MailErrorCode {
@@ -155,6 +157,18 @@ var (
 		"The recipient email address was rejected by the mail server.",
 		MailErrorResolveMethodNone,
 	)
+	ErrMailRecipientTemporaryRejected = MError(
+		MailErrorWarning,
+		MailErrorCodeRecipientTemporaryRejected,
+		"The recipient mail server temporarily rejected the address.",
+		MailErrorResolveMethodRetry,
+	)
+	ErrMailDeliveryUnknown = MError(
+		MailErrorWarning,
+		MailErrorCodeDeliveryUnknown,
+		"The SMTP connection ended while the provider was finalizing delivery; acceptance is unknown.",
+		MailErrorResolveMethodNone,
+	)
 	ErrMailQuotaExceeded = MError(
 		MailErrorCritical,
 		MailErrorCodeQuotaExceeded,
@@ -205,9 +219,12 @@ func (e *MailError) GetUserErrorInfo() UserErrorInfo {
 	case MailErrorCodeAccountSuspended:
 		info.Title = "Account Suspended"
 		info.ActionRequired = "Contact your email provider to resolve this issue"
-	case MailErrorCodeRecipientRejected:
+	case MailErrorCodeRecipientRejected, MailErrorCodeRecipientTemporaryRejected:
 		info.Title = "Recipient Rejected"
 		info.ActionRequired = "The recipient address was not accepted"
+	case MailErrorCodeDeliveryUnknown:
+		info.Title = "Delivery Unknown"
+		info.ActionRequired = "Review provider evidence before retrying"
 	}
 
 	return info

--- a/internal/models/advanced_outreach.go
+++ b/internal/models/advanced_outreach.go
@@ -92,6 +92,8 @@ type DeliverabilityEventType string
 
 const (
 	DeliverabilityEventBounce      DeliverabilityEventType = "bounce"
+	DeliverabilityEventSoftBounce  DeliverabilityEventType = "soft_bounce"
+	DeliverabilityEventDelivered   DeliverabilityEventType = "delivered"
 	DeliverabilityEventComplaint   DeliverabilityEventType = "complaint"
 	DeliverabilityEventUnsubscribe DeliverabilityEventType = "unsubscribe"
 	DeliverabilityEventOpen        DeliverabilityEventType = "open"

--- a/internal/models/event.go
+++ b/internal/models/event.go
@@ -20,6 +20,7 @@ type JobEventType string
 const (
 	JobEventTypeNewEmail         JobEventType = "NEW_EMAIL"
 	JobEventTypeInboundBounce    JobEventType = "INBOUND_BOUNCE"
+	JobEventTypeInboundDelivery  JobEventType = "INBOUND_DELIVERY"
 	JobEventTypeInboundComplaint JobEventType = "INBOUND_COMPLAINT"
 	JobEventTypeRemoveEmail      JobEventType = "REMOVE_EMAIL"
 	JobEventTypeFlagsAdd         JobEventType = "FLAGS_ADD"

--- a/internal/models/event_w_delivery.go
+++ b/internal/models/event_w_delivery.go
@@ -1,0 +1,14 @@
+package models
+
+import "github.com/google/uuid"
+
+// JobEventInboundDelivery is emitted only for an explicit positive DSN.
+type JobEventInboundDelivery struct {
+	UserID            uuid.UUID `json:"user_id"`
+	EmailID           uuid.UUID `json:"email_id"`
+	OriginalMessageID string    `json:"original_message_id"`
+	Recipient         string    `json:"recipient,omitempty"`
+	EnhancedStatus    string    `json:"enhanced_status,omitempty"`
+	SMTPStatus        string    `json:"smtp_status,omitempty"`
+	Diagnostic        string    `json:"diagnostic,omitempty"`
+}

--- a/internal/pkg/dsn/dsn.go
+++ b/internal/pkg/dsn/dsn.go
@@ -15,6 +15,9 @@ type Report struct {
 	// IsBounce is true when the message looks like a delivery-status report at
 	// all (worth acting on); false for ordinary mail.
 	IsBounce bool
+	// IsDelivery is true only for an explicit delivered action with 2.x proof.
+	IsDelivery bool
+	Action     string
 	// Permanent is true only when a 5.x.x status or an explicit permanent
 	// "Action: failed" was found. Transient (4.x.x / delayed) stays false.
 	Permanent bool
@@ -100,6 +103,7 @@ func Parse(body string) Report {
 		}
 	}
 	if a := reAction.FindStringSubmatch(body); a != nil {
+		r.Action = strings.ToLower(strings.TrimSpace(a[1]))
 		if strings.EqualFold(a[1], "failed") && r.hasNo4xx(body) {
 			// "failed" is permanent per RFC 3464, but a co-present 4.x.x status
 			// (retry-then-fail) means transient — defer to the status code.
@@ -109,6 +113,8 @@ func Parse(body string) Report {
 		} else if strings.EqualFold(a[1], "delayed") && r.BounceClass == "" {
 			r.BounceClass = "SOFT"
 			r.IsBounce = true
+		} else if strings.EqualFold(a[1], "delivered") && strings.HasPrefix(r.EnhancedStatus, "2") {
+			r.IsDelivery = true
 		}
 	}
 
@@ -120,7 +126,7 @@ func Parse(body string) Report {
 	if ids := reMessageID.FindAllStringSubmatch(body, -1); len(ids) > 0 {
 		r.OriginalMessageID = strings.TrimSpace(ids[len(ids)-1][1])
 	}
-	if r.BounceClass == "" {
+	if r.BounceClass == "" && !r.IsDelivery {
 		r.BounceClass = "UNKNOWN"
 	}
 

--- a/internal/pkg/dsn/dsn_test.go
+++ b/internal/pkg/dsn/dsn_test.go
@@ -67,7 +67,7 @@ func TestParseOrdinaryBody(t *testing.T) {
 
 func TestSuccessfulDSNIsNotMisreportedAsBounce(t *testing.T) {
 	r := Parse("Action: delivered\nStatus: 2.0.0\nDiagnostic-Code: smtp; 250 queued")
-	if r.IsBounce || r.Permanent || r.BounceClass != "UNKNOWN" {
+	if r.IsBounce || r.Permanent || !r.IsDelivery || r.BounceClass != "UNKNOWN" {
 		t.Fatalf("successful DSN must not become a bounce: %+v", r)
 	}
 }

--- a/internal/repository/pg_outreach_touchpoints.go
+++ b/internal/repository/pg_outreach_touchpoints.go
@@ -380,6 +380,139 @@ func (r *outreachRepository) CancelOpenTouchpoints(ctx context.Context, orgID, a
 	return int(ct.RowsAffected()), nil
 }
 
+// GetOutreachRecipientSuppression reads the platform's canonical suppression row.
+func (r *outreachRepository) GetOutreachRecipientSuppression(ctx context.Context, orgID uuid.UUID, email string) (*models.SuppressedRecipient, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return nil, nil
+	}
+	var out models.SuppressedRecipient
+	var metadata []byte
+	err := r.db.QueryRow(ctx, `
+		SELECT id, organization_id, email, reason, source, campaign_id,
+			expires_at, metadata, created_at, updated_at
+		FROM suppressed_recipients
+		WHERE organization_id=$1 AND lower(email)=$2
+		  AND (expires_at IS NULL OR expires_at > now())`, orgID, email).Scan(
+		&out.ID, &out.OrganizationID, &out.Email, &out.Reason, &out.Source,
+		&out.CampaignID, &out.ExpiresAt, &metadata, &out.CreatedAt, &out.UpdatedAt,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	_ = json.Unmarshal(metadata, &out.Metadata)
+	return &out, nil
+}
+
+// UpsertOutreachRecipientSuppression writes the canonical recipient row idempotently.
+func (r *outreachRepository) UpsertOutreachRecipientSuppression(ctx context.Context, suppression *models.SuppressedRecipient) error {
+	if suppression == nil {
+		return errors.New("recipient suppression is required")
+	}
+	email := strings.ToLower(strings.TrimSpace(suppression.Email))
+	if suppression.OrganizationID == uuid.Nil || email == "" {
+		return errors.New("organization and recipient are required")
+	}
+	metadata, err := json.Marshal(suppression.Metadata)
+	if err != nil {
+		return err
+	}
+	_, err = r.db.Exec(ctx, `
+		INSERT INTO suppressed_recipients (
+			organization_id, email, reason, source, campaign_id, expires_at,
+			metadata, created_at, updated_at
+		) VALUES ($1,$2,$3,$4,$5,$6,$7,now(),now())
+		ON CONFLICT (organization_id,email) DO UPDATE SET
+			reason=excluded.reason, source=excluded.source,
+			campaign_id=COALESCE(excluded.campaign_id,suppressed_recipients.campaign_id),
+			expires_at=excluded.expires_at, metadata=excluded.metadata, updated_at=now()`,
+		suppression.OrganizationID, email, suppression.Reason, suppression.Source,
+		suppression.CampaignID, suppression.ExpiresAt, metadata)
+	return err
+}
+
+// CancelSuppressedOutreachRecipient projects suppression into exact-recipient work.
+func (r *outreachRepository) CancelSuppressedOutreachRecipient(ctx context.Context, orgID uuid.UUID, email, terminalState, reason string) (int, error) {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" {
+		return 0, nil
+	}
+	if terminalState == "" {
+		terminalState = models.TouchpointCancelled
+	}
+	if reason == "" {
+		reason = "recipient_suppressed"
+	}
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	verification := ""
+	setBounced, setDNC, setBlocked := false, false, false
+	switch terminalState {
+	case models.TouchpointBounced:
+		verification, setBounced = models.OutreachVerifyBounced, true
+	case models.TouchpointDNC:
+		verification, setDNC = models.OutreachVerifyDoNotContact, true
+	default:
+		setBlocked = true
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE outreach_contact_candidates
+		SET bounced=bounced OR $3, do_not_contact=do_not_contact OR $4,
+			blocked=blocked OR $5, block_reason=CASE WHEN $3 OR $4 OR $5 THEN $6 ELSE block_reason END,
+			verification_status=CASE WHEN $7<>'' THEN $7 ELSE verification_status END,
+			updated_at=now()
+		WHERE organization_id=$1 AND lower(email)=$2`, orgID, email,
+		setBounced, setDNC, setBlocked, reason, verification); err != nil {
+		return 0, err
+	}
+
+	if _, err := tx.Exec(ctx, `
+		UPDATE confenge_dispatch_queue q
+		SET status='cancelled', cancel_reason=$3, last_error=$3,
+			reserved_until=NULL, updated_at=now()
+		FROM outreach_touchpoints t
+		WHERE t.organization_id=$1 AND lower(t.recipient)=$2
+		  AND t.draft_id=q.draft_id AND q.organization_id=t.organization_id
+		  AND q.status IN ('queued','reserved')`, orgID, email, reason); err != nil {
+		return 0, err
+	}
+	if _, err := tx.Exec(ctx, `
+		UPDATE confenge_delegated_first_touch_decisions d
+		SET state='CANCELLED',
+			blocker_codes=CASE WHEN d.blocker_codes @> to_jsonb(ARRAY[$3]::text[])
+				THEN d.blocker_codes ELSE d.blocker_codes || to_jsonb(ARRAY[$3]::text[]) END,
+			updated_at=now()
+		FROM outreach_touchpoints t
+		WHERE t.organization_id=$1 AND lower(t.recipient)=$2
+		  AND d.organization_id=t.organization_id AND d.touchpoint_id=t.id
+		  AND d.state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')`, orgID, email, reason); err != nil {
+		return 0, err
+	}
+	ct, err := tx.Exec(ctx, `
+		UPDATE outreach_touchpoints
+		SET state=$3, stop_reason=$4, approved_by=NULL, approved_at=NULL,
+			approved_content_hash='', authorization_mode='',
+			campaign_policy_authorization_id=NULL, authorization_policy_hash='',
+			authorization_at=NULL, updated_at=now()
+		WHERE organization_id=$1 AND lower(recipient)=$2
+		  AND state IN ('PLANNED','DUE','DRAFTED','AI_REWRITE_PENDING',
+			'ENRICHMENT_PENDING','REJECTED_REWRITE_PENDING','NEEDS_REVIEW',
+			'APPROVED','QUEUED')`, orgID, email, terminalState, reason)
+	if err != nil {
+		return 0, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return int(ct.RowsAffected()), nil
+}
+
 func (r *outreachRepository) ListDuePlannedTouchpoints(ctx context.Context, orgID uuid.UUID, now time.Time, limit int) ([]models.OutreachTouchpoint, error) {
 	if now.IsZero() {
 		now = time.Now().UTC()


### PR DESCRIPTION
## Summary

- records `attempted` at the worker boundary, provider `accepted`, explicit `delivered`, `delivery_unknown`, hard and soft bounce, complaint, reply classes, and opt-out in the existing CONFENGE commercial chain
- projects hard bounce, complaint, and opt-out into the canonical `suppressed_recipients` row and cancels only the exact recipient's pending work
- makes `AssertTransportable` re-read canonical suppression immediately before transport, including for work queued before the suppression arrived
- keeps soft bounce and no-reply non-terminal, preserves UNKNOWN, and sends out-of-order or impossible facts to the existing exception queue
- stops incompatible future work after a human reply, marks the correlated touchpoint, retains human triage, and disables CONFENGE instant reply action chains
- accepts explicit provider/webhook `delivered` and `soft_bounce` events and replays their ledger projection with the provider idempotency key
- slices non-PII metrics by route class, source, source run, cohort, provider, and sender mailbox

## Authority and safety

This change adds no ledger or bounce database. It uses `outreach_intel_chains`, `outreach_intel_event_receipts`, `outreach_intel_exceptions`, the existing outreach outcome outbox, and canonical `suppressed_recipients` rows. A hard bounce never invalidates another mailbox or the company identity.

## Verification

- `make fmt`
- `make lint`
- focused CONFENGE suppression, reply, provider replay, ordering, and restart tests
- `go test ./internal/app/advanced ./internal/app/confenge/intel ./internal/app/consumer ./internal/app/worker ./internal/app/worker/wmail ./internal/client/smtpimap/smtp ./internal/pkg/dsn ./cmd/consumer`
- `pnpm types:check` in `docs/`
- `pnpm lint` in `docs/` (two pre-existing warnings, zero errors)
- PostgreSQL due-time suppression test compiles and skips locally when `WARMBLY_TEST_POSTGRES_DSN` is unset

Refs #47 and #43.
