### PR TITLE
feat: enforce mailbox-bound CONFENGE capacity envelopes with factual transport forecasts and alerts

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1410,7 +1410,7 @@ func main() {
 			integrationServiceForHandler, // AutomationRunner for campaign run_automation steps
 		)
 		if tasksService != nil && confengeServiceForHandler != nil {
-			// CONFENGE global governor on final campaign email send path.
+			// CONFENGE mailbox governor on the final campaign email send path.
 			if gate, ok := confengeServiceForHandler.(tasks.ConfengeOutboundGate); ok {
 				tasksService.WireConfengeDispatch(gate)
 			}

--- a/docs/confenge/mailbox-capacity-readiness-2026-08-26.md
+++ b/docs/confenge/mailbox-capacity-readiness-2026-08-26.md
@@ -1,0 +1,80 @@
+# Mailbox capacity readiness (sanitized)
+
+Captured read-only from the CONFENGE runtime on 2026-08-26 at 13:35 UTC. No resume, dispatch, SMTP, credential read, database write, or mailbox creation was performed.
+
+## Runtime identity and transport state
+
+| Item | Readback |
+| --- | --- |
+| Deployed SHA | `36253ca2f1e57947dc8801be31b12f9ddd0e7b24` |
+| Schema version | `129` |
+| Worktree | Clean |
+| Backend / worker / consumer | PASS / PASS / PASS |
+| Postgres / Redis / NATS | PASS / PASS / PASS |
+| Hostinger SMTP / IMAP reachability | PASS / PASS |
+| Provider plan class | `BUSINESS_EMAIL_STARTER` |
+| Dispatch control row | `paused=false` |
+| Process pause env | `false` |
+| Host kill-switch file | absent |
+| Persistent volume kill switch | **engaged** |
+| Effective transport state | **PAUSED** |
+
+The volume kill switch is the dominant source. The database row alone must not be interpreted as permission to send.
+
+## Configured mailbox inventory
+
+Exactly one email account has a real SMTP/IMAP or OAuth credential record. No seed, fixture, inferred, or uncredentialed account is included.
+
+| Field | Mailbox 1 |
+| --- | --- |
+| Enabled / status | yes / `active` |
+| Provider | `smtp_imap`, operational provider Hostinger |
+| Credentials | stored |
+| Worker | assigned |
+| Created | 2026-08-09 |
+| DNS auth | `passing`; SPF, DKIM, and DMARC present |
+| Auth checked | 2026-08-25 15:30 UTC |
+| Configured daily cap | 50 attempts/day |
+| Minimum wait | 600 seconds |
+| Derived mailbox cap | 6 attempts/hour |
+| Business window | Mon–Fri, 09:00–18:00, `America/Sao_Paulo` |
+| Warmup evidence | start unknown, `warmup_days=0` |
+| Provider advertised ceiling | 1000 outgoing messages/rolling 24h/mailbox, from the operator-confirmed hPanel evidence recorded in #43 |
+| Scheduler envelope | 50/day and 6/hour, which is stricter than the advertised provider ceiling |
+
+The provider ceiling is external operational evidence and is not rewritten as a database fact by this change. Until a typed per-mailbox provider source exists, the API reports the provider cap as unknown and enforces the stricter configured envelope.
+
+## Observed throughput and deliverability
+
+| Signal | Readback |
+| --- | --- |
+| CONFENGE campaign tasks created / completed | none |
+| Latest provider attempt | unknown |
+| Latest provider acceptance | unknown |
+| Latest bounce | unknown |
+| Latest complaint | unknown |
+| Latest reply | unknown |
+| Unresolved mailbox provider errors | 0 |
+| Email touchpoints queued | 1 |
+| Dispatch queue email rows queued | 1, representing the same approved draft |
+
+`unknown` means the current schema has no mailbox-bound factual observation. It does not mean zero. Migration `000130` adds the binding needed for later attempts, acceptances, and provider failures to be attributed to the real mailbox.
+
+## Derived forecast at capture time
+
+The forecast basis is one ready mailbox, 50/day, 600-second minimum wait, 6/hour, business days only, 09:00–18:00 São Paulo, no recorded attempt, and one deduplicated queued message.
+
+| Forecast | Value |
+| --- | --- |
+| Effective slots next 24h | 0, because transport is paused |
+| Effective slots next 7d | 0, because transport is paused |
+| Potential slots next 24h | 55 |
+| Potential slots next 7d | 255 |
+| Estimated days to drain queued | unknown while paused |
+| Delivery promised | no |
+
+The potential figures are time-sensitive and were derived at 10:35 in `America/Sao_Paulo`. They can cross two mailbox calendar days inside a 24-hour horizon. They are not a delivery estimate. If the kill switch remains engaged, the queue may grow indefinitely while the send rate remains zero.
+
+## Readiness conclusion
+
+The existing transport inventory is one real mailbox. The code must accept that constraint and let backlog wait. No additional mailbox, sender identity, warmup history, provider success, or deliverability signal was inferred. After this change is deployed, `GET /confenge/dispatch/status` will calculate the same classes of evidence continuously and expose the exact pause source, mailbox health, next slot, alerts, and forecast.

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -96,6 +96,9 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | POST | `/confenge/review/drafts/:id/decision` | `WRITE_CONTACTS` |
 | POST | `/confenge/touchpoints/:id/approve` | `WRITE_CONTACTS` |
 | POST | `/confenge/touchpoints/:id/queue` | `WRITE_CONTACTS` |
+| GET | `/confenge/dispatch/status` | `READ_CONTACTS` |
+| POST | `/confenge/dispatch/pause` | `WRITE_CONTACTS` |
+| POST | `/confenge/dispatch/resume` | `WRITE_CONTACTS` |
 | GET | `/confenge/cockpit` | `READ_CONTACTS` |
 | GET | `/confenge/inbound` | `READ_CONTACTS` |
 | POST | `/confenge/inbound/:leadId/outcome` | `WRITE_CONTACTS` |
@@ -120,6 +123,8 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | POST | `/confenge/manual-queue/:id/action` | `WRITE_CONTACTS` |
 
 `GET /contacts/custom-fields` lists the distinct custom-field keys used across your contacts (frequency-ranked), for building personalization pickers. It returns a flat string array under `data`, capped at 200 keys.
+
+`GET /confenge/dispatch/status` reports configured mailbox envelopes and observed transport facts separately. Only email accounts with a stored SMTP/IMAP or OAuth credential record appear. Each mailbox includes enabled state, provider type, worker assignment, SPF/DKIM/DMARC state, mailbox and warmup age when known, configured daily cap, minimum wait, derived hourly cap, business window, latest attempt/acceptance/bounce/complaint/reply/provider rejection, health reason, pause source, and next eligible slot. Provider ceilings remain `null` and are listed under `unknown` until an explicit source is stored. The aggregate forecast reports effective and potential slots for 24 hours and 7 days, plus estimated queue drain time when transport has effective capacity. While paused, effective next-slot fields are absent because resume time is unknown. A slot is capacity for an attempt, not a delivery promise. `POST /confenge/dispatch/pause` and `POST /confenge/dispatch/resume` are naturally idempotent state assignments and keep the file and durable kill controls authoritative.
 
 `GET /confenge/inbound` is the INBOUND NOW queue. Default `include_synthetic=0`. `POST /confenge/inbound/:leadId/acknowledge` records a human acknowledgement (actor required, idempotent). `POST /confenge/inbound/:leadId/resolve` records a no-action resolution with a reason code. Neither contacts the lead nor sets WON, LOST, pipeline, or revenue. `POST /confenge/inbound/:leadId/outcome` remains the first-action registrar.
 

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -199,9 +199,15 @@ Execution state (`PLANNED`, `READY`, `IN_PROGRESS`, `COMPLETED`, `NEEDS_FOLLOWUP
 
 The extra-cli plug contract (additive fields the future producer can fill) is documented in `docs/confenge/commercial-actions.md`.
 
-## Global dispatch governor
+## Mailbox capacity and dispatch governor
 
-CONFENGE outbound email and WhatsApp share one local rolling-hour cap (default 10 sends/hour, min gap 360s, timezone America/Sao_Paulo). The governor is the final gate before provider send: approved items that exceed capacity re-compete for future slots and never burst after restart.
+CONFENGE email pacing is mailbox-first. The campaign scheduler selects an existing email account, and the final transport reservation is bound to that exact account and task. The mailbox's configured `campaign_limit`, `min_wait_time`, readiness, and factual provider state are checked inside the same transaction that reserves the slot. The shared governor remains an additional ceiling across email and WhatsApp. It cannot increase a mailbox envelope.
+
+Only accounts with stored SMTP/IMAP or OAuth credentials are inventoried. A mailbox is blocked when it is disabled, has no assigned worker, lacks credentials, has unknown or failing SPF/DKIM/DMARC state, is quarantined by an existing health authority, or has an unresolved factual authentication, provider-block, rate-limit, or connectivity failure. Provider 4xx/5xx responses, hard bounces, complaints, replies, attempts, and acceptances remain separate observations. A bounce or complaint rate does not create a new threshold here. Existing explicit campaign/provider policies remain authoritative.
+
+For each mailbox, the hourly cap is derived from the minimum wait and tightened by any explicit cap. The daily cap is the configured mailbox campaign limit. Attempts that reached the provider consume that daily envelope even when the provider later rejects them. A growing queue cannot raise either cap, and retries retain the same account/recipient/sequence idempotency key across mailboxes.
+
+The status forecast simulates the configured business window, business days, mailbox daily and rolling-hour limits, minimum wait, occupied reservations, observed attempts, provider acceptances, and the shared ceiling. It returns slots for the next 24 hours and 7 days and an estimated queue drain time only while effective capacity exists. During a pause, effective slots are zero and potential slots remain visible. These are possible attempt slots, not promised deliveries.
 
 | Env | Default |
 | --- | --- |

--- a/internal/app/confenge/dispatch/adaptive.go
+++ b/internal/app/confenge/dispatch/adaptive.go
@@ -7,7 +7,7 @@ import "time"
 type AdaptiveHealth struct {
 	// Commits in the evaluation batch (successful sends).
 	Commits int
-	// HardBounceRate in [0,1] over the same window.
+	// HardBounceRate is factual telemetry only. Policy must set an explicit signal.
 	HardBounceRate float64
 	// AuthFailure / reputation / throttle signals.
 	AuthFailure            bool
@@ -62,10 +62,6 @@ func EvaluateAdaptiveRate(current, start, maxRate, batchSize int, h AdaptiveHeal
 	if h.SystemicRecipientIssue {
 		down := stepDown(current, start)
 		return AdaptiveDecision{NextSendsPerHour: down, NextMinGap: MinGapForRate(down), Action: "step_down", Reason: "systemic_recipient_issue"}
-	}
-	if h.HardBounceRate > 0.02 {
-		down := stepDown(current, start)
-		return AdaptiveDecision{NextSendsPerHour: down, NextMinGap: MinGapForRate(down), Action: "step_down", Reason: "hard_bounce_gt_2pct"}
 	}
 	// Need a full healthy batch before climbing.
 	if h.Commits < batchSize {

--- a/internal/app/confenge/dispatch/adaptive_test.go
+++ b/internal/app/confenge/dispatch/adaptive_test.go
@@ -21,10 +21,14 @@ func TestAdaptiveStepUp10to15to20(t *testing.T) {
 	}
 }
 
-func TestAdaptiveRetreatOnBounceAndAuth(t *testing.T) {
+func TestAdaptiveRetreatRequiresExplicitBouncePolicySignal(t *testing.T) {
 	d := EvaluateAdaptiveRate(20, 10, 20, 20, AdaptiveHealth{Commits: 20, HardBounceRate: 0.03})
+	if d.Action != "hold" || d.NextSendsPerHour != 20 {
+		t.Fatalf("observed bounce rate without policy signal got action=%s rate=%d", d.Action, d.NextSendsPerHour)
+	}
+	d = EvaluateAdaptiveRate(20, 10, 20, 20, AdaptiveHealth{Commits: 20, SystemicRecipientIssue: true})
 	if d.Action != "step_down" || d.NextSendsPerHour != 15 {
-		t.Fatalf("bounce retreat got action=%s rate=%d", d.Action, d.NextSendsPerHour)
+		t.Fatalf("explicit bounce policy signal got action=%s rate=%d", d.Action, d.NextSendsPerHour)
 	}
 	d = EvaluateAdaptiveRate(15, 10, 20, 20, AdaptiveHealth{Commits: 20, AuthFailure: true})
 	if d.Action != "step_down" || d.NextSendsPerHour != 10 {

--- a/internal/app/confenge/dispatch/capacity.go
+++ b/internal/app/confenge/dispatch/capacity.go
@@ -1,0 +1,245 @@
+package dispatch
+
+import (
+	"math"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+var smtpStatusPattern = regexp.MustCompile(`\b([45])(?:[0-9]{2}|\.[0-9](?:\.[0-9])?)\b`)
+
+const (
+	AlertAuthFailure         = "auth_failure"
+	AlertProviderInterrupted = "provider_interrupted"
+	AlertRepeated4xx         = "repeated_provider_4xx"
+	AlertRepeated5xx         = "repeated_provider_5xx"
+	AlertRateLimit           = "rate_limit_rejection"
+	AlertComplaint           = "complaint"
+	AlertMailboxDisabled     = "mailbox_disabled"
+	AlertQueueRunoff         = "queue_runoff_without_capacity"
+)
+
+func DerivedHourlyCap(minGap time.Duration) int {
+	if minGap <= 0 {
+		return 1
+	}
+	capN := int(time.Hour / minGap)
+	if capN < 1 {
+		return 1
+	}
+	return capN
+}
+
+func effectiveMailboxCap(configured int, provider *int) int {
+	capN := configured
+	if provider != nil && *provider > 0 && (capN < 1 || *provider < capN) {
+		capN = *provider
+	}
+	if capN < 0 {
+		return 0
+	}
+	return capN
+}
+
+func minPositive(values ...int) int {
+	out := 0
+	for _, value := range values {
+		if value > 0 && (out == 0 || value < out) {
+			out = value
+		}
+	}
+	return out
+}
+
+// ClassifyProviderError classifies facts without inferring thresholds or volume changes.
+func ClassifyProviderError(code, text string) string {
+	code = strings.ToUpper(strings.TrimSpace(code))
+	upper := strings.ToUpper(text)
+	switch code {
+	case "GOOGLE_AUTHENTICATION_FAILED", "INVALID_CREDENTIALS", "AUTHENTICATION_FAILED":
+		return "auth_failure"
+	case "AUTHORIZATION_FAILED", "ACCOUNT_SUSPENDED", "GOOGLE_FORBIDDEN", "GOOGLE_PAYMENT_REQUIRED":
+		return "provider_block"
+	case "RATE_LIMIT_EXCEEDED", "SENDING_TOO_FAST", "QUOTA_EXCEEDED":
+		return "rate_limit"
+	case "SERVER_UNREACHABLE", "CONNECTION_LOST", "IMAP_UNKNOWN":
+		return "provider_interrupted"
+	case "RECIPIENT_REJECTED":
+		return "recipient_rejection"
+	}
+	if match := smtpStatusPattern.FindStringSubmatch(upper); len(match) == 2 {
+		if match[1] == "4" {
+			return "provider_4xx"
+		}
+		return "provider_5xx"
+	}
+	return "unknown"
+}
+
+type forecastMailbox struct {
+	mailbox MailboxCapacity
+	cursor  time.Time
+	times   []time.Time
+	used    map[string]int
+}
+
+func buildCapacityForecast(now time.Time, cfg Config, mailboxes []MailboxCapacity, globalOccupied []time.Time, queued int, paused bool) (CapacityForecast, *time.Time) {
+	now = now.UTC()
+	end24 := now.Add(24 * time.Hour)
+	end7 := now.Add(7 * 24 * time.Hour)
+	potential, first := simulateCapacity(now, end7, cfg, mailboxes, globalOccupied)
+	forecast := CapacityForecast{DeliveryPromised: false}
+	for _, slot := range potential {
+		if slot.Before(end24) {
+			forecast.PotentialSlotsNext24h++
+		}
+		forecast.PotentialSlotsNext7d++
+	}
+	if paused {
+		return forecast, nil
+	}
+	forecast.SlotsNext24h = forecast.PotentialSlotsNext24h
+	forecast.SlotsNext7d = forecast.PotentialSlotsNext7d
+	if queued > 0 && forecast.SlotsNext7d > 0 {
+		days := int(math.Ceil(float64(queued*7) / float64(forecast.SlotsNext7d)))
+		if days < 1 {
+			days = 1
+		}
+		forecast.EstimatedDaysToDrain = &days
+	}
+	return forecast, first
+}
+
+func simulateCapacity(now, end time.Time, cfg Config, mailboxes []MailboxCapacity, globalOccupied []time.Time) ([]time.Time, *time.Time) {
+	states := make([]forecastMailbox, 0, len(mailboxes))
+	for i := range mailboxes {
+		mailbox := mailboxes[i]
+		if mailbox.Health == "blocked" || mailbox.EffectiveDailyCap < 1 || mailbox.EffectiveHourlyCap < 1 {
+			continue
+		}
+		cursor := now
+		if mailbox.NextEligibleSlot != nil && mailbox.NextEligibleSlot.After(cursor) {
+			cursor = mailbox.NextEligibleSlot.UTC()
+		}
+		states = append(states, forecastMailbox{
+			mailbox: mailbox,
+			cursor:  cursor,
+			times:   append([]time.Time(nil), mailbox.occupiedAt...),
+			used:    map[string]int{localDateKey(now, cfg.Timezone): mailbox.UsedToday},
+		})
+	}
+	if len(states) == 0 {
+		return nil, nil
+	}
+	globalTimes := append([]time.Time(nil), globalOccupied...)
+	var slots []time.Time
+	for len(slots) < 100000 {
+		selected := -1
+		var candidate time.Time
+		for i := range states {
+			next, ok := nextMailboxCandidate(&states[i], cfg, end)
+			if ok && (selected < 0 || next.Before(candidate)) {
+				selected, candidate = i, next
+			}
+		}
+		if selected < 0 || !candidate.Before(end) {
+			break
+		}
+		globalNext := nextRollingSlot(candidate, globalTimes, cfg.SendsPerHour, cfg.MinGap, RollingWindow)
+		globalNext = NextEligibleSlot(globalNext, cfg.Timezone, cfg.WindowStart, cfg.WindowEnd, cfg.BusinessDaysOnly)
+		if globalNext.After(candidate) {
+			states[selected].cursor = globalNext
+			continue
+		}
+		slots = append(slots, candidate)
+		globalTimes = append(globalTimes, candidate)
+		state := &states[selected]
+		state.times = append(state.times, candidate)
+		state.used[localDateKey(candidate, cfg.Timezone)]++
+		state.cursor = candidate.Add(time.Duration(state.mailbox.ConfiguredMinWaitSec) * time.Second)
+	}
+	if len(slots) == 0 {
+		return slots, nil
+	}
+	first := slots[0]
+	return slots, &first
+}
+
+func nextMailboxCandidate(state *forecastMailbox, cfg Config, end time.Time) (time.Time, bool) {
+	for i := 0; i < 10000; i++ {
+		candidate := NextEligibleSlot(state.cursor, cfg.Timezone, cfg.WindowStart, cfg.WindowEnd, cfg.BusinessDaysOnly)
+		if !candidate.Before(end) {
+			return time.Time{}, false
+		}
+		dayKey := localDateKey(candidate, cfg.Timezone)
+		if state.used[dayKey] >= state.mailbox.EffectiveDailyCap {
+			state.cursor = nextLocalDay(candidate, cfg.Timezone)
+			continue
+		}
+		next := nextRollingSlot(candidate, state.times, state.mailbox.EffectiveHourlyCap,
+			time.Duration(state.mailbox.ConfiguredMinWaitSec)*time.Second, RollingWindow)
+		next = NextEligibleSlot(next, cfg.Timezone, cfg.WindowStart, cfg.WindowEnd, cfg.BusinessDaysOnly)
+		if next.After(candidate) {
+			state.cursor = next
+			continue
+		}
+		return candidate, true
+	}
+	return time.Time{}, false
+}
+
+func nextRollingSlot(candidate time.Time, occupied []time.Time, capN int, minGap, window time.Duration) time.Time {
+	if window <= 0 {
+		window = RollingWindow
+	}
+	sorted := append([]time.Time(nil), occupied...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i].Before(sorted[j]) })
+	for i := 0; i < len(sorted)+2; i++ {
+		var active []time.Time
+		cutoff := candidate.Add(-window)
+		var last time.Time
+		for _, value := range sorted {
+			if !value.Before(cutoff) && !value.After(candidate) {
+				active = append(active, value)
+				last = value
+			}
+		}
+		next := candidate
+		if capN > 0 && len(active) >= capN {
+			capNext := active[0].Add(window).Add(time.Microsecond)
+			if capNext.After(next) {
+				next = capNext
+			}
+		}
+		if minGap > 0 && !last.IsZero() {
+			gapNext := last.Add(minGap)
+			if gapNext.After(next) {
+				next = gapNext
+			}
+		}
+		if !next.After(candidate) {
+			return candidate
+		}
+		candidate = next
+	}
+	return candidate
+}
+
+func localDateKey(value time.Time, timezone string) string {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	return value.In(loc).Format("2006-01-02")
+}
+
+func nextLocalDay(value time.Time, timezone string) time.Time {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	local := value.In(loc)
+	return time.Date(local.Year(), local.Month(), local.Day()+1, 0, 0, 0, 0, loc).UTC()
+}

--- a/internal/app/confenge/dispatch/capacity_pg.go
+++ b/internal/app/confenge/dispatch/capacity_pg.go
@@ -1,0 +1,675 @@
+package dispatch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+)
+
+type pgRowQuerier interface {
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+var errMailboxNotConfigured = errors.New("configured mailbox not found")
+
+type mailboxAuthority struct {
+	id                 uuid.UUID
+	organizationID     uuid.UUID
+	email              string
+	status             string
+	provider           string
+	dailyCap           int
+	minWaitSeconds     int
+	timezone           string
+	credentialsReady   bool
+	workerAssigned     bool
+	authState          string
+	authSPF            bool
+	authDKIM           bool
+	authDMARC          bool
+	authDMARCPolicy    string
+	authCheckedAt      *time.Time
+	createdAt          time.Time
+	warmupStartedAt    *time.Time
+	warmupDays         int
+	coldRampStartedAt  *time.Time
+	riskBand           string
+	warmupHealth       string
+	warmupHealthReason string
+	blockedUntil       *time.Time
+	latestErrorCode    string
+}
+
+func (s *PGStore) GetMailboxEnvelope(ctx context.Context, orgID, emailAccountID uuid.UUID, now time.Time) (MailboxEnvelope, error) {
+	authority, err := queryMailboxAuthority(ctx, s.db, orgID, emailAccountID, false)
+	if err != nil {
+		return MailboxEnvelope{}, err
+	}
+	return authority.envelope(now), nil
+}
+
+func queryMailboxAuthority(ctx context.Context, q pgRowQuerier, orgID, emailAccountID uuid.UUID, lock bool) (mailboxAuthority, error) {
+	query := `
+		SELECT ea.id, ea.organization_id, ea.email, ea.status::text, ea.provider::text,
+		       ea.campaign_limit, ea.min_wait_time, ea.timezone,
+		       CASE WHEN ea.provider = 'smtp_imap' THEN EXISTS (
+		           SELECT 1 FROM email_accounts_smtp_imap smtp WHERE smtp.email_account_id = ea.id
+		       ) ELSE EXISTS (
+		           SELECT 1 FROM email_accounts_oauth oauth WHERE oauth.email_account_id = ea.id
+		       ) END AS credentials_ready,
+		       ea.worker_id IS NOT NULL,
+		       ea.auth_state, ea.auth_spf, ea.auth_dkim, ea.auth_dmarc,
+		       ea.auth_dmarc_policy, ea.auth_checked_at, ea.created_at,
+		       ea.warmup, ea.warmup_days, ea.cold_ramp_started_at, ea.risk_band::text,
+		       COALESCE(health.health_state, 'healthy'),
+		       COALESCE(health.last_health_reason, ''), health.blocked_until,
+		       COALESCE(last_error.error_code, '')
+		FROM email_accounts ea
+		LEFT JOIN LATERAL (
+		    SELECT wpp.health_state, wpp.last_health_reason, wpp.blocked_until
+		    FROM warmup_pool_participants wpp
+		    WHERE wpp.email_account_id = ea.id
+		    ORDER BY CASE wpp.health_state
+		        WHEN 'blocked' THEN 5 WHEN 'quarantined' THEN 4
+		        WHEN 'throttled' THEN 3 WHEN 'watch' THEN 2 ELSE 1 END DESC
+		    LIMIT 1
+		) health ON true
+		LEFT JOIN LATERAL (
+		    SELECT eae.error_code
+		    FROM email_account_errors eae
+		    WHERE eae.email_account_id = ea.id AND eae.resolved_at IS NULL
+		    ORDER BY eae.created_at DESC
+		    LIMIT 1
+		) last_error ON true
+		WHERE ea.organization_id = $1 AND ea.id = $2`
+	if lock {
+		query += " FOR SHARE OF ea"
+	}
+	var out mailboxAuthority
+	err := q.QueryRow(ctx, query, orgID, emailAccountID).Scan(
+		&out.id, &out.organizationID, &out.email, &out.status, &out.provider,
+		&out.dailyCap, &out.minWaitSeconds, &out.timezone,
+		&out.credentialsReady, &out.workerAssigned,
+		&out.authState, &out.authSPF, &out.authDKIM, &out.authDMARC,
+		&out.authDMARCPolicy, &out.authCheckedAt, &out.createdAt,
+		&out.warmupStartedAt, &out.warmupDays, &out.coldRampStartedAt, &out.riskBand,
+		&out.warmupHealth, &out.warmupHealthReason, &out.blockedUntil,
+		&out.latestErrorCode,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return out, errMailboxNotConfigured
+	}
+	return out, err
+}
+
+func (m mailboxAuthority) envelope(now time.Time) MailboxEnvelope {
+	minGap := time.Duration(m.minWaitSeconds) * time.Second
+	hourly := DerivedHourlyCap(minGap)
+	out := MailboxEnvelope{
+		EmailAccountID:    m.id,
+		OrganizationID:    m.organizationID,
+		DailyCap:          effectiveMailboxCap(m.dailyCap, nil),
+		HourlyCap:         hourly,
+		MinGap:            minGap,
+		Ready:             true,
+		Timezone:          m.timezone,
+		ProviderCapSource: "unknown",
+	}
+	switch {
+	case m.status != "active":
+		out.Ready, out.HealthReason = false, "mailbox_disabled"
+	case !m.credentialsReady:
+		out.Ready, out.HealthReason = false, "credentials_missing"
+	case !m.workerAssigned:
+		out.Ready, out.HealthReason = false, "worker_missing"
+	case m.authState == "unknown" || m.authCheckedAt == nil:
+		out.Ready, out.HealthReason = false, "dns_auth_unknown"
+	case m.authState != "passing" || !m.authSPF || !m.authDKIM || !m.authDMARC:
+		out.Ready, out.HealthReason = false, "dns_auth_not_passing"
+	case m.riskBand == "quarantine":
+		out.Ready, out.HealthReason = false, "mailbox_quarantined"
+	case (m.warmupHealth == "blocked" || m.warmupHealth == "quarantined") &&
+		(m.blockedUntil == nil || m.blockedUntil.After(now)):
+		out.Ready, out.HealthReason = false, "warmup_"+m.warmupHealth
+	default:
+		errorClass := ClassifyProviderError(m.latestErrorCode, "")
+		switch errorClass {
+		case "auth_failure", "provider_block", "rate_limit", "provider_interrupted":
+			out.Ready, out.HealthReason = false, errorClass
+		}
+	}
+	if out.DailyCap < 1 || out.HourlyCap < 1 || out.MinGap <= 0 {
+		out.Ready, out.HealthReason = false, "mailbox_rate_bounds_invalid"
+	}
+	return out
+}
+
+func (s *PGStore) MailboxCapacitySnapshot(ctx context.Context, orgID uuid.UUID, now time.Time, cfg Config) (MailboxCapacitySnapshot, error) {
+	rows, err := s.db.Query(ctx, `
+		SELECT ea.id
+		FROM email_accounts ea
+		WHERE ea.organization_id = $1
+		  AND CASE WHEN ea.provider = 'smtp_imap' THEN EXISTS (
+		      SELECT 1 FROM email_accounts_smtp_imap smtp WHERE smtp.email_account_id = ea.id
+		  ) ELSE EXISTS (
+		      SELECT 1 FROM email_accounts_oauth oauth WHERE oauth.email_account_id = ea.id
+		  ) END
+		ORDER BY lower(ea.email), ea.id`, orgID)
+	if err != nil {
+		return MailboxCapacitySnapshot{}, err
+	}
+	var ids []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return MailboxCapacitySnapshot{}, err
+		}
+		ids = append(ids, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return MailboxCapacitySnapshot{}, err
+	}
+	rows.Close()
+
+	startToday, endToday := localDayBounds(now, cfg.Timezone)
+	snapshot := MailboxCapacitySnapshot{Mailboxes: make([]MailboxCapacity, 0, len(ids))}
+	for _, id := range ids {
+		authority, err := queryMailboxAuthority(ctx, s.db, orgID, id, false)
+		if err != nil {
+			return MailboxCapacitySnapshot{}, err
+		}
+		envelope := authority.envelope(now)
+		mailbox := MailboxCapacity{
+			EmailAccountID:       authority.id,
+			Email:                authority.email,
+			Enabled:              authority.status == "active",
+			Status:               authority.status,
+			Provider:             authority.provider,
+			CredentialsReady:     authority.credentialsReady,
+			WorkerAssigned:       authority.workerAssigned,
+			AuthState:            authority.authState,
+			AuthSPF:              authority.authSPF,
+			AuthDKIM:             authority.authDKIM,
+			AuthDMARC:            authority.authDMARC,
+			AuthDMARCPolicy:      authority.authDMARCPolicy,
+			AuthCheckedAt:        authority.authCheckedAt,
+			MailboxAgeDays:       wholeDays(now.Sub(authority.createdAt)),
+			WarmupStartedAt:      authority.warmupStartedAt,
+			WarmupDaysObserved:   authority.warmupDays,
+			ColdRampStartedAt:    authority.coldRampStartedAt,
+			ConfiguredDailyCap:   authority.dailyCap,
+			ConfiguredMinWaitSec: authority.minWaitSeconds,
+			DerivedHourlyCap:     DerivedHourlyCap(envelope.MinGap),
+			EffectiveDailyCap:    envelope.DailyCap,
+			EffectiveHourlyCap:   minPositive(envelope.HourlyCap, cfg.SendsPerHour),
+			ProviderDailyCap:     envelope.ProviderDailyCap,
+			ProviderHourlyCap:    envelope.ProviderHourlyCap,
+			ProviderCapSource:    envelope.ProviderCapSource,
+			BusinessWindow: MailboxBusinessWindow{
+				Timezone: cfg.Timezone, Start: cfg.WindowStart, End: cfg.WindowEnd,
+				BusinessDaysOnly: cfg.BusinessDaysOnly,
+			},
+			Health:       "ready",
+			HealthReason: "ready",
+			Unknown:      []string{"provider_daily_cap", "provider_hourly_cap"},
+		}
+		if authority.warmupStartedAt != nil {
+			age := wholeDays(now.Sub(*authority.warmupStartedAt))
+			mailbox.WarmupAgeDays = &age
+		} else {
+			mailbox.Unknown = append(mailbox.Unknown, "warmup_age")
+		}
+		if !envelope.Ready {
+			mailbox.Health, mailbox.HealthReason = "blocked", envelope.HealthReason
+		}
+		if authority.warmupHealth == "watch" || authority.warmupHealth == "throttled" {
+			signal := "warmup_" + authority.warmupHealth
+			mailbox.HealthSignals = append(mailbox.HealthSignals, signal)
+			if mailbox.Health == "ready" {
+				mailbox.Health = "degraded"
+				mailbox.HealthReason = signal
+			}
+		}
+		if err := s.fillMailboxSignals(ctx, &mailbox, startToday, endToday, now); err != nil {
+			return MailboxCapacitySnapshot{}, err
+		}
+		if err := s.fillMailboxErrors(ctx, &mailbox, now); err != nil {
+			return MailboxCapacitySnapshot{}, err
+		}
+		candidate := nextRollingSlot(now, mailbox.occupiedAt, mailbox.EffectiveHourlyCap, envelope.MinGap, RollingWindow)
+		if mailbox.UsedToday >= mailbox.EffectiveDailyCap {
+			candidate = nextLocalDay(now, cfg.Timezone)
+		}
+		candidate = NextEligibleSlot(candidate, cfg.Timezone, cfg.WindowStart, cfg.WindowEnd, cfg.BusinessDaysOnly)
+		if mailbox.Health != "blocked" {
+			mailbox.NextEligibleSlot = &candidate
+		}
+		snapshot.Mailboxes = append(snapshot.Mailboxes, mailbox)
+	}
+	if err := s.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM (
+		    SELECT q.message_key
+		    FROM confenge_dispatch_queue q
+		    WHERE q.organization_id = $1 AND q.channel = 'EMAIL' AND q.status IN ('queued','reserved')
+		      AND NOT EXISTS (
+		          SELECT 1 FROM outreach_touchpoints tp
+		          WHERE tp.organization_id=q.organization_id AND tp.draft_id=q.draft_id
+		            AND tp.channel='EMAIL' AND tp.state='QUEUED'
+		      )
+		    UNION
+		    SELECT 'touchpoint:' || tp.id::text
+		    FROM outreach_touchpoints tp
+		    WHERE tp.organization_id = $1 AND tp.channel = 'EMAIL' AND tp.state = 'QUEUED'
+		) backlog`, orgID).Scan(&snapshot.QueuedMessages); err != nil {
+		return MailboxCapacitySnapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func (s *PGStore) fillMailboxSignals(ctx context.Context, mailbox *MailboxCapacity, startToday, endToday, now time.Time) error {
+	if mailbox == nil {
+		return nil
+	}
+	err := s.db.QueryRow(ctx, `
+		SELECT
+		  (SELECT max(r.attempted_at) FROM confenge_dispatch_reservations r WHERE r.email_account_id=$1),
+		  (SELECT max(ds.sent_at) FROM confenge_dispatch_sends ds WHERE ds.email_account_id=$1),
+		  (SELECT max(de.created_at) FROM deliverability_events de JOIN tasks t ON t.id=de.task_id WHERE t.email_account_id=$1 AND de.event_type='bounce'),
+		  (SELECT max(de.created_at) FROM deliverability_events de JOIN tasks t ON t.id=de.task_id WHERE t.email_account_id=$1 AND de.event_type='complaint'),
+		  (SELECT max(de.created_at) FROM deliverability_events de JOIN tasks t ON t.id=de.task_id WHERE t.email_account_id=$1 AND de.event_type='reply'),
+		  (SELECT max(df.occurred_at) FROM confenge_dispatch_failures df WHERE df.email_account_id=$1 AND df.error_class <> 'unknown'),
+		  COALESCE((SELECT df.error_class FROM confenge_dispatch_failures df WHERE df.email_account_id=$1 AND df.error_class <> 'unknown' ORDER BY df.occurred_at DESC LIMIT 1), ''),
+		  (SELECT count(*) FROM confenge_dispatch_sends ds WHERE ds.email_account_id=$1 AND ds.sent_at >= $2),
+		  (SELECT count(*) FROM confenge_dispatch_sends ds WHERE ds.email_account_id=$1 AND ds.sent_at >= $3 AND ds.sent_at < $4),
+		  (SELECT count(*) FROM confenge_dispatch_sends ds WHERE ds.email_account_id=$1 AND ds.sent_at >= $5)
+	`, mailbox.EmailAccountID, now.Add(-time.Hour), startToday, endToday, now.Add(-7*24*time.Hour)).Scan(
+		&mailbox.Latest.AttemptAt, &mailbox.Latest.AcceptedAt, &mailbox.Latest.BounceAt,
+		&mailbox.Latest.ComplaintAt, &mailbox.Latest.ReplyAt,
+		&mailbox.Latest.ProviderRejectionAt, &mailbox.Latest.ProviderErrorClass,
+		&mailbox.Throughput.AcceptedLastHour, &mailbox.Throughput.AcceptedToday,
+		&mailbox.Throughput.AcceptedLast7d,
+	)
+	if err != nil {
+		return err
+	}
+	rows, err := s.db.Query(ctx, `
+		SELECT max(observed_at) AS observed_at FROM (
+		    SELECT 'task:' || t.id::text AS use_key, t.completed_at AS observed_at
+		    FROM tasks t
+		    WHERE t.email_account_id=$1 AND t.task_type='campaign' AND t.status='completed'
+		      AND t.completed_at >= $2
+		    UNION ALL
+		    SELECT COALESCE('task:' || ds.task_id::text, 'dispatch-send:' || ds.id::text), ds.sent_at
+		    FROM confenge_dispatch_sends ds
+		    WHERE ds.email_account_id=$1 AND ds.sent_at >= $2
+		    UNION ALL
+		    SELECT COALESCE('task:' || r.task_id::text, 'reservation:' || r.id::text), r.attempted_at
+		    FROM confenge_dispatch_reservations r
+		    WHERE r.email_account_id=$1 AND r.attempted_at >= $2 AND r.state <> 'committed'
+		    UNION ALL
+		    SELECT COALESCE('task:' || r.task_id::text, 'reservation:' || r.id::text), r.reserved_at
+		    FROM confenge_dispatch_reservations r
+		    WHERE r.email_account_id=$1 AND r.state='reserved' AND r.lease_until > $3
+		      AND r.attempted_at IS NULL
+		) observed GROUP BY use_key ORDER BY max(observed_at)`, mailbox.EmailAccountID, now.Add(-RollingWindow), now)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var observed time.Time
+		if err := rows.Scan(&observed); err != nil {
+			rows.Close()
+			return err
+		}
+		mailbox.occupiedAt = append(mailbox.occupiedAt, observed)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	return s.db.QueryRow(ctx, `
+		SELECT COUNT(*) FROM (
+		    SELECT t.id::text AS use_key
+		    FROM tasks t
+		    WHERE t.email_account_id=$1 AND t.task_type='campaign' AND t.status='completed'
+		      AND t.completed_at >= $2 AND t.completed_at < $3
+		    UNION
+		    SELECT COALESCE(r.task_id::text, 'reservation:' || r.id::text)
+		    FROM confenge_dispatch_reservations r
+		    WHERE r.email_account_id=$1 AND (
+		      (r.reserved_at >= $2 AND r.reserved_at < $3 AND r.state IN ('reserved','committed'))
+		      OR (r.attempted_at >= $2 AND r.attempted_at < $3)
+		    )
+		) used`, mailbox.EmailAccountID, startToday, endToday).Scan(&mailbox.UsedToday)
+}
+
+func (s *PGStore) fillMailboxErrors(ctx context.Context, mailbox *MailboxCapacity, now time.Time) error {
+	type fact struct {
+		class string
+		key   string
+		at    time.Time
+	}
+	var facts []fact
+	rows, err := s.db.Query(ctx, `
+		SELECT COALESCE(task_id::text, 'account-error:' || id::text), error_code, message, created_at
+		FROM email_account_errors
+		WHERE email_account_id=$1 AND resolved_at IS NULL
+		ORDER BY created_at DESC`, mailbox.EmailAccountID)
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var key, code, message string
+		var at time.Time
+		if err := rows.Scan(&key, &code, &message, &at); err != nil {
+			rows.Close()
+			return err
+		}
+		facts = append(facts, fact{class: ClassifyProviderError(code, message), key: key, at: at})
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	rows, err = s.db.Query(ctx, `
+		SELECT COALESCE(task_id::text, 'failure:' || id::text), error_class, occurred_at
+		FROM confenge_dispatch_failures
+		WHERE email_account_id=$1 AND occurred_at >= $2
+		ORDER BY occurred_at DESC`, mailbox.EmailAccountID, now.Add(-24*time.Hour))
+	if err != nil {
+		return err
+	}
+	for rows.Next() {
+		var item fact
+		if err := rows.Scan(&item.key, &item.class, &item.at); err != nil {
+			rows.Close()
+			return err
+		}
+		facts = append(facts, item)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return err
+	}
+	rows.Close()
+	counts := map[string]int{}
+	latest := map[string]time.Time{}
+	seen := map[string]bool{}
+	for _, item := range facts {
+		factKey := item.class + "|" + item.key
+		if seen[factKey] {
+			if item.at.After(latest[item.class]) {
+				latest[item.class] = item.at
+			}
+			continue
+		}
+		seen[factKey] = true
+		counts[item.class]++
+		if item.at.After(latest[item.class]) {
+			latest[item.class] = item.at
+		}
+	}
+	mailbox.errorCounts = counts
+	mailbox.errorLatest = latest
+	blocking := ""
+	for _, class := range []string{"auth_failure", "provider_block", "rate_limit", "provider_interrupted"} {
+		if counts[class] > 0 {
+			blocking = class
+			mailbox.HealthSignals = append(mailbox.HealthSignals, class)
+			break
+		}
+	}
+	if blocking != "" {
+		mailbox.Health, mailbox.HealthReason = "blocked", blocking
+		mailbox.NextEligibleSlot = nil
+	}
+	for _, class := range []string{"provider_4xx", "provider_5xx"} {
+		if counts[class] > 0 {
+			mailbox.HealthSignals = append(mailbox.HealthSignals, class)
+			if mailbox.Health == "ready" {
+				mailbox.Health, mailbox.HealthReason = "degraded", class
+			}
+		}
+	}
+	if mailbox.Latest.BounceAt != nil {
+		mailbox.HealthSignals = append(mailbox.HealthSignals, "hard_bounce_observed")
+		if mailbox.Health == "ready" {
+			mailbox.Health, mailbox.HealthReason = "degraded", "hard_bounce_observed"
+		}
+	}
+	if mailbox.Latest.ComplaintAt != nil {
+		mailbox.HealthSignals = append(mailbox.HealthSignals, "complaint_observed")
+		if mailbox.Health == "ready" {
+			mailbox.Health, mailbox.HealthReason = "degraded", "complaint_observed"
+		}
+	}
+	return nil
+}
+
+func listMailboxOccupiedTx(ctx context.Context, tx pgx.Tx, emailAccountID uuid.UUID, now time.Time, window time.Duration) ([]time.Time, time.Time, error) {
+	rows, err := tx.Query(ctx, `
+		SELECT max(observed_at) AS observed_at FROM (
+		    SELECT 'task:' || t.id::text AS use_key, t.completed_at AS observed_at
+		    FROM tasks t
+		    WHERE t.email_account_id=$1 AND t.task_type='campaign' AND t.status='completed'
+		      AND t.completed_at >= $2 AND t.completed_at <= $3
+		    UNION ALL
+		    SELECT COALESCE('task:' || ds.task_id::text, 'dispatch-send:' || ds.id::text), ds.sent_at
+		    FROM confenge_dispatch_sends ds
+		    WHERE ds.email_account_id=$1 AND ds.sent_at >= $2 AND ds.sent_at <= $3
+		    UNION ALL
+		    SELECT COALESCE('task:' || r.task_id::text, 'reservation:' || r.id::text), r.attempted_at
+		    FROM confenge_dispatch_reservations r
+		    WHERE r.email_account_id=$1 AND r.attempted_at >= $2 AND r.attempted_at <= $3
+		      AND r.state <> 'committed'
+		    UNION ALL
+		    SELECT COALESCE('task:' || r.task_id::text, 'reservation:' || r.id::text), r.reserved_at
+		    FROM confenge_dispatch_reservations r
+		    WHERE r.email_account_id=$1 AND r.state='reserved' AND r.lease_until > $3
+		      AND r.attempted_at IS NULL AND r.reserved_at >= $2 AND r.reserved_at <= $3
+		) observed GROUP BY use_key ORDER BY max(observed_at)`, emailAccountID, now.Add(-window), now)
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	defer rows.Close()
+	var values []time.Time
+	var last time.Time
+	for rows.Next() {
+		var value time.Time
+		if err := rows.Scan(&value); err != nil {
+			return nil, time.Time{}, err
+		}
+		values = append(values, value)
+		if value.After(last) {
+			last = value
+		}
+	}
+	return values, last, rows.Err()
+}
+
+func countMailboxDailyUseTx(ctx context.Context, tx pgx.Tx, emailAccountID uuid.UUID, start, end time.Time) (int, error) {
+	var used int
+	err := tx.QueryRow(ctx, `
+		SELECT COUNT(*) FROM (
+		    SELECT t.id::text AS use_key
+		    FROM tasks t
+		    WHERE t.email_account_id=$1 AND t.task_type='campaign' AND t.status='completed'
+		      AND t.completed_at >= $2 AND t.completed_at < $3
+		    UNION
+		    SELECT COALESCE(r.task_id::text, 'reservation:' || r.id::text)
+		    FROM confenge_dispatch_reservations r
+		    WHERE r.email_account_id=$1 AND (
+		      (r.reserved_at >= $2 AND r.reserved_at < $3 AND r.state IN ('reserved','committed'))
+		      OR (r.attempted_at >= $2 AND r.attempted_at < $3)
+		    )
+		) used`, emailAccountID, start, end).Scan(&used)
+	return used, err
+}
+
+func (s *PGStore) MarkAttempt(ctx context.Context, messageKey string, attemptedAt time.Time) error {
+	if attemptedAt.IsZero() {
+		attemptedAt = time.Now().UTC()
+	}
+	tag, err := s.db.Exec(ctx, `
+		UPDATE confenge_dispatch_reservations
+		SET attempted_at = CASE
+		    WHEN attempted_at IS NULL OR attempted_at < $2 THEN $2 ELSE attempted_at END
+		WHERE message_key=$1`, messageKey, attemptedAt.UTC())
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return fmt.Errorf("dispatch reservation not found for provider attempt")
+	}
+	return nil
+}
+
+func (s *PGStore) RecordProviderFailure(ctx context.Context, taskID uuid.UUID, errorCode, errorText string, occurredAt time.Time) error {
+	if taskID == uuid.Nil {
+		return nil
+	}
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	var reservationID, orgID uuid.UUID
+	var emailAccountID, draftID *uuid.UUID
+	var channel, messageKey string
+	err = tx.QueryRow(ctx, `
+		SELECT id, organization_id, email_account_id, draft_id, channel, message_key
+		FROM confenge_dispatch_reservations
+		WHERE task_id=$1
+		ORDER BY reserved_at DESC
+		LIMIT 1
+		FOR UPDATE`, taskID).Scan(&reservationID, &orgID, &emailAccountID, &draftID, &channel, &messageKey)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return tx.Commit(ctx)
+	}
+	if err != nil {
+		return err
+	}
+	errorClass := ClassifyProviderError(errorCode, errorText)
+	_, err = tx.Exec(ctx, `
+		INSERT INTO confenge_dispatch_failures
+			(organization_id, email_account_id, task_id, channel, message_key, draft_id,
+			 error_code, error_class, error_text, occurred_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)
+		ON CONFLICT (task_id, error_code) WHERE task_id IS NOT NULL AND error_code <> ''
+		DO UPDATE SET error_class=EXCLUDED.error_class, error_text=EXCLUDED.error_text,
+		              occurred_at=GREATEST(confenge_dispatch_failures.occurred_at, EXCLUDED.occurred_at)`,
+		orgID, emailAccountID, taskID, channel, messageKey, draftID,
+		errorCode, errorClass, errorText, occurredAt.UTC())
+	if err != nil {
+		return err
+	}
+	_, err = tx.Exec(ctx, `
+		UPDATE confenge_dispatch_reservations
+		SET state='failed', last_error=$2, attempted_at=COALESCE(attempted_at,$3)
+		WHERE id=$1 AND state='reserved'`, reservationID, errorText, occurredAt.UTC())
+	if err != nil {
+		return err
+	}
+	return tx.Commit(ctx)
+}
+
+func localDayBounds(now time.Time, timezone string) (time.Time, time.Time) {
+	loc, err := time.LoadLocation(timezone)
+	if err != nil {
+		loc = time.UTC
+	}
+	local := now.In(loc)
+	start := time.Date(local.Year(), local.Month(), local.Day(), 0, 0, 0, 0, loc)
+	return start.UTC(), start.AddDate(0, 0, 1).UTC()
+}
+
+func wholeDays(duration time.Duration) int {
+	if duration <= 0 {
+		return 0
+	}
+	return int(duration / (24 * time.Hour))
+}
+
+func healthAlert(mailbox *MailboxCapacity, code, severity, reason string, count int, at time.Time) CapacityAlert {
+	id := mailbox.EmailAccountID
+	alert := CapacityAlert{Code: code, Severity: severity, EmailAccountID: &id, Count: count, Reason: reason}
+	if !at.IsZero() {
+		value := at.UTC()
+		alert.OccurredAt = &value
+	}
+	return alert
+}
+
+func mailboxAlerts(mailbox *MailboxCapacity) []CapacityAlert {
+	if mailbox == nil {
+		return nil
+	}
+	var alerts []CapacityAlert
+	switch mailbox.HealthReason {
+	case "auth_failure", "dns_auth_unknown", "dns_auth_not_passing", "credentials_missing":
+		alerts = append(alerts, healthAlert(mailbox, AlertAuthFailure, "critical", mailbox.HealthReason, 1, timeOrZero(mailbox.AuthCheckedAt)))
+	case "provider_interrupted", "worker_missing":
+		alerts = append(alerts, healthAlert(mailbox, AlertProviderInterrupted, "critical", mailbox.HealthReason, 1, timeOrZero(mailbox.Latest.ProviderRejectionAt)))
+	case "rate_limit":
+		alerts = append(alerts, healthAlert(mailbox, AlertRateLimit, "critical", mailbox.HealthReason, 1, timeOrZero(mailbox.Latest.ProviderRejectionAt)))
+	case "provider_block":
+		alerts = append(alerts, healthAlert(mailbox, AlertProviderInterrupted, "critical", mailbox.HealthReason, 1, timeOrZero(mailbox.Latest.ProviderRejectionAt)))
+	case "mailbox_disabled":
+		alerts = append(alerts, healthAlert(mailbox, AlertMailboxDisabled, "critical", mailbox.HealthReason, 1, time.Time{}))
+	}
+	if mailbox.errorCounts["auth_failure"] > 0 && mailbox.HealthReason != "auth_failure" {
+		alerts = append(alerts, healthAlert(mailbox, AlertAuthFailure, "critical", "provider authentication failure observed", mailbox.errorCounts["auth_failure"], mailbox.errorLatest["auth_failure"]))
+	}
+	if mailbox.errorCounts["provider_interrupted"] > 0 && mailbox.HealthReason != "provider_interrupted" {
+		alerts = append(alerts, healthAlert(mailbox, AlertProviderInterrupted, "critical", "provider interruption observed", mailbox.errorCounts["provider_interrupted"], mailbox.errorLatest["provider_interrupted"]))
+	}
+	if mailbox.errorCounts["provider_block"] > 0 && mailbox.HealthReason != "provider_block" {
+		alerts = append(alerts, healthAlert(mailbox, AlertProviderInterrupted, "critical", "provider block observed", mailbox.errorCounts["provider_block"], mailbox.errorLatest["provider_block"]))
+	}
+	if mailbox.errorCounts["rate_limit"] > 0 && mailbox.HealthReason != "rate_limit" {
+		alerts = append(alerts, healthAlert(mailbox, AlertRateLimit, "critical", "provider rate-limit rejection observed", mailbox.errorCounts["rate_limit"], mailbox.errorLatest["rate_limit"]))
+	}
+	if mailbox.Latest.ComplaintAt != nil {
+		alerts = append(alerts, healthAlert(mailbox, AlertComplaint, "critical", "complaint_observed", 1, *mailbox.Latest.ComplaintAt))
+	}
+	if mailbox.errorCounts["provider_4xx"] >= 2 {
+		alerts = append(alerts, healthAlert(mailbox, AlertRepeated4xx, "warning", "repeated factual provider 4xx responses", mailbox.errorCounts["provider_4xx"], mailbox.errorLatest["provider_4xx"]))
+	}
+	if mailbox.errorCounts["provider_5xx"] >= 2 {
+		alerts = append(alerts, healthAlert(mailbox, AlertRepeated5xx, "warning", "repeated factual provider 5xx responses", mailbox.errorCounts["provider_5xx"], mailbox.errorLatest["provider_5xx"]))
+	}
+	return alerts
+}
+
+func timeOrZero(value *time.Time) time.Time {
+	if value == nil {
+		return time.Time{}
+	}
+	return *value
+}
+
+func normalizeHealthSignals(values []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		out = append(out, value)
+	}
+	return out
+}

--- a/internal/app/confenge/dispatch/capacity_test.go
+++ b/internal/app/confenge/dispatch/capacity_test.go
@@ -1,0 +1,295 @@
+package dispatch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func mailboxTestConfig() Config {
+	cfg := testCfg()
+	cfg.SendsPerHour = 100
+	cfg.MinGap = 0
+	cfg.BusinessDaysOnly = false
+	return cfg
+}
+
+func readyTestMailbox(orgID, mailboxID uuid.UUID, dailyCap int, minGap time.Duration) MailboxEnvelope {
+	return MailboxEnvelope{
+		EmailAccountID: mailboxID,
+		OrganizationID: orgID,
+		DailyCap:       dailyCap,
+		HourlyCap:      DerivedHourlyCap(minGap),
+		MinGap:         minGap,
+		Ready:          true,
+		Timezone:       "UTC",
+	}
+}
+
+func reserveMailbox(t *testing.T, governor *Governor, orgID, mailboxID uuid.UUID, key string) ReserveResult {
+	t.Helper()
+	result, err := governor.TryReserve(context.Background(), ReserveRequest{
+		OrganizationID: orgID,
+		EmailAccountID: &mailboxID,
+		Channel:        ChannelEmail,
+		MessageKey:     key,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return result
+}
+
+func TestMailboxEnvelopeSeparatesSlotsWithoutDuplicatingMessage(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	clock := &FixedClock{T: now}
+	store := NewMemoryStore()
+	orgID, mailboxA, mailboxB := uuid.New(), uuid.New(), uuid.New()
+	store.SetMailboxEnvelope(readyTestMailbox(orgID, mailboxA, 50, 10*time.Minute))
+	store.SetMailboxEnvelope(readyTestMailbox(orgID, mailboxB, 50, 10*time.Minute))
+	governor := NewGovernor(mailboxTestConfig(), store, clock)
+
+	first := reserveMailbox(t, governor, orgID, mailboxA, "account-recipient-sequence")
+	if !first.Allowed {
+		t.Fatalf("first mailbox slot denied: %s", first.Reason)
+	}
+	if err := governor.Commit(context.Background(), first.Reservation.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	sameMailbox := reserveMailbox(t, governor, orgID, mailboxA, "other-recipient")
+	if sameMailbox.Allowed || sameMailbox.Reason != "mailbox_min_gap" {
+		t.Fatalf("same mailbox must honor its own min wait: %+v", sameMailbox)
+	}
+	if !sameMailbox.NextSlot.Equal(now.Add(10 * time.Minute)) {
+		t.Fatalf("next mailbox slot=%s want=%s", sameMailbox.NextSlot, now.Add(10*time.Minute))
+	}
+
+	otherMailbox := reserveMailbox(t, governor, orgID, mailboxB, "second-account-recipient")
+	if !otherMailbox.Allowed {
+		t.Fatalf("second configured mailbox should have an independent slot: %s", otherMailbox.Reason)
+	}
+	if err := governor.Commit(context.Background(), otherMailbox.Reservation.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	disabled := readyTestMailbox(orgID, mailboxB, 50, 10*time.Minute)
+	disabled.Ready = false
+	disabled.HealthReason = "mailbox_disabled"
+	store.SetMailboxEnvelope(disabled)
+	replayOnOtherMailbox := reserveMailbox(t, governor, orgID, mailboxB, "account-recipient-sequence")
+	if !replayOnOtherMailbox.Allowed || !replayOnOtherMailbox.AlreadyCommitted {
+		t.Fatalf("same account/recipient/sequence key must remain idempotent across mailboxes: %+v", replayOnOtherMailbox)
+	}
+}
+
+func TestOpenMessageLeaseCannotMoveAcrossMailboxes(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	clock := &FixedClock{T: now}
+	store := NewMemoryStore()
+	orgID, mailboxA, mailboxB, taskA, taskB := uuid.New(), uuid.New(), uuid.New(), uuid.New(), uuid.New()
+	store.SetMailboxEnvelope(readyTestMailbox(orgID, mailboxA, 50, 10*time.Minute))
+	store.SetMailboxEnvelope(readyTestMailbox(orgID, mailboxB, 50, 10*time.Minute))
+	governor := NewGovernor(mailboxTestConfig(), store, clock)
+
+	first, err := governor.TryReserve(context.Background(), ReserveRequest{
+		OrganizationID: orgID, EmailAccountID: &mailboxA, TaskID: &taskA,
+		Channel: ChannelEmail, MessageKey: "one-recipient-sequence",
+	})
+	if err != nil || !first.Allowed {
+		t.Fatalf("first binding failed: result=%+v err=%v", first, err)
+	}
+	second, err := governor.TryReserve(context.Background(), ReserveRequest{
+		OrganizationID: orgID, EmailAccountID: &mailboxB, TaskID: &taskB,
+		Channel: ChannelEmail, MessageKey: "one-recipient-sequence",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if second.Allowed || second.Reason != "message_binding_conflict" || !second.NextSlot.Equal(first.Reservation.LeaseUntil) {
+		t.Fatalf("open message moved across mailbox/task binding: %+v", second)
+	}
+}
+
+func TestMailboxDailyCapCountsAttemptsAndQueueCannotRaiseRate(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	clock := &FixedClock{T: now}
+	store := NewMemoryStore()
+	orgID, mailboxID := uuid.New(), uuid.New()
+	store.SetMailboxEnvelope(readyTestMailbox(orgID, mailboxID, 2, 10*time.Minute))
+	governor := NewGovernor(mailboxTestConfig(), store, clock)
+
+	for i := 0; i < 500; i++ {
+		draftID := uuid.New()
+		if err := governor.Enqueue(context.Background(), EnqueueRequest{
+			OrganizationID: orgID,
+			EmailAccountID: &mailboxID,
+			Channel:        ChannelEmail,
+			DraftID:        draftID,
+			MessageKey:     fmt.Sprintf("queued:%d", i),
+			DueAt:          now.Add(-time.Hour),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	first := reserveMailbox(t, governor, orgID, mailboxID, "attempted:1")
+	if !first.Allowed {
+		t.Fatalf("first reserve denied: %s", first.Reason)
+	}
+	if err := governor.MarkAttempt(context.Background(), "attempted:1", now); err != nil {
+		t.Fatal(err)
+	}
+	if err := governor.RecordProviderFailure(context.Background(), uuid.New(), "421", "421 temporary rejection", now); err != nil {
+		t.Fatal(err)
+	}
+	clock.Advance(10 * time.Minute)
+	second := reserveMailbox(t, governor, orgID, mailboxID, "attempted:2")
+	if !second.Allowed {
+		t.Fatalf("second reserve denied: %s", second.Reason)
+	}
+	if err := governor.MarkAttempt(context.Background(), "attempted:2", clock.Now()); err != nil {
+		t.Fatal(err)
+	}
+	clock.Advance(10 * time.Minute)
+	third := reserveMailbox(t, governor, orgID, mailboxID, "attempted:3")
+	if third.Allowed || third.Reason != "mailbox_daily_cap" {
+		t.Fatalf("backlog must wait after two mailbox attempts: %+v", third)
+	}
+
+	status, err := governor.Status(context.Background(), &orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.QueuedApproved != 500 {
+		t.Fatalf("queued=%d want=500", status.QueuedApproved)
+	}
+	if len(status.Mailboxes) != 1 || status.Mailboxes[0].UsedToday != 2 {
+		t.Fatalf("daily attempt usage not reflected: %+v", status.Mailboxes)
+	}
+	if status.Forecast.SlotsNext24h > 2 {
+		t.Fatalf("queue size inflated mailbox forecast: %+v", status.Forecast)
+	}
+}
+
+func TestCapacityForecastIsDerivedAndNeverPromisesDelivery(t *testing.T) {
+	now := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC) // Monday
+	cfg := mailboxTestConfig()
+	cfg.WindowStart = "09:00"
+	cfg.WindowEnd = "18:00"
+	cfg.BusinessDaysOnly = true
+	mailbox := MailboxCapacity{
+		ConfiguredDailyCap:   50,
+		ConfiguredMinWaitSec: 600,
+		EffectiveDailyCap:    50,
+		EffectiveHourlyCap:   6,
+		Health:               "ready",
+	}
+
+	forecast, first := buildCapacityForecast(now, cfg, []MailboxCapacity{mailbox}, nil, 100, false)
+	if first == nil || !first.Equal(now) {
+		t.Fatalf("first slot=%v want=%s", first, now)
+	}
+	if forecast.SlotsNext24h != 50 || forecast.SlotsNext7d != 250 {
+		t.Fatalf("forecast=%+v want 50/250 configured slots", forecast)
+	}
+	if forecast.EstimatedDaysToDrain == nil || *forecast.EstimatedDaysToDrain != 3 {
+		t.Fatalf("derived drain estimate=%v want=3 calendar days", forecast.EstimatedDaysToDrain)
+	}
+	if forecast.DeliveryPromised {
+		t.Fatal("capacity slots must never be represented as delivery promises")
+	}
+
+	paused, pausedNext := buildCapacityForecast(now, cfg, []MailboxCapacity{mailbox}, nil, 100, true)
+	if paused.SlotsNext24h != 0 || paused.PotentialSlotsNext24h != 50 || paused.EstimatedDaysToDrain != nil {
+		t.Fatalf("paused forecast must separate potential from effective capacity: %+v", paused)
+	}
+	if pausedNext != nil {
+		t.Fatalf("paused transport exposed an effective next slot: %v", pausedNext)
+	}
+}
+
+func TestSanitizedRuntimeForecastCrossesMailboxCalendarDays(t *testing.T) {
+	now := time.Date(2026, 8, 26, 13, 35, 0, 0, time.UTC) // Wednesday 10:35 in São Paulo
+	cfg := mailboxTestConfig()
+	cfg.Timezone = "America/Sao_Paulo"
+	cfg.WindowStart = "09:00"
+	cfg.WindowEnd = "18:00"
+	cfg.BusinessDaysOnly = true
+	cfg.SendsPerHour = 6
+	mailbox := MailboxCapacity{
+		ConfiguredDailyCap:   50,
+		ConfiguredMinWaitSec: 600,
+		EffectiveDailyCap:    50,
+		EffectiveHourlyCap:   6,
+		Health:               "ready",
+	}
+
+	forecast, _ := buildCapacityForecast(now, cfg, []MailboxCapacity{mailbox}, nil, 1, true)
+	if forecast.PotentialSlotsNext24h != 55 || forecast.PotentialSlotsNext7d != 255 {
+		t.Fatalf("time-sensitive runtime forecast=%+v want potential 55/255", forecast)
+	}
+	if forecast.SlotsNext24h != 0 || forecast.EstimatedDaysToDrain != nil {
+		t.Fatalf("engaged kill switch must leave no effective forecast: %+v", forecast)
+	}
+}
+
+func TestProviderErrorsStayFactualWithoutInventedThresholds(t *testing.T) {
+	cases := map[string]string{
+		"421 service unavailable": "provider_4xx",
+		"smtp 4.7.0 deferred":     "provider_4xx",
+		"550 mailbox unavailable": "provider_5xx",
+		"smtp 5.1.1 rejected":     "provider_5xx",
+		"RATE_LIMIT_EXCEEDED":     "rate_limit",
+		"one hard bounce":         "unknown",
+	}
+	for input, want := range cases {
+		if got := ClassifyProviderError(input, input); got != want {
+			t.Errorf("ClassifyProviderError(%q)=%q want=%q", input, got, want)
+		}
+	}
+}
+
+func TestBlockedMailboxRaisesAuthAndQueueRunoffAlerts(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	clock := &FixedClock{T: now}
+	store := NewMemoryStore()
+	orgID, mailboxID, draftID := uuid.New(), uuid.New(), uuid.New()
+	envelope := readyTestMailbox(orgID, mailboxID, 50, 10*time.Minute)
+	envelope.Ready = false
+	envelope.HealthReason = "auth_failure"
+	store.SetMailboxEnvelope(envelope)
+	governor := NewGovernor(mailboxTestConfig(), store, clock)
+	if err := governor.Enqueue(context.Background(), EnqueueRequest{
+		OrganizationID: orgID,
+		EmailAccountID: &mailboxID,
+		Channel:        ChannelEmail,
+		DraftID:        draftID,
+		MessageKey:     "blocked-auth",
+		DueAt:          now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	status, err := governor.Status(context.Background(), &orgID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if status.Forecast.SlotsNext24h != 0 {
+		t.Fatalf("blocked mailbox exposed capacity: %+v", status.Forecast)
+	}
+	want := map[string]bool{AlertAuthFailure: false, AlertQueueRunoff: false}
+	for _, alert := range status.Alerts {
+		if _, ok := want[alert.Code]; ok {
+			want[alert.Code] = true
+		}
+	}
+	for code, found := range want {
+		if !found {
+			t.Errorf("missing %s alert: %+v", code, status.Alerts)
+		}
+	}
+}

--- a/internal/app/confenge/dispatch/governor.go
+++ b/internal/app/confenge/dispatch/governor.go
@@ -2,6 +2,7 @@ package dispatch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -80,6 +81,8 @@ func (g *Governor) TryReserve(ctx context.Context, req ReserveRequest) (ReserveR
 		capN = DefaultSendsPerHour
 	}
 	out := ReserveResult{Cap: capN}
+	effectiveGap := g.cfg.MinGap
+	var mailbox *MailboxEnvelope
 
 	if req.MessageKey == "" {
 		return out, fmt.Errorf("message_key required")
@@ -87,13 +90,47 @@ func (g *Governor) TryReserve(ctx context.Context, req ReserveRequest) (ReserveR
 	if req.Channel != ChannelEmail && req.Channel != ChannelWhatsApp {
 		return out, fmt.Errorf("invalid channel %q", req.Channel)
 	}
+	if _, committed, err := g.store.GetSendByKey(ctx, req.MessageKey); err != nil {
+		return out, err
+	} else if committed {
+		out.Allowed = true
+		out.AlreadyCommitted = true
+		out.Reason = "already_sent"
+		return out, nil
+	}
+	if req.Channel == ChannelEmail {
+		mailboxStore, ok := g.store.(MailboxStore)
+		if !ok {
+			return out, fmt.Errorf("dispatch store cannot resolve mailbox capacity")
+		}
+		mailboxID := uuid.Nil
+		if req.EmailAccountID != nil {
+			mailboxID = *req.EmailAccountID
+		}
+		envelope, err := mailboxStore.GetMailboxEnvelope(ctx, req.OrganizationID, mailboxID, now)
+		if errors.Is(err, errMailboxNotConfigured) {
+			out.Reason = "mailbox_not_configured"
+			return out, nil
+		}
+		if err != nil {
+			return out, err
+		}
+		mailbox = &envelope
+		if !envelope.Ready {
+			out.Reason = envelope.HealthReason
+			return out, nil
+		}
+		if envelope.MinGap > effectiveGap {
+			effectiveGap = envelope.MinGap
+		}
+	}
 
 	if g.cfg.EnvPaused {
 		out.Reason = "env_paused"
 		if g.cfg.EnvPauseReason != "" {
 			out.Reason = g.cfg.EnvPauseReason
 		}
-		out.NextSlot = now.Add(g.cfg.MinGap)
+		out.NextSlot = NextEligibleSlot(now.Add(effectiveGap), g.cfg.Timezone, g.cfg.WindowStart, g.cfg.WindowEnd, g.cfg.BusinessDaysOnly)
 		return out, nil
 	}
 	ctrl, err := g.store.GetControl(ctx)
@@ -105,7 +142,7 @@ func (g *Governor) TryReserve(ctx context.Context, req ReserveRequest) (ReserveR
 		if ctrl.PauseReason != "" {
 			out.Reason = ctrl.PauseReason
 		}
-		out.NextSlot = now.Add(g.cfg.MinGap)
+		out.NextSlot = NextEligibleSlot(now.Add(effectiveGap), g.cfg.Timezone, g.cfg.WindowStart, g.cfg.WindowEnd, g.cfg.BusinessDaysOnly)
 		return out, nil
 	}
 
@@ -126,7 +163,7 @@ func (g *Governor) TryReserve(ctx context.Context, req ReserveRequest) (ReserveR
 	// Full reserve decision under store serialization (multi-worker safe).
 	atomic, err := g.store.TryReserveAtomic(ctx, AtomicReserveInput{
 		Req: req, Now: now, Cap: capN, MinGap: g.cfg.MinGap,
-		LeaseTTL: g.cfg.LeaseTTL, Window: RollingWindow,
+		Mailbox: mailbox, LeaseTTL: g.cfg.LeaseTTL, Window: RollingWindow,
 	})
 	if err != nil {
 		return out, err
@@ -136,6 +173,9 @@ func (g *Governor) TryReserve(ctx context.Context, req ReserveRequest) (ReserveR
 	out.Reservation = atomic.Reservation
 	out.Reason = atomic.Reason
 	out.NextSlot = atomic.NextSlot
+	if !out.NextSlot.IsZero() {
+		out.NextSlot = NextEligibleSlot(out.NextSlot, g.cfg.Timezone, g.cfg.WindowStart, g.cfg.WindowEnd, g.cfg.BusinessDaysOnly)
+	}
 	out.SentLastHour = atomic.SentLastHour
 	return out, nil
 }
@@ -172,7 +212,8 @@ func (g *Governor) Enqueue(ctx context.Context, req EnqueueRequest) error {
 		req.DueAt = g.clock.Now().UTC()
 	}
 	return g.store.Enqueue(ctx, &QueueItem{
-		OrganizationID: req.OrganizationID, Channel: req.Channel, DraftID: req.DraftID,
+		OrganizationID: req.OrganizationID, EmailAccountID: req.EmailAccountID,
+		Channel: req.Channel, DraftID: req.DraftID,
 		MessageKey: req.MessageKey, RecipientRef: req.RecipientRef,
 		DueAt: req.DueAt.UTC(), Priority: req.Priority,
 		Status: QueueQueued, CreatedAt: g.clock.Now().UTC(),
@@ -199,6 +240,7 @@ func (g *Governor) Status(ctx context.Context, orgID *uuid.UUID) (Status, error)
 	st := Status{
 		Cap: g.cfg.SendsPerHour, MinGapSeconds: int(g.cfg.MinGap / time.Second),
 		Timezone: g.cfg.Timezone, WindowStart: g.cfg.WindowStart, WindowEnd: g.cfg.WindowEnd,
+		CapacitySource: "global_legacy",
 	}
 	_, _ = g.store.ExpireStaleReservations(ctx, now)
 	sent, err := g.store.CountSendsSince(ctx, now.Add(-RollingWindow))
@@ -230,8 +272,17 @@ func (g *Governor) Status(ctx context.Context, orgID *uuid.UUID) (Status, error)
 			st.PauseReason = "env_paused"
 		}
 	}
+	if g.cfg.EnvPaused {
+		st.PauseSource = "environment"
+	} else if ctrl.Paused {
+		st.PauseSource = "durable_control"
+	}
 	inWin, _ := InSendWindowBusiness(now, g.cfg.Timezone, g.cfg.WindowStart, g.cfg.WindowEnd, g.cfg.BusinessDaysOnly)
 	st.InSendWindow = inWin
+	occupied, last, err := g.store.ListOccupied(ctx, now, RollingWindow)
+	if err != nil {
+		return st, err
+	}
 	if st.Paused {
 		// A pause gap is plain arithmetic and lands wherever it lands, so on a
 		// Sunday it used to advertise a Sunday slot beside in_send_window=false.
@@ -242,10 +293,6 @@ func (g *Governor) Status(ctx context.Context, orgID *uuid.UUID) (Status, error)
 		t := NextWindowOpenBusiness(now, g.cfg.Timezone, g.cfg.WindowStart, g.cfg.WindowEnd, g.cfg.BusinessDaysOnly)
 		st.NextSlotAt = &t
 	} else {
-		occupied, last, err := g.store.ListOccupied(ctx, now, RollingWindow)
-		if err != nil {
-			return st, err
-		}
 		snap := WindowSnapshot{
 			OccupiedAt: occupied, LastOccupied: last,
 			Cap: g.cfg.SendsPerHour, MinGap: g.cfg.MinGap, Window: RollingWindow, Now: now,
@@ -263,7 +310,49 @@ func (g *Governor) Status(ctx context.Context, orgID *uuid.UUID) (Status, error)
 		return st, err
 	}
 	st.RecentFailures = fails
+	if orgID != nil {
+		if capacityStore, ok := g.store.(MailboxStore); ok {
+			snapshot, err := capacityStore.MailboxCapacitySnapshot(ctx, *orgID, now, g.cfg)
+			if err != nil {
+				return st, err
+			}
+			st.CapacitySource = "mailbox_envelopes"
+			st.Mailboxes = snapshot.Mailboxes
+			st.QueuedApproved = snapshot.QueuedMessages
+			st.Forecast, st.NextSlotAt = buildCapacityForecast(now, g.cfg, st.Mailboxes, occupied, snapshot.QueuedMessages, st.Paused)
+			for i := range st.Mailboxes {
+				st.Mailboxes[i].HealthSignals = normalizeHealthSignals(st.Mailboxes[i].HealthSignals)
+				if st.Paused {
+					st.Mailboxes[i].PauseSource = st.PauseSource
+					st.Mailboxes[i].NextEligibleSlot = nil
+				}
+				st.Alerts = append(st.Alerts, mailboxAlerts(&st.Mailboxes[i])...)
+			}
+			if snapshot.QueuedMessages > 0 && st.Forecast.SlotsNext24h == 0 {
+				st.Alerts = append(st.Alerts, CapacityAlert{
+					Code: AlertQueueRunoff, Severity: "critical", Count: snapshot.QueuedMessages,
+					Reason: "approved queue has no effective mailbox capacity in the next 24 hours",
+				})
+			}
+		}
+	}
 	return st, nil
+}
+
+func (g *Governor) MarkAttempt(ctx context.Context, messageKey string, attemptedAt time.Time) error {
+	store, ok := g.store.(MailboxStore)
+	if !ok {
+		return fmt.Errorf("dispatch store cannot record mailbox attempt")
+	}
+	return store.MarkAttempt(ctx, messageKey, attemptedAt)
+}
+
+func (g *Governor) RecordProviderFailure(ctx context.Context, taskID uuid.UUID, errorCode, errorText string, occurredAt time.Time) error {
+	store, ok := g.store.(MailboxStore)
+	if !ok {
+		return fmt.Errorf("dispatch store cannot record provider failure")
+	}
+	return store.RecordProviderFailure(ctx, taskID, errorCode, errorText, occurredAt)
 }
 
 func (g *Governor) RecordFailure(ctx context.Context, orgID uuid.UUID, channel, messageKey string, draftID *uuid.UUID, errText string) error {

--- a/internal/app/confenge/dispatch/memory_store.go
+++ b/internal/app/confenge/dispatch/memory_store.go
@@ -12,25 +12,51 @@ import (
 
 // MemoryStore is a multi-goroutine-safe in-memory Store for unit tests.
 type MemoryStore struct {
-	mu           sync.Mutex
-	control      ControlState
-	reservations map[string]*Reservation
-	byResID      map[uuid.UUID]*Reservation
-	sends        map[string]time.Time
-	sendTimes    []time.Time
-	queue        map[string]*QueueItem
-	queueByID    map[uuid.UUID]*QueueItem
-	failures     []FailureRecord
+	mu            sync.Mutex
+	control       ControlState
+	reservations  map[string]*Reservation
+	byResID       map[uuid.UUID]*Reservation
+	sends         map[string]time.Time
+	sendMailboxes map[string]uuid.UUID
+	sendTimes     []time.Time
+	queue         map[string]*QueueItem
+	queueByID     map[uuid.UUID]*QueueItem
+	failures      []FailureRecord
+	mailboxes     map[uuid.UUID]MailboxEnvelope
 }
 
 func NewMemoryStore() *MemoryStore {
 	return &MemoryStore{
-		reservations: map[string]*Reservation{},
-		byResID:      map[uuid.UUID]*Reservation{},
-		sends:        map[string]time.Time{},
-		queue:        map[string]*QueueItem{},
-		queueByID:    map[uuid.UUID]*QueueItem{},
+		reservations:  map[string]*Reservation{},
+		byResID:       map[uuid.UUID]*Reservation{},
+		sends:         map[string]time.Time{},
+		sendMailboxes: map[string]uuid.UUID{},
+		queue:         map[string]*QueueItem{},
+		queueByID:     map[uuid.UUID]*QueueItem{},
+		mailboxes:     map[uuid.UUID]MailboxEnvelope{},
 	}
+}
+
+// SetMailboxEnvelope configures a factual mailbox budget for tests.
+func (m *MemoryStore) SetMailboxEnvelope(envelope MailboxEnvelope) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.mailboxes[envelope.EmailAccountID] = envelope
+}
+
+func (m *MemoryStore) GetMailboxEnvelope(_ context.Context, orgID, emailAccountID uuid.UUID, _ time.Time) (MailboxEnvelope, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if envelope, ok := m.mailboxes[emailAccountID]; ok {
+		return envelope, nil
+	}
+	// Existing unit tests exercise the global governor without a database. Keep
+	// that fixture lane permissive; production PGStore has no such fallback.
+	return MailboxEnvelope{
+		EmailAccountID: emailAccountID, OrganizationID: orgID,
+		DailyCap: 1000000, HourlyCap: 1000000, Ready: true,
+		Timezone: "UTC", ProviderCapSource: "unknown",
+	}, nil
 }
 
 func (m *MemoryStore) GetControl(ctx context.Context) (ControlState, error) {
@@ -115,6 +141,14 @@ func (m *MemoryStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInpu
 
 	if existing := m.reservations[in.Req.MessageKey]; existing != nil &&
 		existing.State == StateReserved && existing.LeaseUntil.After(now) {
+		mailboxConflict := in.Req.Channel == ChannelEmail && in.Req.EmailAccountID != nil &&
+			(existing.EmailAccountID == nil || *existing.EmailAccountID != *in.Req.EmailAccountID)
+		taskConflict := in.Req.TaskID != nil && (existing.TaskID == nil || *existing.TaskID != *in.Req.TaskID)
+		if mailboxConflict || taskConflict {
+			out.Reason = "message_binding_conflict"
+			out.NextSlot = existing.LeaseUntil
+			return out, nil
+		}
 		existing.LeaseUntil = now.Add(in.LeaseTTL)
 		cp := *existing
 		out.Allowed = true
@@ -122,6 +156,64 @@ func (m *MemoryStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInpu
 		out.Reason = "existing_lease"
 		out.SentLastHour = countTimes(m.sendTimes, now.Add(-window), now)
 		return out, nil
+	}
+
+	if in.Req.Channel == ChannelEmail && in.Mailbox != nil {
+		var mailboxTimes []time.Time
+		var mailboxLast time.Time
+		for key, sentAt := range m.sends {
+			if m.sendMailboxes[key] == in.Mailbox.EmailAccountID && !sentAt.Before(now.Add(-window)) && !sentAt.After(now) {
+				mailboxTimes = append(mailboxTimes, sentAt)
+				if sentAt.After(mailboxLast) {
+					mailboxLast = sentAt
+				}
+			}
+		}
+		for _, reservation := range m.reservations {
+			if reservation.EmailAccountID == nil || *reservation.EmailAccountID != in.Mailbox.EmailAccountID ||
+				reservation.State != StateReserved || !reservation.LeaseUntil.After(now) {
+				continue
+			}
+			observed := reservation.ReservedAt
+			if reservation.AttemptedAt != nil {
+				observed = *reservation.AttemptedAt
+			}
+			if !observed.Before(now.Add(-window)) && !observed.After(now) {
+				mailboxTimes = append(mailboxTimes, observed)
+				if observed.After(mailboxLast) {
+					mailboxLast = observed
+				}
+			}
+		}
+		mailboxCap := in.Mailbox.HourlyCap
+		if in.Req.CapOverride > 0 {
+			mailboxCap = minPositive(mailboxCap, in.Req.CapOverride)
+		}
+		mailboxSnapshot := WindowSnapshot{
+			OccupiedAt: mailboxTimes, LastOccupied: mailboxLast,
+			Cap: mailboxCap, MinGap: in.Mailbox.MinGap, Window: window, Now: now,
+		}
+		if ok, reason, next := mailboxSnapshot.CanGrant(); !ok {
+			out.Reason, out.NextSlot = "mailbox_"+reason, next
+			return out, nil
+		}
+		usedToday := 0
+		date := localDateKey(now, in.Mailbox.Timezone)
+		for _, reservation := range m.reservations {
+			if reservation.EmailAccountID == nil || *reservation.EmailAccountID != in.Mailbox.EmailAccountID {
+				continue
+			}
+			reservedToday := localDateKey(reservation.ReservedAt, in.Mailbox.Timezone) == date &&
+				(reservation.State == StateReserved || reservation.State == StateCommitted)
+			attemptedToday := reservation.AttemptedAt != nil && localDateKey(*reservation.AttemptedAt, in.Mailbox.Timezone) == date
+			if reservedToday || attemptedToday {
+				usedToday++
+			}
+		}
+		if usedToday >= in.Mailbox.DailyCap {
+			out.Reason, out.NextSlot = "mailbox_daily_cap", nextLocalDay(now, in.Mailbox.Timezone)
+			return out, nil
+		}
 	}
 
 	occupied, last := m.occupiedLocked(now, window)
@@ -146,6 +238,8 @@ func (m *MemoryStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInpu
 	res := &Reservation{
 		ID:             uuid.New(),
 		OrganizationID: in.Req.OrganizationID,
+		EmailAccountID: in.Req.EmailAccountID,
+		TaskID:         in.Req.TaskID,
 		Channel:        in.Req.Channel,
 		MessageKey:     in.Req.MessageKey,
 		DraftID:        in.Req.DraftID,
@@ -230,6 +324,9 @@ func (m *MemoryStore) CommitReservation(ctx context.Context, id uuid.UUID, sentA
 	t := sentAt
 	r.CommittedAt = &t
 	m.sends[r.MessageKey] = sentAt
+	if r.EmailAccountID != nil {
+		m.sendMailboxes[r.MessageKey] = *r.EmailAccountID
+	}
 	m.sendTimes = append(m.sendTimes, sentAt)
 	return nil
 }
@@ -249,6 +346,15 @@ func (m *MemoryStore) ReleaseReservation(ctx context.Context, id uuid.UUID, stat
 	}
 	r.State = state
 	r.LastError = errText
+	if errText != "" {
+		orgID := r.OrganizationID
+		m.failures = append(m.failures, FailureRecord{
+			ID: uuid.New(), OrganizationID: &orgID, EmailAccountID: r.EmailAccountID,
+			TaskID: r.TaskID, Channel: r.Channel, MessageKey: r.MessageKey,
+			DraftID: r.DraftID, ErrorClass: "unknown", ErrorText: errText,
+			OccurredAt: time.Now().UTC(),
+		})
+	}
 	return nil
 }
 
@@ -276,6 +382,9 @@ func (m *MemoryStore) Enqueue(ctx context.Context, item *QueueItem) error {
 		existing.DueAt = item.DueAt
 		existing.Priority = item.Priority
 		existing.RecipientRef = item.RecipientRef
+		if item.EmailAccountID != nil {
+			existing.EmailAccountID = item.EmailAccountID
+		}
 		existing.Status = QueueQueued
 		return nil
 	}
@@ -453,4 +562,143 @@ func (m *MemoryStore) CountSendsSince(ctx context.Context, since time.Time) (int
 		}
 	}
 	return n, nil
+}
+
+func (m *MemoryStore) MarkAttempt(_ context.Context, messageKey string, attemptedAt time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	reservation := m.reservations[messageKey]
+	if reservation == nil {
+		return fmt.Errorf("dispatch reservation not found for provider attempt")
+	}
+	value := attemptedAt.UTC()
+	reservation.AttemptedAt = &value
+	return nil
+}
+
+func (m *MemoryStore) RecordProviderFailure(_ context.Context, taskID uuid.UUID, errorCode, errorText string, occurredAt time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, reservation := range m.reservations {
+		if reservation.TaskID == nil || *reservation.TaskID != taskID {
+			continue
+		}
+		reservation.State = StateFailed
+		reservation.LastError = errorText
+		at := occurredAt.UTC()
+		reservation.AttemptedAt = &at
+		orgID := reservation.OrganizationID
+		m.failures = append(m.failures, FailureRecord{
+			ID: uuid.New(), OrganizationID: &orgID, EmailAccountID: reservation.EmailAccountID,
+			TaskID: &taskID, Channel: reservation.Channel, MessageKey: reservation.MessageKey,
+			DraftID: reservation.DraftID, ErrorCode: errorCode,
+			ErrorClass: ClassifyProviderError(errorCode, errorText), ErrorText: errorText, OccurredAt: at,
+		})
+		return nil
+	}
+	return nil
+}
+
+func (m *MemoryStore) MailboxCapacitySnapshot(_ context.Context, orgID uuid.UUID, now time.Time, cfg Config) (MailboxCapacitySnapshot, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := MailboxCapacitySnapshot{}
+	for _, envelope := range m.mailboxes {
+		if envelope.OrganizationID != uuid.Nil && envelope.OrganizationID != orgID {
+			continue
+		}
+		mailbox := MailboxCapacity{
+			EmailAccountID: envelope.EmailAccountID, Enabled: envelope.Ready,
+			Status: "active", CredentialsReady: true, WorkerAssigned: true,
+			AuthState: "passing", AuthSPF: true, AuthDKIM: true, AuthDMARC: true,
+			ConfiguredDailyCap:   envelope.DailyCap,
+			ConfiguredMinWaitSec: int(envelope.MinGap / time.Second),
+			DerivedHourlyCap:     envelope.HourlyCap,
+			EffectiveDailyCap:    envelope.DailyCap,
+			EffectiveHourlyCap:   minPositive(envelope.HourlyCap, cfg.SendsPerHour),
+			ProviderCapSource:    "unknown",
+			BusinessWindow: MailboxBusinessWindow{
+				Timezone: cfg.Timezone, Start: cfg.WindowStart, End: cfg.WindowEnd,
+				BusinessDaysOnly: cfg.BusinessDaysOnly,
+			},
+			Health: "ready", HealthReason: "ready",
+			Unknown: []string{"provider_daily_cap", "provider_hourly_cap", "warmup_age"},
+		}
+		if !envelope.Ready {
+			mailbox.Health, mailbox.HealthReason = "blocked", envelope.HealthReason
+		}
+		day := localDateKey(now, envelope.Timezone)
+		for key, sentAt := range m.sends {
+			if m.sendMailboxes[key] != envelope.EmailAccountID {
+				continue
+			}
+			if mailbox.Latest.AcceptedAt == nil || sentAt.After(*mailbox.Latest.AcceptedAt) {
+				value := sentAt
+				mailbox.Latest.AcceptedAt = &value
+			}
+			if !sentAt.Before(now.Add(-time.Hour)) {
+				mailbox.Throughput.AcceptedLastHour++
+				mailbox.occupiedAt = append(mailbox.occupiedAt, sentAt)
+			}
+			if localDateKey(sentAt, envelope.Timezone) == day {
+				mailbox.Throughput.AcceptedToday++
+			}
+			if !sentAt.Before(now.Add(-7 * 24 * time.Hour)) {
+				mailbox.Throughput.AcceptedLast7d++
+			}
+		}
+		for _, reservation := range m.reservations {
+			if reservation.EmailAccountID == nil || *reservation.EmailAccountID != envelope.EmailAccountID {
+				continue
+			}
+			if reservation.AttemptedAt != nil {
+				if mailbox.Latest.AttemptAt == nil || reservation.AttemptedAt.After(*mailbox.Latest.AttemptAt) {
+					value := *reservation.AttemptedAt
+					mailbox.Latest.AttemptAt = &value
+				}
+				if !reservation.AttemptedAt.Before(now.Add(-time.Hour)) && reservation.State != StateCommitted {
+					mailbox.occupiedAt = append(mailbox.occupiedAt, *reservation.AttemptedAt)
+				}
+			}
+			reservedToday := localDateKey(reservation.ReservedAt, envelope.Timezone) == day &&
+				(reservation.State == StateReserved || reservation.State == StateCommitted)
+			attemptedToday := reservation.AttemptedAt != nil && localDateKey(*reservation.AttemptedAt, envelope.Timezone) == day
+			if reservedToday || attemptedToday {
+				mailbox.UsedToday++
+			}
+			if reservation.State == StateReserved && reservation.AttemptedAt == nil && reservation.LeaseUntil.After(now) &&
+				!reservation.ReservedAt.Before(now.Add(-time.Hour)) {
+				mailbox.occupiedAt = append(mailbox.occupiedAt, reservation.ReservedAt)
+			}
+		}
+		for _, failure := range m.failures {
+			if failure.EmailAccountID == nil || *failure.EmailAccountID != envelope.EmailAccountID {
+				continue
+			}
+			if failure.ErrorClass == "" || failure.ErrorClass == "unknown" {
+				continue
+			}
+			if mailbox.Latest.ProviderRejectionAt == nil || failure.OccurredAt.After(*mailbox.Latest.ProviderRejectionAt) {
+				value := failure.OccurredAt
+				mailbox.Latest.ProviderRejectionAt = &value
+				mailbox.Latest.ProviderErrorClass = failure.ErrorClass
+			}
+		}
+		candidate := nextRollingSlot(now, mailbox.occupiedAt, mailbox.EffectiveHourlyCap, envelope.MinGap, RollingWindow)
+		if mailbox.UsedToday >= mailbox.EffectiveDailyCap {
+			candidate = nextLocalDay(now, envelope.Timezone)
+		}
+		candidate = NextEligibleSlot(candidate, cfg.Timezone, cfg.WindowStart, cfg.WindowEnd, cfg.BusinessDaysOnly)
+		if envelope.Ready {
+			mailbox.NextEligibleSlot = &candidate
+		}
+		out.Mailboxes = append(out.Mailboxes, mailbox)
+	}
+	for _, item := range m.queue {
+		if item.OrganizationID == orgID && item.Channel == ChannelEmail &&
+			(item.Status == QueueQueued || item.Status == QueueReserved) {
+			out.QueuedMessages++
+		}
+	}
+	return out, nil
 }

--- a/internal/app/confenge/dispatch/pg_store.go
+++ b/internal/app/confenge/dispatch/pg_store.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -89,11 +90,11 @@ func (s *PGStore) GetReservationByKey(ctx context.Context, messageKey string) (*
 	var draftID *uuid.UUID
 	var committedAt *time.Time
 	err := s.db.QueryRow(ctx, `
-		SELECT id, organization_id, channel, message_key, draft_id, state,
-		       reserved_at, lease_until, committed_at
+		SELECT id, organization_id, email_account_id, task_id, channel, message_key, draft_id, state,
+		       reserved_at, attempted_at, lease_until, committed_at
 		FROM confenge_dispatch_reservations WHERE message_key = $1`, messageKey,
-	).Scan(&r.ID, &r.OrganizationID, &r.Channel, &r.MessageKey, &draftID, &r.State,
-		&r.ReservedAt, &r.LeaseUntil, &committedAt)
+	).Scan(&r.ID, &r.OrganizationID, &r.EmailAccountID, &r.TaskID, &r.Channel, &r.MessageKey, &draftID, &r.State,
+		&r.ReservedAt, &r.AttemptedAt, &r.LeaseUntil, &committedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil
 	}
@@ -145,9 +146,9 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 	_, _ = tx.Exec(ctx, `
 		UPDATE confenge_dispatch_reservations
 		SET state = 'released', last_error = 'lease_expired'
-		WHERE state = 'reserved' AND lease_until <= $1`, now)
+			WHERE state = 'reserved' AND lease_until <= $1`, now)
 
-	// Already sent?
+	// Provider-confirmed replays remain final after later mailbox disablement.
 	var sentAt time.Time
 	err = tx.QueryRow(ctx, `SELECT sent_at FROM confenge_dispatch_sends WHERE message_key = $1`, in.Req.MessageKey).Scan(&sentAt)
 	if err == nil {
@@ -164,15 +165,56 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 		return out, err
 	}
 
+	if in.Req.Channel == ChannelEmail {
+		if in.Req.EmailAccountID == nil || *in.Req.EmailAccountID == uuid.Nil {
+			out.Reason = "mailbox_missing"
+			if err := tx.Commit(ctx); err != nil {
+				return out, err
+			}
+			return out, nil
+		}
+		authority, aerr := queryMailboxAuthority(ctx, tx, in.Req.OrganizationID, *in.Req.EmailAccountID, true)
+		if errors.Is(aerr, errMailboxNotConfigured) {
+			out.Reason = "mailbox_not_configured"
+			if err := tx.Commit(ctx); err != nil {
+				return out, err
+			}
+			return out, nil
+		}
+		if aerr != nil {
+			return out, aerr
+		}
+		envelope := authority.envelope(now)
+		in.Mailbox = &envelope
+		if !envelope.Ready {
+			out.Reason = envelope.HealthReason
+			if err := tx.Commit(ctx); err != nil {
+				return out, err
+			}
+			return out, nil
+		}
+	}
+
 	// Existing open lease?
 	var existing Reservation
 	var draftID *uuid.UUID
 	err = tx.QueryRow(ctx, `
-		SELECT id, organization_id, channel, message_key, draft_id, state, reserved_at, lease_until
-		FROM confenge_dispatch_reservations WHERE message_key = $1`, in.Req.MessageKey,
-	).Scan(&existing.ID, &existing.OrganizationID, &existing.Channel, &existing.MessageKey,
-		&draftID, &existing.State, &existing.ReservedAt, &existing.LeaseUntil)
+			SELECT id, organization_id, email_account_id, task_id, channel, message_key, draft_id, state, reserved_at, attempted_at, lease_until
+			FROM confenge_dispatch_reservations WHERE message_key = $1`, in.Req.MessageKey,
+	).Scan(&existing.ID, &existing.OrganizationID, &existing.EmailAccountID, &existing.TaskID, &existing.Channel, &existing.MessageKey,
+		&draftID, &existing.State, &existing.ReservedAt, &existing.AttemptedAt, &existing.LeaseUntil)
 	if err == nil && existing.State == StateReserved && existing.LeaseUntil.After(now) {
+		mailboxConflict := in.Req.Channel == ChannelEmail && in.Req.EmailAccountID != nil &&
+			(existing.EmailAccountID == nil || *existing.EmailAccountID != *in.Req.EmailAccountID)
+		taskConflict := in.Req.TaskID != nil && (existing.TaskID == nil || *existing.TaskID != *in.Req.TaskID)
+		if mailboxConflict || taskConflict {
+			out.Reason = "message_binding_conflict"
+			out.NextSlot = existing.LeaseUntil
+			if err := tx.Commit(ctx); err != nil {
+				return out, err
+			}
+			return out, nil
+		}
 		_, _ = tx.Exec(ctx, `UPDATE confenge_dispatch_reservations SET lease_until = $2, worker_token = COALESCE(NULLIF($3,''), worker_token) WHERE id = $1`,
 			existing.ID, now.Add(in.LeaseTTL), in.Req.WorkerToken)
 		existing.DraftID = draftID
@@ -188,6 +230,42 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 	}
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return out, err
+	}
+
+	if in.Req.Channel == ChannelEmail && in.Mailbox != nil {
+		mailboxTimes, mailboxLast, merr := listMailboxOccupiedTx(ctx, tx, in.Mailbox.EmailAccountID, now, window)
+		if merr != nil {
+			return out, merr
+		}
+		mailboxCap := in.Mailbox.HourlyCap
+		if in.Req.CapOverride > 0 {
+			mailboxCap = minPositive(mailboxCap, in.Req.CapOverride)
+		}
+		mailboxSnapshot := WindowSnapshot{
+			OccupiedAt: mailboxTimes, LastOccupied: mailboxLast,
+			Cap: mailboxCap, MinGap: in.Mailbox.MinGap, Window: window, Now: now,
+		}
+		if ok, reason, next := mailboxSnapshot.CanGrant(); !ok {
+			out.Reason = "mailbox_" + reason
+			out.NextSlot = next
+			if err := tx.Commit(ctx); err != nil {
+				return out, err
+			}
+			return out, nil
+		}
+		start, end := localDayBounds(now, in.Mailbox.Timezone)
+		used, uerr := countMailboxDailyUseTx(ctx, tx, in.Mailbox.EmailAccountID, start, end)
+		if uerr != nil {
+			return out, uerr
+		}
+		if used >= in.Mailbox.DailyCap {
+			out.Reason = "mailbox_daily_cap"
+			out.NextSlot = end
+			if err := tx.Commit(ctx); err != nil {
+				return out, err
+			}
+			return out, nil
+		}
 	}
 
 	// Count occupied under lock.
@@ -247,9 +325,10 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 	resID := uuid.New()
 	_, err = tx.Exec(ctx, `
 		INSERT INTO confenge_dispatch_reservations
-			(id, organization_id, channel, message_key, draft_id, state, reserved_at, lease_until, worker_token)
-		VALUES ($1,$2,$3,$4,$5,'reserved',$6,$7,$8)`,
-		resID, in.Req.OrganizationID, in.Req.Channel, in.Req.MessageKey, in.Req.DraftID,
+			(id, organization_id, email_account_id, task_id, channel, message_key, draft_id, state, reserved_at, lease_until, worker_token)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,'reserved',$8,$9,$10)`,
+		resID, in.Req.OrganizationID, in.Req.EmailAccountID, in.Req.TaskID,
+		in.Req.Channel, in.Req.MessageKey, in.Req.DraftID,
 		now, now.Add(in.LeaseTTL), in.Req.WorkerToken,
 	)
 	if err != nil {
@@ -261,6 +340,7 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 	out.Allowed = true
 	out.Reservation = &Reservation{
 		ID: resID, OrganizationID: in.Req.OrganizationID, Channel: in.Req.Channel,
+		EmailAccountID: in.Req.EmailAccountID, TaskID: in.Req.TaskID,
 		MessageKey: in.Req.MessageKey, DraftID: in.Req.DraftID, State: StateReserved,
 		ReservedAt: now, LeaseUntil: now.Add(in.LeaseTTL), WorkerToken: in.Req.WorkerToken,
 	}
@@ -287,9 +367,9 @@ func (s *PGStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt ti
 	var r Reservation
 	var draftID *uuid.UUID
 	err = tx.QueryRow(ctx, `
-		SELECT id, organization_id, channel, message_key, draft_id, state
+		SELECT id, organization_id, email_account_id, task_id, channel, message_key, draft_id, state
 		FROM confenge_dispatch_reservations WHERE id = $1 FOR UPDATE`, id,
-	).Scan(&r.ID, &r.OrganizationID, &r.Channel, &r.MessageKey, &draftID, &r.State)
+	).Scan(&r.ID, &r.OrganizationID, &r.EmailAccountID, &r.TaskID, &r.Channel, &r.MessageKey, &draftID, &r.State)
 	if err != nil {
 		return err
 	}
@@ -300,10 +380,10 @@ func (s *PGStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt ti
 
 	_, err = tx.Exec(ctx, `
 		INSERT INTO confenge_dispatch_sends
-			(organization_id, channel, message_key, draft_id, reservation_id, sent_at)
-		VALUES ($1,$2,$3,$4,$5,$6)
+			(organization_id, email_account_id, task_id, channel, message_key, draft_id, reservation_id, sent_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
 		ON CONFLICT (message_key) DO NOTHING`,
-		r.OrganizationID, r.Channel, r.MessageKey, r.DraftID, r.ID, sentAt,
+		r.OrganizationID, r.EmailAccountID, r.TaskID, r.Channel, r.MessageKey, r.DraftID, r.ID, sentAt,
 	)
 	if err != nil {
 		return err
@@ -323,10 +403,36 @@ func (s *PGStore) ReleaseReservation(ctx context.Context, id uuid.UUID, state, e
 	if state == "" {
 		state = StateReleased
 	}
-	_, err := s.db.Exec(ctx, `
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	var orgID uuid.UUID
+	var emailAccountID, taskID, draftID *uuid.UUID
+	var channel, messageKey string
+	err = tx.QueryRow(ctx, `
 		UPDATE confenge_dispatch_reservations SET state = $2, last_error = $3
-		WHERE id = $1 AND state = 'reserved'`, id, state, errText)
-	return err
+		WHERE id = $1 AND state = 'reserved'
+		RETURNING organization_id, email_account_id, task_id, channel, message_key, draft_id`,
+		id, state, errText).Scan(&orgID, &emailAccountID, &taskID, &channel, &messageKey, &draftID)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return tx.Commit(ctx)
+	}
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(errText) != "" {
+		_, err = tx.Exec(ctx, `
+			INSERT INTO confenge_dispatch_failures
+				(organization_id, email_account_id, task_id, channel, message_key, draft_id, error_code, error_class, error_text, occurred_at)
+			VALUES ($1,$2,$3,$4,$5,$6,'','unknown',$7,now())`,
+			orgID, emailAccountID, taskID, channel, messageKey, draftID, errText)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
 }
 
 func (s *PGStore) ExpireStaleReservations(ctx context.Context, now time.Time) (int, error) {
@@ -346,9 +452,10 @@ func (s *PGStore) Enqueue(ctx context.Context, item *QueueItem) error {
 	}
 	_, err := s.db.Exec(ctx, `
 		INSERT INTO confenge_dispatch_queue
-			(id, organization_id, channel, draft_id, message_key, recipient_ref, due_at, priority, status, created_at, updated_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,'queued', now(), now())
+			(id, organization_id, email_account_id, channel, draft_id, message_key, recipient_ref, due_at, priority, status, created_at, updated_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,'queued', now(), now())
 		ON CONFLICT (message_key) DO UPDATE SET
+			email_account_id = COALESCE(EXCLUDED.email_account_id, confenge_dispatch_queue.email_account_id),
 			due_at = EXCLUDED.due_at,
 			priority = EXCLUDED.priority,
 			recipient_ref = EXCLUDED.recipient_ref,
@@ -357,8 +464,8 @@ func (s *PGStore) Enqueue(ctx context.Context, item *QueueItem) error {
 				ELSE 'queued'
 			END,
 			updated_at = now()`,
-		item.ID, item.OrganizationID, item.Channel, item.DraftID, item.MessageKey, item.RecipientRef,
-		item.DueAt, item.Priority,
+		item.ID, item.OrganizationID, item.EmailAccountID, item.Channel, item.DraftID, item.MessageKey,
+		item.RecipientRef, item.DueAt, item.Priority,
 	)
 	return err
 }
@@ -413,14 +520,14 @@ func (s *PGStore) ClaimNextQueued(ctx context.Context, now time.Time) (*QueueIte
 
 	var q QueueItem
 	err = tx.QueryRow(ctx, `
-		SELECT id, organization_id, channel, draft_id, message_key, COALESCE(recipient_ref,''), due_at, priority, attempts, status,
+			SELECT id, organization_id, email_account_id, channel, draft_id, message_key, COALESCE(recipient_ref,''), due_at, priority, attempts, status,
 		       cancel_reason, last_error, created_at
 		FROM confenge_dispatch_queue
 		WHERE status = 'queued' AND due_at <= $1
 		ORDER BY due_at ASC, priority DESC, created_at ASC
 		LIMIT 1
 		FOR UPDATE SKIP LOCKED`, now,
-	).Scan(&q.ID, &q.OrganizationID, &q.Channel, &q.DraftID, &q.MessageKey, &q.RecipientRef, &q.DueAt,
+	).Scan(&q.ID, &q.OrganizationID, &q.EmailAccountID, &q.Channel, &q.DraftID, &q.MessageKey, &q.RecipientRef, &q.DueAt,
 		&q.Priority, &q.Attempts, &q.Status, &q.CancelReason, &q.LastError, &q.CreatedAt)
 	if errors.Is(err, pgx.ErrNoRows) {
 		_ = tx.Commit(ctx)
@@ -472,9 +579,10 @@ func (s *PGStore) RecordFailure(ctx context.Context, f FailureRecord) error {
 	}
 	_, err := s.db.Exec(ctx, `
 		INSERT INTO confenge_dispatch_failures
-			(id, organization_id, channel, message_key, draft_id, error_text, occurred_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7)`,
-		f.ID, f.OrganizationID, f.Channel, f.MessageKey, f.DraftID, f.ErrorText, f.OccurredAt,
+			(id, organization_id, email_account_id, task_id, channel, message_key, draft_id, error_code, error_class, error_text, occurred_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+		f.ID, f.OrganizationID, f.EmailAccountID, f.TaskID, f.Channel, f.MessageKey, f.DraftID,
+		f.ErrorCode, firstNonEmptyString(f.ErrorClass, "unknown"), f.ErrorText, f.OccurredAt,
 	)
 	return err
 }
@@ -484,7 +592,8 @@ func (s *PGStore) ListRecentFailures(ctx context.Context, limit int) ([]FailureR
 		limit = DefaultMaxRecentFails
 	}
 	rows, err := s.db.Query(ctx, `
-		SELECT id, organization_id, channel, message_key, draft_id, error_text, occurred_at
+		SELECT id, organization_id, email_account_id, task_id, channel, message_key, draft_id,
+		       error_code, error_class, error_text, occurred_at
 		FROM confenge_dispatch_failures ORDER BY occurred_at DESC LIMIT $1`, limit)
 	if err != nil {
 		return nil, err
@@ -493,12 +602,20 @@ func (s *PGStore) ListRecentFailures(ctx context.Context, limit int) ([]FailureR
 	var out []FailureRecord
 	for rows.Next() {
 		var f FailureRecord
-		if err := rows.Scan(&f.ID, &f.OrganizationID, &f.Channel, &f.MessageKey, &f.DraftID, &f.ErrorText, &f.OccurredAt); err != nil {
+		if err := rows.Scan(&f.ID, &f.OrganizationID, &f.EmailAccountID, &f.TaskID, &f.Channel, &f.MessageKey,
+			&f.DraftID, &f.ErrorCode, &f.ErrorClass, &f.ErrorText, &f.OccurredAt); err != nil {
 			return nil, err
 		}
 		out = append(out, f)
 	}
 	return out, rows.Err()
+}
+
+func firstNonEmptyString(value, fallback string) string {
+	if strings.TrimSpace(value) != "" {
+		return value
+	}
+	return fallback
 }
 
 func (s *PGStore) CountActiveLeases(ctx context.Context, now time.Time) (int, error) {

--- a/internal/app/confenge/dispatch/store.go
+++ b/internal/app/confenge/dispatch/store.go
@@ -13,6 +13,7 @@ type AtomicReserveInput struct {
 	Now      time.Time
 	Cap      int
 	MinGap   time.Duration
+	Mailbox  *MailboxEnvelope
 	LeaseTTL time.Duration
 	Window   time.Duration
 }
@@ -63,4 +64,17 @@ type Store interface {
 
 	CountActiveLeases(ctx context.Context, now time.Time) (int, error)
 	CountSendsSince(ctx context.Context, since time.Time) (int, error)
+}
+
+// MailboxStore resolves real email envelopes; WhatsApp keeps the shared ceiling only.
+type MailboxStore interface {
+	GetMailboxEnvelope(ctx context.Context, orgID, emailAccountID uuid.UUID, now time.Time) (MailboxEnvelope, error)
+	MailboxCapacitySnapshot(ctx context.Context, orgID uuid.UUID, now time.Time, cfg Config) (MailboxCapacitySnapshot, error)
+	MarkAttempt(ctx context.Context, messageKey string, attemptedAt time.Time) error
+	RecordProviderFailure(ctx context.Context, taskID uuid.UUID, errorCode, errorText string, occurredAt time.Time) error
+}
+
+type MailboxCapacitySnapshot struct {
+	Mailboxes      []MailboxCapacity
+	QueuedMessages int
 }

--- a/internal/app/confenge/dispatch/types.go
+++ b/internal/app/confenge/dispatch/types.go
@@ -1,5 +1,5 @@
-// Package dispatch implements the CONFENGE global outbound governor:
-// a multi-worker-safe rolling-hour cap shared by email and WhatsApp.
+// Package dispatch implements mailbox-first CONFENGE email pacing plus the
+// shared multi-worker-safe outbound ceiling for email and WhatsApp.
 //
 // Pacing is operational capacity and reputation protection, not anti-spam evasion.
 package dispatch
@@ -109,11 +109,14 @@ func MinGapForRate(sendsPerHour int) time.Duration {
 type Reservation struct {
 	ID             uuid.UUID
 	OrganizationID uuid.UUID
+	EmailAccountID *uuid.UUID
+	TaskID         *uuid.UUID
 	Channel        string
 	MessageKey     string
 	DraftID        *uuid.UUID
 	State          string
 	ReservedAt     time.Time
+	AttemptedAt    *time.Time
 	LeaseUntil     time.Time
 	CommittedAt    *time.Time
 	WorkerToken    string
@@ -122,6 +125,8 @@ type Reservation struct {
 
 type ReserveRequest struct {
 	OrganizationID uuid.UUID
+	EmailAccountID *uuid.UUID
+	TaskID         *uuid.UUID
 	Channel        string
 	MessageKey     string
 	DraftID        *uuid.UUID
@@ -144,6 +149,7 @@ type ReserveResult struct {
 type QueueItem struct {
 	ID             uuid.UUID
 	OrganizationID uuid.UUID
+	EmailAccountID *uuid.UUID
 	Channel        string
 	DraftID        uuid.UUID
 	MessageKey     string
@@ -159,6 +165,7 @@ type QueueItem struct {
 
 type EnqueueRequest struct {
 	OrganizationID uuid.UUID
+	EmailAccountID *uuid.UUID
 	Channel        string
 	DraftID        uuid.UUID
 	MessageKey     string
@@ -177,25 +184,132 @@ type ControlState struct {
 type FailureRecord struct {
 	ID             uuid.UUID  `json:"id"`
 	OrganizationID *uuid.UUID `json:"organization_id,omitempty"`
+	EmailAccountID *uuid.UUID `json:"email_account_id,omitempty"`
+	TaskID         *uuid.UUID `json:"task_id,omitempty"`
 	Channel        string     `json:"channel"`
 	MessageKey     string     `json:"message_key"`
 	DraftID        *uuid.UUID `json:"draft_id,omitempty"`
+	ErrorCode      string     `json:"error_code,omitempty"`
+	ErrorClass     string     `json:"error_class"`
 	ErrorText      string     `json:"error_text"`
 	OccurredAt     time.Time  `json:"occurred_at"`
 }
 
+// MailboxEnvelope keeps unknown provider caps nullable instead of guessing them.
+type MailboxEnvelope struct {
+	EmailAccountID    uuid.UUID
+	OrganizationID    uuid.UUID
+	DailyCap          int
+	HourlyCap         int
+	MinGap            time.Duration
+	Ready             bool
+	HealthReason      string
+	Timezone          string
+	ProviderDailyCap  *int
+	ProviderHourlyCap *int
+	ProviderCapSource string
+}
+
+type MailboxBusinessWindow struct {
+	Timezone         string `json:"timezone"`
+	Start            string `json:"start"`
+	End              string `json:"end"`
+	BusinessDaysOnly bool   `json:"business_days_only"`
+}
+
+type MailboxThroughput struct {
+	AcceptedLastHour int `json:"accepted_last_hour"`
+	AcceptedToday    int `json:"accepted_today"`
+	AcceptedLast7d   int `json:"accepted_last_7d"`
+}
+
+type MailboxLatestSignals struct {
+	AttemptAt           *time.Time `json:"attempt_at,omitempty"`
+	AcceptedAt          *time.Time `json:"accepted_at,omitempty"`
+	BounceAt            *time.Time `json:"bounce_at,omitempty"`
+	ComplaintAt         *time.Time `json:"complaint_at,omitempty"`
+	ReplyAt             *time.Time `json:"reply_at,omitempty"`
+	ProviderRejectionAt *time.Time `json:"provider_rejection_at,omitempty"`
+	ProviderErrorClass  string     `json:"provider_error_class,omitempty"`
+}
+
+type MailboxCapacity struct {
+	EmailAccountID       uuid.UUID             `json:"email_account_id"`
+	Email                string                `json:"email"`
+	Enabled              bool                  `json:"enabled"`
+	Status               string                `json:"status"`
+	Provider             string                `json:"provider"`
+	CredentialsReady     bool                  `json:"credentials_ready"`
+	WorkerAssigned       bool                  `json:"worker_assigned"`
+	AuthState            string                `json:"auth_state"`
+	AuthSPF              bool                  `json:"auth_spf"`
+	AuthDKIM             bool                  `json:"auth_dkim"`
+	AuthDMARC            bool                  `json:"auth_dmarc"`
+	AuthDMARCPolicy      string                `json:"auth_dmarc_policy,omitempty"`
+	AuthCheckedAt        *time.Time            `json:"auth_checked_at,omitempty"`
+	MailboxAgeDays       int                   `json:"mailbox_age_days"`
+	WarmupStartedAt      *time.Time            `json:"warmup_started_at,omitempty"`
+	WarmupAgeDays        *int                  `json:"warmup_age_days,omitempty"`
+	WarmupDaysObserved   int                   `json:"warmup_days_observed"`
+	ColdRampStartedAt    *time.Time            `json:"cold_ramp_started_at,omitempty"`
+	ConfiguredDailyCap   int                   `json:"configured_daily_cap"`
+	ConfiguredMinWaitSec int                   `json:"configured_min_wait_seconds"`
+	DerivedHourlyCap     int                   `json:"derived_hourly_cap"`
+	EffectiveDailyCap    int                   `json:"effective_daily_cap"`
+	EffectiveHourlyCap   int                   `json:"effective_hourly_cap"`
+	ProviderDailyCap     *int                  `json:"provider_daily_cap,omitempty"`
+	ProviderHourlyCap    *int                  `json:"provider_hourly_cap,omitempty"`
+	ProviderCapSource    string                `json:"provider_cap_source"`
+	BusinessWindow       MailboxBusinessWindow `json:"business_window"`
+	Throughput           MailboxThroughput     `json:"observed_throughput"`
+	Latest               MailboxLatestSignals  `json:"latest"`
+	PauseSource          string                `json:"pause_source,omitempty"`
+	Health               string                `json:"health"`
+	HealthReason         string                `json:"health_reason"`
+	HealthSignals        []string              `json:"health_signals,omitempty"`
+	Unknown              []string              `json:"unknown,omitempty"`
+	UsedToday            int                   `json:"used_today"`
+	NextEligibleSlot     *time.Time            `json:"next_eligible_slot,omitempty"`
+	occupiedAt           []time.Time
+	errorCounts          map[string]int
+	errorLatest          map[string]time.Time
+}
+
+type CapacityAlert struct {
+	Code           string     `json:"code"`
+	Severity       string     `json:"severity"`
+	EmailAccountID *uuid.UUID `json:"email_account_id,omitempty"`
+	Count          int        `json:"count,omitempty"`
+	OccurredAt     *time.Time `json:"occurred_at,omitempty"`
+	Reason         string     `json:"reason"`
+}
+
+type CapacityForecast struct {
+	SlotsNext24h          int  `json:"slots_next_24h"`
+	SlotsNext7d           int  `json:"slots_next_7d"`
+	PotentialSlotsNext24h int  `json:"potential_slots_next_24h"`
+	PotentialSlotsNext7d  int  `json:"potential_slots_next_7d"`
+	EstimatedDaysToDrain  *int `json:"estimated_days_to_drain,omitempty"`
+	DeliveryPromised      bool `json:"delivery_promised"`
+}
+
 type Status struct {
-	SentLastHour   int             `json:"sent_last_hour"`
-	Cap            int             `json:"cap"`
-	MinGapSeconds  int             `json:"min_gap_seconds"`
-	NextSlotAt     *time.Time      `json:"next_slot_at,omitempty"`
-	QueuedApproved int             `json:"queued_approved"`
-	Paused         bool            `json:"paused"`
-	PauseReason    string          `json:"pause_reason,omitempty"`
-	InSendWindow   bool            `json:"in_send_window"`
-	Timezone       string          `json:"timezone"`
-	WindowStart    string          `json:"window_start"`
-	WindowEnd      string          `json:"window_end"`
-	ActiveLeases   int             `json:"active_leases"`
-	RecentFailures []FailureRecord `json:"recent_failures,omitempty"`
+	SentLastHour   int               `json:"sent_last_hour"`
+	Cap            int               `json:"cap"`
+	MinGapSeconds  int               `json:"min_gap_seconds"`
+	NextSlotAt     *time.Time        `json:"next_slot_at,omitempty"`
+	QueuedApproved int               `json:"queued_approved"`
+	Paused         bool              `json:"paused"`
+	PauseReason    string            `json:"pause_reason,omitempty"`
+	InSendWindow   bool              `json:"in_send_window"`
+	Timezone       string            `json:"timezone"`
+	WindowStart    string            `json:"window_start"`
+	WindowEnd      string            `json:"window_end"`
+	ActiveLeases   int               `json:"active_leases"`
+	RecentFailures []FailureRecord   `json:"recent_failures,omitempty"`
+	PauseSource    string            `json:"pause_source,omitempty"`
+	CapacitySource string            `json:"capacity_source"`
+	Mailboxes      []MailboxCapacity `json:"mailboxes"`
+	Forecast       CapacityForecast  `json:"forecast"`
+	Alerts         []CapacityAlert   `json:"alerts,omitempty"`
 }

--- a/internal/app/confenge/dispatch_gate.go
+++ b/internal/app/confenge/dispatch_gate.go
@@ -14,7 +14,7 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
-// WireDispatch attaches the global outbound governor (email + WhatsApp share one cap).
+// WireDispatch attaches mailbox-first email pacing and the shared outbound ceiling.
 // Safe to call with nil db (uses memory store for tests) or with pool for production.
 func (s *service) WireDispatch(db *pgxpool.Pool) {
 	cfg := dispatch.LoadConfig()
@@ -98,7 +98,6 @@ func (s *service) releaseOutbound(ctx context.Context, res *dispatch.Reservation
 		return
 	}
 	_ = s.governor.Release(ctx, res.ID, errText)
-	_ = s.governor.RecordFailure(ctx, res.OrganizationID, res.Channel, res.MessageKey, res.DraftID, errText)
 }
 
 // DispatchStatus returns observability for GET /confenge/dispatch/status.
@@ -113,7 +112,40 @@ func (s *service) DispatchStatus(ctx context.Context, orgID uuid.UUID) (dispatch
 	if err != nil {
 		return dispatch.Status{}, errx.New(errx.Internal, err.Error())
 	}
+	fileKillSwitch := FileKillSwitchActive()
+	if fileKillSwitch || s.cfg.SendingPaused {
+		st.Paused = true
+		st.PauseReason = "confenge_sending_paused"
+		st.PauseSource = "configuration"
+		if fileKillSwitch {
+			st.PauseReason = "kill_switch_engaged"
+			st.PauseSource = "file_kill_switch"
+		}
+		st.Forecast.SlotsNext24h = 0
+		st.Forecast.SlotsNext7d = 0
+		st.Forecast.EstimatedDaysToDrain = nil
+		st.NextSlotAt = nil
+		for i := range st.Mailboxes {
+			st.Mailboxes[i].PauseSource = st.PauseSource
+			st.Mailboxes[i].NextEligibleSlot = nil
+		}
+		if st.QueuedApproved > 0 && !hasCapacityAlert(st.Alerts, dispatch.AlertQueueRunoff) {
+			st.Alerts = append(st.Alerts, dispatch.CapacityAlert{
+				Code: dispatch.AlertQueueRunoff, Severity: "critical", Count: st.QueuedApproved,
+				Reason: "approved queue has no effective mailbox capacity while transport is paused",
+			})
+		}
+	}
 	return st, nil
+}
+
+func hasCapacityAlert(alerts []dispatch.CapacityAlert, code string) bool {
+	for _, alert := range alerts {
+		if alert.Code == code {
+			return true
+		}
+	}
+	return false
 }
 
 // PauseDispatch sets the durable kill switch.

--- a/internal/app/confenge/outbound_gate.go
+++ b/internal/app/confenge/outbound_gate.go
@@ -61,6 +61,12 @@ type CampaignGateResult struct {
 	Err           error // only meaningful for GateTransient
 }
 
+// CampaignTransportBinding binds a reservation to the scheduler-selected mailbox and task.
+type CampaignTransportBinding struct {
+	EmailAccountID uuid.UUID
+	TaskID         uuid.UUID
+}
+
 // PermanentSuppress reports whether the campaign task may org-wide suppress / bounce-mark.
 // Only GateHardBlock is true; Transient/Deferred/Already/Proceed never permanent-suppress.
 func (r CampaignGateResult) PermanentSuppress() bool {
@@ -85,6 +91,24 @@ func MessageKeyCampaignEmail(campaignID, contactID, sequenceID uuid.UUID) string
 // CAMPAIGN_POLICY revalidation always runs for open transportable touchpoints on
 // the resolved account, independent of MessageContextHash presence.
 func (s *service) GateCampaignEmail(ctx context.Context, orgID uuid.UUID, campaignName, recipientEmail string, campaignID, contactID, sequenceID uuid.UUID) CampaignGateResult {
+	return s.gateCampaignEmail(ctx, orgID, campaignName, recipientEmail, campaignID, contactID, sequenceID, CampaignTransportBinding{})
+}
+
+// GateCampaignEmailForTransport requires the scheduler-selected mailbox and task binding.
+func (s *service) GateCampaignEmailForTransport(ctx context.Context, orgID uuid.UUID, campaignName, recipientEmail string, campaignID, contactID, sequenceID uuid.UUID, binding CampaignTransportBinding) CampaignGateResult {
+	return s.gateCampaignEmail(ctx, orgID, campaignName, recipientEmail, campaignID, contactID, sequenceID, binding)
+}
+
+func (s *service) gateCampaignEmail(ctx context.Context, orgID uuid.UUID, campaignName, recipientEmail string, campaignID, contactID, sequenceID uuid.UUID, binding CampaignTransportBinding) CampaignGateResult {
+	var emailAccountID, taskID *uuid.UUID
+	if binding.EmailAccountID != uuid.Nil {
+		value := binding.EmailAccountID
+		emailAccountID = &value
+	}
+	if binding.TaskID != uuid.Nil {
+		value := binding.TaskID
+		taskID = &value
+	}
 	isConfenge := IsConfengeCampaign(campaignName)
 	var enrolledTouchpoint *models.OutreachTouchpoint
 	if s != nil && s.repo != nil && campaignID != uuid.Nil {
@@ -259,6 +283,8 @@ func (s *service) GateCampaignEmail(ctx context.Context, orgID uuid.UUID, campai
 	}
 	res, err := s.governor.TryReserve(ctx, dispatch.ReserveRequest{
 		OrganizationID: orgID,
+		EmailAccountID: emailAccountID,
+		TaskID:         taskID,
 		Channel:        dispatch.ChannelEmail,
 		MessageKey:     key,
 		CapOverride:    capOverride,
@@ -283,14 +309,7 @@ func (s *service) GateCampaignEmail(ctx context.Context, orgID uuid.UUID, campai
 		if due.IsZero() {
 			due = time.Now().UTC().Add(s.governor.Config().MinGap)
 		}
-		_ = s.governor.Enqueue(ctx, dispatch.EnqueueRequest{
-			OrganizationID: orgID,
-			Channel:        dispatch.ChannelEmail,
-			DraftID:        uuid.Nil,
-			MessageKey:     key,
-			RecipientRef:   strings.TrimSpace(strings.ToLower(recipientEmail)),
-			DueAt:          due,
-		})
+		// The campaign task already provides durable retry; do not add a zero-draft queue row.
 		return CampaignGateResult{Kind: GateDeferred, NextSlot: due, Reason: res.Reason}
 	}
 	if cohortAuthID != uuid.Nil && res.Reservation != nil {
@@ -649,6 +668,13 @@ func (s *service) ObserveCampaignEmailAttempt(ctx context.Context, orgID, campai
 	if touchpoint == nil {
 		return ErrCampaignTouchpointNotFound
 	}
+	messageKey := MessageKeyCampaignEmail(campaignID, contactID, sequenceID)
+	if s.governor == nil {
+		return fmt.Errorf("dispatch governor unavailable for provider attempt")
+	}
+	if err := s.governor.MarkAttempt(ctx, messageKey, attemptedAt); err != nil {
+		return err
+	}
 	if !isBoundedCohortTouch(touchpoint) {
 		return nil
 	}
@@ -656,7 +682,6 @@ func (s *service) ObserveCampaignEmailAttempt(ctx context.Context, orgID, campai
 	if touchpoint.ContactCandidateID != nil {
 		cand, _ = s.repo.GetCandidate(ctx, orgID, *touchpoint.ContactCandidateID)
 	}
-	messageKey := MessageKeyCampaignEmail(campaignID, contactID, sequenceID)
 	if err := s.assertBoundedCohortTransport(ctx, touchpoint, cand, messageKey); err != nil {
 		return err
 	}
@@ -664,6 +689,14 @@ func (s *service) ObserveCampaignEmailAttempt(ctx context.Context, orgID, campai
 		OccurredAt: attemptedAt, ProviderName: "smtp",
 	})
 	return nil
+}
+
+// RecordCampaignEmailFailure persists a factual mailbox-bound rejection.
+func (s *service) RecordCampaignEmailFailure(ctx context.Context, taskID uuid.UUID, errorCode, errorText string, occurredAt time.Time) error {
+	if s == nil || s.governor == nil {
+		return fmt.Errorf("dispatch governor unavailable for provider failure")
+	}
+	return s.governor.RecordProviderFailure(ctx, taskID, errorCode, errorText, occurredAt)
 }
 
 func (s *service) transitionCompletedTouchpoint(ctx context.Context, orgID uuid.UUID, tp *models.OutreachTouchpoint, now time.Time, providerMessageID string) error {
@@ -773,7 +806,6 @@ func (s *service) ReleaseCampaignEmail(ctx context.Context, reservationID uuid.U
 	}
 	if s.governor != nil && reservationID != uuid.Nil {
 		_ = s.governor.Release(ctx, reservationID, errText)
-		_ = s.governor.RecordFailure(ctx, uuid.Nil, dispatch.ChannelEmail, "", nil, errText)
 	}
 	if s.cohortStore != nil && reservationID != uuid.Nil {
 		_ = s.cohortStore.ReleaseSlotByLease(ctx, reservationID.String(), errText)

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -101,13 +101,14 @@ type Service interface {
 	SendApprovedWhatsApp(ctx context.Context, orgID, userID, draftID uuid.UUID) (*models.OutreachDraft, *errx.Error)
 	HandleWhatsAppInbound(ctx context.Context, orgID uuid.UUID, ev whatsapp.ChannelEvent) (whatsapp.InboundResult, error)
 
-	// Global dispatch governor (email + WhatsApp shared cap).
+	// Mailbox-first email pacing with a shared email and WhatsApp ceiling.
 	WireDispatch(db *pgxpool.Pool)
 	DispatchStatus(ctx context.Context, orgID uuid.UUID) (dispatch.Status, *errx.Error)
 	PauseDispatch(ctx context.Context, orgID, userID uuid.UUID, reason string) *errx.Error
 	ResumeDispatch(ctx context.Context, orgID, userID uuid.UUID) *errx.Error
 	CompleteCampaignEmail(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, providerMessageID string, acceptedAt time.Time) error
 	ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, attemptedAt time.Time) error
+	RecordCampaignEmailFailure(ctx context.Context, taskID uuid.UUID, errorCode, errorText string, occurredAt time.Time) error
 	ProcessDispatchQueueOnce(ctx context.Context) (bool, error)
 	ProcessEditorialRecoveryOnce(ctx context.Context) (bool, error)
 	ProcessDraftGenerationOnce(ctx context.Context) (bool, error)

--- a/internal/app/consumer/confenge_failure.go
+++ b/internal/app/consumer/confenge_failure.go
@@ -1,0 +1,31 @@
+package jobs
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func (s *JobsService) recordConfengeMailboxFailure(ctx context.Context, taskID uuid.UUID, errorCode, errorText string, occurredAt time.Time) error {
+	if s == nil || s.ConfengeSends == nil || taskID == uuid.Nil {
+		return nil
+	}
+	if occurredAt.IsZero() {
+		occurredAt = time.Now().UTC()
+	}
+	return s.ConfengeSends.RecordCampaignEmailFailure(ctx, taskID, errorCode, errorText, occurredAt)
+}
+
+func (s *JobsService) recordConfengeEmailError(ctx context.Context, event models.EmailErrorEvent) error {
+	taskID, err := uuid.Parse(event.TaskID)
+	if err != nil {
+		return nil
+	}
+	occurredAt := time.Unix(event.Timestamp, 0).UTC()
+	if event.Timestamp <= 0 {
+		occurredAt = time.Now().UTC()
+	}
+	return s.recordConfengeMailboxFailure(ctx, taskID, event.ErrorCode, event.Message, occurredAt)
+}

--- a/internal/app/consumer/event_email_error.go
+++ b/internal/app/consumer/event_email_error.go
@@ -80,7 +80,7 @@ func (s *JobsService) HandleEmailAuthError(ctx context.Context, event models.Ema
 		)
 	}
 
-	return nil
+	return s.recordConfengeEmailError(ctx, event)
 }
 
 // HandleEmailDisabled handles errors indicating the account has been disabled
@@ -152,7 +152,7 @@ func (s *JobsService) HandleEmailDisabled(ctx context.Context, event models.Emai
 		)
 	}
 
-	return nil
+	return s.recordConfengeEmailError(ctx, event)
 }
 
 // HandleEmailRateLimited handles rate limit exceeded errors (anti-abuse)
@@ -231,7 +231,7 @@ func (s *JobsService) HandleEmailRateLimited(ctx context.Context, event models.E
 		)
 	}
 
-	return nil
+	return s.recordConfengeEmailError(ctx, event)
 }
 
 // HandleEmailServerError handles temporary server errors (may auto-resolve)
@@ -295,7 +295,7 @@ func (s *JobsService) HandleEmailServerError(ctx context.Context, event models.E
 		)
 	}
 
-	return nil
+	return s.recordConfengeEmailError(ctx, event)
 }
 
 // ptrString returns a pointer to a string, or nil if empty

--- a/internal/app/consumer/event_email_failed.go
+++ b/internal/app/consumer/event_email_failed.go
@@ -15,8 +15,14 @@ func (s *JobsService) HandleEmailFailed(ctx context.Context, event *models.SendE
 	if event == nil || event.TaskID == uuid.Nil {
 		return fmt.Errorf("invalid EMAIL_FAILED result")
 	}
+	errorCode, errorText := "", strings.TrimSpace(event.LegacyErrorMsg)
+	if event.Error != nil {
+		errorCode = strings.TrimSpace(event.Error.Code)
+		errorText = strings.TrimSpace(event.Error.Message)
+	}
+	observedErr := s.recordConfengeMailboxFailure(ctx, event.TaskID, errorCode, errorText, event.SentAt)
 	if event.Error == nil || !strings.EqualFold(event.Error.Code, string(errx.MailErrorCodeRecipientRejected)) {
-		return nil
+		return observedErr
 	}
 	if s.AdvancedService == nil {
 		return fmt.Errorf("deliverability service is not configured")
@@ -24,5 +30,5 @@ func (s *JobsService) HandleEmailFailed(ctx context.Context, event *models.SendE
 	if xerr := s.AdvancedService.RecordOutboundBounce(ctx, event.TaskID, event.Error.Message); xerr != nil {
 		return fmt.Errorf("record outbound SMTP rejection: %w", xerr)
 	}
-	return nil
+	return observedErr
 }

--- a/internal/app/consumer/event_email_sent_test.go
+++ b/internal/app/consumer/event_email_sent_test.go
@@ -51,6 +51,10 @@ func (c *emailSentCompletion) ObserveCampaignEmailAttempt(_ context.Context, org
 	return c.err
 }
 
+func (c *emailSentCompletion) RecordCampaignEmailFailure(_ context.Context, _ uuid.UUID, _, _ string, _ time.Time) error {
+	return nil
+}
+
 func (c *emailSentCompletion) CompleteCampaignEmail(_ context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, providerMessageID string, _ time.Time) error {
 	c.called++
 	c.orgID = orgID

--- a/internal/app/consumer/service.go
+++ b/internal/app/consumer/service.go
@@ -52,6 +52,7 @@ type JobsService struct {
 	ConfengeSends    interface {
 		ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, attemptedAt time.Time) error
 		CompleteCampaignEmail(ctx context.Context, orgID, campaignID, contactID, sequenceID uuid.UUID, providerMessageID string, acceptedAt time.Time) error
+		RecordCampaignEmailFailure(ctx context.Context, taskID uuid.UUID, errorCode, errorText string, occurredAt time.Time) error
 	}
 
 	// Cache for dead worker detection

--- a/internal/infrastructure/db/migrations/000130_confenge_mailbox_capacity.down.sql
+++ b/internal/infrastructure/db/migrations/000130_confenge_mailbox_capacity.down.sql
@@ -1,0 +1,24 @@
+DROP INDEX IF EXISTS confenge_dispatch_failures_mailbox_idx;
+DROP INDEX IF EXISTS confenge_dispatch_failures_task_code_uidx;
+DROP INDEX IF EXISTS confenge_dispatch_queue_mailbox_idx;
+DROP INDEX IF EXISTS confenge_dispatch_sends_mailbox_idx;
+DROP INDEX IF EXISTS confenge_dispatch_reservations_mailbox_idx;
+
+ALTER TABLE confenge_dispatch_failures
+    DROP CONSTRAINT IF EXISTS confenge_dispatch_failures_error_class_check,
+    DROP COLUMN IF EXISTS error_class,
+    DROP COLUMN IF EXISTS error_code,
+    DROP COLUMN IF EXISTS task_id,
+    DROP COLUMN IF EXISTS email_account_id;
+
+ALTER TABLE confenge_dispatch_queue
+    DROP COLUMN IF EXISTS email_account_id;
+
+ALTER TABLE confenge_dispatch_sends
+    DROP COLUMN IF EXISTS task_id,
+    DROP COLUMN IF EXISTS email_account_id;
+
+ALTER TABLE confenge_dispatch_reservations
+    DROP COLUMN IF EXISTS attempted_at,
+    DROP COLUMN IF EXISTS task_id,
+    DROP COLUMN IF EXISTS email_account_id;

--- a/internal/infrastructure/db/migrations/000130_confenge_mailbox_capacity.up.sql
+++ b/internal/infrastructure/db/migrations/000130_confenge_mailbox_capacity.up.sql
@@ -1,0 +1,45 @@
+-- Nullable bindings preserve historical rows whose mailbox cannot be reconstructed safely.
+ALTER TABLE confenge_dispatch_reservations
+    ADD COLUMN IF NOT EXISTS email_account_id uuid REFERENCES email_accounts(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS task_id uuid REFERENCES tasks(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS attempted_at timestamptz;
+
+ALTER TABLE confenge_dispatch_sends
+    ADD COLUMN IF NOT EXISTS email_account_id uuid REFERENCES email_accounts(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS task_id uuid REFERENCES tasks(id) ON DELETE SET NULL;
+
+ALTER TABLE confenge_dispatch_queue
+    ADD COLUMN IF NOT EXISTS email_account_id uuid REFERENCES email_accounts(id) ON DELETE SET NULL;
+
+ALTER TABLE confenge_dispatch_failures
+    ADD COLUMN IF NOT EXISTS email_account_id uuid REFERENCES email_accounts(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS task_id uuid REFERENCES tasks(id) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS error_code text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS error_class text NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE confenge_dispatch_failures
+    DROP CONSTRAINT IF EXISTS confenge_dispatch_failures_error_class_check,
+    ADD CONSTRAINT confenge_dispatch_failures_error_class_check CHECK (error_class IN (
+        'unknown', 'auth_failure', 'provider_interrupted', 'provider_4xx',
+        'provider_5xx', 'rate_limit', 'provider_block', 'recipient_rejection'
+    ));
+
+CREATE INDEX IF NOT EXISTS confenge_dispatch_reservations_mailbox_idx
+    ON confenge_dispatch_reservations (email_account_id, reserved_at DESC)
+    WHERE email_account_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS confenge_dispatch_sends_mailbox_idx
+    ON confenge_dispatch_sends (email_account_id, sent_at DESC)
+    WHERE email_account_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS confenge_dispatch_queue_mailbox_idx
+    ON confenge_dispatch_queue (email_account_id, status, due_at)
+    WHERE email_account_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS confenge_dispatch_failures_mailbox_idx
+    ON confenge_dispatch_failures (email_account_id, occurred_at DESC)
+    WHERE email_account_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS confenge_dispatch_failures_task_code_uidx
+    ON confenge_dispatch_failures (task_id, error_code)
+    WHERE task_id IS NOT NULL AND error_code <> '';

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -627,14 +627,14 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 		Attachments:    attachmentRefs,
 	}
 
-	// CONFENGE global dispatch governor: final gate before worker/SMTP for
-	// CONFENGE-attributed campaigns (shared rolling-hour cap with WhatsApp).
-	// Switch only on GateKind — never treat infrastructure errors as DNC.
+	// CONFENGE applies the mailbox envelope and shared ceiling before worker/SMTP.
+	// Switch only on GateKind; never treat infrastructure errors as DNC.
 	var confengeLease uuid.UUID
 	if s.confengeGate != nil && campaign.OrganizationID != nil {
-		gate := s.confengeGate.GateCampaignEmail(
+		gate := s.confengeGate.GateCampaignEmailForTransport(
 			ctx, *campaign.OrganizationID, campaign.Name, contact.Email,
 			campaign.ID, contact.ID, sequence.ID,
+			confenge.CampaignTransportBinding{EmailAccountID: accountID, TaskID: taskID},
 		)
 		switch gate.Kind {
 		case confenge.GateHardBlock:

--- a/internal/tasks/confenge_gate.go
+++ b/internal/tasks/confenge_gate.go
@@ -9,13 +9,13 @@ import (
 )
 
 // ConfengeOutboundGate is the optional final gate for CONFENGE-attributed campaign email.
-// Implemented by confenge.Service; nil means no global CONFENGE pacing.
+// Implemented by confenge.Service; nil means no CONFENGE mailbox pacing.
 type ConfengeOutboundGate interface {
-	GateCampaignEmail(ctx context.Context, orgID uuid.UUID, campaignName, recipientEmail string, campaignID, contactID, sequenceID uuid.UUID) confenge.CampaignGateResult
+	GateCampaignEmailForTransport(ctx context.Context, orgID uuid.UUID, campaignName, recipientEmail string, campaignID, contactID, sequenceID uuid.UUID, binding confenge.CampaignTransportBinding) confenge.CampaignGateResult
 	ReleaseCampaignEmail(ctx context.Context, reservationID uuid.UUID, errText string)
 }
 
-// WireConfengeDispatch attaches the CONFENGE global outbound governor to campaign sends.
+// WireConfengeDispatch attaches CONFENGE mailbox pacing to campaign sends.
 func (s *tasksService) WireConfengeDispatch(g ConfengeOutboundGate) {
 	s.confengeGate = g
 }

--- a/internal/tasks/service.go
+++ b/internal/tasks/service.go
@@ -75,7 +75,7 @@ type TasksService interface {
 	// single completion with one optional web search).
 	SetAITools(src AIToolSource)
 
-	// WireConfengeDispatch attaches the optional CONFENGE global dispatch gate.
+	// WireConfengeDispatch attaches the optional CONFENGE mailbox dispatch gate.
 	WireConfengeDispatch(g ConfengeOutboundGate)
 	SetOrgRiskPolicy(p OrgRiskPolicy)
 }
@@ -135,7 +135,7 @@ type tasksService struct {
 	// agent over (SetAITools). Nil = research degrades.
 	aiTools AIToolSource
 
-	// confengeGate paces CONFENGE campaign email with the shared global governor.
+	// confengeGate applies mailbox pacing plus the shared CONFENGE ceiling.
 	confengeGate ConfengeOutboundGate
 
 	// warmupSettings caches the warmup generation settings in-process so the

--- a/web/src/app/app/confenge/page.tsx
+++ b/web/src/app/app/confenge/page.tsx
@@ -67,6 +67,7 @@ import type {
   ConfengeTouchpoint,
   ConfengeWorkingQueueItem,
 	ConfengeDelegatedFirstTouchStatus,
+  ConfengeDispatchStatus,
 } from "@/lib/api/models/app/confenge/Confenge";
 import type { AppError } from "@/lib/api/client/normalizeError";
 import { channelLabel, formatFeedAge, formatPtBrDate, intentLabel, purposeLabel, reasonLabel, stateLabel } from "./labels";
@@ -134,6 +135,18 @@ export default function ConfengePage() {
   const [body, setBody] = useState("");
   const [recipient, setRecipient] = useState("");
   const [pilotSelection, setPilotSelection] = useState<string[]>([]);
+  const configuredMailboxes = dispatchStatus.data?.mailboxes ?? [];
+  const acceptedByMailboxesLastHour = configuredMailboxes.reduce(
+    (sum, mailbox) => sum + mailbox.observed_throughput.accepted_last_hour,
+    0,
+  );
+  const mailboxHourlyEnvelope = configuredMailboxes.reduce(
+    (sum, mailbox) => sum + (mailbox.health === "blocked" ? 0 : mailbox.effective_hourly_cap),
+    0,
+  );
+  const effectiveHourlyEnvelope = dispatchStatus.data
+    ? Math.min(dispatchStatus.data.cap, mailboxHourlyEnvelope)
+    : 0;
 
   useEffect(() => {
     const previousLang = document.documentElement.lang;
@@ -222,12 +235,12 @@ export default function ConfengePage() {
         { id: "review", label: "Exceções para revisar", value: w.needs_review },
         { id: "sent", label: "Enviadas", value: s?.sent ?? 0 },
         { id: "replied", label: "Respondidas", value: s?.replied ?? 0 },
-        { id: "rate", label: "Envios na hora", value: dispatchStatus.data ? `${dispatchStatus.data.sent_last_hour}/${dispatchStatus.data.cap}` : "—" },
+        { id: "rate", label: "Aceitas / envelope", value: dispatchStatus.data ? `${acceptedByMailboxesLastHour}/${effectiveHourlyEnvelope}` : "—" },
       ];
     }
     if (!s) return core;
     return core;
-  }, [summary.data, workingOverview.data, dispatchStatus.data]);
+  }, [summary.data, workingOverview.data, dispatchStatus.data, acceptedByMailboxesLastHour, effectiveHourlyEnvelope]);
 
   const capacityLabel = useMemo(() => {
     const w = workingOverview.data;
@@ -350,7 +363,7 @@ export default function ConfengePage() {
               }
               data-testid="confenge-dispatch-quota"
             >
-              {dispatchStatus.data.sent_last_hour}/{dispatchStatus.data.cap} na última hora
+              {acceptedByMailboxesLastHour}/{effectiveHourlyEnvelope} aceitas / envelope por hora
             </span>
             {dispatchStatus.data.paused ? (
               <button
@@ -386,6 +399,8 @@ export default function ConfengePage() {
       </PageTopbar>
       <div className="flex flex-col gap-4 p-4 md:p-6 max-w-6xl mx-auto w-full">
         <DelegatedFirstTouchPanel status={firstTouchPolicy.data} loading={firstTouchPolicy.isLoading} />
+
+        {dispatchStatus.data && <MailboxCapacityPanel status={dispatchStatus.data} />}
 
         {firstTouchPolicy.data?.policy_active ? (
           <details className="rounded-md border border-slate-200 bg-white">
@@ -1196,6 +1211,157 @@ export default function ConfengePage() {
       </div>
     </Page>
   );
+}
+
+function MailboxCapacityPanel({ status }: { status: ConfengeDispatchStatus }) {
+  const mailboxes = status.mailboxes ?? [];
+  const forecast = status.forecast ?? {
+    slots_next_24h: 0,
+    slots_next_7d: 0,
+    potential_slots_next_24h: 0,
+    potential_slots_next_7d: 0,
+    delivery_promised: false,
+  };
+  const drain = status.queued_approved === 0
+    ? "Fila vazia"
+    : forecast.estimated_days_to_drain
+      ? `${forecast.estimated_days_to_drain} dias estimados`
+      : "Sem estimativa enquanto não há capacidade efetiva";
+
+  return (
+    <section data-testid="confenge-mailbox-capacity" className="rounded-md border border-slate-200 bg-white">
+      <div className="shrink-0 px-3 h-10 flex items-center justify-between gap-3 border-b border-slate-200">
+        <div>
+          <span className="text-[12.5px] font-medium text-slate-900">Capacidade real de transporte</span>
+          <span className="ml-2 text-[11px] text-slate-500">{mailboxes.length} {mailboxes.length === 1 ? "mailbox configurada" : "mailboxes configuradas"}</span>
+        </div>
+        <span className={`rounded-md px-2 py-1 text-[10px] uppercase tracking-[0.14em] ${status.paused ? "bg-amber-50 text-amber-800" : "bg-sky-50 text-sky-700"}`}>
+          {status.paused ? "Transporte pausado" : "Envelope ativo"}
+        </span>
+      </div>
+      <div className="grid gap-2 border-b border-slate-100 p-3 sm:grid-cols-4">
+        <ReadinessItem label="Slots em 24 h" value={String(forecast.slots_next_24h)} />
+        <ReadinessItem label="Slots em 7 dias" value={String(forecast.slots_next_7d)} />
+        <ReadinessItem label="Fila aprovada" value={String(status.queued_approved)} />
+        <ReadinessItem label="Prazo para drenar" value={drain} />
+      </div>
+      {status.paused && forecast.potential_slots_next_24h > 0 && (
+        <p className="border-b border-slate-100 px-3 py-2 text-[11.5px] text-amber-800">
+          A configuração comportaria {forecast.potential_slots_next_24h} slots nas próximas 24 horas, mas a pausa mantém a capacidade efetiva em zero.
+        </p>
+      )}
+      {(status.alerts?.length ?? 0) > 0 && (
+        <div className="border-b border-slate-100 bg-amber-50 px-3 py-2 text-[11.5px] text-amber-900">
+          {status.alerts!.map((alert) => (
+            <div key={`${alert.code}-${alert.email_account_id ?? "org"}`} className="flex items-start gap-1.5">
+              <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+              <span>{capacityReasonLabel(alert.code)}: {alert.reason}{alert.count && alert.count > 1 ? ` (${alert.count})` : ""}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="divide-y divide-slate-100">
+        {mailboxes.map((mailbox) => (
+          <div key={mailbox.email_account_id} className="grid gap-2 px-3 py-3 lg:grid-cols-[minmax(180px,1.2fr)_repeat(4,minmax(110px,1fr))]">
+            <div>
+              <div className="text-[12.5px] font-medium text-slate-900">{mailbox.email}</div>
+              <div className="mt-0.5 text-[11px] text-slate-500">
+                {mailbox.provider} · {mailbox.mailbox_age_days} dias cadastrada
+              </div>
+              <div className={`mt-1 text-[11px] ${mailbox.health === "blocked" ? "text-rose-700" : mailbox.health === "degraded" ? "text-amber-700" : "text-emerald-700"}`}>
+                {capacityHealthLabel(mailbox.health)} · {capacityReasonLabel(mailbox.health_reason)}
+              </div>
+            </div>
+            <div className="text-[11.5px] text-slate-600">
+              <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Autenticação</div>
+              <div className="mt-1">{mailbox.auth_state === "passing" && mailbox.auth_spf && mailbox.auth_dkim && mailbox.auth_dmarc ? "SPF, DKIM e DMARC válidos" : capacityReasonLabel(mailbox.health_reason)}</div>
+              <div className="text-[11px] text-slate-400">Credencial {mailbox.credentials_ready ? "presente" : "ausente"} · worker {mailbox.worker_assigned ? "atribuído" : "ausente"}</div>
+            </div>
+            <div className="text-[11.5px] text-slate-600">
+              <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Envelope configurado</div>
+              <div className="mt-1 tabular-nums">{mailbox.configured_daily_cap}/dia · {mailbox.effective_hourly_cap}/hora efetivos</div>
+              <div className="text-[11px] text-slate-400">Espera mínima {Math.round(mailbox.configured_min_wait_seconds / 60)} min</div>
+              <div className="text-[11px] text-slate-400">Provider: {mailbox.provider_daily_cap ? `${mailbox.provider_daily_cap}/dia` : "limite desconhecido"}</div>
+              {mailbox.latest.provider_rejection_at && <div className="text-[11px] text-amber-700">Última rejeição: {capacityReasonLabel(mailbox.latest.provider_error_class ?? "unknown")} · {formatCapacityTimestamp(mailbox.latest.provider_rejection_at, mailbox.business_window.timezone)}</div>}
+            </div>
+            <div className="text-[11.5px] text-slate-600">
+              <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Observado</div>
+              <div className="mt-1 tabular-nums">{mailbox.observed_throughput.accepted_today} aceitas hoje</div>
+              <div className="text-[11px] text-slate-400">{mailbox.used_today}/{mailbox.effective_daily_cap} tentativas ou reservas consumidas</div>
+              <div className="text-[11px] text-slate-400">Warmup: {mailbox.warmup_age_days === undefined ? "sem evidência" : `${mailbox.warmup_age_days} dias`}</div>
+              <div className="text-[11px] text-slate-400">Última tentativa: {formatCapacityTimestamp(mailbox.latest.attempt_at, mailbox.business_window.timezone) ?? "desconhecida"}</div>
+              <div className="text-[11px] text-slate-400">Última aceitação: {formatCapacityTimestamp(mailbox.latest.accepted_at, mailbox.business_window.timezone) ?? "desconhecida"}</div>
+              {mailbox.latest.bounce_at && <div className="text-[11px] text-amber-700">Bounce: {formatCapacityTimestamp(mailbox.latest.bounce_at, mailbox.business_window.timezone)}</div>}
+              {mailbox.latest.complaint_at && <div className="text-[11px] text-rose-700">Complaint: {formatCapacityTimestamp(mailbox.latest.complaint_at, mailbox.business_window.timezone)}</div>}
+              {mailbox.latest.reply_at && <div className="text-[11px] text-emerald-700">Reply: {formatCapacityTimestamp(mailbox.latest.reply_at, mailbox.business_window.timezone)}</div>}
+            </div>
+            <div className="text-[11.5px] text-slate-600">
+              <div className="text-[10px] uppercase tracking-[0.14em] text-slate-400">Próximo slot</div>
+              <div className="mt-1 tabular-nums">{formatCapacityTimestamp(mailbox.next_eligible_slot, mailbox.business_window.timezone) ?? "Indisponível"}</div>
+              <div className="text-[11px] text-slate-400">{mailbox.business_window.start}–{mailbox.business_window.end} · {mailbox.business_window.timezone}</div>
+            </div>
+          </div>
+        ))}
+        {mailboxes.length === 0 && (
+          <div className="px-3 py-6 text-center text-[12.5px] text-slate-500">
+            Nenhuma mailbox realmente configurada e autorizada foi encontrada. A fila permanece aguardando.
+          </div>
+        )}
+      </div>
+      <p className="border-t border-slate-100 px-3 py-2 text-[11px] text-slate-400">
+        Slots são capacidade de tentativa, não promessa de entrega. Limites do provider aparecem como desconhecidos até existir uma fonte explícita.
+      </p>
+    </section>
+  );
+}
+
+function capacityHealthLabel(value: string): string {
+  if (value === "ready") return "Saudável";
+  if (value === "degraded") return "Degradada";
+  if (value === "blocked") return "Bloqueada";
+  return stateLabel(value);
+}
+
+function capacityReasonLabel(value: string): string {
+  const labels: Record<string, string> = {
+    ready: "Pronta para reservar slots",
+    mailbox_disabled: "Mailbox desabilitada",
+    credentials_missing: "Credenciais ausentes",
+    worker_missing: "Worker não atribuído",
+    dns_auth_unknown: "Autenticação DNS desconhecida",
+    dns_auth_not_passing: "SPF, DKIM ou DMARC não estão válidos",
+    mailbox_quarantined: "Mailbox em quarentena",
+    warmup_blocked: "Warmup bloqueado",
+    warmup_quarantined: "Warmup em quarentena",
+    warmup_watch: "Warmup em observação",
+    warmup_throttled: "Warmup limitado",
+    mailbox_rate_bounds_invalid: "Limites da mailbox inválidos",
+    auth_failure: "Falha de autenticação",
+    provider_interrupted: "Provider interrompido",
+    provider_block: "Bloqueio do provider",
+    rate_limit: "Rejeição por limite do provider",
+    provider_4xx: "Resposta 4xx do provider",
+    provider_5xx: "Resposta 5xx do provider",
+    hard_bounce_observed: "Hard bounce observado",
+    complaint_observed: "Complaint observada",
+    repeated_provider_4xx: "Respostas 4xx repetidas",
+    repeated_provider_5xx: "Respostas 5xx repetidas",
+    rate_limit_rejection: "Rejeição por rate limit",
+    complaint: "Complaint",
+    queue_runoff_without_capacity: "Fila sem capacidade efetiva",
+  };
+  return labels[value] ?? reasonLabel(value);
+}
+
+function formatCapacityTimestamp(value?: string, timezone?: string): string | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+    timeZone: timezone || "America/Sao_Paulo",
+  }).format(date);
 }
 
 function DelegatedFirstTouchPanel({

--- a/web/src/lib/api/models/app/confenge/Confenge.ts
+++ b/web/src/lib/api/models/app/confenge/Confenge.ts
@@ -833,11 +833,80 @@ export type ConfengeTouchpoint = {
 export type ConfengeDispatchFailure = {
     id: string;
     organization_id?: string;
+    email_account_id?: string;
+    task_id?: string;
     channel: string;
     message_key: string;
     draft_id?: string;
+    error_code?: string;
+    error_class: string;
     error_text: string;
     occurred_at: string;
+};
+
+export type ConfengeMailboxCapacity = {
+    email_account_id: string;
+    email: string;
+    enabled: boolean;
+    status: string;
+    provider: string;
+    credentials_ready: boolean;
+    worker_assigned: boolean;
+    auth_state: string;
+    auth_spf: boolean;
+    auth_dkim: boolean;
+    auth_dmarc: boolean;
+    auth_dmarc_policy?: string;
+    auth_checked_at?: string;
+    mailbox_age_days: number;
+    warmup_started_at?: string;
+    warmup_age_days?: number;
+    warmup_days_observed: number;
+    cold_ramp_started_at?: string;
+    configured_daily_cap: number;
+    configured_min_wait_seconds: number;
+    derived_hourly_cap: number;
+    effective_daily_cap: number;
+    effective_hourly_cap: number;
+    provider_daily_cap?: number;
+    provider_hourly_cap?: number;
+    provider_cap_source: string;
+    business_window: {
+        timezone: string;
+        start: string;
+        end: string;
+        business_days_only: boolean;
+    };
+    observed_throughput: {
+        accepted_last_hour: number;
+        accepted_today: number;
+        accepted_last_7d: number;
+    };
+    latest: {
+        attempt_at?: string;
+        accepted_at?: string;
+        bounce_at?: string;
+        complaint_at?: string;
+        reply_at?: string;
+        provider_rejection_at?: string;
+        provider_error_class?: string;
+    };
+    pause_source?: string;
+    health: string;
+    health_reason: string;
+    health_signals?: string[];
+    unknown?: string[];
+    used_today: number;
+    next_eligible_slot?: string;
+};
+
+export type ConfengeCapacityAlert = {
+    code: string;
+    severity: string;
+    email_account_id?: string;
+    count?: number;
+    occurred_at?: string;
+    reason: string;
 };
 
 export type ConfengeDispatchStatus = {
@@ -854,4 +923,16 @@ export type ConfengeDispatchStatus = {
     window_end: string;
     active_leases: number;
     recent_failures?: ConfengeDispatchFailure[];
+    pause_source?: string;
+    capacity_source: string;
+    mailboxes: ConfengeMailboxCapacity[];
+    forecast: {
+        slots_next_24h: number;
+        slots_next_7d: number;
+        potential_slots_next_24h: number;
+        potential_slots_next_7d: number;
+        estimated_days_to_drain?: number;
+        delivery_promised: boolean;
+    };
+    alerts?: ConfengeCapacityAlert[];
 };


### PR DESCRIPTION
## O que muda

- vincula cada reserva, tentativa, aceitação e falha CONFENGE à mailbox e task realmente selecionadas pelo scheduler
- inventaria somente contas com credencial SMTP/IMAP ou OAuth armazenada e falha fechado para mailbox ausente, desabilitada, sem worker, sem autenticação DNS comprovada ou com bloqueio factual vigente
- aplica `campaign_limit`, `min_wait_time`, cap horário derivado, uso diário e janela de negócio por mailbox dentro da transação de reserva; o cap compartilhado permanece apenas como teto adicional
- mantém uma chave idempotente por account/recipient/sequence e impede que um lease aberto migre para outra mailbox ou task
- separa cap configurado, throughput aceito observado, rejeição do provider, sinais de deliverability e campos unknown; nenhum cap de provider é inferido
- registra attempts e erros reais do worker/consumer e expõe alertas para auth, interrupção/bloqueio do provider, 4xx/5xx repetidos, rate limit, complaint, mailbox disabled e fila sem capacidade
- remove o threshold adaptativo hardcoded de 2% de bounce; taxas só alteram pacing quando uma policy authority explícita emite o sinal
- simula slots em 24 h e 7 d, além de dias para drenar a fila quando há capacidade efetiva; pausa mostra apenas capacidade potencial e nunca promete entrega
- adiciona painel operacional no dashboard, documentação de API/guia e relatório sanitizado em `docs/confenge/mailbox-capacity-readiness-2026-08-26.md`

## Readback runtime sanitizado

Capturado somente leitura em 2026-08-26 13:35 UTC, antes deste código ser implantado:

- runtime `36253ca2`, schema 129, checkout limpo e serviços/Hostinger SMTP+IMAP PASS
- exatamente 1 mailbox credenciada: `active`, `smtp_imap`/Hostinger, worker atribuído, SPF/DKIM/DMARC `passing`
- envelope configurado 50 tentativas/dia, 600 s de espera, 6/h derivado, Mon-Fri 09:00-18:00 America/Sao_Paulo
- warmup sem início comprovado e `warmup_days=0`
- zero reservation, acceptance, provider failure e deliverability event CONFENGE observados; esses campos permanecem unknown, não zero inventado
- 1 touchpoint QUEUED e 1 dispatch row para o mesmo draft aprovado, contabilizados como um backlog lógico
- kill switch do volume engajado: capacidade efetiva 0; capacidade potencial derivada 55 slots/24 h e 255/7 d; drain unknown enquanto pausado

Nenhuma mailbox, credencial, warmup, resume, dispatch, SMTP ou estado remoto foi criado ou alterado.

## Verificação

- `make fmt`
- `make lint`
- `go test ./internal/app/confenge/dispatch ./internal/app/consumer ./internal/tasks -count=1`
- compile check de `./internal/app/confenge` e `./cmd/backend`
- `pnpm typecheck` e `pnpm lint` em `web/` (0 erros; warnings preexistentes)
- `pnpm types:check` e `pnpm lint` em `docs/` (0 erros; 2 warnings preexistentes)
- migration up/down e SQL de ocupação validados dentro de transação com rollback no Postgres local

Refs #151
Refs #43