### PR TITLE
feat: prevent delegated first-touch dispatch panics and preserve valid queue transit states

### DIFF
--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -217,7 +217,10 @@ func (s *service) ReconcileDelegatedFirstTouchLedger(ctx context.Context, orgID 
 			  AND d.state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')
 			  AND (
 				(d.state IN ('APPROVED','APPROVED_NOT_SCHEDULED') AND t.state <> 'APPROVED')
-				OR (d.state='QUEUED' AND (t.state <> 'QUEUED' OR q.status IS DISTINCT FROM 'queued'))
+				OR (d.state='QUEUED' AND (
+					t.state NOT IN ('QUEUED','SENT')
+					OR (t.state='QUEUED' AND (q.status IS NULL OR q.status NOT IN ('queued','reserved','sent')))
+				))
 			  )
 		)
 		UPDATE confenge_delegated_first_touch_decisions d

--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -653,6 +653,7 @@ func TestDelegatedFirstTouchLedgerReconciliationPreservesTransportTransitStatesP
 		queueState      string
 		touchpointState string
 	}{
+		{name: "waiting queue", queueState: "queued", touchpointState: models.TouchpointQueued},
 		{name: "claimed queue", queueState: "reserved", touchpointState: models.TouchpointQueued},
 		{name: "campaign handoff", queueState: "sent", touchpointState: models.TouchpointQueued},
 		{name: "provider completion projection", queueState: "sent", touchpointState: models.TouchpointSent},

--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -647,6 +647,51 @@ func TestDelegatedFirstTouchLedgerReconciliationRepairsOlderQueueCancellationPos
 	}
 }
 
+func TestDelegatedFirstTouchLedgerReconciliationPreservesTransportTransitStatesPostgres(t *testing.T) {
+	tests := []struct {
+		name            string
+		queueState      string
+		touchpointState string
+	}{
+		{name: "claimed queue", queueState: "reserved", touchpointState: models.TouchpointQueued},
+		{name: "campaign handoff", queueState: "sent", touchpointState: models.TouchpointQueued},
+		{name: "provider completion projection", queueState: "sent", touchpointState: models.TouchpointSent},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := newDelegatedPGFixture(t)
+			report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+			if xerr != nil || report == nil || report.Queued != 1 {
+				t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+			}
+			if _, err := f.pool.Exec(f.ctx, `
+				UPDATE confenge_dispatch_queue SET status=$2
+				WHERE organization_id=$1`, f.orgID, tt.queueState); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := f.pool.Exec(f.ctx, `
+				UPDATE outreach_touchpoints SET state=$2
+				WHERE organization_id=$1`, f.orgID, tt.touchpointState); err != nil {
+				t.Fatal(err)
+			}
+
+			reconciled, err := f.svc.ReconcileDelegatedFirstTouchLedger(f.ctx, f.orgID)
+			if err != nil || reconciled != 0 {
+				t.Fatalf("valid transport transit state was reconciled: count=%d err=%v", reconciled, err)
+			}
+			var state string
+			if err := f.pool.QueryRow(f.ctx, `
+				SELECT state FROM confenge_delegated_first_touch_decisions
+				WHERE organization_id=$1`, f.orgID).Scan(&state); err != nil {
+				t.Fatal(err)
+			}
+			if state != "QUEUED" {
+				t.Fatalf("valid transport transit state cancelled delegated decision: %s", state)
+			}
+		})
+	}
+}
+
 func TestDelegatedFirstTouchQueueAuditGapCancelsBeforeTransportPostgres(t *testing.T) {
 	f := newDelegatedPGFixture(t)
 	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)

--- a/internal/app/confenge/dispatch_queue_worker.go
+++ b/internal/app/confenge/dispatch_queue_worker.go
@@ -7,6 +7,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	"github.com/warmbly/warmbly/internal/errx"
 	"github.com/warmbly/warmbly/internal/models"
 )
 
@@ -77,7 +78,8 @@ func (s *service) ProcessDispatchQueueOnce(ctx context.Context) (bool, error) {
 	if actor == uuid.Nil {
 		actor, _ = s.repo.GetOrgOwnerUserID(ctx, item.OrganizationID)
 	}
-	var xerr error
+	// Keep the concrete pointer type so a nil *errx.Error stays nil.
+	var xerr *errx.Error
 	if tp.Channel == models.OutreachChannelWhatsApp {
 		xerr = s.dispatchWhatsAppTouch(ctx, item.OrganizationID, actor, tp)
 	} else {


### PR DESCRIPTION
## Summary

- keep the dispatch result as `*errx.Error` so a successful email handoff cannot become a non-nil typed interface and panic the backend
- treat `reserved` and `sent` dispatch-queue states as legitimate transit states while the provider-confirmed touchpoint remains `QUEUED`
- preserve the brief `touchpoint=SENT`, `decision=QUEUED` completion transition so reconciliation cannot cancel a real provider acceptance in the middle of projection

## Production evidence

The first controlled resume on release `f89612f8e9a326ddb205b8b3fc9800137009619c` exposed both races before SMTP:

- the canonical queue was claimed and the approved draft was enrolled
- the dispatch worker panicked while evaluating a typed nil `*errx.Error`
- backend restart found the queue in the legitimate `reserved` lease and incorrectly projected `canonical_queue_state_drift`
- the canonical pause was re-engaged immediately
- provider-attempt and provider-accepted counters remained zero

## Verification

- targeted PostgreSQL reconciliation tests pass for `queued`, `reserved`, handoff `sent`, and provider-completion transit states
- the existing cancellation reconciliation test still passes
- `gofmt -l cmd internal` is empty
- `make lint` passes
