### PR TITLE
feat: materialize complete current-run INITIAL backlogs for 10k manifests

### DIFF
--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -83,6 +83,7 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | POST | `/contacts/:id/research` | `AI_RESEARCH` |
 | GET | `/contacts/:id/research` | `AI_RESEARCH` |
 | POST | `/contacts/research/batch` | `AI_RESEARCH` |
+| POST | `/confenge/sync` | `WRITE_CONTACTS` |
 | POST | `/confenge/pilot/cohort/prepare` | `WRITE_CONTACTS` |
 | POST | `/confenge/drafts/invalidate-prior-composer` | `WRITE_CONTACTS` |
 | GET | `/confenge/cohorts` | `READ_CONTACTS` |
@@ -120,6 +121,8 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | POST | `/confenge/manual-queue/:id/action` | `WRITE_CONTACTS` |
 
 `GET /contacts/custom-fields` lists the distinct custom-field keys used across your contacts (frequency-ranked), for building personalization pickers. It returns a flat string array under `data`, capped at 200 keys.
+
+`POST /confenge/sync` validates and imports a complete `confenge.outreach.manifest.v1`, resumes stale chunk leases idempotently, and publishes a new current run only after the account denominator and prepared `INITIAL` backlog close. The response includes `imported`, `supplier_confirmed`, `candidate_attributed`, `initial_touchpoint_prepared`, `delegated_eligible`, `held_exception`, and `stale_initial_retired` under `data.counts`. A replay of the same snapshot is a `noop` with the stored counts.
 
 `GET /confenge/inbound` is the INBOUND NOW queue. Default `include_synthetic=0`. `POST /confenge/inbound/:leadId/acknowledge` records a human acknowledgement (actor required, idempotent). `POST /confenge/inbound/:leadId/resolve` records a no-action resolution with a reason code. Neither contacts the lead nor sets WON, LOST, pipeline, or revenue. `POST /confenge/inbound/:leadId/outcome` remains the first-action registrar.
 

--- a/docs/content/docs/guides/confenge-outreach.mdx
+++ b/docs/content/docs/guides/confenge-outreach.mdx
@@ -110,6 +110,21 @@ Use `?dry_run=true` for counts only (`creates`, `updates`, `unchanged`, `missing
 
 Companies with eligible current target-fit but no enrollable contact enter as `NEEDS_CONTACT`. They are not discarded and are not forced into the contacts table.
 
+### Manifest sync and prepared backlog
+
+`POST /api/v1/confenge/sync` validates the complete `confenge.outreach.manifest.v1` before publishing a new current run. It checks every chunk hash, source binding, declared count, pagination marker, and cross-chunk company and lead identity. Validated chunks are staged in a private temporary directory and imported with at most four chunks active, so a large manifest does not require every chunk payload to remain in memory or thousands of account writes to run serially. The safety ceilings are 100,000 leads, 1,000 chunks, and 1 GiB of staged payload. These ceilings protect the host without truncating the supported 1,000 to 10,000 account range.
+
+Each chunk uses a durable idempotency key. A retry reads back a completed chunk, and a `RUNNING` chunk with no activity for two minutes is reclaimed and replayed against the same import run. A `source_run_id` is immutable and cannot later identify another snapshot, including after it becomes historical. The manifest becomes current only after every chunk completes, deactivations apply, and the backlog denominator closes. A corrupt, incomplete, or partial attempt never replaces the last completed `source_run_id` in feed state.
+
+For every current account, the sync records one of these outcomes:
+
+- a canonical `DUE` touchpoint with `ordinal=1`, `purpose=INITIAL`, `channel=EMAIL`, the unique preferred current recipient, and the current `source_run_id`
+- a stable `initial_backlog_reason_code` such as missing, conflicting, ineligible, or non-delegated recipient, unknown or conflicting supplier role, stale supplier evidence, target-fit suppression, or account suppression
+
+Prepared manifest touchpoints are the delegated worker backlog. They do not appear in the human review queue or create a parallel commercial-action queue merely because the feed is large. Manual `POST /confenge/import` keeps its existing commercial-action planning behavior. The worker leases one due item at a time, records a durable retry after failure, and submits the item through the same delegated policy validator used by manual manifests. A refresh cancels open `INITIAL` work from the previous run with `source_run_superseded`; historical rows remain readable for audit.
+
+The sync response and persisted feed state expose the stage counts `imported`, `supplier_confirmed`, `candidate_attributed`, `initial_touchpoint_prepared`, `delegated_eligible`, `held_exception`, and `stale_initial_retired`. `delegated_eligible + held_exception` must equal `imported` before publication. An idempotent replay returns the stored stage counts and creates no new touchpoint.
+
 ## Target-fit authorization
 
 `extra-cli` is the sole authority for CONFENGE target-fit. Warmbly does not infer ICP membership from company names, industry text, public contracts, email availability, old scores, or prior `enrollable` values.
@@ -158,6 +173,7 @@ Target-fit is updated only by a current authoritative decision. A downgrade take
 | `GET /confenge/accounts` | Staged companies |
 | `GET /confenge/accounts/:id` | Company with candidates and evidence |
 | `POST /confenge/import` | Dry-run or apply feed |
+| `POST /confenge/sync` | Validate a complete manifest, resume chunks, and materialize the current-run `INITIAL` backlog |
 | `GET /confenge/import-runs` | Import audit history |
 | `GET /confenge/touchpoints/review` | Human review queue, including recoverable editorial states |
 | `GET /confenge/review/drafts` | Control Center review alias with exact content hashes and the editorial verdict per row |

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -1202,8 +1202,18 @@ func (s *service) prepareDelegatedTouchpoint(ctx context.Context, orgID uuid.UUI
 		return nil, nil, fmt.Errorf("first_touch_lookup_failed")
 	}
 	var tp *models.OutreachTouchpoint
+	var legacy *models.OutreachTouchpoint
 	for i := range all {
-		if all[i].Ordinal != 1 || all[i].Channel != models.OutreachChannelEmail {
+		if all[i].Ordinal != 1 || all[i].Purpose != models.TouchpointPurposeInitial ||
+			all[i].Channel != models.OutreachChannelEmail {
+			continue
+		}
+		if all[i].SourceRunID == "" {
+			row := all[i]
+			legacy = &row
+			continue
+		}
+		if all[i].SourceRunID != manifest.SourceRunID {
 			continue
 		}
 		if tp != nil {
@@ -1211,6 +1221,9 @@ func (s *service) prepareDelegatedTouchpoint(ctx context.Context, orgID uuid.UUI
 		}
 		row := all[i]
 		tp = &row
+	}
+	if tp == nil {
+		tp = legacy
 	}
 	if tp != nil {
 		switch tp.State {
@@ -1220,11 +1233,11 @@ func (s *service) prepareDelegatedTouchpoint(ctx context.Context, orgID uuid.UUI
 		}
 	} else {
 		tp = &models.OutreachTouchpoint{
-			ID:             uuid.NewSHA1(uuid.NameSpaceOID, []byte(DelegatedFirstTouchPolicyV1+"\x00touchpoint\x00"+orgID.String()+"\x00"+acc.ID.String())),
+			ID:             uuid.NewSHA1(uuid.NameSpaceOID, []byte(DelegatedFirstTouchPolicyV1+"\x00touchpoint\x00"+orgID.String()+"\x00"+manifest.SourceRunID+"\x00"+acc.ID.String())),
 			OrganizationID: orgID, AccountID: acc.ID, Ordinal: 1, CadenceStep: "INITIAL",
 			Channel: models.OutreachChannelEmail, Purpose: models.TouchpointPurposeInitial,
 			DueAt: time.Now().UTC(), State: models.TouchpointNeedsReview,
-			IdempotencyKey: "delegated-first-touch:" + acc.ID.String(),
+			IdempotencyKey: "delegated-first-touch:" + manifest.SourceRunID + ":" + acc.ID.String(),
 		}
 	}
 	draftID := uuid.NewSHA1(uuid.NameSpaceOID, []byte(DelegatedFirstTouchPolicyV1+"\x00draft\x00"+orgID.String()+"\x00"+acc.ID.String()))
@@ -1243,6 +1256,7 @@ func (s *service) prepareDelegatedTouchpoint(ctx context.Context, orgID uuid.UUI
 	tp.FactUsed = "Atuação como contratada em contrato público confirmada."
 	tp.EvidenceIDs = append([]string{}, entry.EvidenceIDs...)
 	tp.GeneratedContextHash = acc.MessageContextHash
+	tp.SourceRunID = manifest.SourceRunID
 	tp.StopReason = ""
 	ClearApproval(tp)
 	RecomputeContentHash(tp)

--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -2,11 +2,13 @@ package confenge
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
@@ -127,6 +129,7 @@ func newDelegatedPGFixture(t *testing.T) *delegatedPGFixture {
 	candidate := &models.OutreachContactCandidate{
 		ID: uuid.New(), OrganizationID: f.orgID, AccountID: account.ID, SourceContactID: "route-delegated",
 		Name: "Equipe", Role: "Atendimento", Email: "contato@empresa.example", SourceURL: "https://empresa.example/contato",
+		SourceDate:         &now,
 		VerificationStatus: models.OutreachVerifyOfficialSource, Confidence: "HIGH", Recommended: true,
 		EmailSendReady: true, OwnershipStatus: "COMPANY_OWNED", RecipientCommercialSuitability: "SUITABLE",
 		LastImportRunID: &importID, ChannelEpistemic: "OBSERVED", RouteFreshness: "FRESH",
@@ -308,23 +311,37 @@ func TestCampaignReadyAcceptsReadBackDelegatedQueueWithoutContact(t *testing.T) 
 	if err := campaignRepo.ValidateCampaignReady(f.ctx, f.campaignID); err == nil || !strings.Contains(err.Error(), "at least one contact") {
 		t.Fatalf("ordinary empty campaign unexpectedly ready: %v", err)
 	}
-	entry := f.manifest.Entries[0]
-	account, err := f.repo.GetAccount(f.ctx, f.orgID, entry.AccountID)
-	if err != nil || account == nil {
-		t.Fatalf("account unavailable: account=%+v err=%v", account, err)
-	}
-	candidate, err := f.repo.GetCandidate(f.ctx, f.orgID, entry.ContactCandidateID)
-	if err != nil || candidate == nil {
-		t.Fatalf("candidate unavailable: candidate=%+v err=%v", candidate, err)
-	}
-	if _, _, err := f.svc.prepareDelegatedTouchpoint(f.ctx, f.orgID, account, candidate, f.manifest, entry); err != nil {
+	if _, err := f.pool.Exec(f.ctx, `UPDATE outreach_contact_candidates SET route_freshness='STALE' WHERE organization_id=$1`, f.orgID); err != nil {
 		t.Fatal(err)
 	}
+	backlog, err := f.repo.MaterializeCurrentInitialBacklog(f.ctx, f.orgID, f.manifest.SourceRunID)
+	if err != nil || backlog.InitialPrepared != 1 || backlog.DelegatedEligible != 0 || backlog.HeldException != 1 {
+		t.Fatalf("static delegated hold was not classified: counts=%+v err=%v", backlog, err)
+	}
+	if ready, err := campaignRepo.HasReadyDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || ready {
+		t.Fatalf("held prepared backlog kept campaign ready: ready=%v err=%v", ready, err)
+	}
+	if pending, err := campaignRepo.HasPendingDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || pending {
+		t.Fatalf("held prepared backlog remained pending: pending=%v err=%v", pending, err)
+	}
+	if _, _, _, err := f.svc.nextDelegatedFirstTouchCandidate(f.ctx, f.orgID); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("delegated worker selected held backlog: %v", err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `UPDATE outreach_contact_candidates SET route_freshness='FRESH' WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+	backlog, err = f.repo.MaterializeCurrentInitialBacklog(f.ctx, f.orgID, f.manifest.SourceRunID)
+	if err != nil || backlog.InitialPrepared != 1 || backlog.DelegatedEligible != 1 || backlog.HeldException != 0 {
+		t.Fatalf("prepared manifest backlog unavailable after correction: counts=%+v err=%v", backlog, err)
+	}
+	if ready, err := campaignRepo.HasReadyDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || ready {
+		t.Fatalf("undecided JIT backlog appeared queue-ready: ready=%v err=%v", ready, err)
+	}
 	if pending, err := campaignRepo.HasPendingDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || !pending {
-		t.Fatalf("current undecided backlog unavailable: pending=%v err=%v", pending, err)
+		t.Fatalf("prepared JIT backlog did not remain pending: pending=%v err=%v", pending, err)
 	}
 	if err := campaignRepo.ValidateCampaignReady(f.ctx, f.campaignID); err != nil {
-		t.Fatalf("current delegated backlog did not keep rolling campaign startable: %v", err)
+		t.Fatalf("prepared JIT backlog did not make campaign startable: %v", err)
 	}
 	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
 	if xerr != nil || report == nil || report.Queued != 1 || len(report.Items) != 1 || report.Items[0].State != "QUEUED" {
@@ -351,6 +368,39 @@ func TestCampaignReadyAcceptsReadBackDelegatedQueueWithoutContact(t *testing.T) 
 	}
 	if ready, err := campaignRepo.HasReadyDelegatedFirstTouch(f.ctx, f.campaignID); err != nil || ready {
 		t.Fatalf("sent delegated work remained ready: ready=%v err=%v", ready, err)
+	}
+}
+
+func TestMaterializeCurrentInitialBacklogRetiresAccountOmittedFromNewRunPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	candidateID := f.manifest.Entries[0].ContactCandidateID
+	legacy := &models.OutreachTouchpoint{
+		OrganizationID: f.orgID, AccountID: f.manifest.Entries[0].AccountID, ContactCandidateID: &candidateID,
+		Ordinal: 1, CadenceStep: "INITIAL", Channel: models.OutreachChannelEmail,
+		Purpose: models.TouchpointPurposeInitial, DueAt: time.Now().UTC(), State: models.TouchpointDue,
+		IdempotencyKey: "legacy-initial-" + uuid.NewString(),
+	}
+	if err := f.repo.InsertTouchpoint(f.ctx, legacy); err != nil {
+		t.Fatal(err)
+	}
+	first, err := f.repo.MaterializeCurrentInitialBacklog(f.ctx, f.orgID, f.manifest.SourceRunID)
+	if err != nil || first.InitialPrepared != 1 || first.StaleRetired != 1 {
+		t.Fatalf("initial backlog unavailable: counts=%+v err=%v", first, err)
+	}
+	newRun := "run-omits-prior-account-" + uuid.NewString()
+	refreshed, err := f.repo.MaterializeCurrentInitialBacklog(f.ctx, f.orgID, newRun)
+	if err != nil || refreshed.Imported != 0 || refreshed.StaleRetired != 1 {
+		t.Fatalf("omitted account backlog was not retired: counts=%+v err=%v", refreshed, err)
+	}
+	var state, reason string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT state,stop_reason FROM outreach_touchpoints
+		WHERE organization_id=$1 AND account_id=$2 AND source_run_id=$3`,
+		f.orgID, f.manifest.Entries[0].AccountID, f.manifest.SourceRunID).Scan(&state, &reason); err != nil {
+		t.Fatal(err)
+	}
+	if state != models.TouchpointCancelled || reason != "source_run_superseded" {
+		t.Fatalf("omitted stale touchpoint survived: state=%s reason=%s", state, reason)
 	}
 }
 
@@ -430,6 +480,9 @@ func TestDelegatedFirstTouchWorkerSkipsMismatchedDecisionBoundByCurrentIdempoten
 	}
 	if touchpointID != secondTouchpoint.ID || accountID != secondAccount.ID || candidateID != secondCandidate.ID {
 		t.Fatalf("historical key mismatch blocked rolling selection: touchpoint=%s account=%s candidate=%s", touchpointID, accountID, candidateID)
+	}
+	if _, _, _, err = f.svc.nextDelegatedFirstTouchCandidate(f.ctx, f.orgID); !errors.Is(err, pgx.ErrNoRows) {
+		t.Fatalf("leased touchpoint was selected twice: %v", err)
 	}
 }
 

--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -17,6 +17,8 @@ import (
 const (
 	delegatedFirstTouchMaxBurst          = 100
 	delegatedFirstTouchIdempotencyPrefix = "delegated-first-touch:"
+	delegatedFirstTouchLease             = 5 * time.Minute
+	delegatedFirstTouchRetryDelay        = 15 * time.Minute
 )
 
 type delegatedFirstTouchProcessor interface {
@@ -45,10 +47,10 @@ func (w *DelegatedFirstTouchWorker) Run(ctx context.Context) {
 	for {
 		for i := 0; i < delegatedFirstTouchMaxBurst; i++ {
 			processed, err := w.processor.ProcessDelegatedFirstTouchOnce(ctx)
+			if err != nil {
+				log.Printf("confenge delegated first-touch autorun deferred: %v", err)
+			}
 			if !processed {
-				if err != nil {
-					log.Printf("confenge delegated first-touch autorun deferred: %v", err)
-				}
 				break
 			}
 			select {
@@ -66,7 +68,7 @@ func (w *DelegatedFirstTouchWorker) Run(ctx context.Context) {
 }
 
 // ProcessDelegatedFirstTouchOnce evaluates one prepared first touch under the active founder grant.
-func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, error) {
+func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (processed bool, returnErr error) {
 	if s == nil || !s.cfg.DelegatedFirstTouchEnabled || !s.cfg.DelegatedFirstTouchAutorunEnabled ||
 		s.delegatedDB == nil || s.policyStore == nil || s.cfg.OperatorOrgID == uuid.Nil {
 		return false, nil
@@ -108,6 +110,12 @@ func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, err
 		}
 		return false, err
 	}
+	deferred := true
+	defer func() {
+		if deferred {
+			s.deferDelegatedFirstTouch(ctx, orgID, touchpointID, returnErr)
+		}
+	}()
 
 	acc, err := s.repo.GetAccount(ctx, orgID, accountID)
 	if err != nil || acc == nil {
@@ -150,31 +158,65 @@ func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, err
 	}
 	report, xerr := s.ApplyDelegatedFirstTouchManifest(ctx, orgID, manifest, false)
 	if xerr != nil {
-		return false, fmt.Errorf("delegated first-touch autorun: %s", xerr.Message)
+		return true, fmt.Errorf("delegated first-touch autorun: %s", xerr.Message)
 	}
+	deferred = false
+	_, _ = s.delegatedDB.Exec(ctx, `
+		UPDATE outreach_touchpoints
+		SET delegated_reserved_until=NULL,delegated_last_error='',updated_at=now()
+		WHERE organization_id=$1 AND id=$2`, orgID, touchpointID)
 	return report != nil && len(report.Items) == 1, nil
 }
 
 func (s *service) nextDelegatedFirstTouchCandidate(ctx context.Context, orgID uuid.UUID) (uuid.UUID, uuid.UUID, uuid.UUID, error) {
 	var touchpointID, accountID, candidateID uuid.UUID
+	now := time.Now().UTC()
 	err := s.delegatedDB.QueryRow(ctx, `
-		SELECT t.id,t.account_id,t.contact_candidate_id
-		FROM outreach_touchpoints t
-		JOIN outreach_accounts a ON a.organization_id=t.organization_id AND a.id=t.account_id
-		JOIN outreach_feed_sync_state feed ON feed.organization_id=t.organization_id
-		WHERE t.organization_id=$1
-		  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
-		  AND t.state='NEEDS_REVIEW' AND t.contact_candidate_id IS NOT NULL
-		  AND feed.last_status='completed' AND a.source_run_id=feed.last_run_id
-		  AND NOT EXISTS (
-		    SELECT 1 FROM confenge_delegated_first_touch_decisions d
-		    WHERE d.organization_id=t.organization_id AND d.account_id=t.account_id
-		      AND (d.evidence_source_run_id=a.source_run_id
-		        OR d.idempotency_key=$2 || a.source_run_id || ':' || a.id::text)
-		  )
-		ORDER BY t.due_at,t.created_at,t.id
-		LIMIT 1`, orgID, delegatedFirstTouchIdempotencyPrefix).Scan(&touchpointID, &accountID, &candidateID)
+		WITH next AS (
+			SELECT t.id
+			FROM outreach_touchpoints t
+			JOIN outreach_accounts a ON a.organization_id=t.organization_id AND a.id=t.account_id
+			JOIN outreach_contact_candidates c
+			  ON c.organization_id=t.organization_id AND c.id=t.contact_candidate_id
+			JOIN outreach_feed_sync_state feed ON feed.organization_id=t.organization_id
+			WHERE t.organization_id=$1
+			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+			  AND t.state IN ('DUE','NEEDS_REVIEW') AND t.contact_candidate_id IS NOT NULL
+			  AND feed.last_status='completed' AND a.source_run_id=feed.last_run_id
+			  AND (t.source_run_id='' OR t.source_run_id=feed.last_run_id)
+			  AND a.initial_backlog_reason_code=''
+			  AND a.last_import_run_id IS NOT NULL AND c.last_import_run_id=a.last_import_run_id
+			  AND t.delegated_retry_at <= $3
+			  AND (t.delegated_reserved_until IS NULL OR t.delegated_reserved_until <= $3)
+			  AND NOT EXISTS (
+			    SELECT 1 FROM confenge_delegated_first_touch_decisions d
+			    WHERE d.organization_id=t.organization_id AND d.account_id=t.account_id
+			      AND (d.evidence_source_run_id=a.source_run_id
+			        OR d.idempotency_key=$2 || a.source_run_id || ':' || a.id::text)
+			  )
+			ORDER BY t.delegated_retry_at,t.due_at,t.created_at,t.id
+			LIMIT 1 FOR UPDATE OF t SKIP LOCKED
+		)
+		UPDATE outreach_touchpoints t
+		SET delegated_reserved_until=$4,delegated_attempts=t.delegated_attempts+1,
+			delegated_last_error='',updated_at=$3
+		FROM next WHERE t.id=next.id
+		RETURNING t.id,t.account_id,t.contact_candidate_id`, orgID, delegatedFirstTouchIdempotencyPrefix,
+		now, now.Add(delegatedFirstTouchLease)).Scan(&touchpointID, &accountID, &candidateID)
 	return touchpointID, accountID, candidateID, err
+}
+
+func (s *service) deferDelegatedFirstTouch(ctx context.Context, orgID, touchpointID uuid.UUID, cause error) {
+	reason := "delegated first-touch processing failed"
+	if cause != nil {
+		reason = cause.Error()
+	}
+	_, _ = s.delegatedDB.Exec(ctx, `
+		UPDATE outreach_touchpoints
+		SET delegated_reserved_until=NULL,delegated_retry_at=$3,
+			delegated_last_error=LEFT($4,500),updated_at=now()
+		WHERE organization_id=$1 AND id=$2`, orgID, touchpointID,
+		time.Now().UTC().Add(delegatedFirstTouchRetryDelay), reason)
 }
 
 func delegatedEntryFromCurrentState(acc *models.OutreachAccount, cand *models.OutreachContactCandidate, touchpointID uuid.UUID, subject, body string) DelegatedFirstTouchEntry {

--- a/internal/app/confenge/draft_generation_worker.go
+++ b/internal/app/confenge/draft_generation_worker.go
@@ -144,6 +144,12 @@ func (s *service) ProcessDraftGenerationOnce(ctx context.Context) (bool, error) 
 					'NEEDS_REVIEW','APPROVED','QUEUED'
 				  )
 			  )
+			  AND NOT ($4 AND EXISTS (
+				SELECT 1 FROM outreach_touchpoints prepared
+				WHERE prepared.organization_id=a.organization_id AND prepared.account_id=a.id
+				  AND prepared.ordinal=1 AND prepared.purpose='INITIAL' AND prepared.channel='EMAIL'
+				  AND prepared.source_run_id=feed.last_run_id AND prepared.state='DUE'
+			  ))
 			ORDER BY a.draft_generation_retry_at, a.created_at, a.id
 			LIMIT 1
 			FOR UPDATE SKIP LOCKED
@@ -154,7 +160,8 @@ func (s *service) ProcessDraftGenerationOnce(ctx context.Context) (bool, error) 
 			updated_at = $1
 		FROM next
 		WHERE a.id = next.id
-		RETURNING a.organization_id, a.id, a.draft_generation_attempts`, now, now.Add(draftGenerationLease), s.draftReviewBacklogTarget()).Scan(&orgID, &accountID, &attempts)
+		RETURNING a.organization_id, a.id, a.draft_generation_attempts`, now, now.Add(draftGenerationLease),
+		s.draftReviewBacklogTarget(), s.cfg.DelegatedFirstTouchEnabled).Scan(&orgID, &accountID, &attempts)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			return false, nil

--- a/internal/app/confenge/feed_sync.go
+++ b/internal/app/confenge/feed_sync.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"path"
 	"strings"
 	"sync"
@@ -30,7 +31,13 @@ type FeedSyncResult struct {
 	Counts         map[string]int `json:"counts,omitempty"`
 }
 
-const feedChunkStaleImportRecoveryAfter = 2 * time.Minute
+const (
+	feedChunkStaleImportRecoveryAfter = 2 * time.Minute
+	feedManifestMaxLeads              = 100_000
+	feedManifestMaxChunks             = 1_000
+	feedManifestMaxStagedBytes        = int64(1 << 30)
+	feedManifestImportConcurrency     = 4
+)
 
 // outreachManifest is confenge.outreach.manifest.v1 (extra-cli export).
 type outreachManifest struct {
@@ -59,6 +66,16 @@ type manifestChunk struct {
 	HasMore     bool   `json:"has_more"`
 }
 
+type validatedManifestChunk struct {
+	manifest manifestChunk
+	path     string
+}
+
+type manifestChunkImportResult struct {
+	completed bool
+	err       string
+}
+
 // org-level single-flight so two sync workers cannot double-import.
 var feedSyncLocks sync.Map // orgID string → *sync.Mutex
 
@@ -67,8 +84,7 @@ func orgFeedSyncLock(orgID uuid.UUID) *sync.Mutex {
 	return v.(*sync.Mutex)
 }
 
-// SyncFeedManifest fetches a confenge.outreach.manifest.v1, validates chunks,
-// imports in order, applies deactivations. Fail-closed on hash mismatch.
+// SyncFeedManifest validates a manifest, imports bounded chunks, and applies deactivations.
 // Never deletes DNC/human state. Never auto-generates or sends.
 func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, manifestURI string) (*FeedSyncResult, *errx.Error) {
 	if xerr := s.requireEnabled(); xerr != nil {
@@ -167,6 +183,16 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 		s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "failed", result, false, nil)
 		return result, errx.New(errx.BadRequest, "manifest generated_at is missing or invalid")
 	}
+	runConflict, conflictErr := s.repo.HasImportRunSnapshotConflict(ctx, orgID, man.Source.RunID, man.Source.SnapshotHash)
+	if conflictErr != nil {
+		s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "failed", result, false, nil)
+		return result, errx.New(errx.ServiceUnavailable, "feed source run history unavailable")
+	}
+	if runConflict || (lastRun != "" && man.Source.RunID == lastRun && man.Source.SnapshotHash != lastSnap) {
+		result.Errors = append(result.Errors, "source run ID reused with different snapshot")
+		s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "failed", result, false, nil)
+		return result, errx.New(errx.Conflict, "source run ID cannot identify more than one snapshot")
+	}
 	if lastGeneratedAt != nil && (generatedAt.Before(lastGeneratedAt.UTC()) ||
 		(generatedAt.Equal(lastGeneratedAt.UTC()) && man.Source.SnapshotHash != lastSnap)) {
 		result.Errors = append(result.Errors, "snapshot rollback rejected")
@@ -182,14 +208,31 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 		result.Status = "noop"
 		result.SkippedSame = true
 		result.RunID = lastRun
-		s.persistFeedSync(ctx, orgID, man.Source.SnapshotHash, lastRun, uri, "completed", result, true, &generatedAt)
+		if current != nil {
+			result.Counts = decodeFeedSyncCounts(current.CountsJSON)
+		}
+		if persistErr := s.persistFeedSync(ctx, orgID, man.Source.SnapshotHash, lastRun, uri, "completed", result, true, &generatedAt); persistErr != nil {
+			result.Status = "partial"
+			result.Errors = append(result.Errors, "feed state publication failed")
+			return result, errx.New(errx.ServiceUnavailable, "feed state publication failed")
+		}
 		return result, nil
 	}
 
 	baseURI := manifestBaseURI(uri)
 	var partialErrs []string
-	chunkPayloads := make([][]byte, 0, len(man.Chunks))
-	for _, ch := range man.Chunks {
+	stageDir, err := os.MkdirTemp("", "warmbly-confenge-feed-")
+	if err != nil {
+		result.Errors = append(result.Errors, "chunk staging unavailable")
+		s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "failed", result, false, nil)
+		return result, errx.New(errx.ServiceUnavailable, "feed chunk staging unavailable")
+	}
+	defer func() { _ = os.RemoveAll(stageDir) }()
+	validatedChunks := make([]validatedManifestChunk, 0, len(man.Chunks))
+	seenCNPJ := make(map[string]string, man.LeadCount)
+	seenLeadID := make(map[string]string, man.LeadCount)
+	var stagedBytes int64
+	for index, ch := range man.Chunks {
 		if strings.TrimSpace(ch.File) == "" {
 			partialErrs = append(partialErrs, "chunk missing file name")
 			continue
@@ -198,7 +241,7 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 		chunkRaw, err := fetcher.Fetch(ctx, chunkURI)
 		if err != nil {
 			partialErrs = append(partialErrs, fmt.Sprintf("%s fetch: %v", ch.File, err))
-			break // fail closed — do not mark snapshot complete
+			break // A fetch failure cannot publish the snapshot.
 		}
 		if ch.ContentHash != "" {
 			sum := sha256.Sum256(chunkRaw)
@@ -213,6 +256,10 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 			partialErrs = append(partialErrs, fmt.Sprintf("%s invalid feed: %v", ch.File, normalizeErr))
 			break
 		}
+		if validateErr := ValidateFeed(chunkFeed); validateErr != nil {
+			partialErrs = append(partialErrs, fmt.Sprintf("%s invalid feed: %v", ch.File, validateErr))
+			break
+		}
 		chunkGeneratedAt, timeErr := time.Parse(time.RFC3339, strings.TrimSpace(chunkFeed.GeneratedAt))
 		if timeErr != nil || chunkFeed.Source.RunID != man.Source.RunID ||
 			chunkFeed.Source.SnapshotHash != man.Source.SnapshotHash || !chunkGeneratedAt.Equal(generatedAt) {
@@ -223,33 +270,45 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 			partialErrs = append(partialErrs, fmt.Sprintf("%s lead_count does not match payload", ch.File))
 			break
 		}
-		chunkPayloads = append(chunkPayloads, chunkRaw)
-	}
-
-	// Validate every remote object before the first database mutation. A corrupt,
-	// missing, or mismatched later chunk must leave the current snapshot untouched.
-	imported := 0
-	for index, chunkRaw := range chunkPayloads {
+		for leadIndex := range chunkFeed.Leads {
+			lead := chunkFeed.Leads[leadIndex]
+			cnpj := NormalizeCNPJ14(lead.Company.CNPJ14)
+			if previous, duplicate := seenCNPJ[cnpj]; duplicate {
+				partialErrs = append(partialErrs, fmt.Sprintf("%s duplicates cnpj14 from %s", ch.File, previous))
+				break
+			}
+			seenCNPJ[cnpj] = ch.File
+			leadID := strings.TrimSpace(lead.SourceLeadID)
+			if previous, duplicate := seenLeadID[leadID]; duplicate {
+				partialErrs = append(partialErrs, fmt.Sprintf("%s duplicates source_lead_id from %s", ch.File, previous))
+				break
+			}
+			seenLeadID[leadID] = ch.File
+		}
 		if len(partialErrs) != 0 {
 			break
 		}
-		ch := man.Chunks[index]
-		chunkURI := joinURI(baseURI, ch.File)
-		idem := fmt.Sprintf("sync:%s:%s:%d", orgID, man.Source.SnapshotHash, ch.ChunkIndex)
-		importRun, xerr := s.ImportFromBytes(ctx, orgID, userID, chunkRaw, ImportOptions{
-			IdempotencyKey:          idem,
-			SourceURI:               chunkURI,
-			resumeStaleRunningAfter: feedChunkStaleImportRecoveryAfter,
-		})
-		if xerr != nil {
-			partialErrs = append(partialErrs, fmt.Sprintf("%s import: %s", ch.File, xerr.Message))
+		stagedBytes += int64(len(chunkRaw))
+		if stagedBytes > feedManifestMaxStagedBytes {
+			partialErrs = append(partialErrs, "manifest staged payload exceeds safe disk ceiling")
 			break
 		}
-		if importRun == nil || importRun.Status != models.OutreachImportCompleted {
-			partialErrs = append(partialErrs, fmt.Sprintf("%s import did not complete", ch.File))
+		stagedPath := path.Join(stageDir, fmt.Sprintf("%06d.chunk", index))
+		if writeErr := os.WriteFile(stagedPath, chunkRaw, 0o600); writeErr != nil {
+			partialErrs = append(partialErrs, fmt.Sprintf("%s staging: %v", ch.File, writeErr))
 			break
 		}
-		imported++
+		validatedChunks = append(validatedChunks, validatedManifestChunk{manifest: ch, path: stagedPath})
+	}
+
+	// Validate every remote object before the first account mutation.
+	imported := 0
+	if len(partialErrs) == 0 {
+		var importErrs []string
+		imported, importErrs = s.importValidatedManifestChunks(
+			ctx, orgID, userID, baseURI, man.Source.SnapshotHash, validatedChunks,
+		)
+		partialErrs = append(partialErrs, importErrs...)
 	}
 	result.ChunksImported = imported
 	result.Errors = partialErrs
@@ -281,6 +340,26 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 		}
 		result.Counts["stale_reviews_retired"] = retired
 		result.Counts["stale_review_accounts_requeued"] = requeued
+		backlog, backlogErr := s.repo.MaterializeCurrentInitialBacklog(ctx, orgID, man.Source.RunID)
+		if backlogErr != nil {
+			result.Status = "partial"
+			result.Errors = append(result.Errors, "initial backlog materialization: "+backlogErr.Error())
+			s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "partial", result, false, nil)
+			return result, errx.New(errx.ServiceUnavailable, "feed initial backlog materialization failed; snapshot not committed")
+		}
+		result.Counts["imported"] = backlog.Imported
+		result.Counts["supplier_confirmed"] = backlog.SupplierConfirmed
+		result.Counts["candidate_attributed"] = backlog.CandidateAttributed
+		result.Counts["initial_touchpoint_prepared"] = backlog.InitialPrepared
+		result.Counts["delegated_eligible"] = backlog.DelegatedEligible
+		result.Counts["held_exception"] = backlog.HeldException
+		result.Counts["stale_initial_retired"] = backlog.StaleRetired
+		if backlog.Imported != man.LeadCount || backlog.DelegatedEligible+backlog.HeldException != man.LeadCount {
+			result.Status = "partial"
+			result.Errors = append(result.Errors, "initial backlog denominator mismatch")
+			s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "partial", result, false, nil)
+			return result, errx.New(errx.ServiceUnavailable, "feed counts did not close; snapshot not committed")
+		}
 		woken, wakeErr := s.wakeEligibleEnrichmentRecovery(ctx, orgID)
 		if wakeErr != nil {
 			result.Status = "partial"
@@ -290,7 +369,11 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 		}
 		result.Counts["enrichment_recovery_woken"] = woken
 		result.Status = "completed"
-		s.persistFeedSync(ctx, orgID, man.Source.SnapshotHash, man.Source.RunID, uri, "completed", result, true, &generatedAt)
+		if persistErr := s.persistFeedSync(ctx, orgID, man.Source.SnapshotHash, man.Source.RunID, uri, "completed", result, true, &generatedAt); persistErr != nil {
+			result.Status = "partial"
+			result.Errors = append(result.Errors, "feed state publication failed")
+			return result, errx.New(errx.ServiceUnavailable, "feed state publication failed")
+		}
 		return result, nil
 	}
 
@@ -298,6 +381,67 @@ func (s *service) SyncFeedManifest(ctx context.Context, orgID uuid.UUID, userID 
 	result.Status = "partial"
 	s.persistFeedSync(ctx, orgID, lastSnap, lastRun, uri, "partial", result, false, nil)
 	return result, errx.New(errx.BadRequest, "feed sync partial: "+strings.Join(partialErrs, "; "))
+}
+
+func (s *service) importValidatedManifestChunks(
+	ctx context.Context,
+	orgID uuid.UUID,
+	userID *uuid.UUID,
+	baseURI, snapshotHash string,
+	chunks []validatedManifestChunk,
+) (int, []string) {
+	results := make([]manifestChunkImportResult, len(chunks))
+	jobs := make(chan int, len(chunks))
+	workers := min(feedManifestImportConcurrency, len(chunks))
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for index := range jobs {
+				staged := chunks[index]
+				ch := staged.manifest
+				chunkRaw, readErr := os.ReadFile(staged.path)
+				if readErr != nil {
+					results[index].err = fmt.Sprintf("%s staged read: %v", ch.File, readErr)
+					continue
+				}
+				idem := fmt.Sprintf("sync:%s:%s:%d", orgID, snapshotHash, ch.ChunkIndex)
+				importRun, xerr := s.ImportFromBytes(ctx, orgID, userID, chunkRaw, ImportOptions{
+					IdempotencyKey:          idem,
+					SourceURI:               joinURI(baseURI, ch.File),
+					resumeStaleRunningAfter: feedChunkStaleImportRecoveryAfter,
+					skipCommercialPlanning:  true,
+				})
+				if xerr != nil {
+					results[index].err = fmt.Sprintf("%s import: %s", ch.File, xerr.Message)
+					continue
+				}
+				if importRun == nil || importRun.Status != models.OutreachImportCompleted {
+					results[index].err = fmt.Sprintf("%s import did not complete", ch.File)
+					continue
+				}
+				results[index].completed = true
+			}
+		}()
+	}
+	for index := range chunks {
+		jobs <- index
+	}
+	close(jobs)
+	wg.Wait()
+
+	completed := 0
+	errs := make([]string, 0)
+	for index := range results {
+		if results[index].completed {
+			completed++
+		}
+		if results[index].err != "" {
+			errs = append(errs, results[index].err)
+		}
+	}
+	return completed, errs
 }
 
 func validateOutreachManifest(manifest *outreachManifest) error {
@@ -309,6 +453,12 @@ func validateOutreachManifest(manifest *outreachManifest) error {
 	}
 	if manifest.ChunkCount != len(manifest.Chunks) || manifest.ChunkCount < 1 {
 		return fmt.Errorf("manifest chunk_count does not match chunks")
+	}
+	if manifest.ChunkCount > feedManifestMaxChunks {
+		return fmt.Errorf("manifest exceeds safe chunk ceiling")
+	}
+	if manifest.LeadCount < 1 || manifest.LeadCount > feedManifestMaxLeads {
+		return fmt.Errorf("manifest lead_count exceeds safe import ceiling")
 	}
 	seenFiles := make(map[string]struct{}, len(manifest.Chunks))
 	totalLeads := 0
@@ -346,6 +496,27 @@ func validateOutreachManifest(manifest *outreachManifest) error {
 		}
 	}
 	return nil
+}
+
+func decodeFeedSyncCounts(raw []byte) map[string]int {
+	out := map[string]int{}
+	var stored map[string]any
+	if json.Unmarshal(raw, &stored) != nil {
+		return out
+	}
+	for key, value := range stored {
+		switch key {
+		case "chunks_total", "chunks_imported", "deactivations", "skipped_same":
+			continue
+		}
+		switch n := value.(type) {
+		case float64:
+			out[key] = int(n)
+		case int:
+			out[key] = n
+		}
+	}
+	return out
 }
 
 func manifestBaseURI(uri string) string {
@@ -395,7 +566,7 @@ func (s *service) lastAppliedSnapshot(ctx context.Context, orgID uuid.UUID) (sna
 	return "", ""
 }
 
-func (s *service) persistFeedSync(ctx context.Context, orgID uuid.UUID, snap, run, uri, status string, res *FeedSyncResult, success bool, sourceGeneratedAt *time.Time) {
+func (s *service) persistFeedSync(ctx context.Context, orgID uuid.UUID, snap, run, uri, status string, res *FeedSyncResult, success bool, sourceGeneratedAt *time.Time) error {
 	now := time.Now().UTC()
 	st := &models.OutreachFeedSyncState{
 		OrganizationID:   orgID,
@@ -426,5 +597,5 @@ func (s *service) persistFeedSync(ctx context.Context, orgID uuid.UUID, snap, ru
 		b, _ := json.Marshal(counts)
 		st.CountsJSON = b
 	}
-	_ = s.repo.UpsertFeedSyncState(ctx, st)
+	return s.repo.UpsertFeedSyncState(ctx, st)
 }

--- a/internal/app/confenge/feed_sync_load_pg_test.go
+++ b/internal/app/confenge/feed_sync_load_pg_test.go
@@ -1,0 +1,355 @@
+package confenge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+const (
+	manifestLoadAccounts  = 10_000
+	manifestLoadChunkSize = 500
+)
+
+func TestPostgresSyncFeedManifestMaterializesTenThousandAndConverges(t *testing.T) {
+	if os.Getenv("WARMBLY_RUN_LOAD_TESTS") != "1" {
+		t.Skip("WARMBLY_RUN_LOAD_TESTS=1 is required")
+	}
+	dsn := os.Getenv("WARMBLY_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+
+	userID, orgID := uuid.New(), uuid.New()
+	if _, err = pool.Exec(ctx, `INSERT INTO users (id,first_name,last_name,email) VALUES ($1,'Manifest','Load',$2)`,
+		userID, "manifest-load-"+userID.String()+"@example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO organizations (id,name,slug,owner_user_id) VALUES ($1,'Manifest Load',$2,$3)`,
+		orgID, "manifest-load-"+orgID.String(), userID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		defer cleanupCancel()
+		if _, cleanupErr := pool.Exec(cleanupCtx, `DELETE FROM organizations WHERE id=$1`, orgID); cleanupErr != nil {
+			t.Errorf("clean load organization: %v", cleanupErr)
+		}
+		if _, cleanupErr := pool.Exec(cleanupCtx, `DELETE FROM users WHERE id=$1`, userID); cleanupErr != nil {
+			t.Errorf("clean load user: %v", cleanupErr)
+		}
+	})
+
+	repo := repository.NewOutreachRepository(pool)
+	svc := NewService(Config{
+		Enabled: true, AppEnv: "test", RequireHumanApproval: true,
+		FeedMaxAge: 24 * time.Hour, MaxFeedPayloadBytes: 16 << 20,
+	}, repo, nil).(*service)
+	svc.WireHumanGate(pool)
+
+	generatedOne := time.Now().UTC().Add(-2 * time.Minute).Truncate(time.Second)
+	manifestOne, chunksOne := writeSyntheticLoadManifest(t, t.TempDir(), "load-run-1", "load-snapshot-1", generatedOne)
+
+	// Leave chunk 3 half-written under an abandoned durable RUNNING lease.
+	staleRun := &models.OutreachImportRun{
+		ID: uuid.New(), OrganizationID: orgID, SourceSystem: "extra-cli",
+		SourceRunID: "load-run-1", SchemaVersion: models.OutreachSchemaV1,
+		SnapshotHash: "load-snapshot-1", PayloadHash: CanonicalPayloadHash(chunksOne[3]),
+		ProfileID: "load", ProfileVersion: "1", Status: models.OutreachImportRunning,
+		IdempotencyKey: fmt.Sprintf("sync:%s:load-snapshot-1:3", orgID),
+		StartedAt:      time.Now().UTC().Add(-10 * time.Minute), UpdatedAt: time.Now().UTC().Add(-10 * time.Minute),
+	}
+	if err = repo.CreateImportRun(ctx, staleRun); err != nil {
+		t.Fatal(err)
+	}
+	var abandoned Feed
+	if err = json.Unmarshal(chunksOne[3], &abandoned); err != nil {
+		t.Fatal(err)
+	}
+	abandoned.Leads = abandoned.Leads[:manifestLoadChunkSize/2]
+	partialCounts, partialErrors, _ := svc.applyFeed(ctx, orgID, staleRun, &abandoned, false, false)
+	if len(partialErrors) != 0 || partialCounts.LeadsProcessed != manifestLoadChunkSize/2 {
+		t.Fatalf("abandoned chunk setup failed: counts=%+v errors=%+v", partialCounts, partialErrors)
+	}
+	if _, err = pool.Exec(ctx, `UPDATE outreach_import_runs SET updated_at=now()-interval '10 minutes' WHERE id=$1`, staleRun.ID); err != nil {
+		t.Fatal(err)
+	}
+	restarted := NewService(svc.cfg, repo, nil).(*service)
+	restarted.WireHumanGate(pool)
+
+	started := time.Now()
+	first, xerr := restarted.SyncFeedManifest(ctx, orgID, &userID, "file://"+manifestOne)
+	if xerr != nil {
+		t.Fatalf("first 10k sync: result=%+v error=%v", first, xerr)
+	}
+	assertLoadFunnel(t, first)
+	assertCurrentLoadBacklog(t, ctx, pool, orgID, "load-run-1", "load-snapshot-1", 0)
+	t.Logf("10k first sync completed in %s with counts=%v", time.Since(started).Round(time.Millisecond), first.Counts)
+
+	recovered, err := repo.GetImportRun(ctx, orgID, staleRun.ID)
+	if err != nil || recovered == nil || recovered.Status != models.OutreachImportCompleted ||
+		!containsString(recovered.Warnings, "resumed_stale_running_import") {
+		t.Fatalf("abandoned chunk did not converge on its durable run: run=%+v error=%v", recovered, err)
+	}
+
+	replay, xerr := restarted.SyncFeedManifest(ctx, orgID, &userID, "file://"+manifestOne)
+	if xerr != nil || replay.Status != "noop" || !replay.SkippedSame {
+		t.Fatalf("same snapshot replay was not idempotent: result=%+v error=%v", replay, xerr)
+	}
+	assertCurrentLoadBacklog(t, ctx, pool, orgID, "load-run-1", "load-snapshot-1", 0)
+
+	generatedTwo := generatedOne.Add(time.Minute)
+	manifestTwo, _ := writeSyntheticLoadManifest(t, t.TempDir(), "load-run-2", "load-snapshot-2", generatedTwo)
+	refreshStarted := time.Now()
+	second, xerr := restarted.SyncFeedManifest(ctx, orgID, &userID, "file://"+manifestTwo)
+	if xerr != nil {
+		t.Fatalf("refresh 10k sync: result=%+v error=%v", second, xerr)
+	}
+	assertLoadFunnel(t, second)
+	assertCurrentLoadBacklog(t, ctx, pool, orgID, "load-run-2", "load-snapshot-2", 9_000)
+	if second.Counts["stale_initial_retired"] != 9_000 {
+		t.Fatalf("stale retirement=%d want=9000", second.Counts["stale_initial_retired"])
+	}
+	t.Logf("10k refresh completed in %s with counts=%v", time.Since(refreshStarted).Round(time.Millisecond), second.Counts)
+
+	replay, xerr = restarted.SyncFeedManifest(ctx, orgID, &userID, "file://"+manifestTwo)
+	if xerr != nil || replay.Status != "noop" || !replay.SkippedSame {
+		t.Fatalf("refreshed snapshot replay was not idempotent: result=%+v error=%v", replay, xerr)
+	}
+	assertCurrentLoadBacklog(t, ctx, pool, orgID, "load-run-2", "load-snapshot-2", 9_000)
+}
+
+func assertLoadFunnel(t *testing.T, result *FeedSyncResult) {
+	t.Helper()
+	if result == nil || result.Status != "completed" || result.ChunksImported != 20 {
+		t.Fatalf("incomplete manifest result: %+v", result)
+	}
+	want := map[string]int{
+		"imported":                    10_000,
+		"supplier_confirmed":          9_000,
+		"candidate_attributed":        9_000,
+		"initial_touchpoint_prepared": 9_000,
+		"delegated_eligible":          8_000,
+		"held_exception":              2_000,
+	}
+	for stage, count := range want {
+		if result.Counts[stage] != count {
+			t.Fatalf("stage %s=%d want=%d; all=%v", stage, result.Counts[stage], count, result.Counts)
+		}
+	}
+}
+
+func assertCurrentLoadBacklog(t *testing.T, ctx context.Context, pool *pgxpool.Pool, orgID uuid.UUID, runID, snapshot string, stale int) {
+	t.Helper()
+	var accounts, currentInitial, duplicateInitial, reviewInitial, staleInitial, drafts, dispatch, commercialActions int
+	var chunkRuns, chunkLeads, invalidChunkRuns int
+	var stateRun, stateStatus string
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM outreach_accounts WHERE organization_id=$1 AND source_run_id=$2`, orgID, runID).Scan(&accounts); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM outreach_touchpoints t
+		JOIN outreach_accounts a ON a.organization_id=t.organization_id AND a.id=t.account_id
+		JOIN outreach_contact_candidates c ON c.organization_id=t.organization_id AND c.id=t.contact_candidate_id
+		WHERE t.organization_id=$1 AND t.source_run_id=$2 AND t.ordinal=1 AND t.purpose='INITIAL'
+		  AND t.channel='EMAIL' AND t.state='DUE' AND a.source_run_id=$2
+		  AND c.last_import_run_id=a.last_import_run_id
+		  AND c.discovery_json->>'preferred_initial'='true'`, orgID, runID).Scan(&currentInitial); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM (
+			SELECT account_id,source_run_id FROM outreach_touchpoints
+			WHERE organization_id=$1 AND ordinal=1 AND purpose='INITIAL' AND channel='EMAIL' AND source_run_id<>''
+			GROUP BY account_id,source_run_id HAVING count(*)<>1
+		) duplicates`, orgID).Scan(&duplicateInitial); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM outreach_touchpoints WHERE organization_id=$1 AND ordinal=1 AND purpose='INITIAL' AND state='NEEDS_REVIEW'`, orgID).Scan(&reviewInitial); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM outreach_touchpoints WHERE organization_id=$1 AND source_run_id<>$2 AND ordinal=1 AND purpose='INITIAL' AND channel='EMAIL' AND state='CANCELLED' AND stop_reason='source_run_superseded'`, orgID, runID).Scan(&staleInitial); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM outreach_drafts WHERE organization_id=$1`, orgID).Scan(&drafts); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM confenge_dispatch_queue WHERE organization_id=$1`, orgID).Scan(&dispatch); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM outreach_commercial_actions WHERE organization_id=$1`, orgID).Scan(&commercialActions); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*),COALESCE(sum((counts->>'leads_processed')::int),0),
+			count(*) FILTER (WHERE status<>'completed' OR snapshot_hash<>$3 OR length(payload_hash)<>64)
+		FROM outreach_import_runs WHERE organization_id=$1 AND source_run_id=$2`, orgID, runID, snapshot).
+		Scan(&chunkRuns, &chunkLeads, &invalidChunkRuns); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(ctx, `SELECT last_run_id,last_status FROM outreach_feed_sync_state WHERE organization_id=$1`, orgID).
+		Scan(&stateRun, &stateStatus); err != nil {
+		t.Fatal(err)
+	}
+	if accounts != 10_000 || currentInitial != 9_000 || duplicateInitial != 0 || reviewInitial != 0 ||
+		staleInitial != stale || drafts != 0 || dispatch != 0 || commercialActions != 0 || chunkRuns != 20 || chunkLeads != 10_000 ||
+		invalidChunkRuns != 0 || stateRun != runID || stateStatus != "completed" {
+		t.Fatalf("backlog mismatch: accounts=%d current=%d duplicates=%d review=%d stale=%d drafts=%d dispatch=%d commercial_actions=%d chunks=%d chunk_leads=%d invalid_chunks=%d state=%s/%s",
+			accounts, currentInitial, duplicateInitial, reviewInitial, staleInitial, drafts, dispatch, commercialActions,
+			chunkRuns, chunkLeads, invalidChunkRuns, stateRun, stateStatus)
+	}
+
+	rows, err := pool.Query(ctx, `
+		SELECT initial_backlog_reason_code,count(*) FROM outreach_accounts
+		WHERE organization_id=$1 AND source_run_id=$2
+		GROUP BY initial_backlog_reason_code`, orgID, runID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	reasons := map[string]int{}
+	for rows.Next() {
+		var reason string
+		var count int
+		if err = rows.Scan(&reason, &count); err != nil {
+			t.Fatal(err)
+		}
+		reasons[reason] = count
+	}
+	if err = rows.Err(); err != nil {
+		t.Fatal(err)
+	}
+	if reasons[""] != 8_000 || reasons["supplier_role_unknown"] != 1_000 ||
+		reasons["preferred_current_recipient_missing"] != 1_000 || len(reasons) != 3 {
+		t.Fatalf("held reason distribution=%v", reasons)
+	}
+}
+
+func writeSyntheticLoadManifest(t *testing.T, dir, runID, snapshot string, generatedAt time.Time) (string, [][]byte) {
+	t.Helper()
+	chunks := make([]map[string]any, 0, manifestLoadAccounts/manifestLoadChunkSize)
+	raws := make([][]byte, 0, manifestLoadAccounts/manifestLoadChunkSize)
+	for start := 0; start < manifestLoadAccounts; start += manifestLoadChunkSize {
+		index := start / manifestLoadChunkSize
+		leads := make([]FeedLead, 0, manifestLoadChunkSize)
+		for i := start; i < start+manifestLoadChunkSize; i++ {
+			leads = append(leads, syntheticLoadLead(i, runID, generatedAt))
+		}
+		feed := Feed{
+			SchemaVersion: models.OutreachSchemaV1, GeneratedAt: generatedAt.Format(time.RFC3339),
+			Source:     FeedSource{System: "extra-cli", RunID: runID, SnapshotHash: snapshot, ProfileID: "load", ProfileVersion: "1"},
+			Pagination: FeedPagination{HasMore: start+manifestLoadChunkSize < manifestLoadAccounts}, Leads: leads,
+		}
+		raw, err := json.Marshal(feed)
+		if err != nil {
+			t.Fatal(err)
+		}
+		filename := fmt.Sprintf("chunk_%04d.json", index)
+		if err = os.WriteFile(filepath.Join(dir, filename), raw, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		sum := sha256.Sum256(raw)
+		chunks = append(chunks, map[string]any{
+			"file": filename, "chunk_index": index, "content_hash": hex.EncodeToString(sum[:]),
+			"lead_count": manifestLoadChunkSize, "has_more": feed.Pagination.HasMore,
+		})
+		raws = append(raws, raw)
+	}
+	manifest := map[string]any{
+		"schema_version": "confenge.outreach.manifest.v1", "generated_at": generatedAt.Format(time.RFC3339),
+		"source": map[string]any{
+			"system": "extra-cli", "run_id": runID, "snapshot_hash": snapshot,
+			"profile_id": "load", "profile_version": "1",
+		},
+		"lead_count": manifestLoadAccounts, "chunk_count": len(chunks), "chunks": chunks,
+		"deactivations": []any{}, "deactivation_count": 0,
+	}
+	manifestRaw, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	manifestPath := filepath.Join(dir, "manifest.json")
+	if err = os.WriteFile(manifestPath, manifestRaw, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return manifestPath, raws
+}
+
+func syntheticLoadLead(index int, runID string, generatedAt time.Time) FeedLead {
+	ready, notBlocked, notFixture, preferred := true, false, false, true
+	cnpj := fmt.Sprintf("%014d", 10_000_000_000_000+index)
+	evidenceID := fmt.Sprintf("role-evidence-%05d", index)
+	evidenceHash := fmt.Sprintf("%064x", index+1)
+	lead := FeedLead{
+		SourceLeadID: fmt.Sprintf("load-lead-%05d", index),
+		Company: FeedCompany{
+			CNPJ14: cnpj, CNPJRoot: cnpj[:8], RazaoSocial: fmt.Sprintf("Empresa Carga %05d Ltda", index),
+			NomeFantasia: fmt.Sprintf("Empresa %05d", index), UF: "SP", Website: fmt.Sprintf("https://empresa%05d.com.br", index),
+		},
+		Priority: FeedPriority{Rank: index + 1, Score: 80, Tier: "HIGH", Confidence: "HIGH"},
+		Moment: FeedMoment{
+			Code: "CONTRACT_EXTENSION", Summary: "Prorrogação contratual publicada",
+			ObservedAt: generatedAt.Format("2006-01-02"), Confidence: "HIGH", EvidenceIDs: []string{evidenceID},
+		},
+		Offer: FeedOffer{ServiceCode: "ADDITIVE_REVIEW", ServiceName: "Revisão de aditivos", EntryOffer: "Leitura técnica", Rationale: "Prorrogação recente"},
+		MessagingContext: FeedMessaging{
+			FactToMention: "Prorrogação contratual publicada em fonte oficial",
+			QuestionToAsk: "Faz sentido revisar os controles?", CTA: "Posso enviar um checklist?",
+		},
+		TargetFitClass: TargetFitConfirmed, TargetFitVersion: "load-fit-v1",
+		TargetFitComputedAt: generatedAt.Format(time.RFC3339), TargetFitSourceWatermark: generatedAt.Format(time.RFC3339),
+		TargetFitFresh: &ready, TargetFitSendTier: "A_AUTOMATIC", EmailSendReady: &ready,
+		CommercialState: "NEW",
+		ContractorRole: FeedContractorRole{
+			Status: ContractorRoleConfirmed, TargetPartyRole: "SUPPLIER", PolicyVersion: DelegatedFirstTouchEvidenceV1,
+			Source: "extra-cli:v_contracts_canonical_v2", SourceRunID: runID, ObservedAt: generatedAt.Format(time.RFC3339),
+			EvidenceHash: evidenceHash, EvidenceReference: "extra-cli:v_contracts_canonical_v2:sha256:" + evidenceHash,
+			EvidenceIDs: []string{evidenceID}, ReasonCodes: []string{"lead_matches_supplier", "lead_differs_from_buyer"},
+			SupplierCNPJ14: cnpj, SupplierIdentityRef: "cnpj:" + cnpj,
+			BuyerCNPJ14: "99000000000001", BuyerIdentityRef: "cnpj:99000000000001",
+			RoleMatchMethod: "SUPPLIER_EXACT_CNPJ14", Confidence: "HIGH",
+		},
+	}
+	if index < 9_000 {
+		email := fmt.Sprintf("contato@empresa%05d.com.br", index)
+		lead.Contacts = []FeedContact{{
+			SourceContactID: fmt.Sprintf("load-contact-%05d", index), Name: "Equipe Comercial", Role: "Comercial", Email: email,
+			SourceURL: fmt.Sprintf("https://empresa%05d.com.br/contato", index), SourceDate: generatedAt.Format("2006-01-02"),
+			VerificationStatus: models.OutreachVerifyOfficialSource, Confidence: "HIGH", Recommended: true,
+			EmailSendReady: &ready, MailboxPurpose: "COMERCIAL", MailboxPurposeSendBlocked: &notBlocked,
+			OwnershipStatus: "COMPANY_OWNED", RecipientCommercialSuitability: "SUITABLE",
+			ProvenanceChainValid: &ready, DerivedFromFixture: &notFixture, RootSourceType: "OFFICIAL_COMPANY_WEBSITE",
+			RouteClass: RouteClassRoleOrDepartment, ControlledEmailEligible: &ready, PreferredInitial: &preferred,
+			MailboxCompanyEvidence: "OBSERVED", MailboxDepartmentEvidence: "OBSERVED",
+			ChannelEpistemic: "OBSERVED", RouteFreshness: "FRESH", RouteSuppression: "NONE", RiskClass: "ALLOWED",
+		}}
+	}
+	if index >= 8_000 && index < 9_000 {
+		lead.ContractorRole = FeedContractorRole{
+			Status: ContractorRoleUnknown, TargetPartyRole: ContractorRoleUnknown, PolicyVersion: DelegatedFirstTouchEvidenceV1,
+			Source: "extra-cli:v_contracts_canonical_v2", SourceRunID: runID, ObservedAt: generatedAt.Format(time.RFC3339),
+			EvidenceHash: evidenceHash, EvidenceReference: "extra-cli:v_contracts_canonical_v2:sha256:" + evidenceHash,
+			ReasonCodes: []string{"supplier_role_not_confirmed"},
+		}
+	}
+	return lead
+}

--- a/internal/app/confenge/feed_sync_test.go
+++ b/internal/app/confenge/feed_sync_test.go
@@ -106,6 +106,9 @@ func TestSyncFeedManifestIdempotentAndHashFailClosed(t *testing.T) {
 	if !res2.SkippedSame || res2.Status != "noop" {
 		t.Fatalf("expected noop, got %+v", res2)
 	}
+	if res2.Counts["imported"] != 1 || res2.Counts["held_exception"] != 1 || res2.Counts["chunks_total"] != 0 {
+		t.Fatalf("noop did not return only persisted stage counts: %+v", res2.Counts)
+	}
 
 	// A producer retry may assign a new run ID to identical snapshot content.
 	// No-op must retain the applied run ID or every account becomes non-current.
@@ -127,6 +130,41 @@ func TestSyncFeedManifestIdempotentAndHashFailClosed(t *testing.T) {
 	state, _ = r.GetFeedSyncState(ctx, org)
 	if state.LastRunID != "run-sync-1" {
 		t.Fatalf("same snapshot drifted authoritative run to %q", state.LastRunID)
+	}
+
+	// Reusing one run id for different content would stale its per-run INITIAL binding.
+	reusedRun := cloneManifestMap(t, man)
+	reusedRun["generated_at"] = "2026-08-09T11:00:00Z"
+	reusedRun["source"] = map[string]any{
+		"system": "extra-cli", "run_id": "run-sync-1", "snapshot_hash": "snap-reused-run",
+		"profile_id": "p", "profile_version": "1",
+	}
+	reusedRaw, _ := json.Marshal(reusedRun)
+	reusedPath := filepath.Join(dir, "manifest_reused_run.json")
+	if err := os.WriteFile(reusedPath, reusedRaw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, xerr := svc.SyncFeedManifest(ctx, org, &user, "file://"+reusedPath); xerr == nil {
+		t.Fatal("source run id reused for a different snapshot must be rejected")
+	}
+	state, _ = r.GetFeedSyncState(ctx, org)
+	if state.LastRunID != "run-sync-1" || state.LastSnapshotHash != "snap-sync-1" {
+		t.Fatalf("reused run displaced the current snapshot: %+v", state)
+	}
+
+	historicalCurrentAt := time.Date(2026, 8, 9, 10, 0, 0, 0, time.UTC)
+	if err := r.UpsertFeedSyncState(ctx, &models.OutreachFeedSyncState{
+		OrganizationID: org, LastSnapshotHash: "snap-current-2", LastRunID: "run-current-2",
+		LastStatus: "completed", SourceGeneratedAt: &historicalCurrentAt,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, xerr := svc.SyncFeedManifest(ctx, org, &user, "file://"+reusedPath); xerr == nil {
+		t.Fatal("historical source run id reused for a different snapshot must be rejected")
+	}
+	state, _ = r.GetFeedSyncState(ctx, org)
+	if state.LastRunID != "run-current-2" || state.LastSnapshotHash != "snap-current-2" {
+		t.Fatalf("historical run reuse displaced the current snapshot: %+v", state)
 	}
 
 	// A different snapshot with an older authoritative timestamp is a rollback,

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -200,6 +200,8 @@ type ImportOptions struct {
 	// holds the organization feed lock. Public imports keep the original
 	// idempotent readback behavior and never reclaim an in-flight run.
 	resumeStaleRunningAfter time.Duration
+	// Manifest sync materializes the canonical backlog instead of a parallel human action queue.
+	skipCommercialPlanning bool
 }
 
 type ApprovalOptions struct {
@@ -386,7 +388,7 @@ func (s *service) ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *
 		}
 	}
 
-	counts, leadErrs, warns := s.applyFeed(ctx, orgID, run, feed, run.DryRun)
+	counts, leadErrs, warns := s.applyFeed(ctx, orgID, run, feed, run.DryRun, !opts.skipCommercialPlanning)
 	run.Counts = counts
 	applyOperatorSummary(&run.Counts, SummarizeOperatorProjection(feed))
 	run.Errors = leadErrs
@@ -452,7 +454,7 @@ func mustJSON(v any) []byte {
 	return b
 }
 
-func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.OutreachImportRun, feed *Feed, dryRun bool) (models.OutreachImportCounts, []models.OutreachImportError, []string) {
+func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.OutreachImportRun, feed *Feed, dryRun, planCommercialActions bool) (models.OutreachImportCounts, []models.OutreachImportError, []string) {
 	var counts models.OutreachImportCounts
 	var leadErrs []models.OutreachImportError
 	var warns []string
@@ -576,7 +578,9 @@ func (s *service) applyFeed(ctx context.Context, orgID uuid.UUID, run *models.Ou
 				counts.LeadsSkippedError++
 			}
 		}
-		s.planAndPersistAccount(ctx, orgID, acc)
+		if planCommercialActions {
+			s.planAndPersistAccount(ctx, orgID, acc)
+		}
 		counts.LeadsProcessed++
 	}
 	return counts, leadErrs, warns

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -181,8 +181,99 @@ func (m *memRepo) GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID
 	return &cp, nil
 }
 
+func (m *memRepo) HasImportRunSnapshotConflict(_ context.Context, orgID uuid.UUID, sourceRunID, snapshotHash string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, run := range m.runs {
+		if run.OrganizationID == orgID && run.SourceRunID == sourceRunID && run.SnapshotHash != "" && run.SnapshotHash != snapshotHash {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
 func (m *memRepo) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error) {
 	return nil, nil
+}
+
+func (m *memRepo) MaterializeCurrentInitialBacklog(_ context.Context, orgID uuid.UUID, sourceRunID string) (repository.OutreachInitialBacklogCounts, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var out repository.OutreachInitialBacklogCounts
+	for _, tp := range m.touchpoints {
+		if tp.OrganizationID == orgID && tp.Ordinal == 1 && tp.Purpose == models.TouchpointPurposeInitial &&
+			tp.Channel == models.OutreachChannelEmail && tp.SourceRunID != sourceRunID && models.TouchpointOpenStates[tp.State] {
+			tp.State = models.TouchpointCancelled
+			tp.StopReason = "source_run_superseded"
+			out.StaleRetired++
+		}
+	}
+	for _, acc := range m.byID {
+		if acc.OrganizationID != orgID || acc.SourceRunID != sourceRunID {
+			continue
+		}
+		out.Imported++
+		supplier := acc.ContractorRoleStatus == ContractorRoleConfirmed && acc.TargetPartyRole == "SUPPLIER" && acc.ContractorRoleSourceRunID == sourceRunID
+		if supplier {
+			out.SupplierConfirmed++
+		}
+		preferred := make([]models.OutreachContactCandidate, 0, 1)
+		for i := range m.cands[acc.ID] {
+			cand := m.cands[acc.ID][i]
+			if cand.LastImportRunID != nil && acc.LastImportRunID != nil && *cand.LastImportRunID == *acc.LastImportRunID && CandidatePreferredInitial(&cand) {
+				preferred = append(preferred, cand)
+			}
+		}
+		attributed := len(preferred) == 1
+		if attributed {
+			out.CandidateAttributed++
+		}
+		candidateEligible := attributed && CandidateEnrollable(&preferred[0])
+		delegatedCandidate := candidateEligible && CandidateControlledEligible(&preferred[0]) && ControlledRouteAllowed(&preferred[0], nil)
+		prepared := candidateEligible && acc.TargetFitEligible && acc.TargetFitFresh && acc.TargetFitClass == TargetFitConfirmed && !acc.Blocked && !acc.DoNotContact
+		if prepared {
+			out.InitialPrepared++
+			key := "prepared-initial:" + sourceRunID + ":" + acc.ID.String()
+			found := false
+			for _, tp := range m.touchpoints {
+				if tp.OrganizationID == orgID && tp.IdempotencyKey == key {
+					found = true
+					break
+				}
+			}
+			if !found {
+				candidateID := preferred[0].ID
+				tp := &models.OutreachTouchpoint{
+					ID: uuid.New(), OrganizationID: orgID, AccountID: acc.ID, ContactCandidateID: &candidateID,
+					Ordinal: 1, CadenceStep: "INITIAL", Channel: models.OutreachChannelEmail,
+					Purpose: models.TouchpointPurposeInitial, DueAt: time.Now().UTC(), State: models.TouchpointDue,
+					Recipient: preferred[0].Email, IdempotencyKey: key, PolicyVersion: models.CadencePolicyVersionV1,
+					ServiceCode: acc.ServiceCode, FactUsed: acc.FactToMention, EvidenceIDs: acc.ContractorRoleEvidenceIDs,
+					GeneratedContextHash: acc.MessageContextHash, SourceRunID: sourceRunID,
+				}
+				m.touchpoints[tp.ID] = tp
+			}
+		}
+		if prepared && supplier && delegatedCandidate {
+			out.DelegatedEligible++
+			acc.InitialBacklogReasonCode = ""
+		} else {
+			switch {
+			case !attributed:
+				acc.InitialBacklogReasonCode = "preferred_current_recipient_missing"
+			case !candidateEligible:
+				acc.InitialBacklogReasonCode = "preferred_current_recipient_ineligible"
+			case !supplier:
+				acc.InitialBacklogReasonCode = "supplier_role_unknown"
+			case !delegatedCandidate:
+				acc.InitialBacklogReasonCode = "preferred_current_recipient_not_delegated"
+			default:
+				acc.InitialBacklogReasonCode = "target_fit_not_current_confirmed"
+			}
+		}
+	}
+	out.HeldException = out.Imported - out.DelegatedEligible
+	return out, nil
 }
 
 func (m *memRepo) GetAccountByCNPJ(ctx context.Context, orgID uuid.UUID, cnpj14 string) (*models.OutreachAccount, error) {

--- a/internal/infrastructure/db/migrations/000130_confenge_current_run_initial_backlog.down.sql
+++ b/internal/infrastructure/db/migrations/000130_confenge_current_run_initial_backlog.down.sql
@@ -1,0 +1,13 @@
+DROP INDEX IF EXISTS outreach_import_runs_org_source_run_snapshot_idx;
+DROP INDEX IF EXISTS outreach_touchpoints_delegated_prepared_idx;
+DROP INDEX IF EXISTS outreach_touchpoints_org_account_run_initial_uidx;
+
+ALTER TABLE outreach_touchpoints
+    DROP COLUMN IF EXISTS delegated_last_error,
+    DROP COLUMN IF EXISTS delegated_attempts,
+    DROP COLUMN IF EXISTS delegated_retry_at,
+    DROP COLUMN IF EXISTS delegated_reserved_until,
+    DROP COLUMN IF EXISTS source_run_id;
+
+ALTER TABLE outreach_accounts
+    DROP COLUMN IF EXISTS initial_backlog_reason_code;

--- a/internal/infrastructure/db/migrations/000130_confenge_current_run_initial_backlog.up.sql
+++ b/internal/infrastructure/db/migrations/000130_confenge_current_run_initial_backlog.up.sql
@@ -1,0 +1,22 @@
+ALTER TABLE outreach_accounts
+    ADD COLUMN IF NOT EXISTS initial_backlog_reason_code text NOT NULL DEFAULT '';
+
+ALTER TABLE outreach_touchpoints
+    ADD COLUMN IF NOT EXISTS source_run_id text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS delegated_reserved_until timestamptz,
+    ADD COLUMN IF NOT EXISTS delegated_retry_at timestamptz NOT NULL DEFAULT now(),
+    ADD COLUMN IF NOT EXISTS delegated_attempts int NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS delegated_last_error text NOT NULL DEFAULT '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_touchpoints_org_account_run_initial_uidx
+    ON outreach_touchpoints (organization_id, account_id, source_run_id)
+    WHERE source_run_id <> '' AND ordinal = 1 AND purpose = 'INITIAL' AND channel = 'EMAIL';
+
+CREATE INDEX IF NOT EXISTS outreach_touchpoints_delegated_prepared_idx
+    ON outreach_touchpoints (organization_id, source_run_id, delegated_retry_at, due_at, id)
+    WHERE ordinal = 1 AND purpose = 'INITIAL' AND channel = 'EMAIL'
+      AND state IN ('DUE', 'NEEDS_REVIEW');
+
+CREATE INDEX IF NOT EXISTS outreach_import_runs_org_source_run_snapshot_idx
+    ON outreach_import_runs (organization_id, source_run_id, snapshot_hash)
+    WHERE source_run_id <> '' AND snapshot_hash <> '';

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -213,6 +213,7 @@ type OutreachAccount struct {
 	TargetFitEligible          bool       `json:"target_fit_eligible"`
 	TargetFitSuppressionReason string     `json:"target_fit_suppression_reason,omitempty"`
 	TargetFitReconciledAt      *time.Time `json:"target_fit_reconciled_at,omitempty"`
+	InitialBacklogReasonCode   string     `json:"initial_backlog_reason_code,omitempty"`
 	// Company-level rollup of best-contact email_send_ready from extra-cli.
 	EmailSendReady bool `json:"email_send_ready,omitempty"`
 
@@ -655,6 +656,7 @@ type OutreachTouchpoint struct {
 	FactUsed             string           `json:"fact_used"`
 	EvidenceIDs          []string         `json:"evidence_ids,omitempty"`
 	GeneratedContextHash string           `json:"generated_context_hash,omitempty"`
+	SourceRunID          string           `json:"source_run_id,omitempty"`
 	CreatedAt            time.Time        `json:"created_at"`
 	UpdatedAt            time.Time        `json:"updated_at"`
 	Account              *OutreachAccount `json:"account,omitempty"`

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -1507,6 +1507,8 @@ func (r *campaignRepository) HasPendingDelegatedFirstTouch(ctx context.Context, 
 			FROM outreach_touchpoints t
 			JOIN outreach_accounts account
 			  ON account.organization_id=t.organization_id AND account.id=t.account_id
+			JOIN outreach_contact_candidates candidate
+			  ON candidate.organization_id=t.organization_id AND candidate.id=t.contact_candidate_id
 			JOIN outreach_feed_sync_state feed
 			  ON feed.organization_id=t.organization_id
 			JOIN outreach_org_settings settings
@@ -1514,8 +1516,11 @@ func (r *campaignRepository) HasPendingDelegatedFirstTouch(ctx context.Context, 
 			JOIN confenge_campaign_policy_authorizations auth
 			  ON auth.organization_id=t.organization_id AND auth.campaign_id=$1
 			WHERE t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
-			  AND t.state='NEEDS_REVIEW' AND t.contact_candidate_id IS NOT NULL
+			  AND t.state IN ('DUE','NEEDS_REVIEW') AND t.contact_candidate_id IS NOT NULL
 			  AND feed.last_status='completed' AND account.source_run_id=feed.last_run_id
+			  AND (t.source_run_id='' OR t.source_run_id=feed.last_run_id)
+			  AND account.initial_backlog_reason_code=''
+			  AND account.last_import_run_id IS NOT NULL AND candidate.last_import_run_id=account.last_import_run_id
 			  AND auth.revoked_at IS NULL AND auth.effective_at <= now()
 			  AND auth.prompt_policy_version='CFG-FIRST-TOUCH-ROUTING-v1'
 			  AND auth.authorized_by_label='founder-approved-first-touch-policy'

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -26,6 +26,7 @@ type OutreachRepository interface {
 	UpdateImportRun(ctx context.Context, run *models.OutreachImportRun) error
 	GetImportRun(ctx context.Context, orgID, id uuid.UUID) (*models.OutreachImportRun, error)
 	GetImportRunByIdempotency(ctx context.Context, orgID uuid.UUID, key string) (*models.OutreachImportRun, error)
+	HasImportRunSnapshotConflict(ctx context.Context, orgID uuid.UUID, sourceRunID, snapshotHash string) (bool, error)
 	ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error)
 
 	// Accounts
@@ -45,6 +46,7 @@ type OutreachRepository interface {
 	UpsertFeedSyncState(ctx context.Context, st *models.OutreachFeedSyncState) error
 	TryAdvisoryLock(ctx context.Context, key int64) (bool, error)
 	AdvisoryUnlock(ctx context.Context, key int64) error
+	MaterializeCurrentInitialBacklog(ctx context.Context, orgID uuid.UUID, sourceRunID string) (OutreachInitialBacklogCounts, error)
 	ListPilotMemberships(ctx context.Context, orgID uuid.UUID, cohortID string) ([]models.OutreachPilotMembership, error)
 	ClaimPilotOperation(ctx context.Context, orgID uuid.UUID, operationKey, requestHash string) error
 	ReservePilotSlot(ctx context.Context, orgID uuid.UUID, cohortID string, accountID uuid.UUID, cnpj14 string, capacity int) (int, error)
@@ -140,6 +142,22 @@ type TargetFitInvalidationCounts struct {
 	Drafts        int `json:"blocked_drafts"`
 	Enrollments   int `json:"detached_enrollments"`
 	DispatchItems int `json:"cancelled_dispatch_items"`
+}
+
+// OutreachInitialBacklogCounts is the current-run funnel published with a feed sync.
+type OutreachInitialBacklogCounts struct {
+	Imported            int
+	SupplierConfirmed   int
+	CandidateAttributed int
+	InitialPrepared     int
+	DelegatedEligible   int
+	HeldException       int
+	StaleRetired        int
+}
+
+// MaterializeCurrentInitialBacklog reconciles the canonical INITIAL backlog for one source run.
+func (r *outreachRepository) MaterializeCurrentInitialBacklog(ctx context.Context, orgID uuid.UUID, sourceRunID string) (OutreachInitialBacklogCounts, error) {
+	return r.materializeCurrentInitialBacklog(ctx, orgID, sourceRunID)
 }
 
 func (r *outreachRepository) InvalidateAccountApprovalsForContext(ctx context.Context, orgID, accountID uuid.UUID, currentContextHash string) error {
@@ -310,6 +328,16 @@ func (r *outreachRepository) GetImportRunByIdempotency(ctx context.Context, orgI
 	return run, err
 }
 
+func (r *outreachRepository) HasImportRunSnapshotConflict(ctx context.Context, orgID uuid.UUID, sourceRunID, snapshotHash string) (bool, error) {
+	var conflict bool
+	err := r.db.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM outreach_import_runs
+			WHERE organization_id=$1 AND source_run_id=$2 AND snapshot_hash<>'' AND snapshot_hash<>$3
+		)`, orgID, strings.TrimSpace(sourceRunID), strings.TrimSpace(snapshotHash)).Scan(&conflict)
+	return conflict, err
+}
+
 func (r *outreachRepository) ListImportRuns(ctx context.Context, orgID uuid.UUID, limit int) ([]models.OutreachImportRun, error) {
 	if limit <= 0 || limit > 100 {
 		limit = 20
@@ -423,7 +451,7 @@ const outreachAccountSelect = `
 		contractor_role_evidence_ids, COALESCE(supplier_cnpj14,''), COALESCE(supplier_identity_ref,''),
 		COALESCE(buyer_cnpj14,''), COALESCE(buyer_identity_ref,''),
 		COALESCE(contractor_role_match_method,'NONE'), COALESCE(contractor_role_confidence,'UNKNOWN'),
-		contractor_role_reason_codes `
+		contractor_role_reason_codes, COALESCE(initial_backlog_reason_code,'') `
 
 func scanAccount(row scannable) (*models.OutreachAccount, error) {
 	var a models.OutreachAccount
@@ -453,7 +481,7 @@ func scanAccount(row scannable) (*models.OutreachAccount, error) {
 		&a.ContractorRoleSourceRunID, &a.ContractorRoleObservedAt, &a.ContractorRoleEvidenceHash,
 		&a.ContractorRoleEvidenceReference, &roleEvidence, &a.SupplierCNPJ14, &a.SupplierIdentityRef,
 		&a.BuyerCNPJ14, &a.BuyerIdentityRef, &a.ContractorRoleMatchMethod, &a.ContractorRoleConfidence,
-		&roleReasons,
+		&roleReasons, &a.InitialBacklogReasonCode,
 	)
 	if err != nil {
 		return nil, err

--- a/internal/repository/pg_outreach_backlog.go
+++ b/internal/repository/pg_outreach_backlog.go
@@ -1,0 +1,196 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+const sourceRunSupersededStopReason = "source_run_superseded"
+
+func (r *outreachRepository) materializeCurrentInitialBacklog(ctx context.Context, orgID uuid.UUID, sourceRunID string) (OutreachInitialBacklogCounts, error) {
+	var out OutreachInitialBacklogCounts
+	sourceRunID = strings.TrimSpace(sourceRunID)
+	if orgID == uuid.Nil || sourceRunID == "" {
+		return out, fmt.Errorf("organization_id and source_run_id are required")
+	}
+	tx, err := r.db.Begin(ctx)
+	if err != nil {
+		return out, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if _, err = tx.Exec(ctx, `
+		UPDATE confenge_dispatch_queue q
+		SET status='cancelled',cancel_reason=$3,last_error=$3,reserved_until=NULL,updated_at=now()
+		FROM outreach_touchpoints t
+		WHERE t.organization_id=$1 AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+		  AND COALESCE(t.source_run_id,'')<>$2 AND t.draft_id=q.draft_id
+		  AND q.organization_id=t.organization_id AND q.status IN ('queued','reserved')`, orgID, sourceRunID, sourceRunSupersededStopReason); err != nil {
+		return out, err
+	}
+	if _, err = tx.Exec(ctx, `
+		UPDATE confenge_delegated_first_touch_decisions d
+		SET state='CANCELLED',blocker_codes=CASE
+			WHEN blocker_codes @> '["source_run_superseded"]'::jsonb THEN blocker_codes
+			ELSE blocker_codes || '["source_run_superseded"]'::jsonb END,updated_at=now()
+		FROM outreach_touchpoints t
+		WHERE t.organization_id=$1 AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+		  AND COALESCE(t.source_run_id,'')<>$2 AND d.organization_id=t.organization_id
+		  AND d.touchpoint_id=t.id AND d.state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')`, orgID, sourceRunID); err != nil {
+		return out, err
+	}
+	if _, err = tx.Exec(ctx, `
+		UPDATE outreach_drafts d
+		SET status='BLOCKED',approved_by=NULL,approved_at=NULL,campaign_id=NULL,
+			enrollment_contact_id=NULL,enrolled_at=NULL,updated_at=now()
+		FROM outreach_touchpoints t
+		WHERE t.organization_id=$1 AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+		  AND COALESCE(t.source_run_id,'')<>$2 AND d.organization_id=t.organization_id
+		  AND d.id=t.draft_id AND d.status NOT IN ('SENT','BLOCKED')`, orgID, sourceRunID); err != nil {
+		return out, err
+	}
+	retired, err := tx.Exec(ctx, `
+		UPDATE outreach_touchpoints t
+		SET state='CANCELLED',stop_reason=$3,approved_content_hash='',approved_by=NULL,
+			approved_at=NULL,authorization_mode='',campaign_policy_authorization_id=NULL,
+			authorization_policy_hash='',authorization_at=NULL,signature_version='',queued_at=NULL,
+			delegated_reserved_until=NULL,delegated_last_error=$3,updated_at=now()
+		WHERE t.organization_id=$1 AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+		  AND COALESCE(t.source_run_id,'')<>$2
+		  AND t.state IN ('PLANNED','DUE','DRAFTED','AI_REWRITE_PENDING','ENRICHMENT_PENDING',
+			'REJECTED_REWRITE_PENDING','NEEDS_REVIEW','APPROVED','QUEUED')`, orgID, sourceRunID, sourceRunSupersededStopReason)
+	if err != nil {
+		return out, err
+	}
+	out.StaleRetired = int(retired.RowsAffected())
+
+	if _, err = tx.Exec(ctx, `
+		CREATE TEMP TABLE confenge_current_initial_backlog ON COMMIT DROP AS
+		WITH candidate_rollup AS (
+			SELECT a.id AS account_id,
+				count(*) FILTER (WHERE c.discovery_json->>'preferred_initial'='true')::int AS preferred_count,
+				(array_agg(c.id ORDER BY c.id) FILTER (WHERE c.discovery_json->>'preferred_initial'='true'))[1] AS candidate_id,
+				bool_or(
+					c.discovery_json->>'preferred_initial'='true'
+					AND c.email<>'' AND NOT c.blocked AND NOT c.do_not_contact AND NOT c.bounced
+					AND c.block_reason NOT ILIKE '%provenance_taint%'
+					AND c.block_reason NOT ILIKE '%provenance_chain%'
+					AND lower(c.email) NOT LIKE 'fixture@%' AND lower(c.email) NOT LIKE 'synthetic@%'
+					AND (
+						c.verification_status NOT IN ('CANDIDATE_UNVERIFIED','NOT_FOUND','INVALID','BOUNCED','DO_NOT_CONTACT')
+						OR (
+							c.discovery_json @> '{"controlled_email_eligible":true}'::jsonb
+							AND upper(COALESCE(c.discovery_json->>'route_class','')) IN
+								('DIRECT_PERSON','ROLE_OR_DEPARTMENT','GENERIC_COMPANY','PUBLIC_COMPANY_FREEMAIL')
+						)
+					)
+				) FILTER (WHERE c.discovery_json->>'preferred_initial'='true') AS preferred_eligible,
+				bool_or(
+					c.discovery_json->>'preferred_initial'='true'
+					AND c.email<>'' AND NOT c.blocked AND NOT c.do_not_contact AND NOT c.bounced
+					AND c.block_reason NOT ILIKE '%provenance_taint%'
+					AND c.block_reason NOT ILIKE '%provenance_chain%'
+					AND lower(c.email) NOT LIKE 'fixture@%' AND lower(c.email) NOT LIKE 'synthetic@%'
+					AND c.discovery_json @> '{"controlled_email_eligible":true}'::jsonb
+					AND upper(COALESCE(c.discovery_json->>'route_class','')) IN
+						('DIRECT_PERSON','ROLE_OR_DEPARTMENT','GENERIC_COMPANY','PUBLIC_COMPANY_FREEMAIL')
+					AND upper(c.channel_epistemic_class)='OBSERVED'
+					AND upper(c.route_freshness)='FRESH'
+					AND upper(c.ownership_status)='COMPANY_OWNED'
+					AND upper(c.route_suppression) IN ('','NONE')
+					AND upper(c.email_derivation)<>'INFERRED'
+					AND c.email LIKE '%@%' AND c.email !~ '[[:space:]]'
+					AND c.source_url ~* '^https?://'
+					AND c.source_date BETWEEN CURRENT_DATE - 29 AND CURRENT_DATE
+				) FILTER (WHERE c.discovery_json->>'preferred_initial'='true') AS preferred_delegated_eligible
+			FROM outreach_accounts a
+			LEFT JOIN outreach_contact_candidates c
+			  ON c.organization_id=a.organization_id AND c.account_id=a.id
+			 AND a.last_import_run_id IS NOT NULL AND c.last_import_run_id=a.last_import_run_id
+			WHERE a.organization_id=$1 AND a.source_run_id=$2
+			GROUP BY a.id
+		), classified AS (
+			SELECT a.id AS account_id,cr.candidate_id,
+				(a.contractor_role_status='CONTRACTOR_ROLE_CONFIRMED'
+				 AND a.target_party_role='SUPPLIER' AND a.contractor_role_source_run_id=$2
+				 AND a.supplier_cnpj14=a.cnpj14 AND a.contractor_role_evidence_hash ~ '^[0-9a-f]{64}$'
+				 AND jsonb_array_length(a.contractor_role_evidence_ids)>0) AS supplier_confirmed,
+				(COALESCE(cr.preferred_count,0)=1 AND cr.candidate_id IS NOT NULL) AS candidate_attributed,
+				(a.target_fit_eligible AND a.target_fit_fresh AND a.target_fit_class='TARGET_CONFIRMED'
+				 AND a.target_fit_version<>'' AND a.target_fit_source_watermark<>''
+				 AND a.target_fit_observed_at IS NOT NULL AND NOT a.blocked AND NOT a.do_not_contact
+				 AND COALESCE(cr.preferred_count,0)=1 AND COALESCE(cr.preferred_eligible,false)) AS initial_prepared,
+				(COALESCE(cr.preferred_count,0)=1 AND COALESCE(cr.preferred_delegated_eligible,false)) AS delegated_candidate,
+				CASE
+					WHEN a.blocked OR a.do_not_contact THEN 'account_suppressed'
+					WHEN NOT a.target_fit_eligible THEN COALESCE(NULLIF(a.target_fit_suppression_reason,''),'target_fit_ineligible')
+					WHEN NOT a.target_fit_fresh OR a.target_fit_class<>'TARGET_CONFIRMED' THEN 'target_fit_not_current_confirmed'
+					WHEN a.target_fit_version='' OR a.target_fit_source_watermark='' OR a.target_fit_observed_at IS NULL THEN 'target_fit_provenance_missing'
+					WHEN COALESCE(cr.preferred_count,0)=0 THEN 'preferred_current_recipient_missing'
+					WHEN cr.preferred_count>1 THEN 'preferred_current_recipient_conflict'
+					WHEN NOT COALESCE(cr.preferred_eligible,false) THEN 'preferred_current_recipient_ineligible'
+					WHEN a.contractor_role_status='PARTY_ROLE_CONFLICT' THEN 'supplier_role_conflict'
+					WHEN a.contractor_role_status<>'CONTRACTOR_ROLE_CONFIRMED' OR a.target_party_role<>'SUPPLIER' THEN 'supplier_role_unknown'
+					WHEN a.contractor_role_source_run_id<>$2 THEN 'supplier_role_stale_source_run'
+					WHEN a.supplier_cnpj14<>a.cnpj14 THEN 'supplier_identity_mismatch'
+					WHEN a.contractor_role_evidence_hash !~ '^[0-9a-f]{64}$' OR jsonb_array_length(a.contractor_role_evidence_ids)=0 THEN 'supplier_role_evidence_incomplete'
+					WHEN NOT COALESCE(cr.preferred_delegated_eligible,false) THEN 'preferred_current_recipient_not_delegated'
+					ELSE ''
+				END AS reason_code
+			FROM outreach_accounts a
+			LEFT JOIN candidate_rollup cr ON cr.account_id=a.id
+			WHERE a.organization_id=$1 AND a.source_run_id=$2
+		)
+		SELECT account_id,candidate_id,supplier_confirmed,candidate_attributed,initial_prepared,
+			(initial_prepared AND supplier_confirmed AND delegated_candidate AND reason_code='') AS delegated_eligible,reason_code
+		FROM classified`, orgID, sourceRunID); err != nil {
+		return out, err
+	}
+
+	if _, err = tx.Exec(ctx, `
+		UPDATE outreach_accounts a
+		SET initial_backlog_reason_code=b.reason_code,updated_at=now()
+		FROM confenge_current_initial_backlog b
+		WHERE a.organization_id=$1 AND a.id=b.account_id`, orgID); err != nil {
+		return out, err
+	}
+	if _, err = tx.Exec(ctx, `
+		INSERT INTO outreach_touchpoints (
+			organization_id,account_id,contact_candidate_id,ordinal,cadence_step,channel,purpose,
+			due_at,state,recipient,idempotency_key,policy_version,service_code,fact_used,evidence_ids,
+			generated_context_hash,source_run_id,delegated_retry_at
+		)
+		SELECT a.organization_id,a.id,b.candidate_id,1,'INITIAL','EMAIL','INITIAL',now(),'DUE',lower(c.email),
+			'prepared-initial:' || $2 || ':' || a.id::text,'confenge.cadence.v1',a.service_code,
+				a.fact_to_mention,CASE WHEN jsonb_array_length(a.contractor_role_evidence_ids)>0
+					THEN a.contractor_role_evidence_ids ELSE a.moment_evidence_ids END,
+			a.message_context_hash,$2,now()
+		FROM confenge_current_initial_backlog b
+		JOIN outreach_accounts a ON a.organization_id=$1 AND a.id=b.account_id
+		JOIN outreach_contact_candidates c ON c.organization_id=a.organization_id AND c.id=b.candidate_id
+		WHERE b.initial_prepared
+		ON CONFLICT DO NOTHING`, orgID, sourceRunID); err != nil {
+		return out, err
+	}
+
+	if err = tx.QueryRow(ctx, `
+		SELECT count(*)::int,
+			count(*) FILTER (WHERE supplier_confirmed)::int,
+			count(*) FILTER (WHERE candidate_attributed)::int,
+			count(*) FILTER (WHERE initial_prepared)::int,
+			count(*) FILTER (WHERE delegated_eligible)::int,
+			count(*) FILTER (WHERE NOT delegated_eligible)::int
+		FROM confenge_current_initial_backlog`).Scan(
+		&out.Imported, &out.SupplierConfirmed, &out.CandidateAttributed,
+		&out.InitialPrepared, &out.DelegatedEligible, &out.HeldException,
+	); err != nil {
+		return out, err
+	}
+	if err = tx.Commit(ctx); err != nil {
+		return out, err
+	}
+	return out, nil
+}

--- a/internal/repository/pg_outreach_touchpoints.go
+++ b/internal/repository/pg_outreach_touchpoints.go
@@ -25,7 +25,7 @@ const outreachTouchpointSelect = `
 		queued_at, sent_at, COALESCE(provider_message_id,''), COALESCE(stop_reason,''),
 		previous_touchpoint_id, COALESCE(idempotency_key,''),
 		COALESCE(policy_version,''), COALESCE(service_code,''), COALESCE(fact_used,''), evidence_ids,
-		COALESCE(generated_context_hash,''),
+		COALESCE(generated_context_hash,''), COALESCE(source_run_id,''),
 		created_at, updated_at `
 
 func scanTouchpoint(row scannable) (*models.OutreachTouchpoint, error) {
@@ -43,7 +43,7 @@ func scanTouchpoint(row scannable) (*models.OutreachTouchpoint, error) {
 		&t.QueuedAt, &t.SentAt, &t.ProviderMessageID, &t.StopReason,
 		&t.PreviousTouchpointID, &t.IdempotencyKey,
 		&t.PolicyVersion, &t.ServiceCode, &t.FactUsed, &evid,
-		&t.GeneratedContextHash,
+		&t.GeneratedContextHash, &t.SourceRunID,
 		&t.CreatedAt, &t.UpdatedAt,
 	)
 	if err != nil {
@@ -86,10 +86,10 @@ func (r *outreachRepository) InsertTouchpoint(ctx context.Context, t *models.Out
 			queued_at, sent_at, provider_message_id, stop_reason,
 			previous_touchpoint_id, idempotency_key,
 			policy_version, service_code, fact_used, evidence_ids,
-			generated_context_hash,
+			generated_context_hash, source_run_id,
 			created_at, updated_at
 		) VALUES (
-			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36
+			$1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13,$14,$15,$16,$17,$18,$19,$20,$21,$22,$23,$24,$25,$26,$27,$28,$29,$30,$31,$32,$33,$34,$35,$36,$37
 		)`,
 		t.ID, t.OrganizationID, t.AccountID, t.ContactCandidateID,
 		t.Ordinal, t.CadenceStep, t.Channel, t.Purpose, t.DueAt, t.State, t.DraftID,
@@ -100,7 +100,7 @@ func (r *outreachRepository) InsertTouchpoint(ctx context.Context, t *models.Out
 		t.QueuedAt, t.SentAt, t.ProviderMessageID, t.StopReason,
 		t.PreviousTouchpointID, t.IdempotencyKey,
 		t.PolicyVersion, t.ServiceCode, t.FactUsed, evid,
-		t.GeneratedContextHash,
+		t.GeneratedContextHash, t.SourceRunID,
 		t.CreatedAt, t.UpdatedAt,
 	)
 	return err
@@ -120,7 +120,8 @@ func (r *outreachRepository) UpdateTouchpoint(ctx context.Context, t *models.Out
 			authorization_mode=$16,
 			campaign_policy_authorization_id=$17, authorization_policy_hash=$18, authorization_at=$19, signature_version=$20,
 			queued_at=$21, sent_at=$22, provider_message_id=$23, stop_reason=$24,
-			service_code=$25, fact_used=$26, evidence_ids=$27, generated_context_hash=$28, updated_at=$29
+			service_code=$25, fact_used=$26, evidence_ids=$27, generated_context_hash=$28,
+			source_run_id=$29, updated_at=$30
 		WHERE organization_id=$1 AND id=$2`,
 		t.OrganizationID, t.ID,
 		t.ContactCandidateID, t.Channel, t.Purpose, t.DueAt, t.State, t.DraftID,
@@ -129,7 +130,7 @@ func (r *outreachRepository) UpdateTouchpoint(ctx context.Context, t *models.Out
 		t.AuthorizationMode,
 		t.CampaignPolicyAuthorizationID, t.AuthorizationPolicyHash, t.AuthorizationAt, t.SignatureVersion,
 		t.QueuedAt, t.SentAt, t.ProviderMessageID, t.StopReason,
-		t.ServiceCode, t.FactUsed, evid, t.GeneratedContextHash, t.UpdatedAt,
+		t.ServiceCode, t.FactUsed, evid, t.GeneratedContextHash, t.SourceRunID, t.UpdatedAt,
 	)
 	if err != nil {
 		return err
@@ -236,6 +237,7 @@ func (r *outreachRepository) ListReviewTouchpoints(ctx context.Context, orgID uu
 			'DUE','DRAFTED','AI_REWRITE_PENDING','ENRICHMENT_PENDING',
 			'REJECTED_REWRITE_PENDING','NEEDS_REVIEW','APPROVED'
 		)
+		AND NOT (t.source_run_id<>'' AND t.idempotency_key LIKE 'prepared-initial:%')
 		ORDER BY t.due_at ASC, t.ordinal ASC
 		LIMIT $2 OFFSET $3`
 	rows, err := r.db.Query(ctx, q, orgID, limit, offset)
@@ -295,7 +297,7 @@ func collectTouchpoints(rows pgx.Rows) ([]models.OutreachTouchpoint, error) {
 func (r *outreachRepository) CASQueueTouchpoint(ctx context.Context, orgID, id uuid.UUID, expectedContentHash string) (*models.OutreachTouchpoint, error) {
 	now := time.Now().UTC()
 	// Must match outreachTouchpointSelect / scanTouchpoint field count.
-	const ret = `id, organization_id, account_id, contact_candidate_id, ordinal, COALESCE(cadence_step,''), COALESCE(channel,'EMAIL'), COALESCE(purpose,''), due_at, state, draft_id, COALESCE(recipient,''), COALESCE(subject,''), COALESCE(body_text,''), COALESCE(content_hash,''), COALESCE(approved_content_hash,''), approved_by, approved_at, COALESCE(authorization_mode,''), campaign_policy_authorization_id, COALESCE(authorization_policy_hash,''), authorization_at, COALESCE(signature_version,''), queued_at, sent_at, COALESCE(provider_message_id,''), COALESCE(stop_reason,''), previous_touchpoint_id, COALESCE(idempotency_key,''), COALESCE(policy_version,''), COALESCE(service_code,''), COALESCE(fact_used,''), evidence_ids, COALESCE(generated_context_hash,''), created_at, updated_at`
+	const ret = `id, organization_id, account_id, contact_candidate_id, ordinal, COALESCE(cadence_step,''), COALESCE(channel,'EMAIL'), COALESCE(purpose,''), due_at, state, draft_id, COALESCE(recipient,''), COALESCE(subject,''), COALESCE(body_text,''), COALESCE(content_hash,''), COALESCE(approved_content_hash,''), approved_by, approved_at, COALESCE(authorization_mode,''), campaign_policy_authorization_id, COALESCE(authorization_policy_hash,''), authorization_at, COALESCE(signature_version,''), queued_at, sent_at, COALESCE(provider_message_id,''), COALESCE(stop_reason,''), previous_touchpoint_id, COALESCE(idempotency_key,''), COALESCE(policy_version,''), COALESCE(service_code,''), COALESCE(fact_used,''), evidence_ids, COALESCE(generated_context_hash,''), COALESCE(source_run_id,''), created_at, updated_at`
 	// Human path: approved_by set. Policy path: authorization_mode=CAMPAIGN_POLICY and approved_by null.
 	row := r.db.QueryRow(ctx, `
 		UPDATE outreach_touchpoints
@@ -324,7 +326,7 @@ func (r *outreachRepository) CASScheduleTouchpoint(ctx context.Context, orgID, i
 		dueAt = time.Now().UTC()
 	}
 	now := time.Now().UTC()
-	const ret = `id, organization_id, account_id, contact_candidate_id, ordinal, COALESCE(cadence_step,''), COALESCE(channel,'EMAIL'), COALESCE(purpose,''), due_at, state, draft_id, COALESCE(recipient,''), COALESCE(subject,''), COALESCE(body_text,''), COALESCE(content_hash,''), COALESCE(approved_content_hash,''), approved_by, approved_at, COALESCE(authorization_mode,''), campaign_policy_authorization_id, COALESCE(authorization_policy_hash,''), authorization_at, COALESCE(signature_version,''), queued_at, sent_at, COALESCE(provider_message_id,''), COALESCE(stop_reason,''), previous_touchpoint_id, COALESCE(idempotency_key,''), COALESCE(policy_version,''), COALESCE(service_code,''), COALESCE(fact_used,''), evidence_ids, COALESCE(generated_context_hash,''), created_at, updated_at`
+	const ret = `id, organization_id, account_id, contact_candidate_id, ordinal, COALESCE(cadence_step,''), COALESCE(channel,'EMAIL'), COALESCE(purpose,''), due_at, state, draft_id, COALESCE(recipient,''), COALESCE(subject,''), COALESCE(body_text,''), COALESCE(content_hash,''), COALESCE(approved_content_hash,''), approved_by, approved_at, COALESCE(authorization_mode,''), campaign_policy_authorization_id, COALESCE(authorization_policy_hash,''), authorization_at, COALESCE(signature_version,''), queued_at, sent_at, COALESCE(provider_message_id,''), COALESCE(stop_reason,''), previous_touchpoint_id, COALESCE(idempotency_key,''), COALESCE(policy_version,''), COALESCE(service_code,''), COALESCE(fact_used,''), evidence_ids, COALESCE(generated_context_hash,''), COALESCE(source_run_id,''), created_at, updated_at`
 	row := tx.QueryRow(ctx, `
 		UPDATE outreach_touchpoints
 		SET state='QUEUED', queued_at=$4, due_at=$5, updated_at=$4


### PR DESCRIPTION
## Resumo

- valida integralmente manifests de até 100.000 contas antes de publicar qualquer estado current, incluindo hashes, contagens, paginação e duplicatas entre chunks
- importa chunks com idempotência durável, lease recuperável e concorrência limitada, sem executar planejamento comercial item a item no caminho do feed
- materializa exatamente um touchpoint `INITIAL`/`EMAIL`/ordinal 1 por conta elegível e source run, ligado ao recipient preferido atual
- aposenta drafts, decisões, dispatch e touchpoints INITIAL de source runs anteriores sem misturar histórico com o run atual
- mantém HOLD/UNKNOWN com reason codes e expõe contagens por estágio: imported, supplier confirmed, candidate attributed, initial prepared, delegated eligible e held/exception
- preserva o backlog canônico e a rolling campaign: trabalho current elegível ainda não decidido mantém a campanha pending, sem criar uma segunda fila nem conceder autoridade de transporte
- adiciona lease e retry ao worker delegado para recuperar abandono sem duplicar trabalho

## Prova PostgreSQL

Teste de carga opt-in em PostgreSQL 16 real com 10.000 contas, 20 chunks de 500 e nenhum serviço SMTP:

- 10.000 imported
- 9.000 supplier confirmed
- 9.000 candidate attributed
- 9.000 INITIAL prepared
- 8.000 delegated eligible
- 2.000 held/exception, sendo 1.000 `SUPPLIER_UNKNOWN` e 1.000 `MISSING_PREFERRED_RECIPIENT`
- restart após chunk parcialmente gravado recuperou o mesmo run e convergiu
- replay não criou duplicatas nem review humano
- refresh completo aposentou 9.000 INITIAL stale e publicou apenas o novo source run
- zero drafts, zero dispatch, zero commercial actions e zero SMTP durante a prova

Resultado isolado: `PASS` em 752,59 s, incluindo ingestão inicial, restart/replay e refresh integral.

## Verificação

- `make fmt`
- `make lint`
- testes unitários de manifest/feed sync
- 5 regressões PostgreSQL de campaign continuity, lease/idempotência e stale source run
- `cd docs && pnpm types:check && pnpm lint` (0 erros, 2 warnings preexistentes)

Advances #155.
Relates #154 and #151.
