### PR TITLE
fix: unblock CONFENGE enrollment gate and deduplicate campaign wakeups

### DIFF
--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -241,6 +241,26 @@ func TestDelegatedFirstTouchApprovesQueuesAuditsAndReplaysOncePostgres(t *testin
 	if xerr != nil || first.Queued != 1 || first.DelegatedApproved != 1 || len(first.Items) != 1 || first.Items[0].State != "QUEUED" {
 		t.Fatalf("first apply did not reach QUEUED: report=%+v err=%v", first, xerr)
 	}
+	enrollmentContactID := uuid.New()
+	if _, err := f.pool.Exec(f.ctx, `
+		INSERT INTO contacts(id,user_id,organization_id,first_name,last_name,email,company,phone,custom_fields)
+		VALUES($1,$2,$3,'Equipe','Alfa',$4,'Empresa Alfa','', '{}'::jsonb)`,
+		enrollmentContactID, f.actorID, f.orgID, "enrollment-"+enrollmentContactID.String()+"@example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_drafts d
+		SET campaign_id=$2,enrollment_contact_id=$3
+		FROM outreach_touchpoints t
+		WHERE t.id=$1 AND t.draft_id=d.id AND t.organization_id=d.organization_id`,
+		first.Items[0].TouchpointID, f.campaignID, enrollmentContactID); err != nil {
+		t.Fatal(err)
+	}
+	enrolledTouchpoint, err := f.repo.GetTouchpointByEnrollment(f.ctx, f.orgID, f.campaignID, enrollmentContactID)
+	if err != nil || enrolledTouchpoint == nil || enrolledTouchpoint.ID != first.Items[0].TouchpointID {
+		t.Fatalf("enrollment did not resolve its exact touchpoint: campaign=%s contact=%s touchpoint=%+v err=%v",
+			f.campaignID, enrollmentContactID, enrolledTouchpoint, err)
+	}
 	if processed, err := f.svc.ProcessDispatchQueueOnce(f.ctx); err != nil || processed {
 		t.Fatalf("paused dispatch mutated transport: processed=%v err=%v", processed, err)
 	}
@@ -288,6 +308,61 @@ func TestDelegatedFirstTouchApprovesQueuesAuditsAndReplaysOncePostgres(t *testin
 		status.Items[0].ApprovalSource != DelegatedFirstTouchApprovalDecision {
 		t.Fatalf("control-center readback is incomplete: status=%+v err=%v", status, statusErr)
 	}
+}
+
+func TestCampaignWakeupDoesNotDuplicateRecentActiveTaskAndRecoversStaleTaskPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	if _, err := f.pool.Exec(f.ctx, `UPDATE campaigns SET status='active' WHERE id=$1`, f.campaignID); err != nil {
+		t.Fatal(err)
+	}
+	var mailboxID uuid.UUID
+	if err := f.pool.QueryRow(f.ctx, `SELECT id FROM email_accounts WHERE organization_id=$1 LIMIT 1`, f.orgID).Scan(&mailboxID); err != nil {
+		t.Fatal(err)
+	}
+
+	taskRepo := repository.NewTaskRepository(f.pool)
+	campaignRepo := repository.NewCampaignRepostory(&infrastructuredb.DB{Pool: f.pool})
+	activeID := uuid.New()
+	created, err := taskRepo.CreateTaskWithLock(f.ctx, &repository.Task{
+		ID: activeID, TaskType: "campaign", EmailAccountID: mailboxID, Status: "active",
+	}, &repository.CampaignTask{TaskID: activeID, CampaignID: &f.campaignID})
+	if err != nil || !created {
+		t.Fatalf("create active wakeup: created=%v err=%v", created, err)
+	}
+
+	duplicateID := uuid.New()
+	created, err = taskRepo.CreateTaskWithLock(f.ctx, &repository.Task{
+		ID: duplicateID, TaskType: "campaign", EmailAccountID: mailboxID, Status: "pending",
+	}, &repository.CampaignTask{TaskID: duplicateID, CampaignID: &f.campaignID})
+	if err != nil || created {
+		t.Fatalf("recent active wakeup must block duplicate: created=%v err=%v", created, err)
+	}
+	if ids, err := campaignRepo.ListCampaignScheduleCandidates(f.ctx, 100); err != nil || containsUUID(ids, f.campaignID) {
+		t.Fatalf("campaign with recent active wakeup became reconcile candidate: ids=%v err=%v", ids, err)
+	}
+
+	if _, err := f.pool.Exec(f.ctx, `UPDATE tasks SET updated_at=NOW()-INTERVAL '16 minutes' WHERE id=$1`, activeID); err != nil {
+		t.Fatal(err)
+	}
+	if ids, err := campaignRepo.ListCampaignScheduleCandidates(f.ctx, 100); err != nil || !containsUUID(ids, f.campaignID) {
+		t.Fatalf("campaign with stale active wakeup was not recoverable: ids=%v err=%v", ids, err)
+	}
+	recoveryID := uuid.New()
+	created, err = taskRepo.CreateTaskWithLock(f.ctx, &repository.Task{
+		ID: recoveryID, TaskType: "campaign", EmailAccountID: mailboxID, Status: "pending",
+	}, &repository.CampaignTask{TaskID: recoveryID, CampaignID: &f.campaignID})
+	if err != nil || !created {
+		t.Fatalf("stale active wakeup blocked recovery: created=%v err=%v", created, err)
+	}
+}
+
+func containsUUID(ids []uuid.UUID, target uuid.UUID) bool {
+	for _, id := range ids {
+		if id == target {
+			return true
+		}
+	}
+	return false
 }
 
 func TestCampaignReadyAcceptsReadBackDelegatedQueueWithoutContact(t *testing.T) {

--- a/internal/repository/pg_campaign.go
+++ b/internal/repository/pg_campaign.go
@@ -54,9 +54,8 @@ type CampaignRepository interface {
 	HasPendingDelegatedFirstTouch(ctx context.Context, campaignID uuid.UUID) (bool, error)
 	UpdateVerificationStatus(ctx context.Context, campaignID uuid.UUID, status string, summary *models.CampaignVerificationSummary) error
 	GetPendingCampaignTasks(ctx context.Context, campaignID uuid.UUID) ([]Task, error)
-	// ListCampaignScheduleCandidates returns active campaigns that have NO pending
-	// task — their self-perpetuating chain died and needs re-seeding. Used by the
-	// campaign reconciler.
+	// ListCampaignScheduleCandidates returns active campaigns that have no live
+	// task. Their self-perpetuating chain died and needs re-seeding.
 	ListCampaignScheduleCandidates(ctx context.Context, limit int) ([]uuid.UUID, error)
 	CountActiveForOrganization(ctx context.Context, orgID uuid.UUID) (int, error)
 	AccountHasActiveCampaign(ctx context.Context, accountID uuid.UUID) (bool, error)
@@ -1566,10 +1565,11 @@ func (r *campaignRepository) GetPendingCampaignTasks(ctx context.Context, campai
 	return tasks, rows.Err()
 }
 
-// ListCampaignScheduleCandidates returns active campaigns with no pending task,
+// ListCampaignScheduleCandidates returns active campaigns with no live task,
 // i.e. chains that stalled (a swallowed enqueue or a crash between ticks left no
-// successor). The reconciler re-seeds each. createCampaignTask's advisory lock
-// makes a concurrent real-tick enqueue safe (one wins, the other no-ops).
+// successor). Recent active tasks are live; stale active tasks can be recovered.
+// The reconciler re-seeds each. createCampaignTask's advisory lock makes a
+// concurrent real-tick enqueue safe (one wins, the other no-ops).
 func (r *campaignRepository) ListCampaignScheduleCandidates(ctx context.Context, limit int) ([]uuid.UUID, error) {
 	query := `
 		SELECT c.id
@@ -1579,7 +1579,11 @@ func (r *campaignRepository) ListCampaignScheduleCandidates(ctx context.Context,
 		    SELECT 1
 		    FROM campaign_tasks ct
 		    JOIN tasks t ON t.id = ct.task_id
-		    WHERE ct.campaign_id = c.id AND t.status = 'pending'
+		    WHERE ct.campaign_id = c.id
+		      AND (
+		        t.status = 'pending'
+		        OR (t.status = 'active' AND t.updated_at >= NOW() - INTERVAL '15 minutes')
+		      )
 		  )
 		LIMIT $1`
 

--- a/internal/repository/pg_outreach_outcomes.go
+++ b/internal/repository/pg_outreach_outcomes.go
@@ -167,11 +167,14 @@ func (r *outreachRepository) FindCandidateByEnrollment(ctx context.Context, orgI
 
 func (r *outreachRepository) GetTouchpointByEnrollment(ctx context.Context, orgID, campaignID, contactID uuid.UUID) (*models.OutreachTouchpoint, error) {
 	row := r.db.QueryRow(ctx, outreachTouchpointSelect+`
-		FROM outreach_touchpoints t
-		JOIN outreach_drafts d ON d.id=t.draft_id AND d.organization_id=t.organization_id
-		WHERE t.organization_id=$1 AND d.campaign_id=$2 AND d.enrollment_contact_id=$3
-		ORDER BY t.updated_at DESC
-		LIMIT 1`, orgID, campaignID, contactID)
+		FROM (
+			SELECT t.*
+			FROM outreach_touchpoints t
+			JOIN outreach_drafts d ON d.id=t.draft_id AND d.organization_id=t.organization_id
+			WHERE t.organization_id=$1 AND d.campaign_id=$2 AND d.enrollment_contact_id=$3
+			ORDER BY t.updated_at DESC
+			LIMIT 1
+		) enrolled_touchpoint`, orgID, campaignID, contactID)
 	touchpoint, err := scanTouchpoint(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil

--- a/internal/repository/pg_task.go
+++ b/internal/repository/pg_task.go
@@ -699,7 +699,7 @@ func (r *taskRepository) DeleteTask(ctx context.Context, taskID uuid.UUID) error
 }
 
 // CreateTaskWithLock creates a campaign task with a PostgreSQL advisory lock.
-// It returns false when the campaign already has a pending wakeup task.
+// It returns false while the campaign already has a live wakeup task.
 func (r *taskRepository) CreateTaskWithLock(ctx context.Context, task *Task, campaignTask *CampaignTask) (bool, error) {
 	tx, err := r.db.Begin(ctx)
 	if err != nil {
@@ -720,7 +720,10 @@ func (r *taskRepository) CreateTaskWithLock(ctx context.Context, task *Task, cam
 			FROM tasks t
 			INNER JOIN campaign_tasks ct ON ct.task_id = t.id
 			WHERE ct.campaign_id = $1
-			  AND t.status = 'pending'
+			  AND (
+			    t.status = 'pending'
+			    OR (t.status = 'active' AND t.updated_at >= NOW() - INTERVAL '15 minutes')
+			  )
 			LIMIT 1
 		`, *campaignTask.CampaignID).Scan(&existing)
 		if err == nil {

--- a/internal/tasks/campaign_reconciler.go
+++ b/internal/tasks/campaign_reconciler.go
@@ -22,7 +22,7 @@ const campaignReconcileBatch = 500
 const overduePendingGrace = 15 * time.Minute
 
 // ReconcileCampaignSchedules re-seeds the wakeup chain for active campaigns that
-// have no pending task. A campaign chain is self-perpetuating (each tick
+// have no live task. A campaign chain is self-perpetuating (each tick
 // enqueues the next), so a swallowed enqueue, a worker bounce mid-tick, or a
 // crash between send and enqueue leaves the campaign stranded with no successor.
 // Unlike warmup, campaigns have no other bootstrap once started, so this sweep


### PR DESCRIPTION
## Why

Production readback on 2026-08-26 found the CONFENGE campaign task retrying every second before transport because GetTouchpointByEnrollment produced SQLSTATE 42702: column reference id is ambiguous. During the short active interval, the five-minute reconciler also created another pending task for the same campaign, contact, and sequence because only pending tasks counted as live.

## What changed

- select the enrolled touchpoint through a single derived relation so the shared typed scanner has no ambiguous columns
- treat pending and recent active campaign tasks as live in both the advisory-lock insert path and reconciler candidate query
- retain recovery for active tasks stale for more than 15 minutes
- add PostgreSQL regressions for the exact delegated enrollment lookup, duplicate prevention, and stale-active recovery

## Safety

This does not resume transport, alter policy, change mailbox/rate/window, or add follow-up. The production kill switch must remain engaged until a contemporary exact-binding transport decision.

## Verification

- PostgreSQL regression tests passed with the full migrated schema
- campaign rolling reconciler tests passed
- make lint passed
- git diff --check passed