### PR TITLE
feat: integrate qualified touchpoint projections with CONFENGE enrollment lookup subqueries

### DIFF
--- a/internal/repository/pg_outreach_outcomes.go
+++ b/internal/repository/pg_outreach_outcomes.go
@@ -174,7 +174,7 @@ func (r *outreachRepository) GetTouchpointByEnrollment(ctx context.Context, orgI
 			WHERE t.organization_id=$1 AND d.campaign_id=$2 AND d.enrollment_contact_id=$3
 			ORDER BY t.updated_at DESC
 			LIMIT 1
-		) enrolled_touchpoint`, orgID, campaignID, contactID)
+		) t`, orgID, campaignID, contactID)
 	touchpoint, err := scanTouchpoint(row)
 	if errors.Is(err, pgx.ErrNoRows) {
 		return nil, nil


### PR DESCRIPTION
P0 integration fix for two concurrent production-safety merges.

PR #209 qualified the shared touchpoint projection through alias t. The subsequent campaign-task idempotency merge wrapped enrollment lookup in a subquery named enrolled_touchpoint. Both changes passed independently, but the combined main head would reference a missing outer alias at runtime.

This one-line integration names the derived relation t, preserving both the qualified projection and the duplicate-wakeup protection.

Verification:
- PostgreSQL: TestDelegatedFirstTouchApprovesQueuesAuditsAndReplaysOncePostgres
- TestOutreachTouchpointSelectQualifiesJoinedColumns
- make lint
- gofmt -l cmd internal (empty)