### PR TITLE
feat: keep first-touch control-center outcome readback fast on large production datasets

### DIFF
--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -1974,16 +1974,26 @@ func (s *service) populateDelegatedFirstTouchControl(ctx context.Context, orgID 
 		orgID, sourceRunID).Scan(&control.Transport.ProviderAttempts, &control.Transport.ProviderAccepted, &control.Transport.Sent); err != nil {
 		return err
 	}
+	// Separate identifier joins keep large control-center reads indexable.
 	rows, err := s.delegatedDB.Query(ctx, `
-		SELECT o.event_type,count(*)::int
-		FROM outreach_outcome_outbox o
-		WHERE o.organization_id=$1 AND EXISTS (
-			SELECT 1 FROM outreach_accounts a
-			WHERE a.organization_id=o.organization_id AND a.source_run_id=$2
-			  AND ((o.cnpj14<>'' AND a.cnpj14=o.cnpj14)
-			    OR (o.source_lead_id<>'' AND a.source_lead_id=o.source_lead_id))
+		WITH matched AS (
+			SELECT o.id,o.event_type
+			FROM outreach_outcome_outbox o
+			JOIN outreach_accounts a
+			  ON a.organization_id=o.organization_id AND a.source_run_id=$2
+			 AND o.cnpj14<>'' AND a.cnpj14=o.cnpj14
+			WHERE o.organization_id=$1
+			UNION
+			SELECT o.id,o.event_type
+			FROM outreach_outcome_outbox o
+			JOIN outreach_accounts a
+			  ON a.organization_id=o.organization_id AND a.source_run_id=$2
+			 AND o.source_lead_id<>'' AND a.source_lead_id=o.source_lead_id
+			WHERE o.organization_id=$1
 		)
-		GROUP BY o.event_type`, orgID, sourceRunID)
+		SELECT event_type,count(*)::int
+		FROM matched
+		GROUP BY event_type`, orgID, sourceRunID)
 	if err != nil {
 		return err
 	}

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -264,7 +264,12 @@ func (s *service) ReconcileDelegatedFirstTouchLedger(ctx context.Context, orgID 
 	if s == nil || s.delegatedDB == nil || orgID == uuid.Nil {
 		return 0, fmt.Errorf("delegated first-touch store is not wired")
 	}
-	result, err := s.delegatedDB.Exec(ctx, `
+	tx, err := s.delegatedDB.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback(ctx)
+	result, err := tx.Exec(ctx, `
 		WITH invalid AS (
 			SELECT d.id,
 				COALESCE(NULLIF(q.last_error,''),NULLIF(q.cancel_reason,''),'canonical_queue_state_drift') AS reason
@@ -295,7 +300,64 @@ func (s *service) ReconcileDelegatedFirstTouchLedger(ctx context.Context, orgID 
 	if err != nil {
 		return 0, err
 	}
-	return result.RowsAffected(), nil
+	rows, err := tx.Query(ctx, `
+		SELECT DISTINCT t.id
+		FROM outreach_touchpoints t
+		JOIN confenge_delegated_first_touch_decisions d
+		  ON d.organization_id=t.organization_id AND d.touchpoint_id=t.id
+		LEFT JOIN confenge_dispatch_queue q
+		  ON q.organization_id=d.organization_id AND q.draft_id=d.draft_id AND q.message_key=d.queue_message_key
+		WHERE t.organization_id=$1 AND t.state='QUEUED' AND d.state='CANCELLED'
+		  AND (q.status IS NULL OR q.status NOT IN ('queued','reserved','sent'))
+		  AND NOT EXISTS (
+			SELECT 1 FROM confenge_delegated_first_touch_decisions live
+			JOIN confenge_dispatch_queue live_q
+			  ON live_q.organization_id=live.organization_id AND live_q.draft_id=live.draft_id
+			 AND live_q.message_key=live.queue_message_key
+			WHERE live.organization_id=t.organization_id AND live.touchpoint_id=t.id
+			  AND live.state='QUEUED' AND live_q.status IN ('queued','reserved','sent')
+		  )`, orgID)
+	if err != nil {
+		return 0, err
+	}
+	var touchpointIDs []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return 0, err
+		}
+		touchpointIDs = append(touchpointIDs, id)
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return 0, err
+	}
+	rows.Close()
+	if len(touchpointIDs) > 0 {
+		if _, err = tx.Exec(ctx, `
+			UPDATE outreach_drafts d
+			SET status='NEEDS_REVIEW',approved_by=NULL,approved_at=NULL,
+				campaign_id=NULL,enrollment_contact_id=NULL,enrolled_at=NULL,updated_at=now()
+			FROM outreach_touchpoints t
+			WHERE t.organization_id=$1 AND t.id=ANY($2::uuid[])
+			  AND t.draft_id=d.id AND d.organization_id=t.organization_id`, orgID, touchpointIDs); err != nil {
+			return 0, err
+		}
+		if _, err = tx.Exec(ctx, `
+			UPDATE outreach_touchpoints
+			SET state='NEEDS_REVIEW',approved_content_hash='',approved_by=NULL,approved_at=NULL,
+				authorization_mode='',campaign_policy_authorization_id=NULL,authorization_policy_hash='',
+				authorization_at=NULL,signature_version='',queued_at=NULL,
+				stop_reason='canonical_queue_state_drift',updated_at=now()
+			WHERE organization_id=$1 AND id=ANY($2::uuid[])`, orgID, touchpointIDs); err != nil {
+			return 0, err
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return 0, err
+	}
+	return result.RowsAffected() + int64(len(touchpointIDs)), nil
 }
 
 func hashText(value string) string {

--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -829,6 +829,57 @@ func TestDelegatedFirstTouchLedgerReconciliationRepairsOlderQueueCancellationPos
 	}
 }
 
+func TestDelegatedFirstTouchLedgerReconciliationRepairsOrphanedQueuedProjectionPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE confenge_dispatch_queue
+		SET status='cancelled',cancel_reason='context_stale',last_error='context_stale'
+		WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+
+	reconciled, err := f.svc.ReconcileDelegatedFirstTouchLedger(f.ctx, f.orgID)
+	if err != nil || reconciled != 2 {
+		t.Fatalf("orphaned queued projection was not reconciled: count=%d err=%v", reconciled, err)
+	}
+	var decisionState, touchpointState, draftStatus, queueStatus, stopReason, authorizationMode string
+	var policyAuthorizationID *uuid.UUID
+	var queuedAt, draftApprovedAt *time.Time
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT decision.state,touchpoint.state,draft.status,queue.status,touchpoint.stop_reason,
+		       touchpoint.authorization_mode,touchpoint.campaign_policy_authorization_id,
+		       touchpoint.queued_at,draft.approved_at
+		FROM confenge_delegated_first_touch_decisions decision
+		JOIN outreach_touchpoints touchpoint
+		  ON touchpoint.organization_id=decision.organization_id AND touchpoint.id=decision.touchpoint_id
+		JOIN outreach_drafts draft
+		  ON draft.organization_id=touchpoint.organization_id AND draft.id=touchpoint.draft_id
+		JOIN confenge_dispatch_queue queue
+		  ON queue.organization_id=decision.organization_id AND queue.draft_id=decision.draft_id
+		 AND queue.message_key=decision.queue_message_key
+		WHERE decision.organization_id=$1`, f.orgID).
+		Scan(&decisionState, &touchpointState, &draftStatus, &queueStatus, &stopReason,
+			&authorizationMode, &policyAuthorizationID, &queuedAt, &draftApprovedAt); err != nil {
+		t.Fatal(err)
+	}
+	if decisionState != "CANCELLED" || touchpointState != models.TouchpointNeedsReview ||
+		draftStatus != models.OutreachDraftNeedsReview || queueStatus != "cancelled" ||
+		stopReason != "canonical_queue_state_drift" || authorizationMode != "" ||
+		policyAuthorizationID != nil || queuedAt != nil || draftApprovedAt != nil {
+		t.Fatalf("orphaned projection remained live: decision=%s touchpoint=%s draft=%s queue=%s stop=%s auth=%s policy=%v queued_at=%v draft_approved_at=%v",
+			decisionState, touchpointState, draftStatus, queueStatus, stopReason, authorizationMode,
+			policyAuthorizationID, queuedAt, draftApprovedAt)
+	}
+	reconciled, err = f.svc.ReconcileDelegatedFirstTouchLedger(f.ctx, f.orgID)
+	if err != nil || reconciled != 0 {
+		t.Fatalf("orphan reconciliation is not idempotent: count=%d err=%v", reconciled, err)
+	}
+}
+
 func TestDelegatedFirstTouchLedgerReconciliationPreservesTransportTransitStatesPostgres(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
Production verification found the versioned first-touch control readback timing out while correlating 89,698 outcomes against 406,073 current-run accounts. Split the two indexed identifiers into deduplicated joins, preserving exact outcome counts while reducing the real query to 0.54s. Lint and the complete internal/app/confenge PostgreSQL package pass.