### PR TITLE
fix(confenge): bind feed freshness to the producer build instead of comparing disjoint run ids (#155)

### DIFF
--- a/internal/app/confenge/cohort_freshness_test.go
+++ b/internal/app/confenge/cohort_freshness_test.go
@@ -9,6 +9,20 @@ import (
 	"github.com/warmbly/warmbly/internal/models"
 )
 
+// Verified values from the real extra-cli production manifest
+// (confenge.outreach.manifest.v1, 2026-08-26). source.run_id is a
+// content-derived feed BUILD id; the freshness run_id is a PNCP INGESTION
+// attempt id. They live in disjoint namespaces and can never be string-equal.
+const (
+	prodSnapshotHash  = "1c507558ec0e803bd2344d565f5adcb541375778b1b247b47e152470f024402a"
+	prodProfileID     = "confenge"
+	prodProfileVer    = "2.0.0"
+	prodModuleVersion = "1.1.1"
+	prodFreshnessHash = "c26a18a410c5f6d3654733a7485db38b7eafbfc77163b630edfa8e63614a91c0"
+	prodSourceRunID   = "run-25d918a5801fa976"
+	prodIngestRunID   = "contracts-90d-20260826T230341Z-5ca7f36505"
+)
+
 func freshSource(now time.Time) *FeedSourceFreshness {
 	expected, fetched := 93, 93
 	lag := 1.0
@@ -16,7 +30,7 @@ func freshSource(now time.Time) *FeedSourceFreshness {
 		ContractVersion: AuthoritativeFreshnessContractV1,
 		Status:          "FRESH", AsOf: now.Add(-time.Minute).Format(time.RFC3339Nano),
 		ExpiresAt: now.Add(time.Hour).Format(time.RFC3339Nano),
-		RunID:     "pncp-run-1", PagesExpected: &expected, PagesFetched: &fetched,
+		RunID:     prodIngestRunID, PagesExpected: &expected, PagesFetched: &fetched,
 		CurrentLagHours: &lag,
 	}
 }
@@ -31,10 +45,57 @@ func completeTargetMembership() *authoritativeTargetMembership {
 	}
 }
 
+// productionManifest models what the real producer actually emits: the same
+// freshness object published twice (top level and nested under source), a
+// producer content hash of it, and a source.run_id that is a commitment over
+// (snapshot_hash, profile_id, profile_version, module_version, freshness_hash).
+func productionManifest(now time.Time) *outreachManifest {
+	top := freshSource(now)
+	nested := *top
+	manifest := &outreachManifest{
+		SchemaVersion:    "confenge.outreach.manifest.v1",
+		ModuleVersion:    prodModuleVersion,
+		SourceFreshness:  top,
+		TargetMembership: completeTargetMembership(),
+	}
+	manifest.Source.System = "extra-cli"
+	manifest.Source.RunID = prodSourceRunID
+	manifest.Source.SnapshotHash = prodSnapshotHash
+	manifest.Source.ProfileID = prodProfileID
+	manifest.Source.ProfileVer = prodProfileVer
+	manifest.Source.Freshness = &nested
+	manifest.Source.FreshnessHash = prodFreshnessHash
+	return manifest
+}
+
+// withFreshness returns a shallow manifest copy whose top-level and nested
+// freshness blocks are independently mutable copies of the originals.
+func withFreshness(manifest *outreachManifest) (*outreachManifest, *FeedSourceFreshness, *FeedSourceFreshness) {
+	clone := *manifest
+	top := *manifest.SourceFreshness
+	nested := *manifest.Source.Freshness
+	clone.SourceFreshness = &top
+	clone.Source.Freshness = &nested
+	return &clone, &top, &nested
+}
+
+func rejects(t *testing.T, manifest *outreachManifest, now time.Time, wantSubstring, label string) {
+	t.Helper()
+	authority, err := validateManifestAuthority(manifest, now, true)
+	if err == nil {
+		t.Fatalf("%s: accepted, authority=%+v", label, authority)
+	}
+	if !strings.Contains(err.Error(), wantSubstring) {
+		t.Fatalf("%s: error %q does not contain %q", label, err.Error(), wantSubstring)
+	}
+	if authority != nil {
+		t.Fatalf("%s: rejected but still returned authority %+v", label, authority)
+	}
+}
+
 func TestManifestAuthorityRequiresContemporaryFreshnessAndCompleteMembership(t *testing.T) {
 	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
-	manifest := &outreachManifest{SourceFreshness: freshSource(now), TargetMembership: completeTargetMembership()}
-	manifest.Source.RunID = "pncp-run-1"
+	manifest := productionManifest(now)
 	authority, err := validateManifestAuthority(manifest, now, true)
 	if err != nil || authority == nil || authority.TargetMembershipCount != 10 || authority.SupplierConfirmedCount != 8 {
 		t.Fatalf("valid authority rejected: authority=%+v err=%v", authority, err)
@@ -42,31 +103,139 @@ func TestManifestAuthorityRequiresContemporaryFreshnessAndCompleteMembership(t *
 
 	missingMembership := *manifest
 	missingMembership.TargetMembership = nil
-	if _, err := validateManifestAuthority(&missingMembership, now, true); err == nil || !strings.Contains(err.Error(), "membership missing") {
-		t.Fatalf("missing membership accepted: %v", err)
-	}
+	rejects(t, &missingMembership, now, "membership missing", "missing membership")
 
-	expired := *manifest
-	expiredFreshness := *manifest.SourceFreshness
-	expiredFreshness.ExpiresAt = now.Format(time.RFC3339Nano)
-	expired.SourceFreshness = &expiredFreshness
-	if _, err := validateManifestAuthority(&expired, now, true); err == nil || !strings.Contains(err.Error(), "expired") {
-		t.Fatalf("expired source accepted: %v", err)
-	}
+	expired, top, _ := withFreshness(manifest)
+	top.ExpiresAt = now.Format(time.RFC3339Nano)
+	rejects(t, expired, now, "expired", "expired source")
+
+	notFresh, top, _ := withFreshness(manifest)
+	top.Status = "STALE"
+	rejects(t, notFresh, now, "STALE", "non-FRESH source")
+
+	futureDated, top, _ := withFreshness(manifest)
+	futureDated.SourceFreshness.AsOf = now.Add(time.Hour).Format(time.RFC3339Nano)
+	rejects(t, futureDated, now, "future-dated", "future-dated source")
+
+	badContract, top, _ := withFreshness(manifest)
+	top.ContractVersion = "PNCP_CONTRACT_FRESHNESS/0.9"
+	rejects(t, badContract, now, "contract unsupported", "unsupported freshness contract")
+
+	shortPages, top, _ := withFreshness(manifest)
+	fetched := 12
+	top.PagesFetched = &fetched
+	rejects(t, shortPages, now, "pagination incomplete", "incomplete pagination")
 
 	incomplete := *manifest
 	incompleteMembership := *manifest.TargetMembership
 	incompleteMembership.MembershipComplete = false
 	incomplete.TargetMembership = &incompleteMembership
-	if _, err := validateManifestAuthority(&incomplete, now, true); err == nil || !strings.Contains(err.Error(), "membership_complete") {
-		t.Fatalf("incomplete membership accepted: %v", err)
+	rejects(t, &incomplete, now, "membership_complete", "incomplete membership")
+
+	badMembershipContract := *manifest
+	badSchema := *manifest.TargetMembership
+	badSchema.SchemaVersion = "confenge.target_membership.v0"
+	badMembershipContract.TargetMembership = &badSchema
+	rejects(t, &badMembershipContract, now, "membership contract unsupported", "unsupported membership contract")
+
+	badCounts := *manifest
+	skewed := *manifest.TargetMembership
+	skewed.TargetConfirmedCount = 9
+	badCounts.TargetMembership = &skewed
+	rejects(t, &badCounts, now, "membership counts are invalid", "skewed membership counts")
+
+	badMembershipHash := *manifest
+	badHash := *manifest.TargetMembership
+	badHash.MembershipHash = "not-a-sha256"
+	badMembershipHash.TargetMembership = &badHash
+	rejects(t, &badMembershipHash, now, "membership_hash is invalid", "invalid membership hash")
+}
+
+// TestManifestAuthorityBindsFreshnessToProducerRunDerivation pins the real
+// binding. The previous gate compared source.run_id (a feed BUILD id from
+// export.py::_run_id) to authoritative_source_freshness.run_id (a PNCP
+// INGESTION attempt id from run_evidence.py::new_run_id) — disjoint namespaces,
+// so it could never pass. The binding below is cryptographic instead.
+func TestManifestAuthorityBindsFreshnessToProducerRunDerivation(t *testing.T) {
+	now := time.Date(2026, 8, 26, 12, 0, 0, 0, time.UTC)
+
+	derived := deriveFeedBuildRunID(prodSnapshotHash, prodProfileID, prodProfileVer, prodModuleVersion, prodFreshnessHash)
+	if derived != prodSourceRunID {
+		t.Fatalf("producer run-id derivation drifted: derived=%q want=%q", derived, prodSourceRunID)
+	}
+	if prodSourceRunID == prodIngestRunID {
+		t.Fatal("fixture no longer models disjoint build/ingestion namespaces")
 	}
 
-	mismatchedRun := *manifest
-	mismatchedRun.Source.RunID = "substituted-run"
-	if _, err := validateManifestAuthority(&mismatchedRun, now, true); err == nil || !strings.Contains(err.Error(), "run_id") {
-		t.Fatalf("freshness attestation for another run accepted: %v", err)
+	manifest := productionManifest(now)
+	authority, err := validateManifestAuthority(manifest, now, true)
+	if err != nil || authority == nil {
+		t.Fatalf("real production manifest values rejected: authority=%+v err=%v", authority, err)
 	}
+	if authority.SourceFreshnessHash != HashAuthoritativeSourceFreshness(manifest.SourceFreshness) {
+		t.Fatalf("authority did not carry the freshness hash: %+v", authority)
+	}
+
+	// Top-level freshness swapped for another ingestion run, nested left alone.
+	substitutedTop, top, _ := withFreshness(manifest)
+	top.RunID = "contracts-90d-20260825T010101Z-deadbeef01"
+	rejects(t, substitutedTop, now, "freshness block was substituted", "substituted top-level freshness")
+
+	// Nested freshness swapped, top-level left alone.
+	substitutedNested, _, nested := withFreshness(manifest)
+	nested.RunID = "contracts-90d-20260825T010101Z-deadbeef01"
+	rejects(t, substitutedNested, now, "freshness block was substituted", "substituted nested freshness")
+
+	emptyNestedRun, _, nested := withFreshness(manifest)
+	nested.RunID = ""
+	rejects(t, emptyNestedRun, now, "run_id is empty", "empty nested freshness run_id")
+
+	emptyTopRun, top, _ := withFreshness(manifest)
+	top.RunID = ""
+	rejects(t, emptyTopRun, now, "run_id is empty", "empty top-level freshness run_id")
+
+	// Well-formed sha256, wrong value: the run-id commitment must not reproduce.
+	tamperedHash := *manifest
+	tamperedHash.Source.FreshnessHash = strings.Repeat("b", 64)
+	rejects(t, &tamperedHash, now, "does not recompute", "tampered authoritative_freshness_hash")
+
+	malformedHash := *manifest
+	malformedHash.Source.FreshnessHash = "not-a-sha256"
+	rejects(t, &malformedHash, now, "not a valid sha256", "malformed authoritative_freshness_hash")
+
+	missingHash := *manifest
+	missingHash.Source.FreshnessHash = ""
+	rejects(t, &missingHash, now, "not a valid sha256", "missing authoritative_freshness_hash")
+
+	uppercaseHash := *manifest
+	uppercaseHash.Source.FreshnessHash = strings.ToUpper(prodFreshnessHash)
+	rejects(t, &uppercaseHash, now, "lowercase hex", "uppercase authoritative_freshness_hash")
+
+	missingModuleVersion := *manifest
+	missingModuleVersion.ModuleVersion = ""
+	rejects(t, &missingModuleVersion, now, "module_version is required", "missing module_version")
+
+	wrongModuleVersion := *manifest
+	wrongModuleVersion.ModuleVersion = "1.1.0"
+	rejects(t, &wrongModuleVersion, now, "does not recompute", "module_version drift")
+
+	missingNested := *manifest
+	missingNested.Source.Freshness = nil
+	rejects(t, &missingNested, now, "source.authoritative_freshness block is missing", "missing nested freshness block")
+
+	tamperedSnapshot := *manifest
+	tamperedSnapshot.Source.SnapshotHash = strings.Repeat("c", 64)
+	rejects(t, &tamperedSnapshot, now, "does not recompute", "tampered snapshot_hash")
+
+	tamperedProfile := *manifest
+	tamperedProfile.Source.ProfileVer = "1.0.0"
+	rejects(t, &tamperedProfile, now, "does not recompute", "tampered profile_version")
+
+	// The old, impossible predicate must not be resurrected: a manifest whose
+	// source.run_id was forced equal to the ingestion run id is a forgery.
+	oldStyleEquality := *manifest
+	oldStyleEquality.Source.RunID = prodIngestRunID
+	rejects(t, &oldStyleEquality, now, "does not recompute", "build run_id forced equal to ingestion run_id")
 }
 
 func TestHashStagedTargetMembershipUsesSortedUniqueRoots(t *testing.T) {

--- a/internal/app/confenge/confenge_scale_rehearsal_pg_test.go
+++ b/internal/app/confenge/confenge_scale_rehearsal_pg_test.go
@@ -143,8 +143,17 @@ func prepareRehearsalManifest(t *testing.T, sourcePath string) (string, outreach
 		}
 		manifest.SourceFreshness.AsOf, _ = freshness["observed_at"].(string)
 	}
+	// Do NOT fabricate a freshness run id here. This used to copy
+	// manifest.source.run_id (a feed BUILD id) into the freshness block (a PNCP
+	// INGESTION attempt id) purely to satisfy the old string-equality gate. The
+	// real binding is cryptographic (see deriveFeedBuildRunID), so a manifest
+	// without a genuine ingestion run id is unbindable and must fail closed.
 	if strings.TrimSpace(manifest.SourceFreshness.RunID) == "" {
-		manifest.SourceFreshness.RunID = manifest.Source.RunID
+		t.Fatalf("rehearsal manifest %s carries no authoritative PNCP freshness run_id", sourcePath)
+	}
+	if manifest.Source.Freshness == nil || strings.TrimSpace(manifest.Source.FreshnessHash) == "" ||
+		strings.TrimSpace(manifest.ModuleVersion) == "" {
+		t.Fatalf("rehearsal manifest %s is missing the producer freshness binding (module_version/source.authoritative_freshness{,_hash})", sourcePath)
 	}
 	baseDir := filepath.Dir(sourcePath)
 	for index := range manifest.Chunks {

--- a/internal/app/confenge/feed_sync.go
+++ b/internal/app/confenge/feed_sync.go
@@ -44,6 +44,10 @@ const (
 // outreachManifest is confenge.outreach.manifest.v1 (extra-cli export).
 type outreachManifest struct {
 	SchemaVersion string `json:"schema_version"`
+	// ModuleVersion is an input to the producer's source.run_id derivation and
+	// is therefore required to verify the freshness binding (see
+	// deriveFeedBuildRunID). Fail-closed: never inferred, never defaulted.
+	ModuleVersion string `json:"module_version"`
 	GeneratedAt   string `json:"generated_at"`
 	Source        struct {
 		System       string `json:"system"`
@@ -52,6 +56,11 @@ type outreachManifest struct {
 		RepoSHA      string `json:"repo_sha"`
 		ProfileID    string `json:"profile_id"`
 		ProfileVer   string `json:"profile_version"`
+		// Freshness is the SAME attestation object the producer also publishes
+		// at manifest.authoritative_source_freshness; FreshnessHash is the
+		// producer's content hash of it and is committed to by source.run_id.
+		Freshness     *FeedSourceFreshness `json:"authoritative_freshness"`
+		FreshnessHash string               `json:"authoritative_freshness_hash"`
 	} `json:"source"`
 	LeadCount        int                            `json:"lead_count"`
 	ChunkCount       int                            `json:"chunk_count"`
@@ -455,8 +464,8 @@ func validateManifestAuthority(manifest *outreachManifest, now time.Time, requir
 	if err := ValidateAuthoritativeSourceFreshness(manifest.SourceFreshness, now); err != nil {
 		return nil, err
 	}
-	if strings.TrimSpace(manifest.SourceFreshness.RunID) != strings.TrimSpace(manifest.Source.RunID) {
-		return nil, fmt.Errorf("authoritative PNCP freshness run_id does not match manifest source run")
+	if err := bindManifestFreshnessToBuild(manifest); err != nil {
+		return nil, err
 	}
 	expiresAt, err := parseFreshnessTime(manifest.SourceFreshness.ExpiresAt)
 	if err != nil {
@@ -494,6 +503,100 @@ func validateManifestAuthority(manifest *outreachManifest, now time.Time, requir
 		TargetMembershipCount:    membership.PopulationCount,
 		SupplierConfirmedCount:   membership.SupplierConfirmedCount,
 	}, nil
+}
+
+// feedBuildRunIDPrefix is the literal prefix the producer prepends to the
+// truncated digest when minting a feed BUILD id.
+const feedBuildRunIDPrefix = "run-"
+
+// deriveFeedBuildRunID recomputes manifest.source.run_id exactly as extra-cli
+// mints it in scripts/warmbly_bridge/export.py::_run_id:
+//
+//	"run-" + sha256(snapshot_hash|profile_id|profile_version|module_version|authoritative_freshness_hash)[:16]
+//
+// WHY THIS REPLACED A STRING COMPARISON.
+//
+// The previous gate required
+//
+//	manifest.authoritative_source_freshness.run_id == manifest.source.run_id
+//
+// which is unsatisfiable by construction against the real producer, because the
+// two identifiers are minted by two different generators in two disjoint
+// namespaces:
+//
+//   - manifest.source.run_id is a content-derived feed BUILD id, minted by
+//     extra-cli scripts/warmbly_bridge/export.py::_run_id (the derivation above).
+//     Real production value: "run-25d918a5801fa976".
+//
+//   - manifest.authoritative_source_freshness.run_id is the PNCP INGESTION
+//     attempt id, minted by extra-cli scripts/crawl/run_evidence.py::new_run_id
+//     as f"{prefix}-{utcstamp}-{uuid4().hex[:10]}" with prefix "contracts-90d".
+//     Real production value: "contracts-90d-20260826T230341Z-5ca7f36505".
+//
+// A build id can never equal an ingestion attempt id, so the gate refused every
+// genuine manifest and left the authority projection empty.
+//
+// The INTENT of that gate was correct and is preserved here, and strengthened
+// from a lexical check into a cryptographic one: source.run_id is itself a
+// commitment over authoritative_freshness_hash, so recomputing it proves the
+// freshness attestation attached to this manifest is the one this feed build
+// was actually produced against, and was not substituted from another run.
+func deriveFeedBuildRunID(snapshotHash, profileID, profileVersion, moduleVersion, freshnessHash string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		snapshotHash, profileID, profileVersion, moduleVersion, freshnessHash,
+	}, "|")))
+	return feedBuildRunIDPrefix + hex.EncodeToString(sum[:])[:16]
+}
+
+// bindManifestFreshnessToBuild proves the authoritative freshness attestation
+// carried by this manifest genuinely belongs to this feed build. Fail-closed:
+// every input to the derivation must be present and well-formed, and no branch
+// may skip the recomputation.
+func bindManifestFreshnessToBuild(manifest *outreachManifest) error {
+	if manifest == nil || manifest.SourceFreshness == nil {
+		return fmt.Errorf("authoritative PNCP freshness missing")
+	}
+	moduleVersion := strings.TrimSpace(manifest.ModuleVersion)
+	if moduleVersion == "" {
+		return fmt.Errorf("manifest module_version is required to bind the authoritative PNCP freshness attestation to this feed build")
+	}
+	freshnessHash := strings.TrimSpace(manifest.Source.FreshnessHash)
+	if !validSHA256(freshnessHash) {
+		return fmt.Errorf("manifest source.authoritative_freshness_hash is not a valid sha256")
+	}
+	if freshnessHash != strings.ToLower(freshnessHash) {
+		return fmt.Errorf("manifest source.authoritative_freshness_hash must be lowercase hex")
+	}
+	nested := manifest.Source.Freshness
+	if nested == nil {
+		return fmt.Errorf("manifest source.authoritative_freshness block is missing")
+	}
+	// The producer writes the same freshness object twice (top level and inside
+	// source). Disagreement means one of the two copies was substituted.
+	nestedRunID := strings.TrimSpace(nested.RunID)
+	topRunID := strings.TrimSpace(manifest.SourceFreshness.RunID)
+	if nestedRunID == "" || topRunID == "" {
+		return fmt.Errorf("authoritative PNCP freshness run_id is empty")
+	}
+	if nestedRunID != topRunID {
+		return fmt.Errorf(
+			"authoritative PNCP freshness block was substituted: source.authoritative_freshness.run_id %q does not match authoritative_source_freshness.run_id %q",
+			nestedRunID, topRunID)
+	}
+	declaredRunID := strings.TrimSpace(manifest.Source.RunID)
+	derivedRunID := deriveFeedBuildRunID(
+		strings.TrimSpace(manifest.Source.SnapshotHash),
+		strings.TrimSpace(manifest.Source.ProfileID),
+		strings.TrimSpace(manifest.Source.ProfileVer),
+		moduleVersion,
+		freshnessHash,
+	)
+	if declaredRunID != derivedRunID {
+		return fmt.Errorf(
+			"manifest source.run_id %q does not recompute from its published build inputs (derived %q): the authoritative PNCP freshness attestation is not bound to this feed build",
+			declaredRunID, derivedRunID)
+	}
+	return nil
 }
 
 func sameFeedAuthority(current *models.OutreachFeedSyncState, authority *feedAuthority) bool {


### PR DESCRIPTION
## Problema

O gate de autoridade do feed exigia `authoritative_source_freshness.run_id == source.run_id` (`feed_sync.go:458`, introduzido em `1a85da7a`, 2026-08-26 20:28 -03). **É insatisfazível por construção** — os dois ids são cunhados por geradores diferentes, em namespaces disjuntos:

| Campo | Gerador (extra-cli) | Forma | Valor real em produção |
|---|---|---|---|
| `source.run_id` | `export.py::_run_id` | `"run-" + sha256(...)[:16]` | `run-25d918a5801fa976` |
| `authoritative_source_freshness.run_id` | `run_evidence.py::new_run_id` | `{prefix}-{utcstamp}-{uuid4hex10}` | `contracts-90d-20260826T230341Z-5ca7f36505` |

Um id de build nunca pode ser igual a um id de tentativa de ingestão. Efeito em produção: todo manifesto legítimo recusado, `outreach_feed_sync_state` com `last_status=failed`, `chunks_imported=0`, `target_membership_count=0`, `source_expires_at=NULL` — **enquanto o feed publicado estava íntegro e `FRESH`**.

O único teste que cobria o gate (`cohort_freshness_test.go:34-37`) fixava **os dois campos na mesma literal** `"pncp-run-1"`, modelando um manifesto que o produtor jamais emite.

## Correção

A intenção do gate — a atestação de freshness precisa pertencer de fato a este build e não pode ser substituída de outro run — é **preservada e fortalecida**, de checagem lexical para criptográfica.

`source.run_id` já é, por construção, um compromisso sha256 sobre `authoritative_freshness_hash` junto com a tupla de build, e **todos os insumos são publicados no manifesto**. Logo o binding é verificável por recomputação:

```
sha256("1c507558…402a|confenge|2.0.0|1.1.1|c26a18a4…a91c0")[:16]
  = 25d918a5801fa976   ==   source.run_id       ← verificado contra os bytes reais de produção
```

Fail-closed em todos os caminhos: `module_version` é obrigatório e nunca inferido, o hash precisa ser sha256 minúsculo, as duas cópias publicadas do objeto de freshness precisam concordar no id de ingestão, e nenhum ramo pula a recomputação. Mensagens de erro distintas por modo de falha.

## Não alterado

`feedManifestMaxLeads` (100.000), `feedManifestMaxChunks` (1.000), `feedManifestMaxStagedBytes` (1 GiB), `hashStagedTargetMembership` e todas as checagens de fechamento de denominador. `git diff` sobre esses símbolos é vazio.

## Testes

Fixtures reescritas para modelar o produtor real (`run-<16 hex>` derivado + `contracts-90d-…`) em vez da literal compartilhada. Novo `TestManifestAuthorityBindsFreshnessToProducerRunDerivation` cobre: valores reais de produção aceitos; bloco de freshness substituído no topo; substituído no aninhado; `authoritative_freshness_hash` adulterado (sha256 válido, valor errado); hash malformado; `module_version` ausente. Toda asserção pré-existente de membership continua rejeitando como antes.

Também removida, em `confenge_scale_rehearsal_pg_test.go`, uma linha que copiava `source.run_id` para dentro do bloco de freshness só para satisfazer o gate antigo — era a mesma categoria de erro em um segundo lugar, e mantê-la fabricaria dado de autoridade.

```
go build ./...                              BUILD OK
go vet ./internal/app/confenge/...          sem diagnósticos
gofmt -l <arquivos alterados>               limpo
go test ./internal/app/confenge/...         670 PASS, 71 SKIP, 1 FAIL
```

A única falha é ambiental e **pré-existente** (`TestProductAcceptanceMultichannelSum`: `Mailpit not reachable`) — verificada rodando idêntica no baseline `91e37d8b` sem estas mudanças. Os 71 skips são gated em `WARMBLY_TEST_POSTGRES_DSN`, incluindo `TestPostgresSyncFeedManifestMaterializesTenThousandAndConverges` e os dois rehearsals de 10k, que consomem manifestos reais de disco e são a checagem certa antes do merge quando houver DSN.

## Residual honesto

O Warmbly **não** recomputa `authoritative_freshness_hash` a partir dos bytes da freshness. A canonicalização do `content_hash_obj` em Python não é fielmente reproduzível em Go (`1.0` vs `1`; campos desconhecidos como `source_window` descartados pelo struct). Este binding defende contra substituição e adulteração **dentro** de um manifesto; não é assinatura do produtor. Fechar isso exige assinatura no lado produtor ou um contrato de canonicalização byte-preserving acordado com o extra-cli — mudança separada.

Nada aqui autoriza envio. Kill switch permanece engaged, `dispatch_control.paused=t`, zero SMTP.

Refs #155, #43. RCA completa em tjsasakifln/extra-cli#468.

🤖 Generated with [Claude Code](https://claude.com/claude-code)