### PR TITLE
fix(confenge): uma só verdade de transporte e um ledger que não afirma o que não observou

### DIFF
--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -63,6 +63,14 @@ func (h *Handler) GetConfengeStatus(c *gin.Context) {
 	} else {
 		readiness = confenge.BuildReadiness(cfg, confenge.ReadinessInputs{})
 	}
+	// Resolve every control that can stop a send, not just the two this config
+	// can see. Reporting cfg.SendingAllowed() alone let this endpoint claim
+	// sending_allowed=true while the durable control row or the business window
+	// was refusing every dispatch claim.
+	transport := cfg.TransportState()
+	if h.ConfengeService != nil {
+		transport = h.ConfengeService.ResolveTransportState(c.Request.Context(), middleware.GetOrganizationID(c))
+	}
 	c.JSON(http.StatusOK, gin.H{
 		"enabled":                 enabled,
 		"auto_send_enabled":       enabled && cfg.AutoSendEnabled,
@@ -71,7 +79,8 @@ func (h *Handler) GetConfengeStatus(c *gin.Context) {
 		"max_initial_email_words": cfg.MaxInitialEmailWords,
 		"feed_configured":         enabled && cfg.FeedURL != "",
 		"kill_switch":             !cfg.SendingAllowed(),
-		"sending_allowed":         cfg.SendingAllowed(),
+		"sending_allowed":         transport.Active,
+		"transport_state":         transport,
 		"readiness":               readiness,
 	})
 }

--- a/internal/app/confenge/dispatch/capacity_contract_test.go
+++ b/internal/app/confenge/dispatch/capacity_contract_test.go
@@ -1,0 +1,105 @@
+package dispatch
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The capacity contract has two independent limits and the scheduler must obey
+// the most conservative one that applies, in either direction. Production runs
+// them equal today (mailbox min_wait_time 600s, CONFENGE_MIN_SEND_GAP_SECONDS
+// 600, CONFENGE_GLOBAL_SENDS_PER_HOUR 6 → 3600/6 = 600), so a regression here
+// would be invisible until the day the two numbers diverge. The correct answer
+// is never to lower one to match the other.
+
+func TestMailboxGapWinsWhenItIsMoreConservativeThanTheGlobalGap(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	store := NewMemoryStore()
+	orgID, mailbox := uuid.New(), uuid.New()
+	store.SetMailboxEnvelope(readyTestMailbox(orgID, mailbox, 50, 30*time.Minute))
+
+	cfg := mailboxTestConfig()
+	cfg.MinGap = 1 * time.Minute // a permissive global stream
+	governor := NewGovernor(cfg, store, &FixedClock{T: now})
+
+	first := reserveMailbox(t, governor, orgID, mailbox, "first")
+	if !first.Allowed {
+		t.Fatalf("first slot denied: %s", first.Reason)
+	}
+	if err := governor.Commit(t.Context(), first.Reservation.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	second := reserveMailbox(t, governor, orgID, mailbox, "second")
+	if second.Allowed {
+		t.Fatal("the global gap must never schedule a mailbox faster than its own min wait")
+	}
+	if second.Reason != "mailbox_min_gap" {
+		t.Fatalf("reason=%q want mailbox_min_gap", second.Reason)
+	}
+	if !second.NextSlot.Equal(now.Add(30 * time.Minute)) {
+		t.Fatalf("next slot=%s want the mailbox gap %s", second.NextSlot, now.Add(30*time.Minute))
+	}
+}
+
+func TestGlobalGapStillAppliesWhenItIsTheMoreConservativeLimit(t *testing.T) {
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+	store := NewMemoryStore()
+	orgID, mailboxA, mailboxB := uuid.New(), uuid.New(), uuid.New()
+	// Both mailboxes are individually permissive; the global stream is not.
+	store.SetMailboxEnvelope(readyTestMailbox(orgID, mailboxA, 50, time.Minute))
+	store.SetMailboxEnvelope(readyTestMailbox(orgID, mailboxB, 50, time.Minute))
+
+	cfg := mailboxTestConfig()
+	cfg.MinGap = 20 * time.Minute
+	governor := NewGovernor(cfg, store, &FixedClock{T: now})
+
+	first := reserveMailbox(t, governor, orgID, mailboxA, "first")
+	if !first.Allowed {
+		t.Fatalf("first slot denied: %s", first.Reason)
+	}
+	if err := governor.Commit(t.Context(), first.Reservation.ID); err != nil {
+		t.Fatal(err)
+	}
+
+	// A different mailbox cannot be used to outrun the global gap.
+	second := reserveMailbox(t, governor, orgID, mailboxB, "second")
+	if second.Allowed {
+		t.Fatal("a second mailbox must not bypass the global send gap")
+	}
+	if !second.NextSlot.Equal(now.Add(20 * time.Minute)) {
+		t.Fatalf("next slot=%s want the global gap %s", second.NextSlot, now.Add(20*time.Minute))
+	}
+}
+
+func TestMailboxDailyCapIsNotWidenedByTheGlobalHourlyRate(t *testing.T) {
+	now := time.Date(2026, 8, 24, 9, 0, 0, 0, time.UTC)
+	clock := &FixedClock{T: now}
+	store := NewMemoryStore()
+	orgID, mailbox := uuid.New(), uuid.New()
+	store.SetMailboxEnvelope(readyTestMailbox(orgID, mailbox, 2, time.Minute))
+
+	cfg := mailboxTestConfig() // SendsPerHour 100, no global gap
+	governor := NewGovernor(cfg, store, clock)
+
+	for i, key := range []string{"one", "two"} {
+		result := reserveMailbox(t, governor, orgID, mailbox, key)
+		if !result.Allowed {
+			t.Fatalf("slot %d denied: %s", i+1, result.Reason)
+		}
+		if err := governor.Commit(t.Context(), result.Reservation.ID); err != nil {
+			t.Fatal(err)
+		}
+		clock.T = clock.T.Add(2 * time.Minute)
+	}
+
+	third := reserveMailbox(t, governor, orgID, mailbox, "three")
+	if third.Allowed {
+		t.Fatal("the mailbox daily cap must hold regardless of the global hourly rate")
+	}
+	if third.Reason != "mailbox_daily_cap" {
+		t.Fatalf("reason=%q want mailbox_daily_cap", third.Reason)
+	}
+}

--- a/internal/app/confenge/dispatch/governor.go
+++ b/internal/app/confenge/dispatch/governor.go
@@ -373,6 +373,11 @@ func (g *Governor) CancelByRecipient(ctx context.Context, orgID uuid.UUID, recip
 	return g.store.CancelQueueByRecipient(ctx, orgID, recipientRef, reason)
 }
 
+// ListQueueByStatus exposes queue rows awaiting reconciliation.
+func (g *Governor) ListQueueByStatus(ctx context.Context, status string, limit int) ([]QueueItem, error) {
+	return g.store.ListQueueByStatus(ctx, status, limit)
+}
+
 func (g *Governor) MarkQueue(ctx context.Context, id uuid.UUID, status, errText string) error {
 	return g.store.UpdateQueueStatus(ctx, id, status, errText)
 }

--- a/internal/app/confenge/dispatch/ledger_state_test.go
+++ b/internal/app/confenge/dispatch/ledger_state_test.go
@@ -1,0 +1,103 @@
+package dispatch
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The queue used to move straight from 'queued' to 'sent' at hand-off, so the
+// stored state asserted a provider acceptance nobody had observed. Production
+// showed six rows in 'sent' with an empty provider-fact table and no touchpoint
+// ever reaching SENT.
+
+func TestAttemptedIsADistinctStateFromSent(t *testing.T) {
+	if QueueAttempted == QueueSent {
+		t.Fatal("a hand-off and a confirmed send must not be the same state")
+	}
+	if QueueAttempted != "attempted" {
+		t.Fatalf("QueueAttempted=%q", QueueAttempted)
+	}
+}
+
+func TestReEnqueueNeverRevivesAnAttemptedMessage(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	orgID := uuid.New()
+	item := &QueueItem{
+		OrganizationID: orgID,
+		Channel:        ChannelEmail,
+		DraftID:        uuid.New(),
+		MessageKey:     "same-message",
+		DueAt:          time.Now().UTC(),
+	}
+	if err := store.Enqueue(ctx, item); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.UpdateQueueStatus(ctx, item.ID, QueueAttempted, ""); err != nil {
+		t.Fatal(err)
+	}
+
+	// The same message key arriving again must not become dispatchable: the
+	// message is already with the transport, only its acceptance is unknown.
+	again := &QueueItem{
+		OrganizationID: orgID,
+		Channel:        ChannelEmail,
+		DraftID:        item.DraftID,
+		MessageKey:     "same-message",
+		DueAt:          time.Now().UTC(),
+	}
+	if err := store.Enqueue(ctx, again); err != nil {
+		t.Fatal(err)
+	}
+	rows, err := store.ListQueueByStatus(ctx, QueueQueued, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("an attempted message was made dispatchable again: %+v", rows)
+	}
+	attempted, err := store.ListQueueByStatus(ctx, QueueAttempted, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(attempted) != 1 {
+		t.Fatalf("attempted rows=%d want 1", len(attempted))
+	}
+}
+
+func TestListQueueByStatusOnlyReturnsTheRequestedState(t *testing.T) {
+	store := NewMemoryStore()
+	ctx := context.Background()
+	orgID := uuid.New()
+	for i, status := range []string{QueueAttempted, QueueSent, QueueCancelled, QueueAttempted} {
+		item := &QueueItem{
+			OrganizationID: orgID,
+			Channel:        ChannelEmail,
+			DraftID:        uuid.New(),
+			MessageKey:     uuid.New().String(),
+			DueAt:          time.Now().UTC().Add(time.Duration(i) * time.Second),
+			CreatedAt:      time.Now().UTC().Add(time.Duration(i) * time.Second),
+		}
+		if err := store.Enqueue(ctx, item); err != nil {
+			t.Fatal(err)
+		}
+		if err := store.UpdateQueueStatus(ctx, item.ID, status, ""); err != nil {
+			t.Fatal(err)
+		}
+	}
+	rows, err := store.ListQueueByStatus(ctx, QueueAttempted, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("attempted rows=%d want 2", len(rows))
+	}
+	for _, row := range rows {
+		if row.Status != QueueAttempted {
+			t.Fatalf("unexpected status %q", row.Status)
+		}
+	}
+}

--- a/internal/app/confenge/dispatch/memory_store.go
+++ b/internal/app/confenge/dispatch/memory_store.go
@@ -376,7 +376,10 @@ func (m *MemoryStore) Enqueue(ctx context.Context, item *QueueItem) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if existing := m.queue[item.MessageKey]; existing != nil {
-		if existing.Status == QueueSent || existing.Status == QueueCancelled {
+		// 'attempted' is terminal for enqueue: the message is already with the
+		// transport and its acceptance is merely unobserved. Re-queueing it would
+		// dispatch the same message a second time.
+		if existing.Status == QueueAttempted || existing.Status == QueueSent || existing.Status == QueueCancelled {
 			return nil
 		}
 		existing.DueAt = item.DueAt
@@ -497,6 +500,25 @@ func (m *MemoryStore) UpdateQueueStatus(ctx context.Context, id uuid.UUID, statu
 		q.LastError = errText
 	}
 	return nil
+}
+
+func (m *MemoryStore) ListQueueByStatus(_ context.Context, status string, limit int) ([]QueueItem, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	var out []QueueItem
+	for _, q := range m.queue {
+		if q != nil && q.Status == status {
+			out = append(out, *q)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].CreatedAt.Before(out[j].CreatedAt) })
+	if len(out) > limit {
+		out = out[:limit]
+	}
+	return out, nil
 }
 
 func (m *MemoryStore) RetryQueue(ctx context.Context, id uuid.UUID, dueAt time.Time, errText string) error {

--- a/internal/app/confenge/dispatch/pg_store.go
+++ b/internal/app/confenge/dispatch/pg_store.go
@@ -465,7 +465,10 @@ func (s *PGStore) Enqueue(ctx context.Context, item *QueueItem) error {
 					'delegated_authority_or_source_binding_advanced',
 					'source_run_superseded'
 				  ) THEN 'queued'
-				WHEN confenge_dispatch_queue.status IN ('sent','cancelled') THEN confenge_dispatch_queue.status
+				-- 'attempted' is terminal for enqueue: the message is already with the
+				-- transport and its acceptance is merely unobserved. Re-queueing it
+				-- would dispatch the same message a second time.
+				WHEN confenge_dispatch_queue.status IN ('attempted','sent','cancelled') THEN confenge_dispatch_queue.status
 				ELSE 'queued'
 			END,
 			cancel_reason = CASE
@@ -658,4 +661,36 @@ func (s *PGStore) EnsureControl(ctx context.Context) error {
 		return fmt.Errorf("ensure confenge_dispatch_control: %w", err)
 	}
 	return nil
+}
+
+// ListQueueByStatus enumerates queue rows in one status, oldest first. It backs
+// the attempted->sent reconciliation, which needs to revisit hand-offs whose
+// provider outcome was not yet observable when the worker released them.
+func (s *PGStore) ListQueueByStatus(ctx context.Context, status string, limit int) ([]QueueItem, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	rows, err := s.db.Query(ctx, `
+		SELECT id, organization_id, email_account_id, channel, draft_id, message_key,
+		       COALESCE(recipient_ref,''), due_at, priority, attempts, status,
+		       cancel_reason, last_error, created_at
+		FROM confenge_dispatch_queue
+		WHERE status = $1
+		ORDER BY updated_at ASC
+		LIMIT $2`, status, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []QueueItem
+	for rows.Next() {
+		var q QueueItem
+		if err := rows.Scan(&q.ID, &q.OrganizationID, &q.EmailAccountID, &q.Channel, &q.DraftID,
+			&q.MessageKey, &q.RecipientRef, &q.DueAt, &q.Priority, &q.Attempts, &q.Status,
+			&q.CancelReason, &q.LastError, &q.CreatedAt); err != nil {
+			return nil, err
+		}
+		out = append(out, q)
+	}
+	return out, rows.Err()
 }

--- a/internal/app/confenge/dispatch/store.go
+++ b/internal/app/confenge/dispatch/store.go
@@ -57,6 +57,8 @@ type Store interface {
 	// ClaimNextQueued transactionally selects the next fair due item and marks it reserved.
 	ClaimNextQueued(ctx context.Context, now time.Time) (*QueueItem, error)
 	UpdateQueueStatus(ctx context.Context, id uuid.UUID, status, errText string) error
+	// ListQueueByStatus enumerates rows awaiting reconciliation, oldest first.
+	ListQueueByStatus(ctx context.Context, status string, limit int) ([]QueueItem, error)
 	RetryQueue(ctx context.Context, id uuid.UUID, dueAt time.Time, errText string) error
 
 	RecordFailure(ctx context.Context, f FailureRecord) error

--- a/internal/app/confenge/dispatch/types.go
+++ b/internal/app/confenge/dispatch/types.go
@@ -23,8 +23,13 @@ const (
 )
 
 const (
-	QueueQueued    = "queued"
-	QueueReserved  = "reserved"
+	QueueQueued   = "queued"
+	QueueReserved = "reserved"
+	// QueueAttempted is the terminal state of a hand-off: the message was given
+	// to the transport and nothing has confirmed what the provider did with it.
+	// It is deliberately not "sent". Promotion to QueueSent requires an observed
+	// provider fact; without one, acceptance stays UNKNOWN.
+	QueueAttempted = "attempted"
 	QueueSent      = "sent"
 	QueueCancelled = "cancelled"
 	QueueFailed    = "failed"

--- a/internal/app/confenge/dispatch_queue_worker.go
+++ b/internal/app/confenge/dispatch_queue_worker.go
@@ -2,6 +2,7 @@ package confenge
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -33,6 +34,10 @@ func (w *DispatchQueueWorker) Run(ctx context.Context) {
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
 	for {
+		// Reconcile first: a provider outcome that arrived while this worker was
+		// idle must be recorded before any new claim, so the ledger never lags
+		// behind the queue it governs.
+		_, _ = w.service.ReconcileAttemptedDispatches(ctx)
 		_, _ = w.service.ProcessDispatchQueueOnce(ctx)
 		select {
 		case <-ctx.Done():
@@ -46,12 +51,15 @@ func (s *service) ProcessDispatchQueueOnce(ctx context.Context) (bool, error) {
 	if s.governor == nil {
 		return false, nil
 	}
-	status, err := s.governor.Status(ctx, nil)
-	if err != nil {
-		return false, err
-	}
-	if status.Paused || !status.InSendWindow || FileKillSwitchActive() || !s.cfg.SendingAllowed() {
+	// One resolved state, shared with the status projection, so the dispatcher
+	// and the founder's dashboard can never disagree about whether transport is
+	// live. Anything other than ACTIVE — including an unreadable control —
+	// refuses the claim.
+	if transport := s.ResolveTransportState(ctx, nil); !transport.Active {
 		return false, nil
+	}
+	if _, err := s.governor.Status(ctx, nil); err != nil {
+		return false, err
 	}
 	item, err := s.governor.ClaimNextQueued(ctx)
 	if err != nil || item == nil {
@@ -94,10 +102,60 @@ func (s *service) ProcessDispatchQueueOnce(ctx context.Context) (bool, error) {
 		}
 		return true, xerr
 	}
-	// QueueSent means handed to the configured transport. Provider-confirmed
-	// delivery remains recorded by CompleteCampaignEmail / WhatsApp completion.
-	if err := s.governor.MarkQueue(ctx, item.ID, dispatch.QueueSent, ""); err != nil {
+	// The hand-off is an attempt, not a send. dispatchEmailTouch enrolls the
+	// draft and leaves SENT to the consumer that sees the provider result, so
+	// writing "sent" here asserted an acceptance nobody had observed. That is how
+	// six queue rows came to read 'sent' with an empty provider-fact table and no
+	// touchpoint ever reaching SENT. ReconcileAttemptedDispatches promotes the row
+	// once a provider fact exists; until then acceptance stays UNKNOWN.
+	if err := s.governor.MarkQueue(ctx, item.ID, dispatch.QueueAttempted, ""); err != nil {
 		return true, err
 	}
 	return true, nil
+}
+
+// ReconcileAttemptedDispatches closes the loop between the queue, the touchpoint
+// projection and the provider fact.
+//
+// An attempted row is promoted to sent only when the touchpoint reached SENT and
+// carries a provider message id; a touchpoint that failed or was cancelled moves
+// the row to the matching terminal state. Anything else is left alone: an
+// outcome that has not been observed is not an outcome.
+func (s *service) ReconcileAttemptedDispatches(ctx context.Context) (int, error) {
+	if s.governor == nil {
+		return 0, nil
+	}
+	items, err := s.governor.ListQueueByStatus(ctx, dispatch.QueueAttempted, 100)
+	if err != nil {
+		return 0, err
+	}
+	reconciled := 0
+	for i := range items {
+		item := items[i]
+		tp, err := s.repo.GetTouchpointByDraft(ctx, item.OrganizationID, item.DraftID)
+		if err != nil {
+			return reconciled, err
+		}
+		if tp == nil {
+			continue
+		}
+		switch {
+		case tp.State == models.TouchpointSent && strings.TrimSpace(tp.ProviderMessageID) != "":
+			if err := s.governor.MarkQueue(ctx, item.ID, dispatch.QueueSent, ""); err != nil {
+				return reconciled, err
+			}
+			reconciled++
+		case tp.State == models.TouchpointFailed:
+			if err := s.governor.MarkQueue(ctx, item.ID, dispatch.QueueFailed, "provider_rejected"); err != nil {
+				return reconciled, err
+			}
+			reconciled++
+		case tp.State == models.TouchpointCancelled:
+			if err := s.governor.MarkQueue(ctx, item.ID, dispatch.QueueCancelled, "touchpoint_cancelled"); err != nil {
+				return reconciled, err
+			}
+			reconciled++
+		}
+	}
+	return reconciled, nil
 }

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -36,6 +36,12 @@ type OrgRiskPolicy interface {
 type Service interface {
 	Enabled() bool
 	Config() Config
+	// ResolveTransportState is the single answer to "may a message leave now?".
+	// Every reader must use it so no two projections can disagree.
+	ResolveTransportState(ctx context.Context, orgID *uuid.UUID) TransportState
+	// ReconcileAttemptedDispatches promotes a hand-off to sent only once a
+	// provider fact exists, and leaves unobserved acceptance UNKNOWN.
+	ReconcileAttemptedDispatches(ctx context.Context) (int, error)
 	// CollectReadiness aggregates operator panel signals for one org.
 	CollectReadiness(ctx context.Context, orgID uuid.UUID, emailReady bool) Readiness
 

--- a/internal/app/confenge/transport_state.go
+++ b/internal/app/confenge/transport_state.go
@@ -1,0 +1,171 @@
+package confenge
+
+import (
+	"context"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
+// Transport state is resolved from every control that can actually stop a send.
+// Before this existed the controls were split across two disagreeing
+// projections: Config.SendingAllowed covered the environment flag and the
+// kill-switch file, while the dispatch governor covered the environment flag,
+// the durable control row and the business window. Only the dispatcher itself
+// ANDed all of them, so GET /confenge/status could report sending_allowed=true
+// while the queue worker refused every claim — or the reverse.
+//
+// One rule now governs every reader: the most restrictive source wins, and a
+// source that cannot be read is never treated as permissive.
+const (
+	TransportActive  = "ACTIVE"
+	TransportPaused  = "PAUSED"
+	TransportUnknown = "UNKNOWN"
+)
+
+// Named sources, stable for dashboards and drift assertions.
+const (
+	TransportSourceEnvironment    = "environment"
+	TransportSourceFileKillSwitch = "file_kill_switch"
+	TransportSourceDurableControl = "durable_control"
+	TransportSourceSendWindow     = "send_window"
+)
+
+// TransportSourceState is one control's contribution to the resolved state.
+type TransportSourceState struct {
+	Source string `json:"source"`
+	State  string `json:"state"`
+	Reason string `json:"reason,omitempty"`
+}
+
+// TransportState is the single answer to "may a message leave right now?".
+type TransportState struct {
+	State    string                 `json:"state"`
+	Active   bool                   `json:"active"`
+	Sources  []TransportSourceState `json:"sources"`
+	Blockers []string               `json:"blockers,omitempty"`
+}
+
+// resolve applies "most restrictive wins": ACTIVE only when every source is
+// ACTIVE; any PAUSED makes it PAUSED; otherwise any UNKNOWN makes it UNKNOWN.
+func resolveTransportState(sources []TransportSourceState) TransportState {
+	out := TransportState{State: TransportActive, Sources: sources}
+	paused := false
+	unknown := false
+	for _, s := range sources {
+		switch s.State {
+		case TransportPaused:
+			paused = true
+		case TransportUnknown:
+			unknown = true
+		}
+		if s.State != TransportActive {
+			blocker := s.Source
+			if s.Reason != "" {
+				blocker = s.Source + ":" + s.Reason
+			}
+			out.Blockers = append(out.Blockers, blocker)
+		}
+	}
+	switch {
+	case paused:
+		out.State = TransportPaused
+	case unknown:
+		out.State = TransportUnknown
+	}
+	out.Active = out.State == TransportActive
+	sort.Strings(out.Blockers)
+	return out
+}
+
+// fileKillSwitchState distinguishes a confirmed absence from an unreadable
+// control. FileKillSwitchActive collapses both into "active" so transport stays
+// fail-closed; the projection must still say which one it saw.
+func fileKillSwitchState() TransportSourceState {
+	path := KillSwitchPath()
+	info, err := os.Stat(path)
+	switch {
+	case err == nil:
+		reason := "kill_switch_file_present"
+		if body, readErr := os.ReadFile(path); readErr == nil { //nolint:gosec // operator-owned control file
+			if first := strings.TrimSpace(strings.SplitN(string(body), "\n", 2)[0]); first != "" {
+				reason = "kill_switch_file:" + first
+			}
+		}
+		_ = info
+		return TransportSourceState{Source: TransportSourceFileKillSwitch, State: TransportPaused, Reason: reason}
+	case os.IsNotExist(err):
+		return TransportSourceState{Source: TransportSourceFileKillSwitch, State: TransportActive}
+	default:
+		return TransportSourceState{
+			Source: TransportSourceFileKillSwitch,
+			State:  TransportUnknown,
+			Reason: "kill_switch_unreadable",
+		}
+	}
+}
+
+// ConfigTransportSources are the controls resolvable without a datastore.
+func (c Config) ConfigTransportSources() []TransportSourceState {
+	env := TransportSourceState{Source: TransportSourceEnvironment, State: TransportActive}
+	if c.SendingPaused {
+		env.State = TransportPaused
+		env.Reason = "env_paused"
+	}
+	return []TransportSourceState{env, fileKillSwitchState()}
+}
+
+// TransportState resolves only the controls this config can see. Callers with a
+// governor must prefer Service.ResolveTransportState so the durable control row
+// and the business window participate.
+func (c Config) TransportState() TransportState {
+	return resolveTransportState(c.ConfigTransportSources())
+}
+
+// ResolveTransportState is the authoritative projection. Every reader — the
+// dispatch queue worker, the status endpoint, the Control Center — must use it
+// so no two of them can disagree about whether transport is live.
+func (s *service) ResolveTransportState(ctx context.Context, orgID *uuid.UUID) TransportState {
+	sources := s.cfg.ConfigTransportSources()
+	if s.governor == nil {
+		sources = append(sources, TransportSourceState{
+			Source: TransportSourceDurableControl,
+			State:  TransportUnknown,
+			Reason: "governor_unavailable",
+		})
+		return resolveTransportState(sources)
+	}
+	status, err := s.governor.Status(ctx, orgID)
+	if err != nil {
+		// An unreadable durable control is not an absent pause.
+		sources = append(sources,
+			TransportSourceState{
+				Source: TransportSourceDurableControl,
+				State:  TransportUnknown,
+				Reason: "durable_control_unreadable",
+			},
+			TransportSourceState{
+				Source: TransportSourceSendWindow,
+				State:  TransportUnknown,
+				Reason: "send_window_unresolved",
+			},
+		)
+		return resolveTransportState(sources)
+	}
+	durable := TransportSourceState{Source: TransportSourceDurableControl, State: TransportActive}
+	if status.Paused {
+		durable.State = TransportPaused
+		durable.Reason = status.PauseReason
+		if durable.Reason == "" {
+			durable.Reason = "paused"
+		}
+	}
+	window := TransportSourceState{Source: TransportSourceSendWindow, State: TransportActive}
+	if !status.InSendWindow {
+		window.State = TransportPaused
+		window.Reason = "outside_send_window"
+	}
+	return resolveTransportState(append(sources, durable, window))
+}

--- a/internal/app/confenge/transport_state_test.go
+++ b/internal/app/confenge/transport_state_test.go
@@ -1,0 +1,170 @@
+package confenge
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// The controls used to live in two projections that could disagree:
+// Config.SendingAllowed saw the env flag and the kill-switch file, the dispatch
+// governor saw the env flag, the durable control row and the business window.
+// These tests pin the one rule that now governs both.
+
+func withKillSwitch(t *testing.T, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "kill-switch")
+	if body != "" {
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write kill switch: %v", err)
+		}
+	}
+	t.Setenv(EnvKillSwitchPath, path)
+}
+
+func sourceState(state TransportState, name string) TransportSourceState {
+	for _, s := range state.Sources {
+		if s.Source == name {
+			return s
+		}
+	}
+	return TransportSourceState{Source: name, State: "MISSING"}
+}
+
+func TestAllSourcesActiveIsTheOnlyWayToBeActive(t *testing.T) {
+	withKillSwitch(t, "")
+	got := resolveTransportState([]TransportSourceState{
+		{Source: TransportSourceEnvironment, State: TransportActive},
+		{Source: TransportSourceFileKillSwitch, State: TransportActive},
+		{Source: TransportSourceDurableControl, State: TransportActive},
+		{Source: TransportSourceSendWindow, State: TransportActive},
+	})
+	if got.State != TransportActive || !got.Active {
+		t.Fatalf("expected ACTIVE, got %+v", got)
+	}
+	if len(got.Blockers) != 0 {
+		t.Fatalf("expected no blockers, got %v", got.Blockers)
+	}
+}
+
+func TestAnyPausedSourceMakesTheWholeStatePaused(t *testing.T) {
+	for _, name := range []string{
+		TransportSourceEnvironment,
+		TransportSourceFileKillSwitch,
+		TransportSourceDurableControl,
+		TransportSourceSendWindow,
+	} {
+		sources := []TransportSourceState{
+			{Source: TransportSourceEnvironment, State: TransportActive},
+			{Source: TransportSourceFileKillSwitch, State: TransportActive},
+			{Source: TransportSourceDurableControl, State: TransportActive},
+			{Source: TransportSourceSendWindow, State: TransportActive},
+		}
+		for i := range sources {
+			if sources[i].Source == name {
+				sources[i].State = TransportPaused
+				sources[i].Reason = "test"
+			}
+		}
+		got := resolveTransportState(sources)
+		if got.State != TransportPaused || got.Active {
+			t.Fatalf("%s paused but resolved %+v", name, got)
+		}
+		if len(got.Blockers) != 1 || got.Blockers[0] != name+":test" {
+			t.Fatalf("%s: expected a named blocker, got %v", name, got.Blockers)
+		}
+	}
+}
+
+func TestUnknownSourceIsNeverActive(t *testing.T) {
+	got := resolveTransportState([]TransportSourceState{
+		{Source: TransportSourceEnvironment, State: TransportActive},
+		{Source: TransportSourceDurableControl, State: TransportUnknown, Reason: "durable_control_unreadable"},
+	})
+	if got.State != TransportUnknown || got.Active {
+		t.Fatalf("UNKNOWN must not be ACTIVE, got %+v", got)
+	}
+}
+
+func TestPausedOutranksUnknown(t *testing.T) {
+	got := resolveTransportState([]TransportSourceState{
+		{Source: TransportSourceEnvironment, State: TransportPaused, Reason: "env_paused"},
+		{Source: TransportSourceDurableControl, State: TransportUnknown},
+	})
+	if got.State != TransportPaused {
+		t.Fatalf("expected PAUSED to win, got %+v", got)
+	}
+}
+
+// The live drift that motivated this: the kill-switch file said "paused" while
+// CONFENGE_SENDING_PAUSED was false, and the status endpoint reported the env
+// flag alone.
+func TestFileKillSwitchOverridesAPermissiveEnvironment(t *testing.T) {
+	withKillSwitch(t, "paused\nreason=deploy_preflight\n")
+	cfg := Config{SendingPaused: false}
+	got := cfg.TransportState()
+	if got.Active || got.State != TransportPaused {
+		t.Fatalf("file kill switch must pause transport, got %+v", got)
+	}
+	if src := sourceState(got, TransportSourceFileKillSwitch); src.Reason != "kill_switch_file:paused" {
+		t.Fatalf("the reason must name the file's own words, got %q", src.Reason)
+	}
+	if cfg.SendingAllowed() {
+		t.Fatal("SendingAllowed and TransportState must agree")
+	}
+}
+
+func TestAbsentKillSwitchWithPermissiveEnvironmentIsActive(t *testing.T) {
+	withKillSwitch(t, "")
+	cfg := Config{SendingPaused: false}
+	got := cfg.TransportState()
+	if !got.Active {
+		t.Fatalf("expected ACTIVE, got %+v", got)
+	}
+	if got.Active != cfg.SendingAllowed() {
+		t.Fatal("SendingAllowed and TransportState must agree")
+	}
+}
+
+func TestEnvironmentPauseIsReportedWithItsReason(t *testing.T) {
+	withKillSwitch(t, "")
+	got := Config{SendingPaused: true}.TransportState()
+	if got.Active {
+		t.Fatalf("expected paused, got %+v", got)
+	}
+	if src := sourceState(got, TransportSourceEnvironment); src.Reason != "env_paused" {
+		t.Fatalf("expected env_paused, got %q", src.Reason)
+	}
+}
+
+func TestUnreadableKillSwitchIsUnknownNotPermissive(t *testing.T) {
+	dir := t.TempDir()
+	// A path whose parent is a regular file makes Stat fail with something
+	// other than NotExist, which must never read as "no kill switch".
+	blocker := filepath.Join(dir, "not-a-dir")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	t.Setenv(EnvKillSwitchPath, filepath.Join(blocker, "kill-switch"))
+	got := Config{SendingPaused: false}.TransportState()
+	if got.Active {
+		t.Fatalf("an unreadable control must never be ACTIVE, got %+v", got)
+	}
+	if src := sourceState(got, TransportSourceFileKillSwitch); src.State != TransportUnknown {
+		t.Fatalf("expected UNKNOWN, got %+v", src)
+	}
+	if FileKillSwitchActive() != true {
+		t.Fatal("the legacy fail-closed helper must still refuse transport")
+	}
+}
+
+func TestConfigOnlyResolutionNeverClaimsToKnowTheDurableControl(t *testing.T) {
+	withKillSwitch(t, "")
+	got := Config{}.TransportState()
+	for _, s := range got.Sources {
+		if s.Source == TransportSourceDurableControl || s.Source == TransportSourceSendWindow {
+			t.Fatalf("config-only resolution must not invent %s", s.Source)
+		}
+	}
+}

--- a/internal/infrastructure/db/migrations/000135_confenge_dispatch_attempted_state.down.sql
+++ b/internal/infrastructure/db/migrations/000135_confenge_dispatch_attempted_state.down.sql
@@ -1,0 +1,15 @@
+DROP INDEX IF EXISTS confenge_dispatch_queue_attempted_idx;
+
+-- Collapsing 'attempted' back into 'sent' re-asserts an acceptance nobody
+-- observed. The rollback keeps the distinction visible by folding it into
+-- 'failed', which is the honest reading of "handed over, never confirmed".
+UPDATE confenge_dispatch_queue
+SET status = 'failed', last_error = COALESCE(NULLIF(last_error, ''), 'attempted_acceptance_unknown')
+WHERE status = 'attempted';
+
+ALTER TABLE confenge_dispatch_queue
+    DROP CONSTRAINT IF EXISTS confenge_dispatch_queue_status_check;
+
+ALTER TABLE confenge_dispatch_queue
+    ADD CONSTRAINT confenge_dispatch_queue_status_check
+    CHECK (status IN ('queued', 'reserved', 'sent', 'cancelled', 'failed'));

--- a/internal/infrastructure/db/migrations/000135_confenge_dispatch_attempted_state.up.sql
+++ b/internal/infrastructure/db/migrations/000135_confenge_dispatch_attempted_state.up.sql
@@ -1,0 +1,43 @@
+-- The dispatch queue had no state between "queued" and "sent", so the worker
+-- marked a row 'sent' the moment it handed the message to the transport. The
+-- code comment said as much ("QueueSent means handed to the configured
+-- transport"), but the stored value asserted something stronger than anything
+-- the system had observed.
+--
+-- Production showed the gap plainly: confenge_dispatch_queue held six rows in
+-- 'sent' while confenge_dispatch_sends -- the provider-fact table -- was empty
+-- and no touchpoint had ever reached SENT. Nothing corroborated the claim.
+--
+-- 'attempted' is the honest terminal state for a hand-off. A row is promoted to
+-- 'sent' only when a provider fact exists. Acceptance that was never observed
+-- stays UNKNOWN instead of being asserted.
+
+ALTER TABLE confenge_dispatch_queue
+    DROP CONSTRAINT IF EXISTS confenge_dispatch_queue_status_check;
+
+ALTER TABLE confenge_dispatch_queue
+    ADD CONSTRAINT confenge_dispatch_queue_status_check
+    CHECK (status IN ('queued', 'reserved', 'attempted', 'sent', 'cancelled', 'failed'));
+
+-- Reconcile the history that exists rather than fabricate one. A row keeps
+-- 'sent' only where a provider fact corroborates it; everything else is demoted
+-- to the state it actually reached. This never invents a send and never deletes
+-- one.
+UPDATE confenge_dispatch_queue q
+SET status = 'attempted'
+WHERE q.status = 'sent'
+  AND NOT EXISTS (
+      SELECT 1 FROM confenge_dispatch_sends s
+      WHERE s.draft_id IS NOT DISTINCT FROM q.draft_id
+        AND s.organization_id = q.organization_id
+  )
+  AND NOT EXISTS (
+      SELECT 1 FROM outreach_touchpoints tp
+      WHERE tp.draft_id IS NOT DISTINCT FROM q.draft_id
+        AND tp.organization_id = q.organization_id
+        AND tp.state = 'SENT'
+  );
+
+CREATE INDEX IF NOT EXISTS confenge_dispatch_queue_attempted_idx
+    ON confenge_dispatch_queue (organization_id, updated_at)
+    WHERE status = 'attempted';


### PR DESCRIPTION
## 1. Duas projeções discordantes sobre "pode enviar agora?"

Os controles estavam repartidos entre duas projeções que podiam discordar:

| controle | `Config.SendingAllowed` | `governor.Status` | dispatcher |
| --- | :-: | :-: | :-: |
| env `CONFENGE_SENDING_PAUSED` | ✓ | ✓ | ✓ |
| arquivo de kill switch | ✓ | — | ✓ |
| linha durável `confenge_dispatch_control` | — | ✓ | ✓ |
| janela comercial | — | ✓ | ✓ |

`GET /confenge/status` lia só a primeira coluna. Estado real em produção no momento do diagnóstico:

```
/data/confenge-ops/kill-switch   → paused, reason=deploy_preflight
confenge_dispatch_control.paused → t, scale_pre_go_release_91e37d8b
CONFENGE_SENDING_PAUSED          → false
```

Duas fontes diziam PAUSED e o endpoint reportava a terceira.

`ResolveTransportState` é a resposta única: a fonte mais restritiva vence, `PAUSED` supera `UNKNOWN`, e uma fonte ilegível (`stat` falhando por algo que não é ENOENT) nunca lê como permissiva. Dispatcher e endpoint consomem a mesma função.

## 2. Contrato de capacidade sem teste de deriva

`min_wait_time` da mailbox = 600s, `CONFENGE_MIN_SEND_GAP_SECONDS` = 600, `3600/CONFENGE_GLOBAL_SENDS_PER_HOUR` = 600. Coincidem hoje — uma regressão seria invisível até divergirem. **Nenhum número foi reduzido.** Os testes fixam a regra nas duas direções e que o cap diário da mailbox não é alargado pela taxa horária global.

## 3. A fila afirmava envio que ninguém observou

O worker marcava `sent` no hand-off. `dispatchEmailTouch` matricula o draft e deixa SENT explicitamente para o consumer que vê o resultado do provedor — o comentário no código já dizia "handed to the configured transport". Estado real:

```
confenge_dispatch_queue     6 linhas status='sent'
confenge_dispatch_sends     0 linhas          ← tabela de fato do provedor
outreach_touchpoints        nenhum SENT
```

Nada corroborava as seis. `attempted` é o estado terminal honesto do hand-off; a promoção a `sent` exige fato do provedor, e `ReconcileAttemptedDispatches` roda a cada tick antes de qualquer claim nova. Aceitação não observada permanece UNKNOWN em vez de ser afirmada.

`attempted` é **terminal para enqueue** — sem isso a mesma mensagem já entregue ao transporte voltaria a `queued` e seria despachada de novo.

A migração reconcilia o histórico sem inventar nem apagar envio: mantém `sent` apenas onde existe fato que o sustente. O rollback dobra `attempted` em `failed`, não em `sent`, porque re-afirmar aceitação seria mentir.

## Testes

```
internal/app/confenge/transport_state_test.go        (8 casos de deriva)
internal/app/confenge/dispatch/capacity_contract_test.go (3 casos)
internal/app/confenge/dispatch/ledger_state_test.go      (3 casos)
go vet ./internal/...                                    limpo
go test ./internal/...                                   1 falha ambiental
```

A única falha é `TestProductAcceptanceMultichannelSum`, que exige Mailpit local — pré-existente e sem relação.

Refs #43 #47 #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)