### PR TITLE
fix(confenge): aposentar explicitamente as linhas superadas por um import mais novo

### DIFF
--- a/internal/app/confenge/reconciliation.go
+++ b/internal/app/confenge/reconciliation.go
@@ -2,6 +2,7 @@ package confenge
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -22,6 +23,47 @@ type TargetFitReconciliationReport struct {
 	BlockedDrafts        int            `json:"blocked_drafts"`
 	DetachedEnrollments  int            `json:"detached_enrollments"`
 	CancelledDispatch    int            `json:"cancelled_dispatch_items"`
+	CurrentSourceRunID   string         `json:"current_source_run_id,omitempty"`
+	SupersededRetired    int            `json:"superseded_rows_retired"`
+	SupersededRoots      int            `json:"superseded_roots"`
+}
+
+// SupersededByCurrentRunReason is recorded on rows retired because a newer
+// import already published a canonical member for the same company root.
+const SupersededByCurrentRunReason = "superseded_by_current_source_run"
+
+// supersededByCurrentRun returns the accounts that a newer import has replaced.
+//
+// Membership is one canonical member per cnpj_root8. Older imports leave their
+// rows behind, and while the transport gate already refuses them with
+// account_source_run_drift, they stay live and can still be counted by any
+// projection that does not repeat that check. Retirement here is evidence, not
+// heuristic: a row is superseded only when the current run publishes a row for
+// the very same root. A root the current run never mentions is left alone —
+// absence of evidence is not evidence of supersession — and nothing is deleted.
+func supersededByCurrentRun(accounts []models.OutreachAccount, currentRunID string) map[uuid.UUID]bool {
+	out := map[uuid.UUID]bool{}
+	if strings.TrimSpace(currentRunID) == "" {
+		return out
+	}
+	currentRoots := map[string]bool{}
+	for i := range accounts {
+		root := strings.TrimSpace(accounts[i].CNPJRoot)
+		if root != "" && accounts[i].SourceRunID == currentRunID {
+			currentRoots[root] = true
+		}
+	}
+	for i := range accounts {
+		acc := &accounts[i]
+		root := strings.TrimSpace(acc.CNPJRoot)
+		if root == "" || acc.SourceRunID == currentRunID || acc.SourceRunID == "" {
+			continue
+		}
+		if currentRoots[root] {
+			out[acc.ID] = true
+		}
+	}
+	return out
 }
 
 func (s *service) ReconcileTargetFit(ctx context.Context, orgID uuid.UUID, dryRun bool) (*TargetFitReconciliationReport, *errx.Error) {
@@ -40,6 +82,14 @@ func (s *service) ReconcileTargetFit(ctx context.Context, orgID uuid.UUID, dryRu
 			break
 		}
 	}
+	// The current feed run is the supersession evidence. Without it, no row is
+	// retired: an unreadable feed state must never look like "everything is old".
+	if feedState, feedErr := s.repo.GetFeedSyncState(ctx, orgID); feedErr == nil && feedState != nil {
+		report.CurrentSourceRunID = feedState.LastRunID
+	}
+	superseded := supersededByCurrentRun(accounts, report.CurrentSourceRunID)
+	supersededRoots := map[string]bool{}
+
 	for i := range accounts {
 		acc := &accounts[i]
 		report.AccountsScanned++
@@ -52,6 +102,13 @@ func (s *service) ReconcileTargetFit(ctx context.Context, orgID uuid.UUID, dryRu
 			report.BeforeOperational++
 		}
 		decision := EvaluateTargetFit(acc)
+		if superseded[acc.ID] {
+			decision = TargetFitAuthorization{Eligible: false, Reason: SupersededByCurrentRunReason}
+			report.SupersededRetired++
+			if root := strings.TrimSpace(acc.CNPJRoot); root != "" {
+				supersededRoots[root] = true
+			}
+		}
 		if decision.Eligible {
 			if contactReady {
 				report.AfterOperational++
@@ -101,5 +158,6 @@ func (s *service) ReconcileTargetFit(ctx context.Context, orgID uuid.UUID, dryRu
 			report.CancelledDispatch += counts.DispatchItems
 		}
 	}
+	report.SupersededRoots = len(supersededRoots)
 	return report, nil
 }

--- a/internal/app/confenge/reconciliation_supersession_test.go
+++ b/internal/app/confenge/reconciliation_supersession_test.go
@@ -1,0 +1,97 @@
+package confenge
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Membership is one canonical member per cnpj_root8. Older imports leave rows
+// behind: production carried 97 TARGET_CONFIRMED rows from superseded runs
+// across 89 roots, every one of them also published by the current run. The
+// transport gate already refused them with account_source_run_drift, but they
+// stayed live and countable.
+
+const currentRun = "run-333a9ea5d4912fe5"
+
+func account(root, runID string) models.OutreachAccount {
+	return models.OutreachAccount{ID: uuid.New(), CNPJRoot: root, SourceRunID: runID}
+}
+
+func TestOlderRowIsRetiredOnlyWhenTheCurrentRunPublishesTheSameRoot(t *testing.T) {
+	current := account("12345678", currentRun)
+	legacy := account("12345678", "run-c48007591e089881")
+	out := supersededByCurrentRun([]models.OutreachAccount{current, legacy}, currentRun)
+
+	if !out[legacy.ID] {
+		t.Fatal("a legacy row whose root the current run republished must be retired")
+	}
+	if out[current.ID] {
+		t.Fatal("the current canonical member must never be retired")
+	}
+}
+
+func TestARootTheCurrentRunNeverMentionsIsLeftAlone(t *testing.T) {
+	// Absence of evidence is not evidence of supersession.
+	elsewhere := account("99999999", currentRun)
+	orphan := account("12345678", "run-c48007591e089881")
+	out := supersededByCurrentRun([]models.OutreachAccount{elsewhere, orphan}, currentRun)
+
+	if out[orphan.ID] {
+		t.Fatal("a root the current run never published must not be retired")
+	}
+}
+
+func TestNoCurrentRunRetiresNothing(t *testing.T) {
+	// An unreadable feed state must never read as "everything is old".
+	rows := []models.OutreachAccount{account("12345678", "run-old"), account("12345678", "run-older")}
+	if len(supersededByCurrentRun(rows, "")) != 0 {
+		t.Fatal("without supersession evidence nothing may be retired")
+	}
+}
+
+func TestRowsWithoutARunAreNotRetired(t *testing.T) {
+	current := account("12345678", currentRun)
+	unattributed := account("12345678", "")
+	out := supersededByCurrentRun([]models.OutreachAccount{current, unattributed}, currentRun)
+	if out[unattributed.ID] {
+		t.Fatal("a row with no run attribution carries no supersession evidence")
+	}
+}
+
+func TestRowsWithoutARootAreNotRetired(t *testing.T) {
+	current := account("12345678", currentRun)
+	rootless := account("", "run-old")
+	out := supersededByCurrentRun([]models.OutreachAccount{current, rootless}, currentRun)
+	if out[rootless.ID] {
+		t.Fatal("supersession is per root; a rootless row cannot be matched")
+	}
+}
+
+func TestEveryLegacyRowOfARepublishedRootIsRetired(t *testing.T) {
+	current := account("12345678", currentRun)
+	rows := []models.OutreachAccount{current}
+	var legacyIDs []uuid.UUID
+	for _, run := range []string{"run-a", "run-b", "run-c"} {
+		row := account("12345678", run)
+		legacyIDs = append(legacyIDs, row.ID)
+		rows = append(rows, row)
+	}
+	out := supersededByCurrentRun(rows, currentRun)
+	for _, id := range legacyIDs {
+		if !out[id] {
+			t.Fatalf("legacy row %s was left live", id)
+		}
+	}
+	if len(out) != len(legacyIDs) {
+		t.Fatalf("retired %d rows, expected exactly %d", len(out), len(legacyIDs))
+	}
+}
+
+func TestRetirementReasonIsNamedNotGeneric(t *testing.T) {
+	if SupersededByCurrentRunReason != "superseded_by_current_source_run" {
+		t.Fatalf("reason=%q", SupersededByCurrentRunReason)
+	}
+}


### PR DESCRIPTION
Membership é **um membro canônico por `cnpj_root8`**. Medido em produção:

```
roots com >1 TARGET_CONFIRMED no run corrente ......... 0     ✓
roots com TARGET_CONFIRMED corrente E de run legado ... 89
linhas TARGET_CONFIRMED de runs superados ............. 97
roots legados que o run corrente nunca publicou ....... 0
```

O run corrente (`run-333a9ea5d4912fe5`) publica 8.653 TARGET_CONFIRMED — exatamente o `membership_count` da projeção de contatos, com `duplicate_member_count: 0`. As 97 linhas legadas são resíduo puro: cada uma tem um substituto corrente para o mesmo root.

O gate de transporte já as recusava (`account_source_run_drift`), mas elas seguiam **vivas e contáveis** por qualquer projeção que não repetisse aquela verificação.

## A aposentadoria é evidência, não heurística

- Uma linha só é superada quando o run corrente publica uma linha **para o mesmo root**.
- Um root que o run corrente nunca mencionou fica intocado — ausência de evidência não é evidência de supersessão.
- Sem run corrente conhecido, **nada** é aposentado: um feed state ilegível jamais pode parecer "tudo é velho".
- Linhas sem root ou sem atribuição de run não carregam evidência e ficam de fora.
- **Nada é apagado.** A linha entra no caminho de supressão que já existe, com razão nomeada `superseded_by_current_source_run`.

7 testes cobrem cada uma dessas fronteiras. `go test ./internal/...` verde exceto `TestProductAcceptanceMultichannelSum`, que exige Mailpit local (ambiental, pré-existente).

Refs #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)