### PR TITLE
fix(confenge): wire Postgres cohort store on first-touch CLI

### DIFF
--- a/cmd/confenge/first_touch.go
+++ b/cmd/confenge/first_touch.go
@@ -130,6 +130,7 @@ func openFirstTouchService(ctx context.Context) (*pgxpool.Pool, confenge.Service
 	svc := confenge.NewService(cfg, repo, nil)
 	svc.WireDispatch(pool)
 	svc.WirePolicyAuth(repository.NewConfengePolicyRepository(pool))
+	svc.WireCohortAuth(confenge.NewPostgresCohortStore(pool))
 	svc.WireDelegatedFirstTouch(pool)
 	svc.WireOrgRisk(orgrisk.NewService(repository.NewOrgRiskRepository(pool), nil))
 	return pool, svc, cfg, nil

--- a/cmd/confenge/first_touch_wire_test.go
+++ b/cmd/confenge/first_touch_wire_test.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestCLIWiresCohortStoreForReplyIngest(t *testing.T) {
+	b, err := os.ReadFile("first_touch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "WireCohortAuth") {
+		t.Fatal("first-touch CLI must WireCohortAuth so IMAP reply ingest can be proven")
+	}
+	if !strings.Contains(s, "NewPostgresCohortStore") {
+		t.Fatal("first-touch CLI must construct NewPostgresCohortStore")
+	}
+	if strings.Contains(s, "NewMemoryCohortStore") {
+		t.Fatal("first-touch CLI must not use NewMemoryCohortStore as cohort authority")
+	}
+	policy := strings.Index(s, "WirePolicyAuth")
+	cohort := strings.Index(s, "WireCohortAuth")
+	if policy < 0 || cohort < policy {
+		t.Fatal("WireCohortAuth must sit with the rest of first-touch boot wiring")
+	}
+}


### PR DESCRIPTION
## Summary

`first-window-readiness` was reporting `imap_reply_ingest_ready=UNKNOWN` / `BLOCKED:imap_reply_ingest_not_ready` while `status.sh` Hostinger IMAP was PASS and the mailbox envelope already showed `provider=smtp_imap`, `credentials_ready=true`.

Cause: `openFirstTouchService` never called `WireCohortAuth(NewPostgresCohortStore(pool))`. `ProbeReplyIngestReadiness` then hit `probeIMAPMailboxAuth` with a nil store and returned `reply_ingest_not_proven`. Backend boot already wires this (guarded by `cmd/backend/confenge_wire_test.go`).

## Test plan

- [x] `go test ./cmd/confenge/`
- [ ] required CI green
- [ ] after deploy: `confenge first-touch first-window-readiness --org-id …` no longer UNKNOWN for IMAP when smtp_imap rows exist