### PR TITLE
fix(confenge): treat observed company-registry recipients as delegated-eligible

### DIFF
--- a/internal/repository/pg_outreach_backlog.go
+++ b/internal/repository/pg_outreach_backlog.go
@@ -103,7 +103,13 @@ func (r *outreachRepository) materializeCurrentInitialBacklog(ctx context.Contex
 					AND upper(c.route_suppression) IN ('','NONE')
 					AND upper(c.email_derivation)<>'INFERRED'
 					AND c.email LIKE '%@%' AND c.email !~ '[[:space:]]'
-					AND c.source_url ~* '^https?://'
+					AND (
+						c.source_url ~* '^https?://'
+						OR (
+							lower(COALESCE(c.source, '')) IN ('company_registry', 'official_registry')
+							AND lower(COALESCE(c.source_type, 'company_registry')) IN ('company_registry', 'real_registry', 'official_registry')
+						)
+					)
 					AND c.source_date BETWEEN CURRENT_DATE - 29 AND CURRENT_DATE
 				) FILTER (WHERE c.discovery_json->>'preferred_initial'='true') AS preferred_delegated_eligible
 			FROM outreach_accounts a

--- a/internal/repository/pg_outreach_backlog_test.go
+++ b/internal/repository/pg_outreach_backlog_test.go
@@ -1,0 +1,24 @@
+package repository
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestDelegatedEligibilityKeepsHTTPGateAndAllowsObservedRegistry(t *testing.T) {
+	b, err := os.ReadFile("pg_outreach_backlog.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "c.source_url ~* '^https?://'") {
+		t.Fatal("http(s) source_url remains required for web-attributed recipients")
+	}
+	if !strings.Contains(s, "company_registry") {
+		t.Fatal("company_registry OBSERVED contacts must be delegated-eligible without inventing a URL")
+	}
+	if !strings.Contains(s, "CURRENT_DATE - 29") {
+		t.Fatal("recipient freshness window must stay 29 days")
+	}
+}


### PR DESCRIPTION
## Summary

Live first-touch autorun had **prepared=6501** and **queued=0**. Every DUE INITIAL account was classified `preferred_current_recipient_not_delegated` because `preferred_delegated_eligible` required `source_url ~ '^https?://'`.

Published extra-cli contacts for those leads are `source=company_registry`, OBSERVED, FRESH, COMPANY_OWNED, `email_derivation` not INFERRED, `source_url=""`. That is extra-cli EMAIL_ROUTE_READY / GENERIC_COMPANY or ROLE. Inventing a URL would be dishonest; dropping the HTTP gate for web routes would be a relaxation.

This keeps the HTTPS gate and 29-day window, and allows observed company-registry provenance without a URL.

## Test plan

- [x] `go test ./internal/repository/`
- [ ] required CI green
- [ ] after deploy: rematerialize current-run backlog, then autorun should fill QUEUED with kill switch still paused