### PR TITLE
fix(confenge): persist registry source_type and rematerialize without c.source

### DIFF
--- a/internal/app/confenge/controlled_route.go
+++ b/internal/app/confenge/controlled_route.go
@@ -35,6 +35,8 @@ type controlledDiscovery struct {
 	PersonUnknown             *bool  `json:"person_unknown,omitempty"`
 	EmailValidated            *bool  `json:"email_validated,omitempty"`
 	RiskClass                 string `json:"risk_class,omitempty"`
+	Source                    string `json:"source,omitempty"`
+	SourceType                string `json:"source_type,omitempty"`
 	PolicyVersion             string `json:"policy_version,omitempty"`
 	SchemaVersion             string `json:"schema_version,omitempty"`
 }
@@ -275,6 +277,18 @@ func mergeControlledDiscovery(existing []byte, fc FeedContact) []byte {
 	}
 	if fc.RiskClass != "" {
 		d.RiskClass = fc.RiskClass
+	}
+	if src := strings.TrimSpace(fc.Source); src != "" {
+		d.Source = src
+	}
+	if st := strings.TrimSpace(fc.SourceType); st != "" {
+		d.SourceType = st
+	}
+	if d.Source == "" && d.SourceType != "" {
+		d.Source = d.SourceType
+	}
+	if d.SourceType == "" && d.Source != "" {
+		d.SourceType = d.Source
 	}
 	if d.RouteClass == "" && d.ControlledEmailEligible == nil {
 		return existing

--- a/internal/app/confenge/controlled_route.go
+++ b/internal/app/confenge/controlled_route.go
@@ -87,6 +87,33 @@ func parseControlledDiscovery(c *models.OutreachContactCandidate) controlledDisc
 	return d
 }
 
+func candidateRegistrySource(c *models.OutreachContactCandidate) string {
+	d := parseControlledDiscovery(c)
+	src := strings.ToLower(strings.TrimSpace(d.Source))
+	if src == "" {
+		src = strings.ToLower(strings.TrimSpace(d.SourceType))
+	}
+	return src
+}
+
+func candidateIsObservedRegistry(c *models.OutreachContactCandidate) bool {
+	if c == nil {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(c.VerificationStatus), models.OutreachVerifyOfficialSource) {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(c.ChannelEpistemic), "OBSERVED") {
+		return false
+	}
+	switch candidateRegistrySource(c) {
+	case "company_registry", "official_registry", "real_registry":
+		return true
+	}
+	// extra-cli READY company_registry ammo imported before source_type was persisted.
+	return strings.TrimSpace(c.SourceURL) == ""
+}
+
 func CandidateRouteClass(c *models.OutreachContactCandidate) string {
 	d := parseControlledDiscovery(c)
 	if class := strings.ToUpper(strings.TrimSpace(d.RouteClass)); class != "" {

--- a/internal/app/confenge/controlled_route_test.go
+++ b/internal/app/confenge/controlled_route_test.go
@@ -75,4 +75,23 @@ func TestLeadToCandidatePersistsRegistrySourceInDiscoveryJSON(t *testing.T) {
 	if d.Source != "company_registry" || d.SourceType != "company_registry" {
 		t.Fatalf("import dropped extra-cli registry source: %+v json=%s", d, cand.DiscoveryJSON)
 	}
+	if !candidateIsObservedRegistry(cand) {
+		t.Fatal("imported company_registry contact must be observed-registry")
+	}
+}
+
+func TestCandidateIsObservedRegistryAcceptsImportedOfficialSourceWithoutURL(t *testing.T) {
+	cand := &models.OutreachContactCandidate{
+		VerificationStatus: models.OutreachVerifyOfficialSource,
+		ChannelEpistemic:   "OBSERVED",
+		SourceURL:          "",
+		DiscoveryJSON:      []byte(`{"route_class":"GENERIC_COMPANY","controlled_email_eligible":true}`),
+	}
+	if !candidateIsObservedRegistry(cand) {
+		t.Fatal("already-imported OFFICIAL_SOURCE with empty URL must be observed-registry")
+	}
+	cand.SourceURL = "https://empresa.example/contato"
+	if candidateIsObservedRegistry(cand) {
+		t.Fatal("web-attributed official source must stay on the HTTP gate")
+	}
 }

--- a/internal/app/confenge/controlled_route_test.go
+++ b/internal/app/confenge/controlled_route_test.go
@@ -1,0 +1,78 @@
+package confenge
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func TestMergeControlledDiscoveryPersistsRegistrySource(t *testing.T) {
+	eligible := true
+	preferred := true
+	unknown := true
+	raw := mergeControlledDiscovery(nil, FeedContact{
+		RouteClass:              RouteClassGenericCompany,
+		ControlledEmailEligible: &eligible,
+		PreferredInitial:        &preferred,
+		MailboxCompanyEvidence:  "OBSERVED",
+		PersonUnknown:           &unknown,
+		RiskClass:               "ALLOWED",
+		Source:                  "company_registry",
+		SourceType:              "company_registry",
+	})
+	var d controlledDiscovery
+	if err := json.Unmarshal(raw, &d); err != nil {
+		t.Fatal(err)
+	}
+	if d.Source != "company_registry" || d.SourceType != "company_registry" {
+		t.Fatalf("registry source dropped on import: %+v json=%s", d, raw)
+	}
+}
+
+func TestMergeControlledDiscoveryCopiesSourceTypeWhenSourceBlank(t *testing.T) {
+	eligible := true
+	raw := mergeControlledDiscovery(nil, FeedContact{
+		RouteClass:              RouteClassPublicCompanyFreemail,
+		ControlledEmailEligible: &eligible,
+		SourceType:              "official_registry",
+	})
+	var d controlledDiscovery
+	if err := json.Unmarshal(raw, &d); err != nil {
+		t.Fatal(err)
+	}
+	if d.Source != "official_registry" || d.SourceType != "official_registry" {
+		t.Fatalf("source_type was not copied onto source: %+v json=%s", d, raw)
+	}
+}
+
+func TestLeadToCandidatePersistsRegistrySourceInDiscoveryJSON(t *testing.T) {
+	eligible, preferred, unknown, notFixture, ready := true, true, true, false, true
+	cand := leadToCandidate(uuid.Nil, uuid.Nil, uuid.Nil, FeedContact{
+		Email:                   "contato@empresa.example",
+		Source:                  "company_registry",
+		SourceType:              "company_registry",
+		VerificationStatus:      models.OutreachVerifyOfficialSource,
+		OwnershipStatus:         "COMPANY_OWNED",
+		ChannelEpistemic:        "OBSERVED",
+		RouteFreshness:          "FRESH",
+		RouteSuppression:        "NONE",
+		RouteClass:              RouteClassGenericCompany,
+		ControlledEmailEligible: &eligible,
+		PreferredInitial:        &preferred,
+		PersonUnknown:           &unknown,
+		DerivedFromFixture:      &notFixture,
+		ProvenanceChainValid:    &ready,
+		MailboxCompanyEvidence:  "OBSERVED",
+		RiskClass:               "ALLOWED",
+	})
+	var d controlledDiscovery
+	if err := json.Unmarshal(cand.DiscoveryJSON, &d); err != nil {
+		t.Fatal(err)
+	}
+	if d.Source != "company_registry" || d.SourceType != "company_registry" {
+		t.Fatalf("import dropped extra-cli registry source: %+v json=%s", d, cand.DiscoveryJSON)
+	}
+}

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -24,21 +24,22 @@ import (
 )
 
 const (
-	DelegatedFirstTouchManifestV1       = "confenge.delegated-first-touch.manifest.v1"
-	DelegatedFirstTouchPolicyV1         = "CFG-FIRST-TOUCH-ROUTING-v1"
-	DelegatedFirstTouchPolicyHashV1     = "3ea77bb047d9db19c061d96c62ae302768f25dbd075db7cccac5fe56d3fe3b99"
-	DelegatedFirstTouchValidatorV1      = "confenge.first-touch.adversarial-qa.v1"
-	DelegatedFirstTouchContactPolicyV1  = "confenge.first-touch-routing.v1"
-	DelegatedFirstTouchEvidenceV1       = "contract-party-role.v1"
-	DelegatedFirstTouchTemplateV1       = "confenge.first-touch-routing.template.v1"
-	DelegatedFirstTouchAuthority        = "founder-approved-first-touch-policy"
-	DelegatedFirstTouchAuthorityRef     = "tjsasakifln/Governance#129"
-	DelegatedFirstTouchApprovalDecision = "DELEGATED_POLICY_APPROVE"
-	ContractorRoleConfirmed             = "CONTRACTOR_ROLE_CONFIRMED"
-	ContractorRoleConflict              = "PARTY_ROLE_CONFLICT"
-	ContractorRoleUnknown               = "UNKNOWN"
-	ReconciliationCorroborated          = "DATALAKE+WEB_CORROBORATED"
-	ReconciliationWebContact            = "DATALAKE_IDENTITY + WEB_CONTACT"
+	DelegatedFirstTouchManifestV1          = "confenge.delegated-first-touch.manifest.v1"
+	DelegatedFirstTouchPolicyV1            = "CFG-FIRST-TOUCH-ROUTING-v1"
+	DelegatedFirstTouchPolicyHashV1        = "3ea77bb047d9db19c061d96c62ae302768f25dbd075db7cccac5fe56d3fe3b99"
+	DelegatedFirstTouchValidatorV1         = "confenge.first-touch.adversarial-qa.v1"
+	DelegatedFirstTouchContactPolicyV1     = "confenge.first-touch-routing.v1"
+	DelegatedFirstTouchEvidenceV1          = "contract-party-role.v1"
+	DelegatedFirstTouchTemplateV1          = "confenge.first-touch-routing.template.v1"
+	DelegatedFirstTouchAuthority           = "founder-approved-first-touch-policy"
+	DelegatedFirstTouchAuthorityRef        = "tjsasakifln/Governance#129"
+	DelegatedFirstTouchApprovalDecision    = "DELEGATED_POLICY_APPROVE"
+	ContractorRoleConfirmed                = "CONTRACTOR_ROLE_CONFIRMED"
+	ContractorRoleConflict                 = "PARTY_ROLE_CONFLICT"
+	ContractorRoleUnknown                  = "UNKNOWN"
+	ReconciliationCorroborated             = "DATALAKE+WEB_CORROBORATED"
+	ReconciliationWebContact               = "DATALAKE_IDENTITY + WEB_CONTACT"
+	DelegatedWebSourceKindOfficialRegistry = "OFFICIAL_COMPANY_REGISTRY"
 )
 
 var delegatedSHA256Pattern = regexp.MustCompile(`^[0-9a-f]{64}$`)
@@ -1383,7 +1384,35 @@ func canonicalStringSet(values []string) string {
 	return strings.Join(out, "\x00")
 }
 
+func delegatedWebSourceObservedFresh(source DelegatedWebSource, now time.Time) bool {
+	return !source.ObservedAt.IsZero() && !source.ObservedAt.After(now.Add(5*time.Minute)) && now.Sub(source.ObservedAt) <= 30*24*time.Hour
+}
+
+func delegatedWebSourceSupportsMailbox(source DelegatedWebSource) bool {
+	switch strings.ToUpper(strings.TrimSpace(source.Supports)) {
+	case "COMPANY_IDENTITY", "COMPANY_MAILBOX", "COMPANY_IDENTITY_AND_MAILBOX":
+		return true
+	default:
+		return false
+	}
+}
+
+func delegatedWebSourceIsOfficialRegistry(source DelegatedWebSource) bool {
+	switch strings.ToUpper(strings.TrimSpace(source.Kind)) {
+	case DelegatedWebSourceKindOfficialRegistry, "COMPANY_REGISTRY", "OFFICIAL_REGISTRY":
+		return true
+	default:
+		return false
+	}
+}
+
 func delegatedWebSourceAllowed(source DelegatedWebSource, now time.Time) bool {
+	if !delegatedWebSourceObservedFresh(source, now) || !delegatedWebSourceSupportsMailbox(source) {
+		return false
+	}
+	if delegatedWebSourceIsOfficialRegistry(source) {
+		return strings.TrimSpace(source.URL) == ""
+	}
 	u, err := url.Parse(strings.TrimSpace(source.URL))
 	if err != nil || (u.Scheme != "https" && u.Scheme != "http") || u.Hostname() == "" {
 		return false
@@ -1394,15 +1423,23 @@ func delegatedWebSourceAllowed(source DelegatedWebSource, now time.Time) bool {
 			return false
 		}
 	}
-	if source.ObservedAt.IsZero() || source.ObservedAt.After(now.Add(5*time.Minute)) || now.Sub(source.ObservedAt) > 30*24*time.Hour {
-		return false
-	}
-	supports := strings.ToUpper(strings.TrimSpace(source.Supports))
-	return supports == "COMPANY_IDENTITY" || supports == "COMPANY_MAILBOX" || supports == "COMPANY_IDENTITY_AND_MAILBOX"
+	return true
 }
 
 func candidateSourceCorroborated(cand *models.OutreachContactCandidate, sources []DelegatedWebSource) bool {
-	if cand == nil || strings.TrimSpace(cand.SourceURL) == "" {
+	if cand == nil {
+		return false
+	}
+	if candidateIsObservedRegistry(cand) && strings.TrimSpace(cand.SourceURL) == "" {
+		for i := range sources {
+			if delegatedWebSourceIsOfficialRegistry(sources[i]) {
+				supports := strings.ToUpper(strings.TrimSpace(sources[i].Supports))
+				return supports == "COMPANY_MAILBOX" || supports == "COMPANY_IDENTITY_AND_MAILBOX"
+			}
+		}
+		return false
+	}
+	if strings.TrimSpace(cand.SourceURL) == "" {
 		return false
 	}
 	want := strings.TrimRight(strings.TrimSpace(cand.SourceURL), "/")

--- a/internal/app/confenge/delegated_first_touch_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_pg_test.go
@@ -513,6 +513,65 @@ func TestMaterializeCurrentInitialBacklogRetiresAccountOmittedFromNewRunPostgres
 	}
 }
 
+func TestMaterializeDelegatedEligibleForRegistryWithoutURLPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_contact_candidates
+		SET source_url='',
+			discovery_json = COALESCE(discovery_json,'{}'::jsonb) || '{"source":"company_registry","source_type":"company_registry"}'::jsonb
+		WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+	backlog, err := f.repo.MaterializeCurrentInitialBacklog(f.ctx, f.orgID, f.manifest.SourceRunID)
+	if err != nil {
+		t.Fatalf("materialize referenced missing candidate columns: %v", err)
+	}
+	if backlog.DelegatedEligible != 1 || backlog.HeldException != 0 {
+		t.Fatalf("company_registry OBSERVED without URL must be delegated eligible: counts=%+v", backlog)
+	}
+}
+
+func TestMaterializeDelegatedEligibleForImportedOfficialSourceWithoutURLPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_contact_candidates SET source_url='' WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+	backlog, err := f.repo.MaterializeCurrentInitialBacklog(f.ctx, f.orgID, f.manifest.SourceRunID)
+	if err != nil {
+		t.Fatalf("materialize referenced missing candidate columns: %v", err)
+	}
+	if backlog.DelegatedEligible != 1 || backlog.HeldException != 0 {
+		t.Fatalf("already-imported OFFICIAL_SOURCE with empty source_url must rematerialize: counts=%+v", backlog)
+	}
+}
+
+func TestMaterializeHoldsNonOfficialEmptyURLWithoutRegistryPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_contact_candidates
+		SET source_url='', verification_status='PUBLIC_DOCUMENT_RECENT'
+		WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+	backlog, err := f.repo.MaterializeCurrentInitialBacklog(f.ctx, f.orgID, f.manifest.SourceRunID)
+	if err != nil {
+		t.Fatalf("materialize referenced missing candidate columns: %v", err)
+	}
+	if backlog.DelegatedEligible != 0 || backlog.InitialPrepared != 1 {
+		t.Fatalf("empty URL without registry/OFFICIAL_SOURCE must stay not-delegated: counts=%+v", backlog)
+	}
+	var reason string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT initial_backlog_reason_code FROM outreach_accounts
+		WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].AccountID).Scan(&reason); err != nil {
+		t.Fatal(err)
+	}
+	if reason != "preferred_current_recipient_not_delegated" {
+		t.Fatalf("held reason=%q", reason)
+	}
+}
+
 func TestDelegatedFirstTouchWorkerIgnoresHistoricalLegacyKeyFromStaleBinding(t *testing.T) {
 	f := newDelegatedPGFixture(t)
 	entry := f.manifest.Entries[0]

--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -245,6 +245,10 @@ func delegatedEntryFromCurrentState(acc *models.OutreachAccount, cand *models.Ou
 		webObservedAt = cand.SourceDate.UTC()
 	}
 	key := delegatedFirstTouchIdempotencyPrefix + acc.SourceRunID + ":" + acc.ID.String()
+	webSources := []DelegatedWebSource{{URL: cand.SourceURL, Kind: "PUBLIC_COMPANY_SOURCE", Supports: "COMPANY_MAILBOX", ObservedAt: webObservedAt}}
+	if candidateIsObservedRegistry(cand) && strings.TrimSpace(cand.SourceURL) == "" {
+		webSources = []DelegatedWebSource{{Kind: DelegatedWebSourceKindOfficialRegistry, Supports: "COMPANY_MAILBOX", ObservedAt: webObservedAt}}
+	}
 	return DelegatedFirstTouchEntry{
 		IdempotencyKey: key, CorrelationID: "touchpoint:" + touchpointID.String(),
 		AccountID: acc.ID, ContactCandidateID: cand.ID, CNPJ14: acc.CNPJ14,
@@ -256,7 +260,7 @@ func delegatedEntryFromCurrentState(acc *models.OutreachAccount, cand *models.Ou
 		RoleMatchMethod: acc.ContractorRoleMatchMethod, RoleConfidence: acc.ContractorRoleConfidence,
 		ContractRoleReasonCodes: append([]string{}, acc.ContractorRoleReasonCodes...), EvidenceObservedAt: observedAt,
 		ReconciliationStatus: ReconciliationWebContact,
-		WebSources:           []DelegatedWebSource{{URL: cand.SourceURL, Kind: "PUBLIC_COMPANY_SOURCE", Supports: "COMPANY_MAILBOX", ObservedAt: webObservedAt}},
+		WebSources:           webSources,
 		Subject:              copy.Subject, BodyText: copy.Body, CopyRulesVersion: DelegatedFirstTouchCopyRulesV1,
 		FactUsed: copy.FactUsed, FactEvidenceIDs: append([]string{}, copy.FactEvidenceIDs...),
 		Practice: copy.Practice, CTA: copy.CTA,

--- a/internal/app/confenge/delegated_first_touch_worker_test.go
+++ b/internal/app/confenge/delegated_first_touch_worker_test.go
@@ -190,3 +190,39 @@ func TestDelegatedEntryUsesSourceObservationDateNotImportTimestamp(t *testing.T)
 		t.Fatalf("missing source date must fail closed, got observation %s", got)
 	}
 }
+
+func TestDelegatedEntryUsesOfficialRegistryWhenSourceURLEmpty(t *testing.T) {
+	sourceDate := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+	acc := &models.OutreachAccount{ID: uuid.New(), CNPJ14: "12345678000190", SourceRunID: "run-current"}
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), AccountID: acc.ID, SourceURL: "",
+		SourceDate: &sourceDate, VerificationStatus: models.OutreachVerifyOfficialSource,
+		ChannelEpistemic: "OBSERVED", OwnershipStatus: "COMPANY_OWNED", RouteFreshness: "FRESH",
+		DiscoveryJSON: []byte(`{"source":"company_registry","source_type":"company_registry","route_class":"GENERIC_COMPANY","controlled_email_eligible":true,"preferred_initial":true}`),
+	}
+	entry := delegatedEntryFromCurrentState(acc, cand, uuid.New(), delegatedRoutingCopy{Subject: "Assunto", Body: "Corpo"})
+	if len(entry.WebSources) != 1 || entry.WebSources[0].Kind != DelegatedWebSourceKindOfficialRegistry || entry.WebSources[0].URL != "" {
+		t.Fatalf("registry entry must not invent a URL: %+v", entry.WebSources)
+	}
+	now := time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC)
+	if !delegatedWebSourceAllowed(entry.WebSources[0], now) {
+		t.Fatal("official registry source must be allowed without HTTP URL")
+	}
+	if !candidateSourceCorroborated(cand, entry.WebSources) {
+		t.Fatal("official registry mailbox association must corroborate without inventing a URL")
+	}
+}
+
+func TestDelegatedWebSourceAllowedKeepsHTTPGateForPublicPages(t *testing.T) {
+	now := time.Date(2026, 8, 28, 0, 0, 0, 0, time.UTC)
+	observed := time.Date(2026, 8, 24, 0, 0, 0, 0, time.UTC)
+	if delegatedWebSourceAllowed(DelegatedWebSource{URL: "", Kind: "PUBLIC_COMPANY_SOURCE", Supports: "COMPANY_MAILBOX", ObservedAt: observed}, now) {
+		t.Fatal("public company source without URL must stay invalid")
+	}
+	if delegatedWebSourceAllowed(DelegatedWebSource{URL: "https://empresa.example/contato", Kind: DelegatedWebSourceKindOfficialRegistry, Supports: "COMPANY_MAILBOX", ObservedAt: observed}, now) {
+		t.Fatal("registry kind must not carry an invented URL")
+	}
+	if !delegatedWebSourceAllowed(DelegatedWebSource{URL: "https://empresa.example/contato", Kind: "PUBLIC_COMPANY_SOURCE", Supports: "COMPANY_MAILBOX", ObservedAt: observed}, now) {
+		t.Fatal("http(s) public company source must remain allowed")
+	}
+}

--- a/internal/app/confenge/schema.go
+++ b/internal/app/confenge/schema.go
@@ -188,6 +188,8 @@ type FeedContact struct {
 	WhatsApp           *FeedWhatsApp `json:"whatsapp,omitempty"`
 	LinkedInURL        string        `json:"linkedin_url"`
 	SourceURL          string        `json:"source_url"`
+	Source             string        `json:"source,omitempty"`
+	SourceType         string        `json:"source_type,omitempty"`
 	SourceDocument     string        `json:"source_document"`
 	SourceDate         string        `json:"source_date"`
 	VerificationStatus string        `json:"verification_status"`

--- a/internal/repository/pg_outreach_backlog.go
+++ b/internal/repository/pg_outreach_backlog.go
@@ -106,8 +106,14 @@ func (r *outreachRepository) materializeCurrentInitialBacklog(ctx context.Contex
 					AND (
 						c.source_url ~* '^https?://'
 						OR (
-							lower(COALESCE(c.source, '')) IN ('company_registry', 'official_registry')
-							AND lower(COALESCE(c.source_type, 'company_registry')) IN ('company_registry', 'real_registry', 'official_registry')
+							lower(COALESCE(NULLIF(c.discovery_json->>'source',''), NULLIF(c.discovery_json->>'source_type',''), ''))
+								IN ('company_registry', 'official_registry')
+							AND lower(COALESCE(NULLIF(c.discovery_json->>'source_type',''), NULLIF(c.discovery_json->>'source',''), 'company_registry'))
+								IN ('company_registry', 'real_registry', 'official_registry')
+						)
+						OR (
+							upper(c.verification_status)='OFFICIAL_SOURCE'
+							AND COALESCE(c.source_url,'')=''
 						)
 					)
 					AND c.source_date BETWEEN CURRENT_DATE - 29 AND CURRENT_DATE

--- a/internal/repository/pg_outreach_backlog_test.go
+++ b/internal/repository/pg_outreach_backlog_test.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -20,5 +21,19 @@ func TestDelegatedEligibilityKeepsHTTPGateAndAllowsObservedRegistry(t *testing.T
 	}
 	if !strings.Contains(s, "CURRENT_DATE - 29") {
 		t.Fatal("recipient freshness window must stay 29 days")
+	}
+	if !strings.Contains(s, "discovery_json->>'source'") || !strings.Contains(s, "discovery_json->>'source_type'") {
+		t.Fatal("registry provenance must be read from discovery_json; outreach_contact_candidates has no source/source_type columns")
+	}
+	if !strings.Contains(s, "OFFICIAL_SOURCE") || !strings.Contains(s, "COALESCE(c.source_url,'')=''") {
+		t.Fatal("already-imported company_registry ammo is OFFICIAL_SOURCE with empty source_url and must rematerialize without a new snapshot")
+	}
+	// c.source / c.source_type are not columns. source_url, source_date, source_document,
+	// source_contact_id, source_run_id (on accounts) remain valid.
+	if regexp.MustCompile(`c\.source[^_a-zA-Z]`).MatchString(s) {
+		t.Fatal("do not reference missing column c.source; use discovery_json")
+	}
+	if regexp.MustCompile(`c\.source_type[^_a-zA-Z]`).MatchString(s) {
+		t.Fatal("do not reference missing column c.source_type; use discovery_json")
 	}
 }


### PR DESCRIPTION
## Why
#220 intended to treat extra-cli `company_registry` OBSERVED recipients as delegated-eligible without inventing an HTTP URL. Two independent defects blocked pre-GO QUEUED:

1. The backlog SQL read `c.source` / `c.source_type`. Those columns do not exist on `outreach_contact_candidates` (`HINT: column c.bounced`). Materialize cannot run, so the live 5489 EMAIL_ROUTE_READY registry contacts stay `preferred_current_recipient_not_delegated`.
2. Even after rematerialize, autorun HOLDs empty-URL registry recipients as `web_source_invalid` and `mailbox_company_association_unproven` because the worker invented a `PUBLIC_COMPANY_SOURCE` with no URL.

The live feed already publishes `source` / `source_type=company_registry`. Warmbly dropped both on import because `FeedContact` had no fields for them.

## What
- Persist extra-cli `source` / `source_type` into `discovery_json` on import.
- Classify delegated eligibility from `discovery_json`, not missing columns.
- Keep the HTTP URL gate for web-attributed recipients and the 29-day recipient window.
- Accept already-imported `OFFICIAL_SOURCE` rows with empty `source_url` so the current snapshot rematerializes without a republish (same-snapshot feed sync is a noop).
- Autorun emits `OFFICIAL_COMPANY_REGISTRY` (no URL) for observed registry contacts; public pages still require `http(s)`.
- `supplier_role_unknown` and `recipient_shared_across_cnpj_identities` stay blocked.

## Tests
- Source-contract test now fails if SQL references `c.source` / `c.source_type` as columns.
- Import merge persists registry source onto discovery JSON.
- Postgres: registry without URL is delegated-eligible; already-imported OFFICIAL_SOURCE without URL rematerializes; non-official empty URL stays `preferred_current_recipient_not_delegated`.
- Worker/validator: registry kind allowed without URL; public page without URL stays invalid; invented registry URL rejected.

## Production follow-through (this campaign)
After merge: deploy exact SHA with transport still paused, rematerialize current run, prove autorun `DELEGATED_POLICY_APPROVE` → `QUEUED(due_at)` with SENT=0 / provider_mutation=0. Do not lift the kill switch in this PR.