### PR TITLE
fix(confenge): bind autorun commercial authority with semantic hash and producer identity

### DIFF
--- a/internal/app/confenge/commercial_authority_test.go
+++ b/internal/app/confenge/commercial_authority_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
 )
 
 func authorityBool(v bool) *bool { return &v }
@@ -309,5 +311,28 @@ func TestLosslessAliasFillsCanonicalAndConflictFailsClosed(t *testing.T) {
 	p.SourceRunIDAlias = "run-other"
 	if got := EvaluateCommercialAuthority(&p, testBinding(), now); got.State != CommercialAuthorityUnknown {
 		t.Fatalf("alias conflict accepted: %+v", got)
+	}
+}
+
+func TestCommercialBindingFromStoredFeedKeepsSemanticAndProducer(t *testing.T) {
+	now := time.Date(2026, 8, 28, 6, 0, 0, 0, time.UTC)
+	p := testAuthorityPayload(CommercialAuthorityCurrent, now)
+	feed := &models.OutreachFeedSyncState{
+		LastRunID:            p.BasisSourceRunID,
+		LastSnapshotHash:     p.BasisSnapshotHash,
+		TargetMembershipHash: p.BasisMembershipHash,
+	}
+	thin := CommercialAuthorityBinding{
+		SourceRunID:    feed.LastRunID,
+		SnapshotHash:   feed.LastSnapshotHash,
+		MembershipHash: feed.TargetMembershipHash,
+	}
+	if got := EvaluateCommercialAuthority(&p, thin, now); got.State != CommercialAuthorityUnknown {
+		t.Fatalf("omitting semantic hash/producer identity must fail closed: %+v", got)
+	}
+	binding := commercialBindingFromStoredFeed(feed, &p)
+	elig := EvaluateOutboundEligibility(testFreshSource(now), &p, binding, TransportState{State: TransportActive}, now, 24*time.Hour, nil, false)
+	if elig.CommercialAuthority.State != CommercialAuthorityCurrent || !elig.AllowNewAdmission {
+		t.Fatalf("stored CURRENT authority must remain CURRENT on autorun apply: %+v", elig.CommercialAuthority)
 	}
 }

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -405,25 +405,32 @@ func firstPresentAuthority(parts ...*FeedCommercialAuthority) *FeedCommercialAut
 	return nil
 }
 
-func EvaluateStoredFeedAuthority(feed *models.OutreachFeedSyncState, now time.Time, maxAge time.Duration) (SourceHealthDecision, CommercialAuthorityDecision) {
-	source := ClassifySourceHealth(feedSourceFreshnessFromState(feed), now, maxAge)
-	if feed == nil {
-		return source, CommercialAuthorityDecision{State: CommercialAuthorityAbsent}
-	}
-	payload := storedCommercialAuthority(feed)
+func commercialBindingFromStoredFeed(feed *models.OutreachFeedSyncState, payload *FeedCommercialAuthority) CommercialAuthorityBinding {
 	semantic, producer := "", ""
 	if payload != nil {
 		payload.NormalizeAliases()
 		semantic = payload.BasisPublicationSemanticHash
 		producer = payload.ProducerIdentity
 	}
-	return source, EvaluateCommercialAuthority(payload, CommercialAuthorityBinding{
+	if feed == nil {
+		return CommercialAuthorityBinding{PublicationSemanticHash: semantic, ProducerIdentity: producer}
+	}
+	return CommercialAuthorityBinding{
 		SourceRunID:             feed.LastRunID,
 		SnapshotHash:            feed.LastSnapshotHash,
 		MembershipHash:          feed.TargetMembershipHash,
 		PublicationSemanticHash: semantic,
 		ProducerIdentity:        producer,
-	}, now)
+	}
+}
+
+func EvaluateStoredFeedAuthority(feed *models.OutreachFeedSyncState, now time.Time, maxAge time.Duration) (SourceHealthDecision, CommercialAuthorityDecision) {
+	source := ClassifySourceHealth(feedSourceFreshnessFromState(feed), now, maxAge)
+	if feed == nil {
+		return source, CommercialAuthorityDecision{State: CommercialAuthorityAbsent}
+	}
+	payload := storedCommercialAuthority(feed)
+	return source, EvaluateCommercialAuthority(payload, commercialBindingFromStoredFeed(feed, payload), now)
 }
 
 func commercialReadback(d CommercialAuthorityDecision) DelegatedFirstTouchAuthorityReadback {
@@ -573,7 +580,7 @@ func (s *service) applyDelegatedFirstTouchManifest(ctx context.Context, orgID uu
 		elig := EvaluateOutboundEligibility(
 			feedSourceFreshnessFromState(feedState),
 			commercialPayload,
-			CommercialAuthorityBinding{SourceRunID: feedState.LastRunID, SnapshotHash: feedState.LastSnapshotHash, MembershipHash: feedState.TargetMembershipHash},
+			commercialBindingFromStoredFeed(feedState, commercialPayload),
 			TransportState{State: TransportActive},
 			now, s.cfg.FeedMaxAge, nil, false,
 		)
@@ -1123,7 +1130,7 @@ func (s *service) validateDelegatedEntry(ctx context.Context, orgID uuid.UUID, m
 			elig := EvaluateOutboundEligibility(
 				feedSourceFreshnessFromState(feedState),
 				commercialPayload,
-				CommercialAuthorityBinding{SourceRunID: feedState.LastRunID, SnapshotHash: feedState.LastSnapshotHash, MembershipHash: feedState.TargetMembershipHash},
+				commercialBindingFromStoredFeed(feedState, commercialPayload),
 				TransportState{State: TransportActive},
 				now, s.cfg.FeedMaxAge, nil, bound,
 			)


### PR DESCRIPTION
## Why
After #221 rematerialize, 5489 DUE INITIAL rows became delegated-eligible. Autorun then deferred every one of them:

`delegated first-touch autorun: commercial_authority_binding_mismatch`

First-touch **status** already reports commercial authority CURRENT. Apply/validate only passed `run/snapshot/membership` into `EvaluateOutboundEligibility`. The stored extra-cli payload includes `basis_publication_semantic_hash` and `producer_identity`. Empty binding fields vs present payload fields is UNKNOWN, fail-closed.

## What
Use `commercialBindingFromStoredFeed` (the same binding status already uses) on apply and `validateDelegatedEntry`. 1-byte drift of membership/semantic/producer hashes still fails closed.

Transport stays paused. Do not lift the kill switch in this PR.

## Tests
- Thin binding (run/snapshot/membership only) against a full payload is UNKNOWN.
- Stored-feed binding keeps CURRENT and allows new admission.