### PR TITLE
fix(confenge): allow CFG-FIRST-TOUCH-ROUTING-v2 on delegated batch rows

### DIFF
--- a/internal/infrastructure/db/migrations/000137_confenge_delegated_policy_v2.down.sql
+++ b/internal/infrastructure/db/migrations/000137_confenge_delegated_policy_v2.down.sql
@@ -1,0 +1,11 @@
+ALTER TABLE confenge_delegated_first_touch_batches
+    DROP CONSTRAINT IF EXISTS confenge_delegated_batch_policy_v1;
+ALTER TABLE confenge_delegated_first_touch_batches
+    ADD CONSTRAINT confenge_delegated_batch_policy_v1
+        CHECK (policy_version = 'CFG-FIRST-TOUCH-ROUTING-v1');
+
+ALTER TABLE confenge_delegated_first_touch_decisions
+    DROP CONSTRAINT IF EXISTS confenge_delegated_decision_policy_v1;
+ALTER TABLE confenge_delegated_first_touch_decisions
+    ADD CONSTRAINT confenge_delegated_decision_policy_v1
+        CHECK (policy_version = 'CFG-FIRST-TOUCH-ROUTING-v1');

--- a/internal/infrastructure/db/migrations/000137_confenge_delegated_policy_v2.up.sql
+++ b/internal/infrastructure/db/migrations/000137_confenge_delegated_policy_v2.up.sql
@@ -1,0 +1,14 @@
+-- CFG-FIRST-TOUCH-ROUTING-v2 is the live authorized policy. The original
+-- delegated batch/decision tables pinned v1 only, so autorun could evaluate
+-- v2 and then fail closed on INSERT.
+ALTER TABLE confenge_delegated_first_touch_batches
+    DROP CONSTRAINT IF EXISTS confenge_delegated_batch_policy_v1;
+ALTER TABLE confenge_delegated_first_touch_batches
+    ADD CONSTRAINT confenge_delegated_batch_policy_v1
+        CHECK (policy_version IN ('CFG-FIRST-TOUCH-ROUTING-v1', 'CFG-FIRST-TOUCH-ROUTING-v2'));
+
+ALTER TABLE confenge_delegated_first_touch_decisions
+    DROP CONSTRAINT IF EXISTS confenge_delegated_decision_policy_v1;
+ALTER TABLE confenge_delegated_first_touch_decisions
+    ADD CONSTRAINT confenge_delegated_decision_policy_v1
+        CHECK (policy_version IN ('CFG-FIRST-TOUCH-ROUTING-v1', 'CFG-FIRST-TOUCH-ROUTING-v2'));

--- a/internal/infrastructure/db/migrations/delegated_policy_v2_test.go
+++ b/internal/infrastructure/db/migrations/delegated_policy_v2_test.go
@@ -1,0 +1,22 @@
+package migrations
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDelegatedBatchConstraintAllowsFirstTouchV2(t *testing.T) {
+	b, err := os.ReadFile(filepath.Join("000137_confenge_delegated_policy_v2.up.sql"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "CFG-FIRST-TOUCH-ROUTING-v1") || !strings.Contains(s, "CFG-FIRST-TOUCH-ROUTING-v2") {
+		t.Fatal("v2 must be additive to v1; do not drop the original policy id")
+	}
+	if !strings.Contains(s, "confenge_delegated_batch_policy_v1") || !strings.Contains(s, "confenge_delegated_decision_policy_v1") {
+		t.Fatal("both batch and decision policy checks must accept v2")
+	}
+}


### PR DESCRIPTION
## Why
After #221 rematerialize and #222 authority binding, autorun still cannot persist QUEUED:

`new row for relation "confenge_delegated_first_touch_batches" violates check constraint "confenge_delegated_batch_policy_v1"`

The live authorized policy is `CFG-FIRST-TOUCH-ROUTING-v2`. The 000128 tables only allowed v1.

## What
Additive migration 000137: batch and decision policy checks accept v1 or v2. v1 remains valid.

Transport stays paused. Do not lift the kill switch in this PR.