### PR TITLE
fix(confenge): keep v2 delegated approvals across retireStale

### DIFF
--- a/internal/app/confenge/delegated_first_touch_refresh.go
+++ b/internal/app/confenge/delegated_first_touch_refresh.go
@@ -47,12 +47,15 @@ func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uu
 		  AND d.touchpoint_id IS NOT NULL
 		  AND (d.evidence_source_run_id<>$2 OR d.source_snapshot_hash<>$3
 		    OR a.id IS NULL OR a.source_run_id<>$2 OR d.runtime_release_sha<>$4
-		    OR d.policy_version<>$5 OR d.policy_hash<>$6
-		    OR ($8 AND ($7::uuid IS NULL OR d.policy_authorization_id<>$7))
-		    OR NOT $9 OR d.source_freshness_hash<>$10 OR d.target_membership_hash<>$11
-		    OR d.target_membership_count<>$12 OR d.source_expires_at IS DISTINCT FROM $13::timestamptz)
+		    OR d.policy_version NOT IN ($5,$6)
+		    OR d.policy_hash<>CASE d.policy_version WHEN $5 THEN $7 WHEN $6 THEN $8 ELSE '' END
+		    OR ($10 AND ($9::uuid IS NULL OR d.policy_authorization_id<>$9))
+		    OR NOT $11 OR d.source_freshness_hash<>$12 OR d.target_membership_hash<>$13
+		    OR d.target_membership_count<>$14 OR d.source_expires_at IS DISTINCT FROM $15::timestamptz)
 		FOR UPDATE OF d`, orgID, sourceRunID, snapshotHash, s.cfg.RepositorySHA,
-		DelegatedFirstTouchPolicyV1, DelegatedFirstTouchPolicyHashV1, policyAuthorizationID, checkPolicyAuthorization,
+		DelegatedFirstTouchPolicyV1, DelegatedFirstTouchPolicyV2,
+		DelegatedFirstTouchPolicyHashV1, DelegatedFirstTouchPolicyHashV2,
+		policyAuthorizationID, checkPolicyAuthorization,
 		authorityValid, sourceFreshnessHash, targetMembershipHash, targetMembershipCount, sourceExpiresAt)
 	if err != nil {
 		return 0, err

--- a/internal/app/confenge/delegated_first_touch_refresh_test.go
+++ b/internal/app/confenge/delegated_first_touch_refresh_test.go
@@ -1,0 +1,32 @@
+package confenge
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestRetireStaleAcceptsFirstTouchV2(t *testing.T) {
+	b, err := os.ReadFile("delegated_first_touch_refresh.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "DelegatedFirstTouchPolicyV2") || !strings.Contains(s, "DelegatedFirstTouchPolicyHashV2") {
+		t.Fatal("retireStale must keep v2 approvals; hardcoding v1 cancelled live DELEGATED_POLICY_APPROVE")
+	}
+	if !strings.Contains(s, "NOT IN ($5,$6)") {
+		t.Fatal("v1 remains valid; v2 is additive")
+	}
+}
+
+func TestNextDelegatedCandidateSkipsCancelledMatchingBinding(t *testing.T) {
+	b, err := os.ReadFile("delegated_first_touch_worker.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if strings.Contains(s, "d.state<>'CANCELLED'") {
+		t.Fatal("a CANCELLED v2 approval with the current binding must not be selected again; that stalls the autorun burst")
+	}
+}

--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -193,9 +193,9 @@ func (s *service) nextDelegatedFirstTouchCandidate(ctx context.Context, orgID uu
 			  AND NOT EXISTS (
 			    SELECT 1 FROM confenge_delegated_first_touch_decisions d
 			    WHERE d.organization_id=t.organization_id AND d.account_id=t.account_id
-			      AND (d.state='SENT' OR (d.state<>'CANCELLED'
-			        AND d.evidence_source_run_id=$2 AND d.source_snapshot_hash=$3
-			        AND d.runtime_release_sha=$4 AND d.policy_authorization_id=$5))
+			      AND (d.state='SENT'
+			        OR (d.evidence_source_run_id=$2 AND d.source_snapshot_hash=$3
+			          AND d.runtime_release_sha=$4 AND d.policy_authorization_id=$5))
 			  )
 			ORDER BY t.delegated_retry_at,t.due_at,t.created_at,t.id
 			LIMIT 1 FOR UPDATE OF t SKIP LOCKED


### PR DESCRIPTION
## Why
Live autorun on SHA `6a87432f` wrote `DELEGATED_POLICY_APPROVE` with `due_at=2026-08-28T12:00:00Z` (next business window), then the next tick cancelled it:

`delegated_authority_or_source_binding_advanced`

`retireStaleDelegatedFirstTouches` compared `policy_version`/`policy_hash` to v1 only. The worker emits v2. The cancelled row was re-selected and idempotency-stalled the burst (`queued_readback` stayed 0).

## What
- Retire only when policy is not v1 or v2, or the hash does not match that version.
- Skip a matching CANCELLED decision in `nextDelegatedFirstTouchCandidate` so the remaining 5484 reservoir can fill.

Transport stays paused.