### PR TITLE
fix(confenge): emit ARMED_FOR_NEXT_BUSINESS_WINDOW after PRE-GO lift

### DIFF
--- a/internal/app/confenge/first_window_readiness.go
+++ b/internal/app/confenge/first_window_readiness.go
@@ -14,9 +14,11 @@ import (
 )
 
 const (
-	FirstWindowReadyForGOAdjudication = "READY_FOR_GO_ADJUDICATION"
-	FirstWindowBlockedPrefix          = "BLOCKED:"
-	FirstWindowGOForControlledPilot   = ReleaseGOForControlledEmailPilot
+	FirstWindowReadyForGOAdjudication     = "READY_FOR_GO_ADJUDICATION"
+	FirstWindowArmedForNextBusinessWindow = "ARMED_FOR_NEXT_BUSINESS_WINDOW"
+	FirstWindowTransportActiveInWindow    = "TRANSPORT_ACTIVE_IN_WINDOW"
+	FirstWindowBlockedPrefix              = "BLOCKED:"
+	FirstWindowGOForControlledPilot       = ReleaseGOForControlledEmailPilot
 )
 
 // FirstWindowReadinessSnapshot is the closed evidence pack for a candidate
@@ -188,8 +190,38 @@ func EvaluateFirstWindowReadiness(snap FirstWindowReadinessSnapshot) FirstWindow
 		rep.Verdict = firstWindowBlocked(blockers[0])
 		return rep
 	}
-	rep.Verdict = FirstWindowReadyForGOAdjudication
+	// READY_FOR_GO_ADJUDICATION is the pre-GO pack. After PRE-GO pauses are
+	// lifted, the same gates plus a live queue become the armed/in-window
+	// transport verdict. This function still never emits GO_FOR_CONTROLLED_EMAIL_PILOT.
+	if firstWindowPreGOPauseEngaged(snap) {
+		rep.Verdict = FirstWindowReadyForGOAdjudication
+		return rep
+	}
+	if snap.Queued <= 0 && snap.Reserved <= 0 {
+		rep.Verdict = FirstWindowReadyForGOAdjudication
+		return rep
+	}
+	if snap.PauseState == TransportActive {
+		rep.Verdict = FirstWindowTransportActiveInWindow
+		return rep
+	}
+	rep.Verdict = FirstWindowArmedForNextBusinessWindow
 	return rep
+}
+
+func firstWindowPreGOPauseEngaged(snap FirstWindowReadinessSnapshot) bool {
+	if snap.KillSwitchEngaged {
+		return true
+	}
+	src := strings.ToLower(strings.TrimSpace(snap.PauseSource))
+	switch src {
+	case PauseSourceKillSwitch, PauseSourceDurable, PauseSourceAPI, PauseSourceWorkerGuard, PauseSourceEnvironment, PauseSourceConfiguration:
+		return true
+	}
+	if strings.Contains(src, "deploy_preflight") || strings.Contains(src, "scale_pre_go") {
+		return true
+	}
+	return false
 }
 
 func firstWindowSnapshotFromLive(

--- a/internal/app/confenge/first_window_readiness_test.go
+++ b/internal/app/confenge/first_window_readiness_test.go
@@ -108,6 +108,61 @@ func TestEvaluateFirstWindowReadinessUnknownPolicyHolds(t *testing.T) {
 	}
 }
 
+func TestEvaluateFirstWindowReadinessArmsWhenOnlySendWindowRemains(t *testing.T) {
+	now := time.Date(2026, 8, 28, 8, 0, 0, 0, time.UTC)
+	snap := readyFirstWindowSnapshot(now)
+	snap.KillSwitchEngaged = false
+	snap.PauseState = TransportPaused
+	snap.PauseSource = TransportSourceSendWindow
+	snap.Queued = 421
+	got := EvaluateFirstWindowReadiness(snap)
+	if got.Verdict != FirstWindowArmedForNextBusinessWindow {
+		t.Fatalf("outside window after PRE-GO lift: %s blockers=%v", got.Verdict, got.Blockers)
+	}
+	if got.Verdict == FirstWindowGOForControlledPilot || strings.Contains(got.Verdict, "GO_FOR_CONTROLLED_EMAIL_PILOT") {
+		t.Fatal("armed snapshot emitted GO_FOR_CONTROLLED_EMAIL_PILOT")
+	}
+}
+
+func TestEvaluateFirstWindowReadinessStaysPreGOWhileKillSwitchEngaged(t *testing.T) {
+	now := time.Date(2026, 8, 28, 8, 0, 0, 0, time.UTC)
+	snap := readyFirstWindowSnapshot(now)
+	snap.Queued = 421
+	got := EvaluateFirstWindowReadiness(snap)
+	if got.Verdict != FirstWindowReadyForGOAdjudication {
+		t.Fatalf("PRE-GO kill switch still engaged: %s", got.Verdict)
+	}
+}
+
+func TestEvaluateFirstWindowReadinessActiveInWindowWithoutPilotGO(t *testing.T) {
+	now := time.Date(2026, 8, 28, 12, 30, 0, 0, time.UTC)
+	snap := readyFirstWindowSnapshot(now)
+	snap.KillSwitchEngaged = false
+	snap.PauseState = TransportActive
+	snap.PauseSource = TransportSourceSendWindow
+	snap.Queued = 421
+	got := EvaluateFirstWindowReadiness(snap)
+	if got.Verdict != FirstWindowTransportActiveInWindow {
+		t.Fatalf("in window after PRE-GO lift: %s blockers=%v", got.Verdict, got.Blockers)
+	}
+	if got.Verdict == FirstWindowGOForControlledPilot {
+		t.Fatal("emitted GO_FOR_CONTROLLED_EMAIL_PILOT")
+	}
+}
+
+func TestEvaluateFirstWindowReadinessDoesNotArmOnWorkerGuard(t *testing.T) {
+	now := time.Date(2026, 8, 28, 8, 0, 0, 0, time.UTC)
+	snap := readyFirstWindowSnapshot(now)
+	snap.KillSwitchEngaged = false
+	snap.PauseState = TransportPaused
+	snap.PauseSource = PauseSourceWorkerGuard
+	snap.Queued = 421
+	got := EvaluateFirstWindowReadiness(snap)
+	if got.Verdict != FirstWindowReadyForGOAdjudication {
+		t.Fatalf("independent worker guard must not look armed: %s", got.Verdict)
+	}
+}
+
 func TestCollectFirstWindowReadinessIndependentAuthorityOnStaleSource(t *testing.T) {
 	now := time.Date(2026, 8, 27, 16, 0, 0, 0, time.UTC)
 	orgID := uuid.New()


### PR DESCRIPTION
## Why

`first-touch first-window-readiness` is frozen at `READY_FOR_GO_ADJUDICATION` whenever hard gates pass. WAVE 2 FINAL already has QUEUED readback, commercial CURRENT, and PRE-GO pause as the only remaining transport block. The campaign must not terminate on that pre-GO label.

## What
After the closed evidence pack has no blockers:
- PRE-GO pause still engaged (`kill_switch_file`, `durable_control`, `worker_guard`, env, deploy_preflight/scale_pre_go) → `READY_FOR_GO_ADJUDICATION`
- PRE-GO gone, queued>0, transport not ACTIVE (São Paulo window closed) → `ARMED_FOR_NEXT_BUSINESS_WINDOW`
- PRE-GO gone, queued>0, transport ACTIVE → `TRANSPORT_ACTIVE_IN_WINDOW`

Still never emits `GO_FOR_CONTROLLED_EMAIL_PILOT`.

Does not lift an independent worker guard. Dispatch still refuses SMTP outside `America/Sao_Paulo` 09:00–18:00.