### PR TITLE
fix: stop first-window readiness blocking an ACTIVE transport for having no pause source

### DIFF
--- a/internal/app/confenge/first_window_readiness.go
+++ b/internal/app/confenge/first_window_readiness.go
@@ -170,7 +170,10 @@ func EvaluateFirstWindowReadiness(snap FirstWindowReadinessSnapshot) FirstWindow
 	add(snap.MinWaitSeconds > 0, "min_wait_time_missing")
 	add(strings.TrimSpace(snap.BusinessTimezone) != "" && strings.TrimSpace(snap.BusinessWindowStart) != "" && strings.TrimSpace(snap.BusinessWindowEnd) != "", "business_window_missing")
 	add(strings.TrimSpace(snap.PauseState) != "", "pause_state_missing")
-	add(strings.TrimSpace(snap.PauseSource) != "", "pause_source_missing")
+	// A fully ACTIVE transport legitimately has no pause source. Requiring one
+	// unconditionally blocked precisely the healthy end state; an unreadable
+	// source while actually paused still fails closed.
+	add(snap.PauseState == TransportActive || strings.TrimSpace(snap.PauseSource) != "", "pause_source_missing")
 	add(snap.OutcomeObservabilityReady.IsPass(), "outcome_observability_not_ready")
 	add(snap.ProviderMutationCount == 0, "provider_mutation_nonzero")
 	if snap.CommercialAuthority.Present {

--- a/internal/app/confenge/first_window_readiness_test.go
+++ b/internal/app/confenge/first_window_readiness_test.go
@@ -257,3 +257,27 @@ func TestReadinessAcceptsAccountDerivedQualificationWithoutFeedAttestation(t *te
 		t.Fatalf("verdict %s blockers=%v", report.Verdict, report.Blockers)
 	}
 }
+
+// An ACTIVE transport has nothing paused, so it has no pause source. Demanding
+// one blocked exactly the state the cutover is trying to reach.
+func TestReadinessActiveTransportNeedsNoPauseSource(t *testing.T) {
+	now := time.Date(2026, 8, 28, 16, 0, 0, 0, time.UTC)
+	snap := readyFirstWindowSnapshot(now)
+	snap.PauseState = TransportActive
+	snap.PauseSource = ""
+	snap.KillSwitchEngaged = false
+	snap.Queued = 3
+	report := EvaluateFirstWindowReadiness(snap)
+	if containsStr(report.Blockers, "pause_source_missing") {
+		t.Fatalf("an unpaused transport was blocked for having no pause source: %v", report.Blockers)
+	}
+	if report.Verdict != FirstWindowTransportActiveInWindow {
+		t.Fatalf("verdict=%s blockers=%v", report.Verdict, report.Blockers)
+	}
+	// Still fail closed when actually paused with an unreadable source.
+	snap.PauseState = TransportPaused
+	snap.PauseSource = ""
+	if !containsStr(EvaluateFirstWindowReadiness(snap).Blockers, "pause_source_missing") {
+		t.Fatal("a paused transport with no readable source stopped failing closed")
+	}
+}


### PR DESCRIPTION
Found during the production cutover. With the kill switch lifted and dispatch resumed, readiness reported `BLOCKED:pause_source_missing` with `pause_state: ACTIVE`, `pause_source: null`, `kill_switch_engaged: false` — that is, it blocked precisely the healthy end state the cutover exists to reach.

`pause_source` was asserted non-empty unconditionally. A fully ACTIVE transport has nothing paused and therefore has no pause source. The gate now requires a source only when transport is actually paused, so an unreadable source while paused still fails closed, which is the behaviour the API docs describe.

Test covers both directions: ACTIVE with no source is not blocked and reaches `TRANSPORT_ACTIVE_IN_WINDOW`; PAUSED with no readable source still blocks.

`gofmt` clean, `golangci-lint` exit 0, tests pass except the pre-existing Mailpit-dependent `TestProductAcceptanceMultichannelSum`.