### PR TITLE
fix: stop the retire sweep cancelling approved first-touch work when no population attestation is published

### DIFF
--- a/internal/app/confenge/delegated_first_touch_carry_forward_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_carry_forward_pg_test.go
@@ -148,3 +148,60 @@ func TestDelegatedReservoirServesCarriedForwardAccountPostgres(t *testing.T) {
 		t.Fatalf("unexpected reservoir row: touchpoint=%s account=%s", gotTouchpoint, gotAccount)
 	}
 }
+
+// A producer that publishes no population attestation has revoked nothing. The
+// durable per-account three-year evidence is the authority, so approved work
+// for a still-QUALIFIED account must survive an unattested feed rather than be
+// mass-cancelled as an advanced binding.
+func TestDelegatedUnattestedPopulationKeepsQualifiedApprovalsPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	qualifyDelegatedPGFixture(t, f)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+
+	// Drop only the population attestation. Every per-account commercial fact
+	// and the structural attestation columns stay exactly as they were.
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_feed_sync_state SET commercial_authority_v2=NULL
+		WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+	state, err := f.repo.GetFeedSyncState(f.ctx, f.orgID)
+	if err != nil || state == nil {
+		t.Fatalf("feed state unavailable: state=%+v err=%v", state, err)
+	}
+	if authority := FeedCommercialAuthorityState(state); authority.Present {
+		t.Fatalf("fixture still carries a population attestation: %+v", authority)
+	}
+
+	retired, err := f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, state.LastRunID, state.LastSnapshotHash)
+	if err != nil || retired != 0 {
+		t.Fatalf("an unattested population retired a qualified decision: retired=%d err=%v", retired, err)
+	}
+	var decisionState, queueState string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT d.state,q.status
+		FROM confenge_delegated_first_touch_decisions d
+		JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.message_key=d.queue_message_key
+		WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID).
+		Scan(&decisionState, &queueState); err != nil {
+		t.Fatal(err)
+	}
+	if decisionState != "QUEUED" || queueState != "queued" {
+		t.Fatalf("qualified decision did not survive an unattested population: decision=%s queue=%s", decisionState, queueState)
+	}
+
+	// Losing the per-account commercial fact still retires the work, so the
+	// fallback is an authority substitution and not a bypass.
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_accounts SET commercial_qualification_state='EXPIRED'
+		WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].AccountID); err != nil {
+		t.Fatal(err)
+	}
+	retired, err = f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, state.LastRunID, state.LastSnapshotHash)
+	if err != nil || retired != 1 {
+		t.Fatalf("an unqualified account survived an unattested population: retired=%d err=%v", retired, err)
+	}
+}

--- a/internal/app/confenge/delegated_first_touch_refresh.go
+++ b/internal/app/confenge/delegated_first_touch_refresh.go
@@ -11,8 +11,10 @@ const delegatedBindingRefreshReason = "delegated_authority_or_source_binding_adv
 // retireStaleDelegatedFirstTouches revokes approvals whose account is no longer
 // commercially QUALIFIED, or whose runtime, policy or membership binding moved.
 // Source run id, snapshot expiry and freshness hash are acquisition provenance
-// and never retire a still-qualified decision.
+// and never retire a still-qualified decision, so sourceRunID and snapshotHash
+// are accepted for call-site symmetry and deliberately not compared.
 func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uuid.UUID, sourceRunID, snapshotHash string, policyAuthorizationIDs ...*uuid.UUID) (int, error) {
+	_, _ = sourceRunID, snapshotHash
 	if s == nil || s.delegatedDB == nil {
 		return 0, nil
 	}
@@ -27,10 +29,17 @@ func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uu
 		policyAuthorizationID = policyAuthorizationIDs[0]
 	}
 	feedState, feedErr := s.repo.GetFeedSyncState(ctx, orgID)
-	authorityValid := feedErr == nil && feedState != nil && feedState.LastRunID == sourceRunID &&
-		feedState.LastSnapshotHash == snapshotHash &&
+	// A producer that published no population attestation has not revoked
+	// anything. Fall back to the durable per-account three-year evidence, the
+	// same authority the first-window readback reads, so an unattested but
+	// individually proven population never retires its own approved work.
+	authority := FeedCommercialAuthorityState(feedState)
+	if !authority.Present {
+		authority = s.commercialQualificationFromAccounts(ctx, orgID, s.now())
+	}
+	authorityValid := feedErr == nil && feedState != nil &&
 		validateAuthoritativeFeedStructure(feedState, true) == nil &&
-		FeedCommercialAuthorityState(feedState).State == CommercialQualified
+		authority.State == CommercialQualified
 	targetMembershipHash, targetMembershipCount := "", 0
 	if feedState != nil {
 		targetMembershipHash = feedState.TargetMembershipHash


### PR DESCRIPTION
## Problem

Production has queued **zero** first touches for two days while holding a reservoir of 3561 READY touchpoints and 8766 commercially qualified accounts. `confenge_dispatch_queue` holds 4404 rows cancelled as `delegated_authority_or_source_binding_advanced`, still accumulating (most recent 2026-08-28 13:17Z).

`retireStaleDelegatedFirstTouches` computed:

```go
authorityValid := ... && FeedCommercialAuthorityState(feedState).State == CommercialQualified
```

The CONFENGE producer has published no population attestation (`outreach_feed_sync_state.commercial_authority_v2 IS NULL`), so that state is ABSENT, `authorityValid` is false, and the `OR NOT $9` arm matches every `APPROVED`/`QUEUED` decision. The autorun calls this sweep before planning on every tick, so each tick cancelled the previous tick's approval.

#227 already established the correct rule for this exact condition on the readiness path: with no population attestation, authority comes from the durable per-account three-year evidence. The retire path never got it, so readiness reported `QUALIFIED` while the sweep cancelled the same population as unqualified.

## Fix

Apply the #227 fallback in the retire sweep, reusing `commercialQualificationFromAccounts` rather than a second rule. Per-company evidence, each hash-verified and inside the rolling three-year window, is strictly stronger than an attestation.

Also stop comparing `LastRunID`/`LastSnapshotHash`, which the function's own doc comment already declared to be acquisition provenance that "never retire a still-qualified decision". The caller passes the feed's own freshly-read values, so the comparison could only ever fail as a TOCTOU race against a concurrent import, and that race would cancel the entire queue.

Losing the per-account commercial fact still retires the work, so this is an authority substitution, not a bypass.

## Verification against production

- `commercial_authority_v2 IS NULL` confirmed
- all eight `validateAuthoritativeFeedStructure` conditions pass
- 8766 accounts `QUALIFIED`, undeactivated, inside the window, across 8661 distinct CNPJ roots

So `authorityValid` becomes true and the sweep stops firing.

## Test

`TestDelegatedUnattestedPopulationKeepsQualifiedApprovalsPostgres` drops only the population attestation, leaving every per-account fact intact, and asserts the queued decision survives; it then expires the account's commercial fact and asserts the decision is still retired. The existing carry-forward test passed only because its fixture stamps an attestation, which is why this regressed unnoticed.