### PR TITLE
fix: advance past a reversible CONFENGE commercial block instead of head-of-line blocking the campaign

### DIFF
--- a/internal/app/confenge/delegated_first_touch_carry_forward_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_carry_forward_pg_test.go
@@ -148,3 +148,60 @@ func TestDelegatedReservoirServesCarriedForwardAccountPostgres(t *testing.T) {
 		t.Fatalf("unexpected reservoir row: touchpoint=%s account=%s", gotTouchpoint, gotAccount)
 	}
 }
+
+// A producer that publishes no population attestation has revoked nothing. The
+// durable per-account three-year evidence is the authority, so approved work
+// for a still-QUALIFIED account must survive an unattested feed rather than be
+// mass-cancelled as an advanced binding.
+func TestDelegatedUnattestedPopulationKeepsQualifiedApprovalsPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	qualifyDelegatedPGFixture(t, f)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+
+	// Drop only the population attestation. Every per-account commercial fact
+	// and the structural attestation columns stay exactly as they were.
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_feed_sync_state SET commercial_authority_v2=NULL
+		WHERE organization_id=$1`, f.orgID); err != nil {
+		t.Fatal(err)
+	}
+	state, err := f.repo.GetFeedSyncState(f.ctx, f.orgID)
+	if err != nil || state == nil {
+		t.Fatalf("feed state unavailable: state=%+v err=%v", state, err)
+	}
+	if authority := FeedCommercialAuthorityState(state); authority.Present {
+		t.Fatalf("fixture still carries a population attestation: %+v", authority)
+	}
+
+	retired, err := f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, state.LastRunID, state.LastSnapshotHash)
+	if err != nil || retired != 0 {
+		t.Fatalf("an unattested population retired a qualified decision: retired=%d err=%v", retired, err)
+	}
+	var decisionState, queueState string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT d.state,q.status
+		FROM confenge_delegated_first_touch_decisions d
+		JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.message_key=d.queue_message_key
+		WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID).
+		Scan(&decisionState, &queueState); err != nil {
+		t.Fatal(err)
+	}
+	if decisionState != "QUEUED" || queueState != "queued" {
+		t.Fatalf("qualified decision did not survive an unattested population: decision=%s queue=%s", decisionState, queueState)
+	}
+
+	// Losing the per-account commercial fact still retires the work, so the
+	// fallback is an authority substitution and not a bypass.
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_accounts SET commercial_qualification_state='EXPIRED'
+		WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].AccountID); err != nil {
+		t.Fatal(err)
+	}
+	retired, err = f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, state.LastRunID, state.LastSnapshotHash)
+	if err != nil || retired != 1 {
+		t.Fatalf("an unqualified account survived an unattested population: retired=%d err=%v", retired, err)
+	}
+}

--- a/internal/app/confenge/delegated_first_touch_refresh.go
+++ b/internal/app/confenge/delegated_first_touch_refresh.go
@@ -11,8 +11,10 @@ const delegatedBindingRefreshReason = "delegated_authority_or_source_binding_adv
 // retireStaleDelegatedFirstTouches revokes approvals whose account is no longer
 // commercially QUALIFIED, or whose runtime, policy or membership binding moved.
 // Source run id, snapshot expiry and freshness hash are acquisition provenance
-// and never retire a still-qualified decision.
+// and never retire a still-qualified decision, so sourceRunID and snapshotHash
+// are accepted for call-site symmetry and deliberately not compared.
 func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uuid.UUID, sourceRunID, snapshotHash string, policyAuthorizationIDs ...*uuid.UUID) (int, error) {
+	_, _ = sourceRunID, snapshotHash
 	if s == nil || s.delegatedDB == nil {
 		return 0, nil
 	}
@@ -27,10 +29,17 @@ func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uu
 		policyAuthorizationID = policyAuthorizationIDs[0]
 	}
 	feedState, feedErr := s.repo.GetFeedSyncState(ctx, orgID)
-	authorityValid := feedErr == nil && feedState != nil && feedState.LastRunID == sourceRunID &&
-		feedState.LastSnapshotHash == snapshotHash &&
+	// A producer that published no population attestation has not revoked
+	// anything. Fall back to the durable per-account three-year evidence, the
+	// same authority the first-window readback reads, so an unattested but
+	// individually proven population never retires its own approved work.
+	authority := FeedCommercialAuthorityState(feedState)
+	if !authority.Present {
+		authority = s.commercialQualificationFromAccounts(ctx, orgID, s.now())
+	}
+	authorityValid := feedErr == nil && feedState != nil &&
 		validateAuthoritativeFeedStructure(feedState, true) == nil &&
-		FeedCommercialAuthorityState(feedState).State == CommercialQualified
+		authority.State == CommercialQualified
 	targetMembershipHash, targetMembershipCount := "", 0
 	if feedState != nil {
 		targetMembershipHash = feedState.TargetMembershipHash

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -666,6 +666,10 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 			// Target-fit is reversible. Skip this detached/ineligible lead without
 			// bounce-marking or adding a sticky global recipient suppression.
 			log.Info().Str("campaign_id", campaign.ID.String()).Str("contact", contact.Email).Str("reason", gate.Reason).Msg("confenge commercial authorization blocked")
+			// Skipping means advancing past the lead. Without this the same
+			// ineligible contact is reselected every cycle and head-of-line
+			// blocks every other contact in the campaign forever.
+			s.advancePastCommercialBlock(ctx, campaign.ID, contact.ID, sequence.ID)
 			_ = s.taskRepo.UpdateTaskStatusWithLock(ctx, taskID, "skipped_suppressed")
 			if s.campaignLogRepo != nil {
 				_ = s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{

--- a/internal/tasks/confenge_gate.go
+++ b/internal/tasks/confenge_gate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 
 	"github.com/warmbly/warmbly/internal/app/confenge"
 )
@@ -18,4 +19,18 @@ type ConfengeOutboundGate interface {
 // WireConfengeDispatch attaches CONFENGE mailbox pacing to campaign sends.
 func (s *tasksService) WireConfengeDispatch(g ConfengeOutboundGate) {
 	s.confengeGate = g
+}
+
+// advancePastCommercialBlock moves campaign routing past a lead the CONFENGE
+// commercial gate rejected. The block is reversible, so this records no bounce
+// and no global recipient suppression: it only stops the campaign reselecting
+// the same ineligible contact on every cycle, which would otherwise head-of-line
+// block every other contact behind it.
+func (s *tasksService) advancePastCommercialBlock(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) {
+	if s.campaignProgressRepo == nil {
+		return
+	}
+	if err := s.campaignProgressRepo.RecordEmailSent(ctx, campaignID, contactID, sequenceID); err != nil {
+		log.Warn().Err(err).Str("campaign_id", campaignID.String()).Msg("confenge gate: failed to advance past commercial block")
+	}
 }

--- a/internal/tasks/confenge_gate_commercial_block_test.go
+++ b/internal/tasks/confenge_gate_commercial_block_test.go
@@ -1,0 +1,68 @@
+package tasks
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+type commercialBlockProgressRepo struct {
+	repository.CampaignProgressRepository
+	sent     int
+	bounced  int
+	sentErr  error
+	lastPair [3]uuid.UUID
+}
+
+func (r *commercialBlockProgressRepo) RecordEmailSent(_ context.Context, campaignID, contactID, sequenceID uuid.UUID) error {
+	r.sent++
+	r.lastPair = [3]uuid.UUID{campaignID, contactID, sequenceID}
+	return r.sentErr
+}
+
+func (r *commercialBlockProgressRepo) RecordEmailBounced(context.Context, uuid.UUID, uuid.UUID, uuid.UUID) error {
+	r.bounced++
+	return nil
+}
+
+// A reversible commercial block must advance campaign routing past the lead.
+// Without this the scheduler reselects the same ineligible contact every cycle
+// and no other contact in the campaign is ever reached.
+func TestAdvancePastCommercialBlockAdvancesWithoutBounce(t *testing.T) {
+	repo := &commercialBlockProgressRepo{}
+	svc := &tasksService{campaignProgressRepo: repo}
+	campaignID, contactID, sequenceID := uuid.New(), uuid.New(), uuid.New()
+
+	svc.advancePastCommercialBlock(context.Background(), campaignID, contactID, sequenceID)
+
+	if repo.sent != 1 {
+		t.Fatalf("commercial block did not advance campaign routing: sent=%d", repo.sent)
+	}
+	if repo.lastPair != [3]uuid.UUID{campaignID, contactID, sequenceID} {
+		t.Fatalf("advanced the wrong pair: %+v", repo.lastPair)
+	}
+	// The block is reversible: it must never bounce-mark the contact.
+	if repo.bounced != 0 {
+		t.Fatalf("a reversible commercial block bounce-marked the contact: bounced=%d", repo.bounced)
+	}
+}
+
+// A progress failure must not panic or escalate; the campaign simply retries.
+func TestAdvancePastCommercialBlockToleratesProgressFailure(t *testing.T) {
+	repo := &commercialBlockProgressRepo{sentErr: errors.New("progress unavailable")}
+	svc := &tasksService{campaignProgressRepo: repo}
+	svc.advancePastCommercialBlock(context.Background(), uuid.New(), uuid.New(), uuid.New())
+	if repo.sent != 1 {
+		t.Fatalf("expected one advance attempt, got %d", repo.sent)
+	}
+}
+
+// A service without a progress repo must stay inert rather than nil-panic.
+func TestAdvancePastCommercialBlockWithoutProgressRepo(t *testing.T) {
+	svc := &tasksService{}
+	svc.advancePastCommercialBlock(context.Background(), uuid.New(), uuid.New(), uuid.New())
+}


### PR DESCRIPTION
## Problem

With the queue restored by #229, CONFENGE still transported nothing. Every campaign task today was consumed by the **same** contact:

```
CONFENGE target-fit blocked reservas@premier.com.br: target_fit_not_operational
```

22 identical skips today, `confenge_dispatch_sends = 0`.

`GateCommercialBlock` marks the task `skipped_suppressed`, logs, creates the next campaign task and returns — but advances **no** campaign progress. `FindNextRoutedPair` selects on `campaign_contact_progress.sent_at`, so a contact with no progress row is reselected on every cycle, forever.

Both sibling branches already advance:

- `GateHardBlock` → `RecordEmailSent` + `RecordEmailBounced` + suppress
- `GateAlready` → `RecordEmailSent`
- `GateCommercialBlock` → nothing

So one target-fit-ineligible lead at the head of the list permanently starves every other contact. In production the two first touches handed off to the campaign (`cordeiroscruzz@gmail.com`, `gerlainefernandesimobadm@gmail.com`) sat enrolled and unreachable behind it.

The gate's own doc comment says this kind is a "reversible target-fit/readiness block; **skip** without global suppression" — the skip was never implemented.

## Fix

Advance campaign routing past the lead, and only that. `advancePastCommercialBlock` records no bounce and adds no global recipient suppression, so the block stays reversible and the lead remains contactable elsewhere; it only stops the campaign reselecting the same ineligible contact every cycle.

## Test

`TestAdvancePastCommercialBlockAdvancesWithoutBounce` pins that the advance happens for the exact pair and that the contact is never bounce-marked, plus tolerance of a progress-repo failure and of an unset repo.