### PR TITLE
fix: stop every deploy cancelling the whole CONFENGE first-touch queue

### DIFF
--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -313,7 +313,7 @@ func (s *service) ReconcileDelegatedFirstTouchLedger(ctx context.Context, orgID 
 				(d.state IN ('APPROVED','APPROVED_NOT_SCHEDULED') AND t.state <> 'APPROVED')
 				OR (d.state='QUEUED' AND (
 					t.state NOT IN ('QUEUED','SENT')
-					OR (t.state='QUEUED' AND (q.status IS NULL OR q.status NOT IN ('queued','reserved','sent')))
+					OR (t.state='QUEUED' AND (q.status IS NULL OR q.status NOT IN ('queued','reserved','attempted','sent')))
 				))
 			  )
 		)
@@ -337,14 +337,14 @@ func (s *service) ReconcileDelegatedFirstTouchLedger(ctx context.Context, orgID 
 		LEFT JOIN confenge_dispatch_queue q
 		  ON q.organization_id=d.organization_id AND q.draft_id=d.draft_id AND q.message_key=d.queue_message_key
 		WHERE t.organization_id=$1 AND t.state='QUEUED' AND d.state='CANCELLED'
-		  AND (q.status IS NULL OR q.status NOT IN ('queued','reserved','sent'))
+		  AND (q.status IS NULL OR q.status NOT IN ('queued','reserved','attempted','sent'))
 		  AND NOT EXISTS (
 			SELECT 1 FROM confenge_delegated_first_touch_decisions live
 			JOIN confenge_dispatch_queue live_q
 			  ON live_q.organization_id=live.organization_id AND live_q.draft_id=live.draft_id
 			 AND live_q.message_key=live.queue_message_key
 			WHERE live.organization_id=t.organization_id AND live.touchpoint_id=t.id
-			  AND live.state='QUEUED' AND live_q.status IN ('queued','reserved','sent')
+			  AND live.state='QUEUED' AND live_q.status IN ('queued','reserved','attempted','sent')
 		  )`, orgID)
 	if err != nil {
 		return 0, err

--- a/internal/app/confenge/delegated_first_touch_carry_forward_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_carry_forward_pg_test.go
@@ -205,3 +205,86 @@ func TestDelegatedUnattestedPopulationKeepsQualifiedApprovalsPostgres(t *testing
 		t.Fatalf("an unqualified account survived an unattested population: retired=%d err=%v", retired, err)
 	}
 }
+
+// A deploy changes the runtime release sha of the process, not the commercial
+// fact, the policy binding or the copy. Comparing it retired every approved and
+// queued first touch on every deploy: production accumulated 7141 cancelled
+// qualified decisions across six release cohorts and never sent a single mail,
+// because the queue was destroyed faster than the send cadence could drain it.
+func TestDelegatedRedeployKeepsQueuedWorkPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	qualifyDelegatedPGFixture(t, f)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+	feed, err := f.repo.GetFeedSyncState(f.ctx, f.orgID)
+	if err != nil || feed == nil {
+		t.Fatalf("feed state unavailable: state=%+v err=%v", feed, err)
+	}
+
+	// The next release ships. Nothing about this account changed.
+	f.svc.cfg.RepositorySHA = "sha-after-redeploy-" + uuid.NewString()
+
+	retired, err := f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, feed.LastRunID, feed.LastSnapshotHash)
+	if err != nil || retired != 0 {
+		t.Fatalf("a redeploy retired still-qualified queued work: retired=%d err=%v", retired, err)
+	}
+	var decisionState, queueState string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT d.state,q.status
+		FROM confenge_delegated_first_touch_decisions d
+		JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.message_key=d.queue_message_key
+		WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID).
+		Scan(&decisionState, &queueState); err != nil {
+		t.Fatal(err)
+	}
+	if decisionState != "QUEUED" || queueState != "queued" {
+		t.Fatalf("queued work did not survive the redeploy: decision=%s queue=%s", decisionState, queueState)
+	}
+}
+
+// The population attestation can be republished over the same members with a
+// new revision. That is an import event, not a revocation, and it must not
+// cancel work already proven against the per-account three-year fact.
+func TestDelegatedMembershipRepublishKeepsQueuedWorkPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	qualifyDelegatedPGFixture(t, f)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+	state, err := f.repo.GetFeedSyncState(f.ctx, f.orgID)
+	if err != nil || state == nil {
+		t.Fatalf("feed state unavailable: state=%+v err=%v", state, err)
+	}
+	account, err := f.repo.GetAccount(f.ctx, f.orgID, f.manifest.Entries[0].AccountID)
+	if err != nil || account == nil {
+		t.Fatalf("account unavailable: account=%+v err=%v", account, err)
+	}
+	// The producer republishes with one more member in the population.
+	state.TargetMembershipHash = strings.Repeat("c", 64)
+	state.TargetMembershipCount += 1
+	qualification := testRootQualification(account.CNPJRoot, time.Now().UTC().AddDate(-1, 0, 0))
+	stampFeedStateWithV2(state, []RootQualification{qualification})
+	if err := f.repo.UpsertFeedSyncState(f.ctx, state); err != nil {
+		t.Fatal(err)
+	}
+
+	retired, err := f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, state.LastRunID, state.LastSnapshotHash)
+	if err != nil || retired != 0 {
+		t.Fatalf("a membership republish retired still-qualified queued work: retired=%d err=%v", retired, err)
+	}
+	var queueState string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT q.status
+		FROM confenge_delegated_first_touch_decisions d
+		JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.message_key=d.queue_message_key
+		WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID).
+		Scan(&queueState); err != nil {
+		t.Fatal(err)
+	}
+	if queueState != "queued" {
+		t.Fatalf("queued work did not survive the republish: queue=%s", queueState)
+	}
+}

--- a/internal/app/confenge/delegated_first_touch_refresh.go
+++ b/internal/app/confenge/delegated_first_touch_refresh.go
@@ -4,15 +4,22 @@ import (
 	"context"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 )
 
 const delegatedBindingRefreshReason = "delegated_authority_or_source_binding_advanced"
 
 // retireStaleDelegatedFirstTouches revokes approvals whose account is no longer
-// commercially QUALIFIED, or whose runtime, policy or membership binding moved.
-// Source run id, snapshot expiry and freshness hash are acquisition provenance
-// and never retire a still-qualified decision, so sourceRunID and snapshotHash
-// are accepted for call-site symmetry and deliberately not compared.
+// commercially QUALIFIED, whose policy binding moved, or whose campaign policy
+// authorization is gone. Acquisition and build provenance never retire a
+// still-qualified decision: source run id, snapshot expiry, freshness hash, the
+// population attestation revision and the runtime release sha are all import or
+// build identity rather than authority, so sourceRunID and snapshotHash are
+// accepted for call-site symmetry and deliberately not compared.
+//
+// Retirement is destructive and irreversible for a queued touch, so it requires
+// positive proof of revocation. Doubt (an unreadable feed, a structurally
+// invalid attestation) blocks transport elsewhere and retires nothing here.
 func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uuid.UUID, sourceRunID, snapshotHash string, policyAuthorizationIDs ...*uuid.UUID) (int, error) {
 	_, _ = sourceRunID, snapshotHash
 	if s == nil || s.delegatedDB == nil {
@@ -29,6 +36,14 @@ func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uu
 		policyAuthorizationID = policyAuthorizationIDs[0]
 	}
 	feedState, feedErr := s.repo.GetFeedSyncState(ctx, orgID)
+	// A feed that could not be read has revoked nothing. Sweeping on an unknown
+	// population would cancel every approved touch on a transient database error.
+	if feedErr != nil {
+		return 0, feedErr
+	}
+	if feedState == nil || validateAuthoritativeFeedStructure(feedState, true) != nil {
+		return 0, nil
+	}
 	// A producer that published no population attestation has not revoked
 	// anything. Fall back to the durable per-account three-year evidence, the
 	// same authority the first-window readback reads, so an unattested but
@@ -37,14 +52,9 @@ func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uu
 	if !authority.Present {
 		authority = s.commercialQualificationFromAccounts(ctx, orgID, s.now())
 	}
-	authorityValid := feedErr == nil && feedState != nil &&
-		validateAuthoritativeFeedStructure(feedState, true) == nil &&
-		authority.State == CommercialQualified
-	targetMembershipHash, targetMembershipCount := "", 0
-	if feedState != nil {
-		targetMembershipHash = feedState.TargetMembershipHash
-		targetMembershipCount = feedState.TargetMembershipCount
-	}
+	// Symmetric with the approval path, which blocks only on a present-and-not-
+	// qualified attestation. Absence of proof is not proof of revocation.
+	authorityRevoked := authority.Present && authority.State != CommercialQualified
 
 	rows, err := tx.Query(ctx, `
 		SELECT d.touchpoint_id
@@ -55,18 +65,16 @@ func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uu
 		  AND d.state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')
 		  AND d.touchpoint_id IS NOT NULL
 		  AND (a.id IS NULL OR a.commercial_qualification_state<>'QUALIFIED'
-		    OR d.runtime_release_sha<>$2
-		    OR d.policy_version NOT IN ($3,$4,$12)
-		    OR d.policy_hash<>CASE d.policy_version WHEN $3 THEN $5 WHEN $4 THEN $6 WHEN $12 THEN $13 ELSE '' END
-		    OR ($8 AND ($7::uuid IS NULL OR d.policy_authorization_id<>$7))
-		    OR NOT $9 OR d.target_membership_hash<>$10
-		    OR d.target_membership_count<>$11)
-		FOR UPDATE OF d`, orgID, s.cfg.RepositorySHA,
+		    OR d.policy_version NOT IN ($2,$3,$8)
+		    OR d.policy_hash<>CASE d.policy_version WHEN $2 THEN $4 WHEN $3 THEN $5 WHEN $8 THEN $9 ELSE '' END
+		    OR ($7 AND ($6::uuid IS NULL OR d.policy_authorization_id<>$6))
+		    OR $10)
+		FOR UPDATE OF d`, orgID,
 		DelegatedFirstTouchPolicyV1, DelegatedFirstTouchPolicyV2,
 		DelegatedFirstTouchPolicyHashV1, DelegatedFirstTouchPolicyHashV2,
 		policyAuthorizationID, checkPolicyAuthorization,
-		authorityValid, targetMembershipHash, targetMembershipCount,
-		DelegatedFirstTouchPolicyV3, DelegatedFirstTouchPolicyHashV3)
+		DelegatedFirstTouchPolicyV3, DelegatedFirstTouchPolicyHashV3,
+		authorityRevoked)
 	if err != nil {
 		return 0, err
 	}
@@ -125,5 +133,10 @@ func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uu
 	if err = tx.Commit(ctx); err != nil {
 		return 0, err
 	}
+	// Retirement cancels durable queued work, so its blast radius is never silent.
+	log.Warn().Str("organization_id", orgID.String()).Int("retired", len(touchpointIDs)).
+		Bool("authority_revoked", authorityRevoked).
+		Bool("policy_authorization_enforced", checkPolicyAuthorization).
+		Msg("confenge: retired delegated first-touch approvals")
 	return len(touchpointIDs), nil
 }

--- a/internal/app/confenge/delegated_first_touch_refresh_test.go
+++ b/internal/app/confenge/delegated_first_touch_refresh_test.go
@@ -40,10 +40,92 @@ func TestRetireStaleIgnoresAcquisitionProvenance(t *testing.T) {
 	if !strings.Contains(s, "a.commercial_qualification_state<>'QUALIFIED'") {
 		t.Fatal("retirement must gate on the commercial fact, not on which run emitted the row")
 	}
-	for _, integrity := range []string{"d.runtime_release_sha<>", "d.policy_hash<>", "d.target_membership_hash<>", "d.target_membership_count<>"} {
-		if !strings.Contains(s, integrity) {
-			t.Fatalf("%s is a content/binding integrity term and must stay", integrity)
+	// A build identity and a population revision are provenance too. Comparing
+	// them retired every approved touch on each deploy and on each republish of
+	// the same membership: six release cohorts, 7141 qualified decisions, and a
+	// production first-touch queue that could never survive long enough to send.
+	for _, provenance := range []string{
+		"d.runtime_release_sha<>",
+		"d.target_membership_hash<>",
+		"d.target_membership_count<>",
+	} {
+		if strings.Contains(s, provenance) {
+			t.Fatalf("%s is build or import provenance and must not retire a qualified decision", provenance)
 		}
+	}
+	for _, integrity := range []string{"d.policy_hash<>", "d.policy_version NOT IN ("} {
+		if !strings.Contains(s, integrity) {
+			t.Fatalf("%s is a policy binding integrity term and must stay", integrity)
+		}
+	}
+}
+
+// Retirement cancels durable queued work, so it must require positive proof of
+// revocation. A feed that could not be read has revoked nothing; sweeping on it
+// cancelled the whole org queue on a transient database error.
+func TestRetireStaleDoesNotSweepOnUnreadableFeed(t *testing.T) {
+	b, err := os.ReadFile("delegated_first_touch_refresh.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "if feedErr != nil {\n\t\treturn 0, feedErr\n\t}") {
+		t.Fatal("a feed read error must abort the sweep, not fall through into a total cancel")
+	}
+	if strings.Contains(s, "OR NOT $9") {
+		t.Fatal("absence of a qualified attestation is not revocation; the sweep must be symmetric with the approval path")
+	}
+	if !strings.Contains(s, "authorityRevoked := authority.Present && authority.State != CommercialQualified") {
+		t.Fatal("only a present-and-unqualified attestation retires population-wide")
+	}
+}
+
+// The autorun must not conflate "policy could not be read" with "policy revoked".
+func TestAutorunDoesNotRetireOnPolicyReadError(t *testing.T) {
+	b, err := os.ReadFile("delegated_first_touch_worker.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if strings.Contains(s, "if err != nil || auth == nil {") {
+		t.Fatal("a transient policy read error must not take the retirement branch")
+	}
+	if !strings.Contains(s, "var noAuthorization *uuid.UUID") {
+		t.Fatal("the no-active-policy sentinel must be explicit, not a bare nil variadic")
+	}
+}
+
+// 'attempted' is the terminal hand-off state, not canonical drift. Omitting it
+// made every backend restart un-enrol correctly dispatched touches and strip
+// their approval.
+func TestLedgerReconcilerTreatsAttemptedAsValidTransit(t *testing.T) {
+	b, err := os.ReadFile("delegated_first_touch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if strings.Contains(s, "'queued','reserved','sent'") {
+		t.Fatal("a queue row in 'attempted' is valid transit and must not be reconciled as drift")
+	}
+	if !strings.Contains(s, "'queued','reserved','attempted','sent'") {
+		t.Fatal("the transit allow-list must include the attempted hand-off state")
+	}
+}
+
+// An attempted row whose touchpoint lost approval can never receive an outcome,
+// and Enqueue treats 'attempted' as terminal, so it would block that draft
+// forever.
+func TestAttemptedReconcilerRecoversOrphanedRows(t *testing.T) {
+	b, err := os.ReadFile("dispatch_queue_worker.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if !strings.Contains(s, "touchpoint_reverted_before_provider_outcome") {
+		t.Fatal("an approval-stripped attempted row must reach a terminal, re-queueable state")
+	}
+	if strings.Contains(s, "models.TouchpointOpenStates[tp.State]") {
+		t.Fatal("QUEUED is the healthy in-flight state and must not be failed as an orphan")
 	}
 }
 

--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -93,9 +93,20 @@ func (s *service) ProcessDelegatedFirstTouchOnce(ctx context.Context) (processed
 		return false, err
 	}
 	auth, err := s.policyStore.GetActiveCampaignPolicy(ctx, orgID, *settings.CampaignID, time.Now().UTC())
-	if err != nil || auth == nil {
-		_, _ = s.retireStaleDelegatedFirstTouches(ctx, orgID, feed.LastRunID, feed.LastSnapshotHash, nil)
+	if err != nil {
+		// A policy read that failed is not a revoked policy. Retiring here would
+		// cancel every approved touch in the org on a transient database error.
 		return false, err
+	}
+	if auth == nil {
+		// No active campaign policy authorization: nothing is authorized to
+		// send, so approvals made under a previous authorization do retire. The
+		// nil pointer is the sentinel the predicate reads as "matches none".
+		var noAuthorization *uuid.UUID
+		if _, retireErr := s.retireStaleDelegatedFirstTouches(ctx, orgID, feed.LastRunID, feed.LastSnapshotHash, noAuthorization); retireErr != nil {
+			return false, retireErr
+		}
+		return false, nil
 	}
 	if _, err = s.retireStaleDelegatedFirstTouches(ctx, orgID, feed.LastRunID, feed.LastSnapshotHash, &auth.ID); err != nil {
 		return false, err

--- a/internal/app/confenge/dispatch_queue_worker.go
+++ b/internal/app/confenge/dispatch_queue_worker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 
 	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
 	"github.com/warmbly/warmbly/internal/errx"
@@ -154,6 +155,21 @@ func (s *service) ReconcileAttemptedDispatches(ctx context.Context) (int, error)
 			if err := s.governor.MarkQueue(ctx, item.ID, dispatch.QueueCancelled, "touchpoint_cancelled"); err != nil {
 				return reconciled, err
 			}
+			reconciled++
+		case tp.State == models.TouchpointNeedsReview:
+			// The touchpoint lost its approval before the outcome was observed, so
+			// no outcome can ever arrive. QUEUED is deliberately not treated this
+			// way: that is the healthy in-flight state while acceptance is still
+			// unknown. Enqueue treats 'attempted' as terminal to prevent a
+			// duplicate dispatch, so leaving the row here would block this draft
+			// from ever being queued again. Fail it with a diagnosable reason; a
+			// re-approval can then legitimately re-queue it.
+			if err := s.governor.MarkQueue(ctx, item.ID, dispatch.QueueFailed, "touchpoint_reverted_before_provider_outcome"); err != nil {
+				return reconciled, err
+			}
+			log.Warn().Str("queue_item_id", item.ID.String()).Str("draft_id", item.DraftID.String()).
+				Str("touchpoint_state", tp.State).
+				Msg("confenge: attempted dispatch orphaned by touchpoint revert")
 			reconciled++
 		}
 	}


### PR DESCRIPTION
## Why

CONFENGE first-touch outbound has never produced a provider-accepted send (`confenge_dispatch_sends = 0`). Production evidence shows why: the delegated retire sweep cancelled **7141 policy-approved decisions** across six release cohorts, each batch matching exactly one deploy.

| release SHA | PR | cancelled |
|---|---|---|
| 73cb566d | #228 | 3561 |
| 8d31f883 | #226 | 1534 |
| f5bd6bc2 | #227 | 1214 |
| a6226601 | #225 | 841 |
| 14c48573 | #224 | 421 |
| 1b5e5c72 | #229 | 412 |

Every cancelled row carried the **same** `target_membership_hash`, the same membership count and the same active policy version as the live feed. The only differing column was `runtime_release_sha`. Deploying #230 destroyed the 412-item queue that #230 was written to drain, and the send cadence (6/hour, business window only) can never outrun the deploy rate.

## What changed

`retireStaleDelegatedFirstTouches`:

- **Release SHA is build provenance, not authority.** A deploy changes the process, not the commercial fact, the policy binding or the copy. The predicate no longer compares it. Copy staleness is already refused by editorial authority at transport, and policy drift is still caught by `policy_version`/`policy_hash`.
- **Population-attestation revision is import provenance.** A republish over the same members changed `target_membership_hash`/`count` and retired everything behind it. Revocation is carried per account by `commercial_qualification_state`, which the feed upsert maintains and the sweep still enforces.
- **Retirement now requires positive proof.** A feed that could not be read has revoked nothing; the sweep aborted into a total cancel on any transient error. It now returns instead. The attestation term is symmetric with the approval path: only a *present and not-qualified* attestation retires population-wide.
- Mass retirement is logged with its blast radius.

`ProcessDelegatedFirstTouchOnce`: a transient policy-read error took the same branch as a genuinely revoked policy, and passed a bare `nil` into a variadic `...*uuid.UUID`, which the predicate reads as "matches every row". Read failure now returns; the no-active-policy case keeps its intended retirement with an explicit sentinel.

`ReconcileDelegatedFirstTouchLedger`: `'attempted'` is the terminal hand-off state, but the transit allow-list only accepted `queued`/`reserved`/`sent`. Every backend restart therefore classified correctly dispatched touches as drift and stripped their approval and enrolment. Production showed three such touchpoints reset to `NEEDS_REVIEW`/`canonical_queue_state_drift` at the 15:51 restart.

`ReconcileAttemptedDispatches`: an `attempted` row whose touchpoint lost approval can never receive an outcome, and `Enqueue` treats `attempted` as terminal to prevent duplicate dispatch, so the draft was blocked forever. Those rows now reach a terminal, re-queueable `failed` state. `QUEUED` is deliberately excluded: it is the healthy in-flight state while acceptance is unknown.

## Safety

No qualification, suppression, dedup, target-fit, cadence or approval gate is weakened. Retirement still fires on: account missing or not `QUALIFIED`, policy version/hash drift, campaign authorization drift, and a producer-revoked population.

## Tests

- redeploy under a new release SHA keeps queued work (PG)
- membership republish keeps queued work (PG)
- feed read error does not sweep; attestation absence is not revocation
- policy read error does not retire
- `attempted` is valid transit, not canonical drift
- orphaned attempted rows recover; `QUEUED` is never failed as an orphan