### PR TITLE
fix: a skipped CONFENGE lead must not consume a mailbox send slot

### DIFF
--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -678,7 +678,12 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 					Metadata: map[string]interface{}{"reason": gate.Reason},
 				})
 			}
-			_ = s.createCampaignTask(ctx, campaign.ID, accountID, nextTime)
+			// Nothing was sent, so this lead must not consume a mailbox send slot.
+			// Pacing at nextTime made every skipped lead cost a full min-gap, so a
+			// handful of ineligible leads at the head of the campaign delayed the
+			// first eligible contact behind them by hours. The gate itself is the
+			// pacing authority and still defers a real send to its own slot.
+			_ = s.createCampaignTask(ctx, campaign.ID, accountID, skipRetryTime(nextTime))
 			executionStatus = "completed"
 			return nil
 
@@ -1240,4 +1245,14 @@ func (s *tasksService) recordSchedulerFailure(ctx context.Context, campaignID uu
 		Message:    message,
 		Metadata:   meta,
 	})
+}
+
+// skipRetryTime paces a cycle that sent no mail. A skip must not burn the
+// mailbox min-gap, but it must not hot-loop either.
+func skipRetryTime(nextTime time.Time) time.Time {
+	soon := time.Now().UTC().Add(30 * time.Second)
+	if !nextTime.IsZero() && nextTime.Before(soon) {
+		return nextTime
+	}
+	return soon
 }

--- a/internal/tasks/confenge_gate_commercial_block_test.go
+++ b/internal/tasks/confenge_gate_commercial_block_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -65,4 +66,31 @@ func TestAdvancePastCommercialBlockToleratesProgressFailure(t *testing.T) {
 func TestAdvancePastCommercialBlockWithoutProgressRepo(t *testing.T) {
 	svc := &tasksService{}
 	svc.advancePastCommercialBlock(context.Background(), uuid.New(), uuid.New(), uuid.New())
+}
+
+// A cycle that sent no mail must not consume the mailbox min-gap. Pacing a skip
+// at the next send slot made each ineligible lead cost a full gap, so a handful
+// of blocked leads at the head of the campaign delayed the first eligible
+// contact behind them by hours.
+func TestSkipRetryTimeDoesNotBurnTheSendSlot(t *testing.T) {
+	now := time.Now().UTC()
+	nextSlot := now.Add(27 * time.Minute)
+
+	got := skipRetryTime(nextSlot)
+
+	if !got.Before(nextSlot) {
+		t.Fatalf("a skip consumed the send slot: got=%s next_slot=%s", got, nextSlot)
+	}
+	if got.Before(now.Add(5 * time.Second)) {
+		t.Fatalf("a skip must not hot-loop: got=%s now=%s", got, now)
+	}
+}
+
+// When the mailbox is already due, the real slot is sooner than the skip delay
+// and must win, so a skip never delays an eligible send.
+func TestSkipRetryTimeKeepsAnAlreadyDueSlot(t *testing.T) {
+	due := time.Now().UTC().Add(-time.Minute)
+	if got := skipRetryTime(due); !got.Equal(due) {
+		t.Fatalf("an already-due slot was pushed back: got=%s due=%s", got, due)
+	}
 }


### PR DESCRIPTION
## Why

#230 correctly stopped a reversible commercial block from head-of-line blocking the campaign, by advancing campaign progress past the ineligible lead. But the skip still rescheduled the next campaign task at `nextTime`, the mailbox's next **send** slot.

Nothing was sent on that cycle. Paying a full `min_wait_time` (600s in CONFENGE production, and the queue is paced at 27 minutes per item) for a lead that produced no mail means a run of ineligible leads at the head of the campaign delays the first eligible contact behind them by hours.

Production today: the CONFENGE campaign has 8 leads ahead of the first freshly dispatched first touch, several of them stale or ineligible. At one min-gap per skip that is a multi-hour delay before any real send can be attempted, inside a 09:00-18:00 business window.

## What changed

On the `GateCommercialBlock` path only, the next campaign task is scheduled at `skipRetryTime(nextTime)`: 30 seconds out, or the real slot if that is already due.

This does not weaken pacing. The CONFENGE outbound gate is the pacing authority and still returns `GateDeferred` with its own `NextSlot` when a genuine send is attempted before the mailbox is due, so actual sends remain min-gap paced. The 30-second floor keeps a fully blocked campaign from hot-looping.

Send, defer, suppress and hard-block paths are untouched.

## Tests

- a skip does not consume the send slot, and does not hot-loop
- an already-due slot is preserved, so a skip never delays an eligible send