### PR TITLE
fix: neither a deploy nor a population republish is authority drift at CONFENGE transport

### DIFF
--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -2493,12 +2493,11 @@ func (s *service) assertDelegatedFirstTouchDecision(ctx context.Context, orgID u
 	if qual := AccountCommercialQualification(acc, now); !qual.AllowsTransport() {
 		return fail(firstNonEmpty(firstHold(qual.ReasonCodes), ReasonQualificationMissing))
 	}
-	// Membership binding only: snapshot expiry and freshness hash move on every
-	// refresh and are acquisition provenance recorded on the decision.
-	if got.TargetMembershipHash != feedState.TargetMembershipHash ||
-		got.TargetMembershipCount != feedState.TargetMembershipCount {
-		return fail("source_authority_binding_drift")
-	}
+	// The population attestation revision is import provenance, like the run id
+	// and snapshot hash above it. A republish over the same members changes the
+	// membership hash and count, and comparing them here cancelled every queued
+	// decision minted against the previous revision. Revocation is carried per
+	// account by the three-year qualification asserted immediately above.
 	var evidenceIDs, roleReasons []string
 	if json.Unmarshal(got.ContractEvidenceIDs, &evidenceIDs) != nil || json.Unmarshal(got.RoleReasonCodes, &roleReasons) != nil {
 		return fail("contractor_role_audit_decode_failed")

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -2404,9 +2404,14 @@ func (s *service) assertDelegatedFirstTouchDecision(ctx context.Context, orgID u
 	if !stateBound {
 		return fail("delegated_decision_queue_state_drift")
 	}
+	// The runtime release sha is the build that made the decision, not the
+	// authority behind it. Comparing it here cancelled every approved touch the
+	// moment a new release shipped: the policy version, policy hash, authority
+	// reference, actor type and evidence version below are what actually bind
+	// this decision, and copy is bound separately by editorial authority.
 	if expected, ok := expectedFirstTouchPolicyHash(got.PolicyVersion); !ok || got.PolicyHash != expected ||
 		got.AuthorityReference != DelegatedFirstTouchAuthorityRef || got.ActorType != "delegated_agent" || got.Authority != DelegatedFirstTouchAuthority ||
-		got.EvidenceVersion != DelegatedFirstTouchEvidenceV1 || got.RuntimeReleaseSHA != s.cfg.RepositorySHA {
+		got.EvidenceVersion != DelegatedFirstTouchEvidenceV1 {
 		return fail("policy_or_authority_drift")
 	}
 	if s.policyStore == nil {

--- a/internal/app/confenge/delegated_first_touch_carry_forward_test.go
+++ b/internal/app/confenge/delegated_first_touch_carry_forward_test.go
@@ -180,15 +180,21 @@ func TestDelegatedFirstTouchGatesCarryNoRunIDRevocation(t *testing.T) {
 		"acc.ContractorRoleSourceRunID != got.SourceRunID",
 		"feedState.LastRunID != got.SourceRunID",
 		"got.SourceExpiresAt.Equal(feedState.SourceExpiresAt",
+		// The attestation revision is import provenance for the same reason the
+		// run id and snapshot hash are: a republish over the same members moves
+		// the hash and count without revoking anything. Revocation is carried
+		// per account by the three-year qualification.
+		"got.TargetMembershipHash != feedState.TargetMembershipHash",
+		"got.TargetMembershipCount != feedState.TargetMembershipCount",
 	} {
 		if strings.Contains(s, revocation) {
 			t.Fatalf("%s revokes a bound decision on acquisition provenance", revocation)
 		}
 	}
 	for _, binding := range []string{
-		"got.TargetMembershipHash != feedState.TargetMembershipHash",
 		"acc.ContractorRoleEvidenceHash != got.EvidenceHash",
 		"got.ContentHash != tp.ContentHash",
+		"AccountCommercialQualification(acc, now); !qual.AllowsTransport()",
 	} {
 		if !strings.Contains(s, binding) {
 			t.Fatalf("%s is a content/binding integrity term and must stay", binding)

--- a/internal/app/confenge/delegated_first_touch_refresh_test.go
+++ b/internal/app/confenge/delegated_first_touch_refresh_test.go
@@ -139,3 +139,28 @@ func TestNextDelegatedCandidateSkipsCancelledMatchingBinding(t *testing.T) {
 		t.Fatal("a CANCELLED v2 approval with the current binding must not be selected again; that stalls the autorun burst")
 	}
 }
+
+// The transport-time assertion must not treat the runtime release sha as
+// authority either. It cancelled a queued first touch the moment a new release
+// shipped: production cancelled construtoralsg@hotmail.com 16 seconds after it
+// came due, with policy_or_authority_drift, because the decision was stamped by
+// the previous release.
+func TestTransportAssertionIgnoresRuntimeReleaseSHA(t *testing.T) {
+	b, err := os.ReadFile("delegated_first_touch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if strings.Contains(s, "got.RuntimeReleaseSHA != s.cfg.RepositorySHA") {
+		t.Fatal("a deploy is not authority drift; the release sha must not cancel a queued first touch at transport")
+	}
+	for _, binding := range []string{
+		"got.PolicyHash != expected",
+		"got.AuthorityReference != DelegatedFirstTouchAuthorityRef",
+		"got.EvidenceVersion != DelegatedFirstTouchEvidenceV1",
+	} {
+		if !strings.Contains(s, binding) {
+			t.Fatalf("%s is a real authority binding and must stay", binding)
+		}
+	}
+}

--- a/internal/app/confenge/delegated_first_touch_refresh_test.go
+++ b/internal/app/confenge/delegated_first_touch_refresh_test.go
@@ -164,3 +164,21 @@ func TestTransportAssertionIgnoresRuntimeReleaseSHA(t *testing.T) {
 		}
 	}
 }
+
+// A republish of the population over the same members must not cancel a queued
+// decision at transport either, for the same reason the retire sweep no longer
+// compares it: revocation is per account, not per attestation revision.
+func TestTransportAssertionIgnoresMembershipRevision(t *testing.T) {
+	b, err := os.ReadFile("delegated_first_touch.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	if strings.Contains(s, "source_authority_binding_drift") {
+		t.Fatal("an import revision is not revocation; it must not cancel a queued first touch at transport")
+	}
+	// The per-account commercial fact is what actually gates transport.
+	if !strings.Contains(s, "AccountCommercialQualification(acc, now); !qual.AllowsTransport()") {
+		t.Fatal("the three-year commercial qualification must still gate transport")
+	}
+}


### PR DESCRIPTION
## Why

#231 stopped the *retire sweep* treating `runtime_release_sha` and the population attestation revision as authority. Both comparisons exist a second time, on the per-touch transport assertion, where `fail(...)` cancels the delegated decision **and** its dispatch queue row.

While the retire sweep was bulk-cancelling on every deploy this was masked, because no row survived long enough to reach transport. With #231 deployed the rows survive, and are now cancelled individually as each becomes due.

Observed in production minutes after deploying `07a287f5`:

```
recipient_ref | construtoralsg@hotmail.com
due_at        | 2026-08-28 16:28:26+00
updated_at    | 2026-08-28 16:28:42+00
status        | cancelled
cancel_reason | policy_or_authority_drift
```

The decision was stamped `bdca96e2`; production now runs `07a287f5`. All 411 remaining queued first touches would be cancelled the same way, one at a time, as they came due. Dispatch is paused in production until this ships.

## What changed

**1. Release sha (`policy_or_authority_drift`).** Dropped from the drift condition. What still binds the decision is unchanged and checked on the same line: policy version and its expected policy hash, the authority reference, the actor type, the authority, and the evidence version. Copy is bound separately by editorial authority (`ComposerVersion`, `TemplateVersion`, `PromptVersion`, `ContentHash`, all still asserted below), and the campaign policy authorization is verified via `GetCampaignPolicyByID`, `validateDelegatedPolicy`, the founder binding, and transport eligibility.

**2. Membership revision (`source_authority_binding_drift`).** A republish over the same members changes `target_membership_hash` and `target_membership_count`, which cancelled every decision minted against the previous revision. This is import provenance, exactly like the run id and snapshot hash the comment above it already exempts. Revocation is carried per account by the three-year commercial qualification asserted immediately above, which is untouched and still fails closed.

Every per-recipient compliance gate is untouched: `RequireEmailOutbound`, controlled-route eligibility, enrollability, message-context freshness, recipient/route-class binding, the shared-CNPJ conflict check, evidence corroboration, import-run binding, feed structural validity, and the contractor-role evidence assertion.

The bounded-cohort path's own `sha_drift` check (`cohort_authorization.go`) is deliberately left alone: that model freezes an operator-authorized artifact to a specific release on purpose.

## Tests

- the release-sha comparison is gone from the transport assertion, while the real authority bindings remain
- the membership-revision comparison is gone, while the three-year commercial qualification still gates transport
