### PR TITLE
fix: the runway watermark must count carried-forward scheduled work

### DIFF
--- a/internal/app/confenge/delegated_first_touch_runway.go
+++ b/internal/app/confenge/delegated_first_touch_runway.go
@@ -321,6 +321,13 @@ func delegatedSendWindowDuration(start, end string) (time.Duration, bool) {
 	return time.Duration(minutes) * time.Minute, true
 }
 
+// delegatedFirstTouchQueueSnapshot measures how much real sending capacity is
+// already committed. That is a question about scheduled slots, not about which
+// run, snapshot, release or authorization minted them: scoping the count to the
+// current identity hid every carried-forward row, so the planner believed the
+// runway was empty and scheduled a second full runway on top of it. Production
+// reached 40 sends a business day against an intended 20, and would have added
+// another runway on every deploy.
 func (s *service) delegatedFirstTouchQueueSnapshot(
 	ctx context.Context,
 	orgID uuid.UUID,
@@ -328,6 +335,7 @@ func (s *service) delegatedFirstTouchQueueSnapshot(
 	policyAuthorizationID uuid.UUID,
 	plan *delegatedFirstTouchRunwayPlan,
 ) error {
+	_, _ = feed, policyAuthorizationID
 	if plan == nil {
 		return nil
 	}
@@ -339,10 +347,8 @@ func (s *service) delegatedFirstTouchQueueSnapshot(
 		FROM confenge_delegated_first_touch_decisions d
 		JOIN confenge_dispatch_queue q
 		  ON q.organization_id=d.organization_id AND q.draft_id=d.draft_id AND q.message_key=d.queue_message_key
-		WHERE d.organization_id=$1 AND d.state='QUEUED' AND q.status IN ('queued','reserved')
-		  AND d.evidence_source_run_id=$2 AND d.source_snapshot_hash=$3
-		  AND d.runtime_release_sha=$4 AND d.policy_authorization_id=$5`,
-		orgID, feed.LastRunID, feed.LastSnapshotHash, s.cfg.RepositorySHA, policyAuthorizationID).
+		WHERE d.organization_id=$1 AND d.state='QUEUED' AND q.status IN ('queued','reserved')`,
+		orgID).
 		Scan(&plan.QueuedCount, &plan.ReservedCount, &furthest)
 	if err != nil {
 		return err

--- a/internal/app/confenge/delegated_first_touch_runway_capacity_test.go
+++ b/internal/app/confenge/delegated_first_touch_runway_capacity_test.go
@@ -1,0 +1,45 @@
+package confenge
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// The runway watermark asks how much sending capacity is already committed.
+// Scoping that count to the current run, snapshot, release sha and policy
+// authorization hid every carried-forward row, so the planner believed the
+// runway was empty and scheduled a second full runway on top of it. Production
+// reached 40 sends a business day against an intended 20, and would have added
+// another runway on every deploy.
+func TestRunwaySnapshotCountsAllScheduledWork(t *testing.T) {
+	b, err := os.ReadFile("delegated_first_touch_runway.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	start := strings.Index(s, "func (s *service) delegatedFirstTouchQueueSnapshot(")
+	if start < 0 {
+		t.Fatal("delegatedFirstTouchQueueSnapshot not found")
+	}
+	end := strings.Index(s[start:], "\nfunc ")
+	if end < 0 {
+		end = len(s) - start
+	}
+	body := s[start : start+end]
+
+	for _, identity := range []string{
+		"d.evidence_source_run_id=",
+		"d.source_snapshot_hash=",
+		"d.runtime_release_sha=",
+		"d.policy_authorization_id=",
+	} {
+		if strings.Contains(body, identity) {
+			t.Fatalf("%s scopes the capacity count to one identity and hides carried-forward scheduled work", identity)
+		}
+	}
+	// A committed slot is still committed regardless of which run minted it.
+	if !strings.Contains(body, "d.state='QUEUED' AND q.status IN ('queued','reserved')") {
+		t.Fatal("the capacity count must still measure real queued and reserved work")
+	}
+}


### PR DESCRIPTION
## Why

`delegatedFirstTouchQueueSnapshot` measures how much sending capacity is already committed, and the autorun stops filling once `CurrentScheduledCount >= TargetScheduledCount`. But it counted only rows matching the **current** identity:

```sql
AND d.evidence_source_run_id=$2 AND d.source_snapshot_hash=$3
AND d.runtime_release_sha=$4 AND d.policy_authorization_id=$5
```

Any work carried forward from a previous run or release is therefore invisible to the watermark, so the planner believes the runway is empty and schedules a **second full runway on top of the existing one**.

This was masked while the retire sweep and the transport assertion were cancelling carried-forward rows (#231, #234). With those fixed, the rows survive and the double-scheduling became visible in production within minutes:

```
queued rows:        411  ->  821
2026-08-28 due:      11  ->   19
per business day:    20  ->   40   (intended: 20)
```

while the readback still reported `current_scheduled_count: 410, target_scheduled_count: 410, TargetReached`. Every future deploy or run advance would add another ~410 rows, without bound.

This is the same "identity as authority" mistake as #231 and #234, expressed as double-scheduling rather than cancellation.

## What changed

The capacity count now measures all real committed slots for the organization: `d.state='QUEUED' AND q.status IN ('queued','reserved')`. Which run, snapshot, release or authorization minted a slot does not change the fact that it occupies one.

No safety property depends on this count. It is a scheduling watermark, not a gate: actual sends remain paced by the mailbox governor (6/hour, 600s min gap, business window), and every per-touch authority and compliance assertion is unchanged.

## Test

Asserts the capacity count carries no run, snapshot, release-sha or authorization scoping, while still measuring real queued and reserved work.