### PR TITLE
fix: a provider-accepted CONFENGE send must be recordable

### DIFF
--- a/cmd/consumer/confenge_wire_test.go
+++ b/cmd/consumer/confenge_wire_test.go
@@ -49,3 +49,17 @@ func TestConfengeReplyPathWiresCRM(t *testing.T) {
 		t.Fatal("consumer production boot must not use NewMemoryCohortStore as cohort authority")
 	}
 }
+
+// The consumer observes the provider result, so it is the only process that can
+// commit the dispatch reservation. Without the governor wired, every accepted
+// CONFENGE send failed with "dispatch governor unavailable for provider
+// attempt" and confenge_dispatch_sends could never be written.
+func TestConsumerWiresConfengeDispatchGovernor(t *testing.T) {
+	b, err := os.ReadFile("main.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), "confengeSvc.WireDispatch(primaryDB.Pool)") {
+		t.Fatal("the consumer must wire the CONFENGE dispatch governor to commit provider-accepted sends")
+	}
+}

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -359,6 +359,11 @@ func main() {
 		// commercial store they would fall back to process memory and disappear
 		// before the backend/Control Center can reconstruct cohort outcomes.
 		confengeSvc.WireIntel(primaryDB.Pool)
+		// The consumer is the only process that observes a provider result, so
+		// it is the only one that can commit the dispatch reservation into
+		// confenge_dispatch_sends. Without the governor, every provider-accepted
+		// CONFENGE send failed to record and retried forever.
+		confengeSvc.WireDispatch(primaryDB.Pool)
 		confengeSvc.WireCohortAuth(confenge.NewPostgresCohortStore(primaryDB.Pool))
 		if sink, ok := confengeSvc.(confenge.OutcomeSink); ok {
 			confengeSink = sink

--- a/internal/app/confenge/delegated_first_touch_refresh_test.go
+++ b/internal/app/confenge/delegated_first_touch_refresh_test.go
@@ -182,3 +182,37 @@ func TestTransportAssertionIgnoresMembershipRevision(t *testing.T) {
 		t.Fatal("the three-year commercial qualification must still gate transport")
 	}
 }
+
+// A provider-accepted send must be recordable. The completion path re-ran the
+// pre-send authority guard, which rejects CAMPAIGN_POLICY because it carries no
+// individual approver, so every provider-confirmed CONFENGE first touch failed
+// to persist: Hostinger accepted the mail, the touchpoint stayed QUEUED and
+// confenge_dispatch_sends stayed empty while the consumer retried forever.
+func TestSentTransitionDoesNotReauthorizeAnAcceptedSend(t *testing.T) {
+	b, err := os.ReadFile("touchpoint_sm.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	start := strings.Index(s, "func transitionToSent(")
+	if start < 0 {
+		t.Fatal("transitionToSent not found")
+	}
+	end := strings.Index(s[start:], "\nfunc ")
+	if end < 0 {
+		end = len(s) - start
+	}
+	body := s[start : start+end]
+	if strings.Contains(body, "checkTransitionTransport(") {
+		t.Fatal("the mail has already left; re-authorizing here can only lose the record of an accepted send")
+	}
+	// The state precondition is a real idempotency guard and must stay.
+	if !strings.Contains(body, "cannot mark sent from state") {
+		t.Fatal("only a QUEUED or APPROVED touchpoint may be marked sent")
+	}
+	// Authority must still be enforced where it can actually stop a send.
+	sm := s
+	if !strings.Contains(sm, "func CanTransport(") {
+		t.Fatal("the pre-send transport guard must still exist")
+	}
+}

--- a/internal/app/confenge/touchpoint_sm.go
+++ b/internal/app/confenge/touchpoint_sm.go
@@ -341,8 +341,23 @@ func transitionToSent(tp *models.OutreachTouchpoint, now time.Time, providerMsgI
 	if tp.State != models.TouchpointQueued && tp.State != models.TouchpointApproved {
 		return fmt.Errorf("cannot mark sent from state %s", tp.State)
 	}
-	if err := checkTransitionTransport(tp, auth, in); err != nil {
-		return err
+	// Recording an observed provider acceptance is not a decision to send: the
+	// message is already with the provider by the time this runs. Re-running the
+	// individual-approval guard here could not prevent anything, it could only
+	// lose the record of mail that already left, and it did. A delegated first
+	// touch carries CAMPAIGN_POLICY authorization with no individual approver by
+	// design, so CanTransport rejected every provider-confirmed CONFENGE send,
+	// leaving the touchpoint QUEUED and confenge_dispatch_sends empty while the
+	// provider had accepted the message.
+	//
+	// Authority is enforced before the send, where it can still stop one: the
+	// outbound gate, the queue gate and the delegated transport assertion. The
+	// bounded-cohort grant keeps its own transport revalidation, which is a
+	// deliberate property of that model.
+	if isBoundedCohortTouch(tp) {
+		if err := CanTransportCohort(tp, auth, in); err != nil {
+			return err
+		}
 	}
 	tp.State = models.TouchpointSent
 	tp.SentAt = &now


### PR DESCRIPTION
## Why

Production reached the provider. At 17:01:58Z the worker logged:

```
task_id:         a37732df-b622-4262-802e-6d7ac95e6299
message_id:      <7e783eea-ee5d-426f-bb21-2db45306e520@confenge.com.br>
provider_msg_id: <7e783eea-ee5d-426f-bb21-2db45306e520@confenge.com.br>
message:         "Email sent successfully"
```

Hostinger accepted a real CONFENGE first touch to `monsani.monsani@gmail.com`. The consumer then failed to record it, in a tight retry loop:

```
error: "campaign_policy cannot transport; individual approval required"
error: "dispatch governor unavailable for provider attempt"
```

The touchpoint stayed `QUEUED` with `sent_at` NULL, and `confenge_dispatch_sends` stayed empty. This is why that table has always read 0: **no provider-accepted send has ever been recordable**, independently of whether one was ever sent.

Two causes.

**1. The consumer has no dispatch governor.** `cmd/backend/main.go` calls `WireDispatch(primaryDB.Pool)`; `cmd/consumer/main.go` wires Intel, CohortAuth and CRM but never the governor. The consumer is the *only* process that observes a provider result, so it is the only one that can commit the reservation into `confenge_dispatch_sends`. Without it, `ObserveCampaignEmailAttempt` fails outright and `CompleteCampaignEmail`'s `commitProviderSend()` cannot run.

**2. The completion path re-ran a pre-send guard.** `transitionToSent` called `CanTransport`, which rejects `AuthorizationMode=CAMPAIGN_POLICY` because it carries no individual approver. That is correct before a send and impossible after one: a delegated first touch is CAMPAIGN_POLICY authorized with `approved_by` NULL by design, so every provider-confirmed CONFENGE send was refused at the moment of recording.

## What changed

- `cmd/consumer/main.go` wires the CONFENGE dispatch governor.
- `transitionToSent` no longer re-authorizes. The state precondition (`QUEUED`/`APPROVED` only) stays, so it remains idempotent and cannot mark an arbitrary touchpoint sent. The bounded-cohort grant keeps its transport revalidation, which is a deliberate property of that model and is covered by `TestTransitionToSentAndQueuedRequireCohortGrant`.

Authority is unchanged everywhere it can still stop a send: the outbound gate, the queue gate, and the delegated transport assertion all run before transport.

## Tests

- the sent transition does not re-authorize, keeps its state precondition, and `CanTransport` still exists for the pre-send path
- the consumer wires the dispatch governor