### PR TITLE
fix: send-time optimization must not park a campaign on a later day

### DIFF
--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -911,7 +911,7 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 	scheduledNext := nextTime
 	if s.advanced != nil && campaign.OrganizationID != nil {
 		if optimized, xerr := s.advanced.OptimizeSendTime(ctx, *campaign.OrganizationID, contact, nextTime); xerr == nil {
-			scheduledNext = optimized
+			scheduledNext = withinDayOptimizedSendTime(nextTime, optimized, campaign.Timezone)
 		}
 	}
 
@@ -1255,4 +1255,31 @@ func skipRetryTime(nextTime time.Time) time.Time {
 		return nextTime
 	}
 	return soon
+}
+
+// withinDayOptimizedSendTime keeps send-time optimization a preference about
+// when inside a day to send, never an authority over which day.
+//
+// The optimizer works from its own preferred-hours list in its own timezone. If
+// the scheduler's slot is past the last preferred hour it rolls to the next day
+// and then past the weekend, so one CONFENGE send at 17:11 UTC on a Friday
+// scheduled the next campaign task for Monday 09:00 UTC: three days of silence
+// after a single send, at 06:00 in the campaign's own timezone, outside its
+// 09:00-18:00 window. An optimization that lands on a later local day than the
+// scheduler chose is discarded and the scheduler's slot stands.
+func withinDayOptimizedSendTime(base, optimized time.Time, timezone string) time.Time {
+	if optimized.IsZero() || optimized.Before(base) {
+		return base
+	}
+	loc, err := time.LoadLocation(strings.TrimSpace(timezone))
+	if err != nil || loc == nil {
+		loc = time.UTC
+	}
+	b, o := base.In(loc), optimized.In(loc)
+	by, bm, bd := b.Date()
+	oy, om, od := o.Date()
+	if by != oy || bm != om || bd != od {
+		return base
+	}
+	return optimized
 }

--- a/internal/tasks/confenge_gate_commercial_block_test.go
+++ b/internal/tasks/confenge_gate_commercial_block_test.go
@@ -94,3 +94,38 @@ func TestSkipRetryTimeKeepsAnAlreadyDueSlot(t *testing.T) {
 		t.Fatalf("an already-due slot was pushed back: got=%s due=%s", got, due)
 	}
 }
+
+// Send-time optimization is a preference about when inside a day to send, not
+// an authority over which day. Unbounded it rolled a CONFENGE send from Friday
+// 17:11 UTC to Monday 09:00 UTC: three days of silence after a single send, at
+// 06:00 in the campaign's own timezone, outside its 09:00-18:00 window.
+func TestOptimizedSendTimeCannotParkTheCampaignOnALaterDay(t *testing.T) {
+	tz := "America/Sao_Paulo"
+	base := time.Date(2026, 8, 28, 17, 11, 0, 0, time.UTC)
+	parked := time.Date(2026, 8, 31, 9, 0, 0, 0, time.UTC)
+
+	if got := withinDayOptimizedSendTime(base, parked, tz); !got.Equal(base) {
+		t.Fatalf("optimization moved the send to a later day: got=%s base=%s", got, base)
+	}
+}
+
+// Within the same local day the optimizer still wins, so the feature keeps working.
+func TestOptimizedSendTimeKeepsAWithinDayPreference(t *testing.T) {
+	tz := "America/Sao_Paulo"
+	base := time.Date(2026, 8, 28, 15, 5, 0, 0, time.UTC)   // 12:05 local
+	better := time.Date(2026, 8, 28, 17, 0, 0, 0, time.UTC) // 14:00 local, same day
+
+	if got := withinDayOptimizedSendTime(base, better, tz); !got.Equal(better) {
+		t.Fatalf("a same-day optimization was discarded: got=%s want=%s", got, better)
+	}
+}
+
+// An optimizer result before the scheduler's slot must never pull a send early,
+// because the slot already encodes the mailbox min-gap.
+func TestOptimizedSendTimeNeverPullsASendEarlier(t *testing.T) {
+	base := time.Date(2026, 8, 28, 17, 11, 0, 0, time.UTC)
+	earlier := base.Add(-2 * time.Hour)
+	if got := withinDayOptimizedSendTime(base, earlier, "America/Sao_Paulo"); !got.Equal(base) {
+		t.Fatalf("optimization pulled the send earlier than its slot: got=%s base=%s", got, base)
+	}
+}


### PR DESCRIPTION
## Why

After the first genuine CONFENGE provider-accepted send (Friday 17:01:56Z), the next campaign task was scheduled for **Monday 2026-08-31 09:00:00Z** — three days of silence after a single send.

The scheduler's own slot was ~17:11Z, well inside the campaign window (09:00-18:00 America/Sao_Paulo = 12:00-21:00 UTC, Mon-Fri). `OptimizeSendTime` then overrode it:

```go
hour := candidate.Hour()                 // 17
for _, h := range preferred { ... }      // [9,10,11,14,15,16] - none >= 17
if chosenHour == -1 {
    candidate = candidate.Add(24 * time.Hour)   // Saturday
    chosenHour = preferred[0]                   // 9
}
// weekend roll -> Monday 09:00
```

The org has no `outreach_settings` row, so `DefaultAdvancedOutreachSettings()` applies: `Enabled: true`, `DefaultContactTimezone: "UTC"`, `PreferredHours: [9,10,11,14,15,16]`. Those hours are in UTC while the campaign sends in America/Sao_Paulo, so the chosen 09:00 UTC is 06:00 local, **outside the campaign's own 09:00-18:00 window** — the task would defer again on arrival.

An optional preference was silently overriding the scheduler's valid slot and could delay sending by days, to a time the campaign cannot send at. This is a plausible contributor to the long-standing "one send, then silence" pattern.

## What changed

`withinDayOptimizedSendTime` keeps send-time optimization a preference about *when inside a day* to send, never an authority over *which day*. An optimized time that lands on a later local day than the scheduler's slot is discarded and the scheduler's slot stands. An optimized time earlier than the slot is also discarded, because the slot already encodes the mailbox min-gap.

Within the same local day the optimizer still wins, so the feature keeps doing its job.

Scoped to the campaign send path, which is the only caller. `OptimizeSendTime` itself is unchanged.

## Tests

- an optimization onto a later day is discarded (the exact Friday 17:11Z -> Monday 09:00Z case)
- a same-day optimization is still applied
- an optimization earlier than the scheduler's slot never pulls a send forward