### PR TITLE
feat: reconcile provider-accepted CONFENGE sends without retransmitting

### DIFF
--- a/cmd/confenge/main.go
+++ b/cmd/confenge/main.go
@@ -38,6 +38,8 @@ func main() {
 		os.Exit(cmdImport(os.Args[2:]))
 	case "reconcile-target-fit":
 		os.Exit(cmdReconcileTargetFit(os.Args[2:]))
+	case "reconcile-provider-accepted":
+		os.Exit(cmdReconcileProviderAccepted(os.Args[2:]))
 	case "stop-sending":
 		os.Exit(cmdStopSending())
 	case "resume-sending":
@@ -75,6 +77,7 @@ Usage:
   confenge bootstrap [--org-id UUID]
   confenge import --feed PATH|file://... [--dry-run] [--org-id UUID]
   confenge reconcile-target-fit [--dry-run] [--org-id UUID]
+  confenge reconcile-provider-accepted --task-id UUID --touchpoint-id UUID --recipient EMAIL --provider-message-id ID --accepted-at RFC3339 --actor UUID [--dry-run|--confirm PROVIDER_ACCEPTED_LOCAL_COMPLETION_FAILED]
   confenge commercial-qualification --corpus PATH [--dry-run] [--org-id UUID]
   confenge stop-sending
   confenge resume-sending

--- a/cmd/confenge/provider_reconciliation.go
+++ b/cmd/confenge/provider_reconciliation.go
@@ -1,0 +1,352 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/app/confenge"
+	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+const providerAcceptedRecoveryConfirmation = "PROVIDER_ACCEPTED_LOCAL_COMPLETION_FAILED"
+
+type providerAcceptedRecoveryTarget struct {
+	OrganizationID    uuid.UUID
+	CampaignID        uuid.UUID
+	ContactID         uuid.UUID
+	SequenceID        uuid.UUID
+	MailboxID         uuid.UUID
+	CampaignName      string
+	TaskStatus        string
+	MailboxProvider   string
+	ReservationID     uuid.UUID
+	ReservationState  string
+	ReservationKey    string
+	ReservationAt     time.Time
+	QueueID           uuid.UUID
+	QueueKey          string
+	QueueStatus       string
+	ExistingSendID    *uuid.UUID
+	ExistingSendAt    *time.Time
+	ProgressSentAt    *time.Time
+	TouchpointAccount uuid.UUID
+}
+
+func cmdReconcileProviderAccepted(args []string) int {
+	maybeLoadDotEnv()
+	fs := flag.NewFlagSet("reconcile-provider-accepted", flag.ContinueOnError)
+	taskRaw := fs.String("task-id", "", "original campaign task UUID")
+	touchpointRaw := fs.String("touchpoint-id", "", "original outreach touchpoint UUID")
+	recipient := fs.String("recipient", "", "exact original recipient")
+	providerMessageID := fs.String("provider-message-id", "", "provider-confirmed Message-ID")
+	acceptedRaw := fs.String("accepted-at", "", "provider acceptance time in RFC3339")
+	actorRaw := fs.String("actor", "", "organization member performing reconciliation")
+	dryRun := fs.Bool("dry-run", false, "validate and report without writing")
+	confirm := fs.String("confirm", "", "required recovery confirmation")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	if (*dryRun && strings.TrimSpace(*confirm) != "") || (!*dryRun && *confirm != providerAcceptedRecoveryConfirmation) {
+		fmt.Fprintf(os.Stderr, "choose --dry-run or --confirm %s\n", providerAcceptedRecoveryConfirmation)
+		return 2
+	}
+
+	taskID, taskErr := uuid.Parse(strings.TrimSpace(*taskRaw))
+	touchpointID, touchpointErr := uuid.Parse(strings.TrimSpace(*touchpointRaw))
+	actorID, actorErr := uuid.Parse(strings.TrimSpace(*actorRaw))
+	acceptedAt, acceptedErr := time.Parse(time.RFC3339Nano, strings.TrimSpace(*acceptedRaw))
+	recipientValue := strings.TrimSpace(strings.ToLower(*recipient))
+	providerIDValue := strings.TrimSpace(*providerMessageID)
+	if taskErr != nil || touchpointErr != nil || actorErr != nil || acceptedErr != nil || recipientValue == "" || providerIDValue == "" {
+		fmt.Fprintln(os.Stderr, "valid --task-id, --touchpoint-id, --recipient, --provider-message-id, --accepted-at, and --actor are required")
+		return 2
+	}
+	if strings.ContainsAny(providerIDValue, "\r\n\t") {
+		fmt.Fprintln(os.Stderr, "provider message id contains invalid whitespace")
+		return 2
+	}
+	acceptedAt = acceptedAt.UTC()
+	if acceptedAt.After(time.Now().UTC().Add(5 * time.Minute)) {
+		fmt.Fprintln(os.Stderr, "provider acceptance time is in the future")
+		return 2
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, primaryDSN())
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "provider reconciliation db: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+
+	target, touchpoint, err := loadProviderAcceptedRecoveryTarget(ctx, pool, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "provider reconciliation refused: %v\n", err)
+		return 1
+	}
+	var actorMember bool
+	if err := pool.QueryRow(ctx, `
+		SELECT EXISTS (
+			SELECT 1 FROM organization_members
+			WHERE organization_id=$1 AND user_id=$2 AND accepted_at IS NOT NULL
+		)`, target.OrganizationID, actorID).Scan(&actorMember); err != nil || !actorMember {
+		fmt.Fprintln(os.Stderr, "provider reconciliation refused: actor is not an accepted organization member")
+		return 1
+	}
+
+	status := "WOULD_RECONCILE"
+	if target.ExistingSendID != nil && touchpoint.State == models.TouchpointSent &&
+		normalizeProviderMessageID(touchpoint.ProviderMessageID) == normalizeProviderMessageID(providerIDValue) {
+		status = "ALREADY_RECONCILED"
+	}
+	if *dryRun {
+		printJSON(providerAcceptedRecoveryOutput(status, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt, target, touchpoint))
+		return 0
+	}
+
+	cfg := confenge.LoadConfig()
+	if !cfg.Enabled {
+		fmt.Fprintln(os.Stderr, "provider reconciliation refused: CONFENGE outreach is disabled")
+		return 1
+	}
+	repo := repository.NewOutreachRepository(pool)
+	svc := confenge.NewService(cfg, repo, nil)
+	svc.WireDispatch(pool)
+	svc.WireCohortAuth(confenge.NewPostgresCohortStore(pool))
+	svc.WireDelegatedFirstTouch(pool)
+	svc.WireIntel(pool)
+	if err := svc.CompleteCampaignEmail(
+		ctx,
+		target.OrganizationID,
+		target.CampaignID,
+		target.ContactID,
+		target.SequenceID,
+		taskID,
+		target.MailboxID,
+		providerIDValue,
+		target.MailboxProvider,
+		acceptedAt,
+	); err != nil {
+		_ = writeProviderRecoveryAudit(ctx, pool, actorID, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt, target, "FAILED", err.Error())
+		fmt.Fprintf(os.Stderr, "provider reconciliation failed: %v\n", err)
+		return 1
+	}
+	if _, err := svc.ReconcileAttemptedDispatches(ctx); err != nil {
+		_ = writeProviderRecoveryAudit(ctx, pool, actorID, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt, target, "PARTIAL", err.Error())
+		fmt.Fprintf(os.Stderr, "provider reconciliation dispatch queue: %v\n", err)
+		return 1
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at)
+		VALUES ($1,$2,$3,$4)
+		ON CONFLICT (campaign_id, contact_id, sequence_id)
+		DO UPDATE SET sent_at=COALESCE(campaign_contact_progress.sent_at, EXCLUDED.sent_at)`,
+		target.CampaignID, target.ContactID, target.SequenceID, acceptedAt); err != nil {
+		_ = writeProviderRecoveryAudit(ctx, pool, actorID, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt, target, "PARTIAL", err.Error())
+		fmt.Fprintf(os.Stderr, "provider reconciliation campaign progress: %v\n", err)
+		return 1
+	}
+	target, touchpoint, err = loadProviderAcceptedRecoveryTarget(ctx, pool, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "provider reconciliation readback: %v\n", err)
+		return 1
+	}
+	if target.QueueStatus != dispatch.QueueSent {
+		governor := dispatch.NewGovernor(dispatch.LoadConfig(), dispatch.NewPGStore(pool), nil)
+		if err := governor.MarkQueue(ctx, target.QueueID, dispatch.QueueSent, ""); err != nil {
+			_ = writeProviderRecoveryAudit(ctx, pool, actorID, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt, target, "PARTIAL", err.Error())
+			fmt.Fprintf(os.Stderr, "provider reconciliation exact dispatch queue: %v\n", err)
+			return 1
+		}
+		target, touchpoint, err = loadProviderAcceptedRecoveryTarget(ctx, pool, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "provider reconciliation final readback: %v\n", err)
+			return 1
+		}
+	}
+	if target.QueueStatus != dispatch.QueueSent || target.ExistingSendID == nil || touchpoint.State != models.TouchpointSent ||
+		normalizeProviderMessageID(touchpoint.ProviderMessageID) != normalizeProviderMessageID(providerIDValue) {
+		err := fmt.Errorf("durable recovery readback is incomplete")
+		_ = writeProviderRecoveryAudit(ctx, pool, actorID, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt, target, "PARTIAL", err.Error())
+		fmt.Fprintf(os.Stderr, "provider reconciliation readback: %v\n", err)
+		return 1
+	}
+	if err := writeProviderRecoveryAudit(ctx, pool, actorID, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt, target, "COMPLETED", ""); err != nil {
+		fmt.Fprintf(os.Stderr, "provider reconciliation audit: %v\n", err)
+		return 1
+	}
+	printJSON(providerAcceptedRecoveryOutput("RECONCILED", taskID, touchpointID, recipientValue, providerIDValue, acceptedAt, target, touchpoint))
+	return 0
+}
+
+func loadProviderAcceptedRecoveryTarget(ctx context.Context, pool *pgxpool.Pool, taskID, touchpointID uuid.UUID, recipient, providerMessageID string, acceptedAt time.Time) (providerAcceptedRecoveryTarget, *models.OutreachTouchpoint, error) {
+	target := providerAcceptedRecoveryTarget{}
+	err := pool.QueryRow(ctx, `
+		SELECT c.organization_id, ct.campaign_id, ct.contact_id, ct.sequence_id,
+		       t.email_account_id, c.name, t.status::text, COALESCE(e.provider,'smtp')
+		FROM tasks t
+		JOIN campaign_tasks ct ON ct.task_id=t.id
+		JOIN campaigns c ON c.id=ct.campaign_id
+		LEFT JOIN email_accounts e ON e.id=t.email_account_id
+		WHERE t.id=$1`, taskID).Scan(
+		&target.OrganizationID, &target.CampaignID, &target.ContactID, &target.SequenceID,
+		&target.MailboxID, &target.CampaignName, &target.TaskStatus, &target.MailboxProvider,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return target, nil, fmt.Errorf("campaign task not found")
+	}
+	if err != nil {
+		return target, nil, err
+	}
+	if !confenge.IsConfengeCampaign(target.CampaignName) {
+		return target, nil, fmt.Errorf("task is not bound to the canonical CONFENGE campaign")
+	}
+	if target.TaskStatus != "completed" {
+		return target, nil, fmt.Errorf("task status is %s, expected completed", target.TaskStatus)
+	}
+
+	repo := repository.NewOutreachRepository(pool)
+	touchpoint, err := repo.GetTouchpointByEnrollment(ctx, target.OrganizationID, target.CampaignID, target.ContactID)
+	if err != nil || touchpoint == nil {
+		return target, nil, fmt.Errorf("enrolled touchpoint not found")
+	}
+	if touchpoint.ID != touchpointID {
+		return target, nil, fmt.Errorf("touchpoint does not match the task enrollment")
+	}
+	if !strings.EqualFold(strings.TrimSpace(touchpoint.Recipient), recipient) {
+		return target, nil, fmt.Errorf("recipient does not match the enrolled touchpoint")
+	}
+	if touchpoint.State != models.TouchpointQueued && touchpoint.State != models.TouchpointApproved && touchpoint.State != models.TouchpointSent {
+		return target, nil, fmt.Errorf("touchpoint state %s is not recoverable by this command", touchpoint.State)
+	}
+	if touchpoint.State == models.TouchpointSent && normalizeProviderMessageID(touchpoint.ProviderMessageID) != normalizeProviderMessageID(providerMessageID) {
+		return target, nil, fmt.Errorf("touchpoint has a different provider message id")
+	}
+	target.TouchpointAccount = touchpoint.AccountID
+
+	var reservationCount int
+	if err := pool.QueryRow(ctx, `SELECT count(*) FROM confenge_dispatch_reservations WHERE task_id=$1`, taskID).Scan(&reservationCount); err != nil {
+		return target, nil, err
+	}
+	if reservationCount != 1 {
+		return target, nil, fmt.Errorf("expected one task reservation, found %d", reservationCount)
+	}
+	var reservationTaskID, reservationMailboxID uuid.UUID
+	err = pool.QueryRow(ctx, `
+		SELECT id, state, message_key, task_id, email_account_id, reserved_at
+		FROM confenge_dispatch_reservations WHERE task_id=$1`, taskID).Scan(
+		&target.ReservationID, &target.ReservationState, &target.ReservationKey,
+		&reservationTaskID, &reservationMailboxID, &target.ReservationAt,
+	)
+	if err != nil {
+		return target, nil, err
+	}
+	expectedKey := confenge.MessageKeyCampaignEmail(target.CampaignID, target.ContactID, target.SequenceID)
+	if reservationTaskID != taskID || reservationMailboxID != target.MailboxID || target.ReservationKey != expectedKey {
+		return target, nil, fmt.Errorf("reservation binding does not match the campaign task")
+	}
+	if acceptedAt.Before(target.ReservationAt.Add(-time.Minute)) {
+		return target, nil, fmt.Errorf("provider acceptance predates the reservation")
+	}
+	if touchpoint.DraftID == nil {
+		return target, nil, fmt.Errorf("touchpoint has no draft binding")
+	}
+	var queueCount int
+	if err := pool.QueryRow(ctx, `
+		SELECT count(*) FROM confenge_dispatch_queue
+		WHERE organization_id=$1 AND draft_id=$2`, target.OrganizationID, *touchpoint.DraftID).Scan(&queueCount); err != nil {
+		return target, nil, err
+	}
+	if queueCount != 1 {
+		return target, nil, fmt.Errorf("expected one delegated dispatch queue row, found %d", queueCount)
+	}
+	if err := pool.QueryRow(ctx, `
+		SELECT id, message_key, status FROM confenge_dispatch_queue
+		WHERE organization_id=$1 AND draft_id=$2`, target.OrganizationID, *touchpoint.DraftID).Scan(
+		&target.QueueID, &target.QueueKey, &target.QueueStatus,
+	); err != nil {
+		return target, nil, fmt.Errorf("dispatch queue binding: %w", err)
+	}
+	if target.QueueStatus != dispatch.QueueAttempted && target.QueueStatus != dispatch.QueueReserved && target.QueueStatus != dispatch.QueueSent {
+		return target, nil, fmt.Errorf("queue status %s is not an accepted hand-off", target.QueueStatus)
+	}
+
+	var conflictingTouchpoint uuid.UUID
+	err = pool.QueryRow(ctx, `
+		SELECT id FROM outreach_touchpoints
+		WHERE id<>$1 AND lower(trim(both '<>' from provider_message_id))=lower($2)
+		LIMIT 1`, touchpointID, normalizeProviderMessageID(providerMessageID)).Scan(&conflictingTouchpoint)
+	if err == nil {
+		return target, nil, fmt.Errorf("provider message id is already bound to another touchpoint")
+	}
+	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
+		return target, nil, err
+	}
+
+	var existingTaskID *uuid.UUID
+	var sendID uuid.UUID
+	var sendAt time.Time
+	err = pool.QueryRow(ctx, `SELECT id, task_id, sent_at FROM confenge_dispatch_sends WHERE message_key=$1`, expectedKey).Scan(&sendID, &existingTaskID, &sendAt)
+	if err == nil {
+		if existingTaskID == nil || *existingTaskID != taskID {
+			return target, nil, fmt.Errorf("durable send is bound to a different task")
+		}
+		target.ExistingSendID = &sendID
+		target.ExistingSendAt = &sendAt
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return target, nil, err
+	}
+	_ = pool.QueryRow(ctx, `
+		SELECT sent_at FROM campaign_contact_progress
+		WHERE campaign_id=$1 AND contact_id=$2 AND sequence_id=$3`,
+		target.CampaignID, target.ContactID, target.SequenceID).Scan(&target.ProgressSentAt)
+	return target, touchpoint, nil
+}
+
+func writeProviderRecoveryAudit(ctx context.Context, pool *pgxpool.Pool, actorID, taskID, touchpointID uuid.UUID, recipient, providerMessageID string, acceptedAt time.Time, target providerAcceptedRecoveryTarget, outcome, failure string) error {
+	return repository.NewAuditRepository(pool).Log(ctx, &models.CreateAuditLog{
+		OrgID: target.OrganizationID, UserID: actorID, Action: models.AuditActionUpdate,
+		EntityType: models.AuditEntityOutreachAccount, EntityID: &target.TouchpointAccount,
+		Changes: map[string]string{
+			"action":        "provider_acceptance_reconciled",
+			"touchpoint_id": touchpointID.String(),
+			"outcome":       outcome,
+		},
+		Metadata: map[string]string{
+			"task_id": taskID.String(), "recipient": recipient,
+			"provider_message_id": providerMessageID, "provider": target.MailboxProvider,
+			"accepted_at": acceptedAt.Format(time.RFC3339Nano), "reservation_id": target.ReservationID.String(),
+			"reason": "provider_accepted_local_completion_failed", "transport_invoked": "false", "failure": failure,
+		},
+	})
+}
+
+func providerAcceptedRecoveryOutput(status string, taskID, touchpointID uuid.UUID, recipient, providerMessageID string, acceptedAt time.Time, target providerAcceptedRecoveryTarget, touchpoint *models.OutreachTouchpoint) map[string]any {
+	return map[string]any{
+		"status": status, "transport_invoked": false,
+		"task_id": taskID, "task_status": target.TaskStatus,
+		"touchpoint_id": touchpointID, "touchpoint_state": touchpoint.State,
+		"recipient": recipient, "provider": target.MailboxProvider,
+		"provider_message_id": providerMessageID, "accepted_at": acceptedAt,
+		"reservation_id": target.ReservationID, "reservation_state": target.ReservationState,
+		"queue_id": target.QueueID, "queue_key": target.QueueKey, "queue_status": target.QueueStatus,
+		"local_send_id": target.ExistingSendID,
+		"local_send_at": target.ExistingSendAt, "campaign_progress_sent_at": target.ProgressSentAt,
+	}
+}
+
+func normalizeProviderMessageID(value string) string {
+	return strings.Trim(strings.TrimSpace(value), "<>")
+}

--- a/docs/confenge/vps-disaster-recovery.md
+++ b/docs/confenge/vps-disaster-recovery.md
@@ -145,6 +145,62 @@ deploy/confenge-vps/pause.sh "incident"
 # or from browser: dispatch pause when available
 ```
 
+## Provider accepted but local completion failed
+
+An `attempted` dispatch is terminal for enqueue. Do not change it back to
+`queued`, replay the campaign task, or insert a `sent` row directly. First
+confirm provider acceptance and capture the original Message-ID and timestamp.
+Keep dispatch paused while reconciling.
+
+The backend image contains the fail-closed operator command. Its dry run checks
+the task, campaign enrollment, touchpoint, recipient, mailbox, reservation,
+queue hand-off, provider Message-ID uniqueness, and organization actor without
+calling the worker or provider:
+
+```bash
+TASK_ID=<original-task-uuid>
+TOUCHPOINT_ID=<original-touchpoint-uuid>
+RECIPIENT=<exact-original-recipient>
+PROVIDER_MESSAGE_ID='<provider-message-id>'
+ACCEPTED_AT=<provider-acceptance-rfc3339>
+ACTOR_ID=<accepted-organization-member-uuid>
+
+deploy/confenge-vps/compose.sh run --rm --no-deps \
+  --entrypoint /app/confenge backend \
+  reconcile-provider-accepted \
+  --task-id "$TASK_ID" \
+  --touchpoint-id "$TOUCHPOINT_ID" \
+  --recipient "$RECIPIENT" \
+  --provider-message-id "$PROVIDER_MESSAGE_ID" \
+  --accepted-at "$ACCEPTED_AT" \
+  --actor "$ACTOR_ID" \
+  --dry-run
+```
+
+Apply only after the dry-run bindings match the provider evidence. The command
+reuses normal campaign completion, preserves the provider acceptance time,
+updates campaign progress only when it is missing, and writes an append-only
+audit entry with `transport_invoked=false`.
+
+```bash
+deploy/confenge-vps/compose.sh run --rm --no-deps \
+  --entrypoint /app/confenge backend \
+  reconcile-provider-accepted \
+  --task-id "$TASK_ID" \
+  --touchpoint-id "$TOUCHPOINT_ID" \
+  --recipient "$RECIPIENT" \
+  --provider-message-id "$PROVIDER_MESSAGE_ID" \
+  --accepted-at "$ACCEPTED_AT" \
+  --actor "$ACTOR_ID" \
+  --confirm PROVIDER_ACCEPTED_LOCAL_COMPLETION_FAILED
+```
+
+Re-running the same command is idempotent. A different task, recipient,
+touchpoint, mailbox, provider Message-ID, or non-accepted queue state is refused.
+Resume dispatch only after the touchpoint is `SENT`, the queue and reservation
+are committed, `confenge_dispatch_sends` has the original task, and the audit
+entry contains the original provider correlation.
+
 ## Network / provider incidents
 
 | Symptom | Action |

--- a/internal/app/confenge/dispatch/governor.go
+++ b/internal/app/confenge/dispatch/governor.go
@@ -186,8 +186,19 @@ func (g *Governor) Commit(ctx context.Context, reservationID uuid.UUID) error {
 
 // CommitByMessageKey records provider-confirmed delivery for an async transport.
 func (g *Governor) CommitByMessageKey(ctx context.Context, messageKey string) error {
+	if g == nil {
+		return fmt.Errorf("dispatch reservation key is unavailable")
+	}
+	return g.CommitByMessageKeyAt(ctx, messageKey, g.clock.Now().UTC())
+}
+
+// CommitByMessageKeyAt preserves the provider-observed acceptance time.
+func (g *Governor) CommitByMessageKeyAt(ctx context.Context, messageKey string, sentAt time.Time) error {
 	if g == nil || g.store == nil || messageKey == "" {
 		return fmt.Errorf("dispatch reservation key is unavailable")
+	}
+	if sentAt.IsZero() {
+		sentAt = g.clock.Now().UTC()
 	}
 	reservation, err := g.store.GetReservationByKey(ctx, messageKey)
 	if err != nil {
@@ -196,7 +207,7 @@ func (g *Governor) CommitByMessageKey(ctx context.Context, messageKey string) er
 	if reservation == nil {
 		return fmt.Errorf("dispatch reservation not found for provider-confirmed send")
 	}
-	return g.store.CommitReservation(ctx, reservation.ID, g.clock.Now().UTC())
+	return g.store.CommitReservation(ctx, reservation.ID, sentAt.UTC())
 }
 
 func (g *Governor) Release(ctx context.Context, reservationID uuid.UUID, errText string) error {

--- a/internal/app/confenge/dispatch/pg_store.go
+++ b/internal/app/confenge/dispatch/pg_store.go
@@ -407,7 +407,7 @@ func (s *PGStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt ti
 	}
 	_, _ = tx.Exec(ctx, `
 		UPDATE confenge_dispatch_queue SET status = 'sent', updated_at = now()
-		WHERE message_key = $1 AND status IN ('queued','reserved')`, r.MessageKey)
+		WHERE message_key = $1 AND status IN ('queued','reserved','attempted')`, r.MessageKey)
 	return tx.Commit(ctx)
 }
 

--- a/internal/app/confenge/outbound_gate.go
+++ b/internal/app/confenge/outbound_gate.go
@@ -622,11 +622,15 @@ func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, 
 	if touchpoint == nil {
 		return ErrCampaignTouchpointNotFound
 	}
-	commitProviderSend := func() error {
+	providerAcceptedAt := acceptedAt.UTC()
+	if providerAcceptedAt.IsZero() {
+		providerAcceptedAt = time.Now().UTC()
+	}
+	commitProviderSend := func(sentAt time.Time) error {
 		if sequenceID == uuid.Nil || s.governor == nil {
 			return fmt.Errorf("provider-confirmed CONFENGE send cannot commit its dispatch reservation")
 		}
-		return s.governor.CommitByMessageKey(ctx, MessageKeyCampaignEmail(campaignID, contactID, sequenceID))
+		return s.governor.CommitByMessageKeyAt(ctx, MessageKeyCampaignEmail(campaignID, contactID, sequenceID), sentAt)
 	}
 	observeAccepted := func() error {
 		var cand *models.OutreachContactCandidate
@@ -634,7 +638,7 @@ func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, 
 			cand, _ = s.repo.GetCandidate(ctx, orgID, *touchpoint.ContactCandidateID)
 		}
 		return s.observeControlledEmail(ctx, orgID, intel.EventProviderAccepted, touchpoint, cand, ControlledEmailContext{
-			OccurredAt: acceptedAt, ProviderName: firstNonEmpty(provider, "smtp"),
+			OccurredAt: providerAcceptedAt, ProviderName: firstNonEmpty(provider, "smtp"),
 			MailboxID: opaqueUUID(mailboxID), StableEventRef: firstNonEmpty(opaqueUUID(taskID), providerMessageID),
 		})
 	}
@@ -643,10 +647,11 @@ func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, 
 			strings.TrimSpace(providerMessageID) != "" && existing != strings.TrimSpace(providerMessageID) {
 			return fmt.Errorf("provider message id conflicts with completed touchpoint")
 		}
-		if err := commitProviderSend(); err != nil {
+		sentAt := firstNonZeroTime(touchpoint.SentAt, providerAcceptedAt)
+		if err := commitProviderSend(sentAt); err != nil {
 			return err
 		}
-		if err := s.markDelegatedFirstTouchSent(ctx, orgID, touchpoint.ID, firstNonZeroTime(touchpoint.SentAt, acceptedAt)); err != nil {
+		if err := s.markDelegatedFirstTouchSent(ctx, orgID, touchpoint.ID, sentAt); err != nil {
 			return err
 		}
 		if err := observeAccepted(); err != nil {
@@ -655,15 +660,12 @@ func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, 
 		return s.releaseNextTouch(ctx, orgID, touchpoint)
 	}
 	if models.TouchpointTerminalStates[touchpoint.State] {
-		if err := commitProviderSend(); err != nil {
+		if err := commitProviderSend(providerAcceptedAt); err != nil {
 			return err
 		}
 		return observeAccepted()
 	}
-	now := acceptedAt.UTC()
-	if now.IsZero() {
-		now = time.Now().UTC()
-	}
+	now := providerAcceptedAt
 	if err := s.transitionCompletedTouchpointKeyed(ctx, orgID, touchpoint, now, providerMessageID, MessageKeyCampaignEmail(campaignID, contactID, sequenceID)); err != nil {
 		return err
 	}
@@ -673,7 +675,7 @@ func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, 
 	if err := s.markDelegatedFirstTouchSent(ctx, orgID, touchpoint.ID, now); err != nil {
 		return err
 	}
-	if err := commitProviderSend(); err != nil {
+	if err := commitProviderSend(now); err != nil {
 		return err
 	}
 	if err := observeAccepted(); err != nil {

--- a/internal/app/confenge/outbound_gate_test.go
+++ b/internal/app/confenge/outbound_gate_test.go
@@ -213,6 +213,104 @@ func TestObserveCampaignEmailAttemptIncludesNonCohortControlledTouch(t *testing.
 	}
 }
 
+type failOnceCommitStore struct {
+	*dispatch.MemoryStore
+	fail bool
+}
+
+func (s *failOnceCommitStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt time.Time) error {
+	if s.fail {
+		s.fail = false
+		return errors.New("injected post-provider persistence failure")
+	}
+	return s.MemoryStore.CommitReservation(ctx, id, sentAt)
+}
+
+func TestCompleteCampaignEmailRecoversProviderAcceptedPersistenceFailure(t *testing.T) {
+	allowConfengeSendingForTest(t)
+	ctx := context.Background()
+	repo := newMemRepoWithSettings()
+	orgID, accountID, candidateID := uuid.New(), uuid.New(), uuid.New()
+	_, _ = repo.UpsertAccount(ctx, &models.OutreachAccount{
+		ID: accountID, OrganizationID: orgID, CNPJ14: "12345678000147",
+	})
+	_, _ = repo.UpsertCandidate(ctx, &models.OutreachContactCandidate{
+		ID: candidateID, OrganizationID: orgID, AccountID: accountID, Email: "accepted@example.com",
+	})
+	campaignID, contactID := bindTransportableEnrollment(t, repo.memRepo, orgID, accountID, candidateID, "accepted@example.com")
+	touchpoint, _ := repo.GetTouchpointByEnrollment(ctx, orgID, campaignID, contactID)
+
+	acceptedAt := time.Date(2026, 8, 28, 17, 1, 58, 0, time.UTC)
+	clock := &dispatch.FixedClock{T: acceptedAt.Add(30 * time.Minute)}
+	mailboxID, sequenceID, taskID := uuid.New(), uuid.New(), uuid.New()
+	baseStore := dispatch.NewMemoryStore()
+	baseStore.SetMailboxEnvelope(dispatch.MailboxEnvelope{
+		EmailAccountID: mailboxID, OrganizationID: orgID, DailyCap: 50, HourlyCap: 20,
+		Ready: true, Timezone: "UTC",
+	})
+	store := &failOnceCommitStore{MemoryStore: baseStore, fail: true}
+	cfg := dispatch.DefaultConfig()
+	cfg.SendsPerHour, cfg.MinGap = 100, 0
+	cfg.WindowStart, cfg.WindowEnd, cfg.Timezone = "00:00", "23:59", "UTC"
+	cfg.BusinessDaysOnly = false
+	governor := dispatch.NewGovernor(cfg, store, clock)
+	messageKey := MessageKeyCampaignEmail(campaignID, contactID, sequenceID)
+	queueID := uuid.New()
+	if err := baseStore.Enqueue(ctx, &dispatch.QueueItem{
+		ID: queueID, OrganizationID: orgID, EmailAccountID: &mailboxID,
+		Channel: dispatch.ChannelEmail, DraftID: *touchpoint.DraftID,
+		MessageKey: dispatch.MessageKeyEmail(*touchpoint.DraftID), RecipientRef: touchpoint.Recipient,
+		Status: dispatch.QueueAttempted, CreatedAt: acceptedAt.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("record delegated hand-off: %v", err)
+	}
+	reserved, err := governor.TryReserve(ctx, dispatch.ReserveRequest{
+		OrganizationID: orgID, EmailAccountID: &mailboxID, TaskID: &taskID,
+		Channel: dispatch.ChannelEmail, MessageKey: messageKey, DraftID: touchpoint.DraftID,
+	})
+	if err != nil || !reserved.Allowed {
+		t.Fatalf("reserve accepted send: result=%+v err=%v", reserved, err)
+	}
+
+	svc := &service{cfg: Config{Enabled: true}, repo: repo, governor: governor}
+	providerMessageID := "<provider-accepted@confenge.com.br>"
+	err = svc.CompleteCampaignEmail(ctx, orgID, campaignID, contactID, sequenceID, taskID, mailboxID, providerMessageID, "smtp", acceptedAt)
+	if err == nil {
+		t.Fatal("the injected local commit failure must surface")
+	}
+	if _, committed, getErr := baseStore.GetSendByKey(ctx, messageKey); getErr != nil || committed {
+		t.Fatalf("failed local commit must not claim a durable send: committed=%v err=%v", committed, getErr)
+	}
+	partiallyCompleted, _ := repo.GetTouchpoint(ctx, orgID, touchpoint.ID)
+	if partiallyCompleted.State != models.TouchpointSent || partiallyCompleted.ProviderMessageID != providerMessageID {
+		t.Fatalf("provider fact must remain replayable after the later commit fails: %+v", partiallyCompleted)
+	}
+
+	if err := svc.CompleteCampaignEmail(ctx, orgID, campaignID, contactID, sequenceID, taskID, mailboxID, providerMessageID, "smtp", acceptedAt); err != nil {
+		t.Fatalf("reconcile provider acceptance: %v", err)
+	}
+	sentAt, committed, err := baseStore.GetSendByKey(ctx, messageKey)
+	if err != nil || !committed {
+		t.Fatalf("reconciliation must commit the provider fact once: committed=%v err=%v", committed, err)
+	}
+	if !sentAt.Equal(acceptedAt) {
+		t.Fatalf("dispatch ledger sent_at=%s want provider acceptance %s", sentAt, acceptedAt)
+	}
+	if reconciled, err := svc.ReconcileAttemptedDispatches(ctx); err != nil || reconciled != 1 {
+		t.Fatalf("reconcile delegated hand-off: count=%d err=%v", reconciled, err)
+	}
+	queue, err := baseStore.ListQueueByStatus(ctx, dispatch.QueueSent, 10)
+	if err != nil || len(queue) != 1 || queue[0].ID != queueID {
+		t.Fatalf("delegated queue must close without sharing the campaign reservation key: queue=%+v err=%v", queue, err)
+	}
+	if err := svc.CompleteCampaignEmail(ctx, orgID, campaignID, contactID, sequenceID, taskID, mailboxID, providerMessageID, "smtp", acceptedAt); err != nil {
+		t.Fatalf("idempotent reconciliation replay: %v", err)
+	}
+	if replayedAt, _, _ := baseStore.GetSendByKey(ctx, messageKey); !replayedAt.Equal(acceptedAt) {
+		t.Fatalf("replay changed durable provider time to %s", replayedAt)
+	}
+}
+
 func TestGateCampaignEmailTransientOnGovernorError(t *testing.T) {
 	allowConfengeSendingForTest(t)
 	// errStore fails TryReserveAtomic (simulates DB blip).


### PR DESCRIPTION
## What changed

- add a fail-closed operator recovery command for provider-accepted, locally uncommitted CONFENGE sends
- preserve the original provider acceptance time in the durable dispatch ledger
- reconcile the distinct campaign reservation and delegated draft queue identities
- make completion replay idempotent after a post-provider persistence failure
- document the paused, dry-run-first production runbook

## Verification

- focused CONFENGE consumer, completion, scheduler, runway, head-of-line, and dispatch tests
- golangci-lint
- gofmt-l cmd internal (no output)