### PR TITLE
feat: repair legacy CONFENGE provider acceptance timestamps on replay

### DIFF
--- a/cmd/confenge/provider_reconciliation.go
+++ b/cmd/confenge/provider_reconciliation.go
@@ -152,7 +152,7 @@ func cmdReconcileProviderAccepted(args []string) int {
 		INSERT INTO campaign_contact_progress (campaign_id, contact_id, sequence_id, sent_at)
 		VALUES ($1,$2,$3,$4)
 		ON CONFLICT (campaign_id, contact_id, sequence_id)
-		DO UPDATE SET sent_at=COALESCE(campaign_contact_progress.sent_at, EXCLUDED.sent_at)`,
+		DO UPDATE SET sent_at=EXCLUDED.sent_at`,
 		target.CampaignID, target.ContactID, target.SequenceID, acceptedAt); err != nil {
 		_ = writeProviderRecoveryAudit(ctx, pool, actorID, taskID, touchpointID, recipientValue, providerIDValue, acceptedAt, target, "PARTIAL", err.Error())
 		fmt.Fprintf(os.Stderr, "provider reconciliation campaign progress: %v\n", err)

--- a/docs/confenge/vps-disaster-recovery.md
+++ b/docs/confenge/vps-disaster-recovery.md
@@ -179,7 +179,7 @@ deploy/confenge-vps/compose.sh run --rm --no-deps \
 
 Apply only after the dry-run bindings match the provider evidence. The command
 reuses normal campaign completion, preserves the provider acceptance time,
-updates campaign progress only when it is missing, and writes an append-only
+aligns campaign progress to that provider-confirmed time, and writes an append-only
 audit entry with `transport_invoked=false`.
 
 ```bash

--- a/internal/app/confenge/dispatch/governor_test.go
+++ b/internal/app/confenge/dispatch/governor_test.go
@@ -69,6 +69,34 @@ func TestCommitByMessageKeyWaitsForProviderConfirmation(t *testing.T) {
 	}
 }
 
+func TestCommitByMessageKeyAtRepairsLegacyCommitTimestamp(t *testing.T) {
+	providerAcceptedAt := time.Date(2026, 8, 28, 17, 1, 58, 0, time.UTC)
+	legacyReplayAt := providerAcceptedAt.Add(2*time.Hour + 26*time.Minute)
+	clock := &FixedClock{T: legacyReplayAt}
+	governor, store := newTestGov(t, clock)
+	key := "email:campaign:legacy-provider-replay"
+	result, err := governor.TryReserve(context.Background(), ReserveRequest{
+		OrganizationID: uuid.New(), Channel: ChannelEmail, MessageKey: key,
+	})
+	if err != nil || !result.Allowed {
+		t.Fatalf("reserve: allowed=%v err=%v", result.Allowed, err)
+	}
+	if err := store.CommitReservation(context.Background(), result.Reservation.ID, legacyReplayAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := governor.CommitByMessageKeyAt(context.Background(), key, providerAcceptedAt); err != nil {
+		t.Fatal(err)
+	}
+	sentAt, sent, err := store.GetSendByKey(context.Background(), key)
+	if err != nil || !sent || !sentAt.Equal(providerAcceptedAt) {
+		t.Fatalf("provider replay must repair legacy send time: sent=%v sent_at=%s err=%v", sent, sentAt, err)
+	}
+	reservation, err := store.GetReservationByKey(context.Background(), key)
+	if err != nil || reservation == nil || reservation.CommittedAt == nil || !reservation.CommittedAt.Equal(providerAcceptedAt) {
+		t.Fatalf("provider replay must repair reservation time: reservation=%+v err=%v", reservation, err)
+	}
+}
+
 func TestCap10Blocks11th(t *testing.T) {
 	clock := &FixedClock{T: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)}
 	g, _ := newTestGov(t, clock)

--- a/internal/app/confenge/dispatch/memory_store.go
+++ b/internal/app/confenge/dispatch/memory_store.go
@@ -319,6 +319,18 @@ func (m *MemoryStore) CommitReservation(ctx context.Context, id uuid.UUID, sentA
 		return fmt.Errorf("reservation not found")
 	}
 	if r.State == StateCommitted {
+		current, sent := m.sends[r.MessageKey]
+		if sent && sentAt.Before(current) {
+			m.sends[r.MessageKey] = sentAt
+			m.sendTimes = m.sendTimes[:0]
+			for _, at := range m.sends {
+				m.sendTimes = append(m.sendTimes, at)
+			}
+		}
+		if r.CommittedAt == nil || sentAt.Before(*r.CommittedAt) {
+			t := sentAt
+			r.CommittedAt = &t
+		}
 		return nil
 	}
 	if _, ok := m.sends[r.MessageKey]; ok {

--- a/internal/app/confenge/dispatch/pg_store.go
+++ b/internal/app/confenge/dispatch/pg_store.go
@@ -387,6 +387,20 @@ func (s *PGStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt ti
 	}
 	r.DraftID = draftID
 	if r.State == StateCommitted {
+		_, err = tx.Exec(ctx, `
+			UPDATE confenge_dispatch_sends
+			SET sent_at = LEAST(sent_at, $2)
+			WHERE message_key = $1`, r.MessageKey, sentAt)
+		if err != nil {
+			return err
+		}
+		_, err = tx.Exec(ctx, `
+			UPDATE confenge_dispatch_reservations
+			SET committed_at = LEAST(COALESCE(committed_at, $2), $2)
+			WHERE id = $1`, id, sentAt)
+		if err != nil {
+			return err
+		}
 		return tx.Commit(ctx)
 	}
 


### PR DESCRIPTION
## Production evidence

The known provider-accepted orphan was finally replayed by the pre-recovery consumer at 2026-08-28T19:28:13Z without a second provider call. Its touchpoint retained the real 2026-08-28T17:01:58Z acceptance time, but the already-committed dispatch send and reservation were stamped at replay time.

## What changed

- make idempotent committed-reservation replay move timestamps only backward to an earlier proven provider acceptance
- preserve capacity accounting in the in-memory store after correction
- add a red-green regression for the exact legacy replay shape

## Verification

- focused dispatch and CONFENGE provider-recovery tests
- golangci-lint
- gofmt-l cmd internal (no output)