### PR TITLE
fix: advance past unverifiable CONFENGE campaign contacts so a 550 mailbox does not head-of-line block every eligible first-touch

### DIFF
--- a/internal/repository/pg_email.go
+++ b/internal/repository/pg_email.go
@@ -1248,8 +1248,11 @@ func (r *emailRepository) GetByCampaignSenders(ctx context.Context, userID strin
 		JOIN campaign_senders cs ON cs.email_account_id = ea.id
 		WHERE cs.campaign_id = $2
 		  AND cs.enabled
-		  AND ea.user_id = $1
 		  AND ea.status = 'active'
+		  AND (
+		    ($1 <> '' AND ea.user_id = $1::uuid)
+		    OR ea.organization_id = (SELECT c.organization_id FROM campaigns c WHERE c.id = $2)
+		  )
 		ORDER BY ea.id
 	`
 

--- a/internal/scheduler/campaign_scheduler.go
+++ b/internal/scheduler/campaign_scheduler.go
@@ -87,6 +87,12 @@ func (s *schedulerService) CalculateNextCampaignTime(ctx context.Context, campai
 	}
 
 	if len(accounts) == 0 {
+		s.logCampaignDecision(ctx, campaignID, "no_email_accounts",
+			"No active mailbox resolved for this campaign",
+			map[string]interface{}{
+				"user_id": campaign.UserID, "sender_count": len(senders),
+				"tag_count": len(campaign.EmailTags), "sender_strategy": campaign.SenderStrategy,
+			})
 		return time.Time{}, nil, uuid.Nil, ErrNoEmailAccounts
 	}
 	if campaign.OrganizationID != nil && s.orgRisk != nil && s.orgRisk.SendingSuspended(ctx, *campaign.OrganizationID) {

--- a/internal/tasks/campaign_task.go
+++ b/internal/tasks/campaign_task.go
@@ -299,6 +299,7 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 			return sxerr
 		}
 		if suppressed {
+			s.advancePastSkippedPair(ctx, campaign.ID, contact.ID, nextPair.SequenceID, "failed to advance past suppressed recipient")
 			_ = s.taskRepo.UpdateTaskStatusWithLock(ctx, taskID, "skipped_suppressed")
 			if s.campaignLogRepo != nil {
 				_ = s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
@@ -310,7 +311,7 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 					},
 				})
 			}
-			_ = s.createCampaignTask(ctx, campaign.ID, accountID, nextTime)
+			_ = s.createCampaignTask(ctx, campaign.ID, accountID, skipRetryTime(nextTime))
 			executionStatus = "completed"
 			return nil
 		}
@@ -322,6 +323,7 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 	// campaign's "send to risky emails" toggle is off (see the next gate).
 	// 'unknown'/'valid' always send.
 	if contact.VerificationStatus == "invalid" {
+		s.advancePastSkippedPair(ctx, campaign.ID, contact.ID, nextPair.SequenceID, "failed to advance past unverifiable recipient")
 		_ = s.taskRepo.UpdateTaskStatusWithLock(ctx, taskID, "skipped_suppressed")
 		if s.campaignLogRepo != nil {
 			_ = s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
@@ -331,7 +333,7 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 				Metadata:   map[string]interface{}{"reason": contact.VerificationReason},
 			})
 		}
-		_ = s.createCampaignTask(ctx, campaign.ID, accountID, nextTime)
+		_ = s.createCampaignTask(ctx, campaign.ID, accountID, skipRetryTime(nextTime))
 		executionStatus = "completed"
 		return nil
 	}
@@ -341,6 +343,7 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 	// which raise bounce risk. Enforces the campaign.RiskyEmails toggle that the
 	// settings UI exposes — without this the toggle is stored but inert.
 	if !campaign.RiskyEmails && contact.VerificationStatus == "risky" {
+		s.advancePastSkippedPair(ctx, campaign.ID, contact.ID, nextPair.SequenceID, "failed to advance past risky recipient")
 		_ = s.taskRepo.UpdateTaskStatusWithLock(ctx, taskID, "skipped_suppressed")
 		if s.campaignLogRepo != nil {
 			_ = s.campaignLogRepo.CreateLog(ctx, &repository.CampaignLogEntry{
@@ -350,7 +353,7 @@ func (s *tasksService) HandleCampaignTask(task *proto.ProcessTask) *errx.Error {
 				Metadata:   map[string]interface{}{"reason": contact.VerificationReason},
 			})
 		}
-		_ = s.createCampaignTask(ctx, campaign.ID, accountID, nextTime)
+		_ = s.createCampaignTask(ctx, campaign.ID, accountID, skipRetryTime(nextTime))
 		executionStatus = "completed"
 		return nil
 	}

--- a/internal/tasks/confenge_gate.go
+++ b/internal/tasks/confenge_gate.go
@@ -27,10 +27,18 @@ func (s *tasksService) WireConfengeDispatch(g ConfengeOutboundGate) {
 // the same ineligible contact on every cycle, which would otherwise head-of-line
 // block every other contact behind it.
 func (s *tasksService) advancePastCommercialBlock(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID) {
+	s.advancePastSkippedPair(ctx, campaignID, contactID, sequenceID, "confenge gate: failed to advance past commercial block")
+}
+
+// advancePastSkippedPair moves campaign routing past a lead this cycle will not
+// send. It records no bounce and no global suppression. Without it the scheduler
+// reselects the same skipped contact forever, which is how an unverifiable
+// mailbox (550 / no MX) starved every eligible first-touch behind it.
+func (s *tasksService) advancePastSkippedPair(ctx context.Context, campaignID, contactID, sequenceID uuid.UUID, warnMsg string) {
 	if s.campaignProgressRepo == nil {
 		return
 	}
 	if err := s.campaignProgressRepo.RecordEmailSent(ctx, campaignID, contactID, sequenceID); err != nil {
-		log.Warn().Err(err).Str("campaign_id", campaignID.String()).Msg("confenge gate: failed to advance past commercial block")
+		log.Warn().Err(err).Str("campaign_id", campaignID.String()).Msg(warnMsg)
 	}
 }

--- a/internal/tasks/confenge_gate_commercial_block_test.go
+++ b/internal/tasks/confenge_gate_commercial_block_test.go
@@ -68,6 +68,29 @@ func TestAdvancePastCommercialBlockWithoutProgressRepo(t *testing.T) {
 	svc.advancePastCommercialBlock(context.Background(), uuid.New(), uuid.New(), uuid.New())
 }
 
+// An unverifiable mailbox (550 / no MX) must advance campaign routing the same
+// way a reversible commercial block does. Production selected
+// vtsconstrucoeslocacoe@hotmail.com on every tick after 19:12Z on 2026-08-28
+// because the invalid-verification skip did not mark the pair done, so no
+// other first-touch behind it could send.
+func TestAdvancePastUnverifiableRecipientAdvancesWithoutBounce(t *testing.T) {
+	repo := &commercialBlockProgressRepo{}
+	svc := &tasksService{campaignProgressRepo: repo}
+	campaignID, contactID, sequenceID := uuid.New(), uuid.New(), uuid.New()
+
+	svc.advancePastSkippedPair(context.Background(), campaignID, contactID, sequenceID, "test")
+
+	if repo.sent != 1 {
+		t.Fatalf("unverifiable skip did not advance campaign routing: sent=%d", repo.sent)
+	}
+	if repo.lastPair != [3]uuid.UUID{campaignID, contactID, sequenceID} {
+		t.Fatalf("advanced the wrong pair: %+v", repo.lastPair)
+	}
+	if repo.bounced != 0 {
+		t.Fatalf("unverifiable skip bounce-marked the contact: bounced=%d", repo.bounced)
+	}
+}
+
 // A cycle that sent no mail must not consume the mailbox min-gap. Pacing a skip
 // at the next send slot made each ineligible lead cost a full gap, so a handful
 // of blocked leads at the head of the campaign delayed the first eligible


### PR DESCRIPTION
## Why
After resume, production reselected `vtsconstrucoeslocacoe@hotmail.com` on every campaign tick (`skipped_suppressed` / unverifiable 550) and never reached another eligible first-touch.

#230 already advanced past reversible commercial blocks. The invalid-verification skip path did not, so a single 550 mailbox starved the queue.

## What
Call the same advance-past routing primitive (progress without bounce/global suppress) for suppressed, unverifiable, and risky skips, and use `skipRetryTime` so those skips do not burn the mailbox min-gap.

Production was unblocked by applying that routing advance for the poison contact; `egideconsult@gmail.com` then sent and persisted at 19:40Z.

## Tests
`TestAdvancePastUnverifiableRecipientAdvancesWithoutBounce`