### PR TITLE
feat: close delegated first-touch authority after provider acceptance

### DIFF
--- a/cmd/consumer/confenge_wire_test.go
+++ b/cmd/consumer/confenge_wire_test.go
@@ -62,4 +62,7 @@ func TestConsumerWiresConfengeDispatchGovernor(t *testing.T) {
 	if !strings.Contains(string(b), "confengeSvc.WireDispatch(primaryDB.Pool)") {
 		t.Fatal("the consumer must wire the CONFENGE dispatch governor to commit provider-accepted sends")
 	}
+	if !strings.Contains(string(b), "confengeSvc.WireDelegatedFirstTouch(primaryDB.Pool)") {
+		t.Fatal("the consumer must wire delegated first-touch state so provider-accepted sends close QUEUED decisions")
+	}
 }

--- a/cmd/consumer/main.go
+++ b/cmd/consumer/main.go
@@ -364,6 +364,8 @@ func main() {
 		// confenge_dispatch_sends. Without the governor, every provider-accepted
 		// CONFENGE send failed to record and retried forever.
 		confengeSvc.WireDispatch(primaryDB.Pool)
+		// Close durable delegated authority in the same process that observes provider results.
+		confengeSvc.WireDelegatedFirstTouch(primaryDB.Pool)
 		confengeSvc.WireCohortAuth(confenge.NewPostgresCohortStore(primaryDB.Pool))
 		if sink, ok := confengeSvc.(confenge.OutcomeSink); ok {
 			confengeSink = sink


### PR DESCRIPTION
Production Send A on the current release reached Hostinger and committed its touchpoint, send, reservation, queue, and campaign progress, but its delegated decision remained QUEUED. CompleteCampaignEmail already marks that decision SENT; the consumer lacked the delegated Postgres wiring and silently skipped it. This wires the same durable delegated store into the provider-result consumer and extends the boot-contract regression test.\n\nVerification: go test ./cmd/consumer; make lint