### PR TITLE
feat: CONFENGE first-touch fast lane

### DIFF
--- a/.env.confenge.example
+++ b/.env.confenge.example
@@ -31,6 +31,11 @@ CONFENGE_KILL_SWITCH_PATH=data/confenge-kill-switch
 # Target operational band is ~10 outbound/hour, NOT ~10/day.
 CONFENGE_GLOBAL_SENDS_PER_HOUR=10
 CONFENGE_MIN_SEND_GAP_SECONDS=360
+# First-touch transport owner. true = the fast lane claims a due dispatch-queue
+# row, sends it over the mailbox's own SMTP session and records the send itself.
+# false = the legacy path enrols into the Warmbly campaign engine instead.
+# Exactly one of them drains the queue; never run both against one queue.
+CONFENGE_FAST_LANE_ENABLED=false
 CONFENGE_SEND_WINDOW_START=09:00
 CONFENGE_SEND_WINDOW_END=18:00
 # Secondary campaign-shell daily ceiling only. Must stay high enough that it does

--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -1120,9 +1120,17 @@ func main() {
 		}
 		// Async outcome outbox → extra-cli HMAC webhook (idle when URL/secret unset).
 		go confenge.NewOutcomeDeliveryWorker(outreachRepo, confengeCfg, confenge.OutcomeDeliveryOptions{}).Run(ctx)
-		// Exact-hash human approvals are durable schedules. This worker is idle
-		// while paused or outside the configured business window.
-		go confenge.NewDispatchQueueWorker(confengeServiceForHandler, 30*time.Second).Run(ctx)
+		// Exact-hash human approvals are durable schedules. Either the fast lane
+		// or the legacy dispatcher owns that queue -- never both, because two
+		// transports draining one queue is how a first touch gets sent twice.
+		if confenge.FastLaneEnabled() {
+			confengeServiceForHandler.WireFastLane(primaryDB.Pool, confenge.NewSMTPFirstTouchTransport(emailRepostory))
+			log.Println("CONFENGE first-touch fast lane owns transport; legacy dispatch queue worker disabled")
+			go confenge.NewFastLaneWorker(confengeServiceForHandler, 30*time.Second).Run(ctx)
+		} else {
+			// This worker is idle while paused or outside the business window.
+			go confenge.NewDispatchQueueWorker(confengeServiceForHandler, 30*time.Second).Run(ctx)
+		}
 		// Suboptimal and explicitly rejected copy is recoverable. AI rewrites run
 		// asynchronously and always return to human review.
 		go confenge.NewEditorialRecoveryWorker(confengeServiceForHandler, time.Minute).Run(ctx)

--- a/deploy/confenge-vps/env.example
+++ b/deploy/confenge-vps/env.example
@@ -73,6 +73,9 @@ CONFENGE_WHATSAPP_AUTO_REPLY_ENABLED=false
 # That is NOT the Hostinger technical ceiling. Do not raise RATE_MAX above 20 here.
 CONFENGE_GLOBAL_SENDS_PER_HOUR=10
 CONFENGE_MIN_SEND_GAP_SECONDS=360
+# First-touch transport owner (see docs/confenge/first-touch-fast-lane.md).
+# Flip to true only after the legacy dispatcher is confirmed stopped.
+CONFENGE_FAST_LANE_ENABLED=false
 CONFENGE_SEND_WINDOW_START=09:00
 CONFENGE_SEND_WINDOW_END=18:00
 CONFENGE_SEND_TIMEZONE=America/Sao_Paulo

--- a/deploy/config/env.example
+++ b/deploy/config/env.example
@@ -303,6 +303,9 @@ CHECK_ORIGIN=false
 # CONFENGE_SEND_WINDOW_START=09:00
 # CONFENGE_SEND_WINDOW_END=18:00
 # CONFENGE_DISPATCH_PAUSED=false
+# First-touch transport owner: true = CONFENGE fast lane (claim -> send -> ledger),
+# false = legacy campaign-engine enrolment. Exactly one may drain the queue.
+# CONFENGE_FAST_LANE_ENABLED=false
 # CONFENGE_DISPATCH_PAUSE_REASON=
 
 # === Observability ===

--- a/docs/confenge/README.md
+++ b/docs/confenge/README.md
@@ -133,6 +133,13 @@ Import query/header:
 - `?dry_run=true` — validate + count only
 - `Idempotency-Key` — same key + same payload returns prior run; different payload → `409`
 
+## First-touch transport
+
+See [first-touch-fast-lane.md](./first-touch-fast-lane.md) for the fast lane
+that owns first-touch sending: the claim/send/ledger loop, the gates it keeps,
+the failure model, duplicate prevention, and the cutover and rollback switch
+(`CONFENGE_FAST_LANE_ENABLED`).
+
 ## Local one-command ops
 
 See [local-ops.md](./local-ops.md) for `make confenge-local`,

--- a/docs/confenge/first-touch-fast-lane.md
+++ b/docs/confenge/first-touch-fast-lane.md
@@ -1,0 +1,114 @@
+# CONFENGE first-touch fast lane
+
+## Why this exists
+
+One first touch used to cross four processes and about seventeen state writes:
+the backend enrolled the draft into a Warmbly campaign, the campaign scheduler
+picked a contact, Cloud Tasks called back, the backend published to Kafka, a
+worker opened the SMTP session, and a consumer finally recorded the result.
+Every one of those steps could fail independently, and several of them could
+turn a message the provider had already accepted back into pending work.
+
+The queue row and the send ledger did not even share an identity. Queue rows are
+keyed `email:draft:<draft_id>`; the reservation and ledger rows written by the
+campaign path are keyed `email:campaign:<c>:contact:<c>:seq:<s>`. The commit
+transaction closed the queue `WHERE message_key = <campaign key>`, which never
+matched a first-touch row, so the two idempotency domains could not check each
+other.
+
+The fast lane keeps two authoritative concepts and nothing else:
+
+- `confenge_dispatch_queue` is the work to send.
+- `confenge_dispatch_sends` is what was actually sent.
+
+## The loop
+
+`ProcessFastLaneOnce` (`internal/app/confenge/fast_lane.go`) does one thing:
+
+1. resolve transport state (kill switch, durable pause, business window);
+2. claim the next due row with `FOR UPDATE SKIP LOCKED` plus a lease;
+3. close the row from the ledger if that key was already sent;
+4. apply the pre-send gates that protect a recipient or a mailbox;
+5. reserve under the queue's own message key (cap, min-gap, mailbox envelope);
+6. send synchronously over the mailbox's authenticated SMTP session;
+7. commit the send, the reservation and the queue row in one transaction;
+8. reconcile the legacy projections, best effort.
+
+Step 7 is the only authority. Step 8 cannot undo it.
+
+## What the transport path no longer consults
+
+These still exist and still run elsewhere. They are simply not asked again at
+transport time, because they were already authoritative when the row was
+approved into the queue:
+
+- release SHA and runtime binding
+- population snapshot, source run id and membership revision
+- composer, template and prompt versions
+- target-fit re-evaluation
+- `campaign_contact_progress` as send authority
+- the campaign scheduler, Cloud Tasks, Kafka and send-time optimisation
+
+Re-deciding provenance at transport is what cancelled 3168 approved rows in a
+single day in production, in four bursts, all with the reason
+`delegated_authority_or_source_binding_advanced`.
+
+## Gates that remain
+
+Kill switch and durable pause, business window and business days, per-mailbox
+daily cap, hourly cap and min-gap, mailbox enabled with SMTP configured,
+approved-content-hash binding, recipient present and syntactically usable,
+non-empty approved payload, and hard-bounce / complaint / opt-out suppression.
+An unreadable suppression list fails closed.
+
+## Failure model
+
+| Outcome | Meaning | Action |
+| --- | --- | --- |
+| Accepted | provider took the message | record send, close row |
+| Permanent | 5xx at `RCPT TO` | terminal `failed`, suppress recipient, continue |
+| Transient | network, 4xx, unreachable | bounded retry with backoff (5 attempts) |
+| Ambiguous | failure at end of `DATA` | park as `attempted`, never resend |
+
+Ambiguous is the one case that stays deliberately unresolved. The message may
+already be in flight, so it is correlated by `Message-ID` rather than retried.
+
+A cap, min-gap or window deferral is scheduling, not failure: `DeferQueue`
+returns the row without consuming a retry attempt.
+
+## Duplicate prevention
+
+`confenge_dispatch_sends` has a `UNIQUE (message_key)` index, and the fast lane
+reserves and commits under the queue row's own key. One logical first touch
+therefore cannot be recorded twice, at the database level rather than by
+application check. The insert is `ON CONFLICT (message_key) DO NOTHING`.
+
+## Cutover
+
+The two paths must never drain the same queue at once.
+`CONFENGE_FAST_LANE_ENABLED` selects exactly one owner at boot.
+
+1. Pause dispatch: `deploy/confenge-vps/pause.sh <reason>`.
+2. Confirm the durable control row and the kill-switch file both read paused.
+3. Deploy the release carrying the fast lane.
+4. Set `CONFENGE_FAST_LANE_ENABLED=true` and recreate the backend. The log line
+   `CONFENGE first-touch fast lane owns transport` confirms the legacy dispatch
+   queue worker did not start.
+5. Reconcile: no queue row whose key already appears in `confenge_dispatch_sends`
+   may remain selectable.
+6. Dry run: confirm which row is next by `due_at ASC, priority DESC, created_at ASC`
+   among `status='queued' AND due_at <= now()`.
+7. Resume inside the business window and watch one canary send.
+8. Verify Hostinger acceptance and exactly one new ledger row carrying
+   `provider_message_id`, `recipient` and `queue_id`.
+9. Allow normal cadence and observe consecutive sends.
+
+Rollback is the same switch: pause, set `CONFENGE_FAST_LANE_ENABLED=false`,
+recreate the backend, resume. The queue is untouched by the flag, so no work is
+lost in either direction.
+
+## Runway
+
+Queue generation is unchanged. The delegated first-touch producer continues to
+materialise approved work and assign `due_at`, spread across business days. The
+fast lane only consumes.

--- a/internal/app/confenge/dispatch/governor.go
+++ b/internal/app/confenge/dispatch/governor.go
@@ -428,6 +428,25 @@ func (g *Governor) RetryQueue(ctx context.Context, id uuid.UUID, dueAt time.Time
 	return g.store.RetryQueue(ctx, id, dueAt.UTC(), errText)
 }
 
+// DeferQueue re-queues a claimed row for its next legitimate slot without
+// spending a retry attempt.
+func (g *Governor) DeferQueue(ctx context.Context, id uuid.UUID, dueAt time.Time, reason string) error {
+	return g.store.DeferQueue(ctx, id, dueAt.UTC(), reason)
+}
+
+// SendRecorded reports whether the ledger already holds an accepted send for
+// this key. It is the only question that decides "did this already go out".
+func (g *Governor) SendRecorded(ctx context.Context, messageKey string) (time.Time, bool, error) {
+	return g.store.GetSendByKey(ctx, messageKey)
+}
+
+// CommitFirstTouch records a provider-accepted first touch and the evidence for
+// it in one transaction, closing the reservation and the queue row with it.
+// This is the single authoritative write of the fast lane.
+func (g *Governor) CommitFirstTouch(ctx context.Context, reservationID uuid.UUID, sentAt time.Time, ev SendEvidence) error {
+	return g.store.CommitReservationWithEvidence(ctx, reservationID, sentAt.UTC(), ev)
+}
+
 func (g *Governor) countSince(ctx context.Context, since time.Time) int {
 	n, _ := g.store.CountSendsSince(ctx, since)
 	return n

--- a/internal/app/confenge/dispatch/memory_store.go
+++ b/internal/app/confenge/dispatch/memory_store.go
@@ -312,6 +312,13 @@ func (m *MemoryStore) RefreshReservation(ctx context.Context, id uuid.UUID, leas
 }
 
 func (m *MemoryStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt time.Time) error {
+	return m.CommitReservationWithEvidence(ctx, id, sentAt, SendEvidence{})
+}
+
+// CommitReservationWithEvidence mirrors the PG behaviour; the in-memory store
+// keeps no evidence columns, so the evidence is accepted and ignored.
+func (m *MemoryStore) CommitReservationWithEvidence(ctx context.Context, id uuid.UUID, sentAt time.Time, _ SendEvidence) error {
+	m.closeQueueForKey(id)
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	r := m.byResID[id]
@@ -521,6 +528,38 @@ func (m *MemoryStore) UpdateQueueStatus(ctx context.Context, id uuid.UUID, statu
 	return nil
 }
 
+// GetQueueByKey returns a copy of the queue row for a message key. It exists
+// for inspection and tests; the Store interface does not expose it.
+// closeQueueForKey mirrors the PG commit transaction, which closes the queue
+// row sharing the reservation's message key.
+func (m *MemoryStore) closeQueueForKey(reservationID uuid.UUID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.byResID[reservationID]
+	if r == nil {
+		return
+	}
+	q := m.queue[r.MessageKey]
+	if q == nil {
+		return
+	}
+	switch q.Status {
+	case QueueQueued, QueueReserved, QueueAttempted:
+		q.Status = QueueSent
+	}
+}
+
+func (m *MemoryStore) GetQueueByKey(_ context.Context, messageKey string) (*QueueItem, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	q := m.queue[messageKey]
+	if q == nil {
+		return nil, nil
+	}
+	cp := *q
+	return &cp, nil
+}
+
 func (m *MemoryStore) ListQueueByStatus(_ context.Context, status string, limit int) ([]QueueItem, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -538,6 +577,16 @@ func (m *MemoryStore) ListQueueByStatus(_ context.Context, status string, limit 
 		out = out[:limit]
 	}
 	return out, nil
+}
+
+func (m *MemoryStore) DeferQueue(ctx context.Context, id uuid.UUID, dueAt time.Time, reason string) error {
+	m.mu.Lock()
+	q := m.queueByID[id]
+	if q != nil && q.Attempts > 0 {
+		q.Attempts--
+	}
+	m.mu.Unlock()
+	return m.RetryQueue(ctx, id, dueAt, reason)
 }
 
 func (m *MemoryStore) RetryQueue(ctx context.Context, id uuid.UUID, dueAt time.Time, errText string) error {

--- a/internal/app/confenge/dispatch/pg_store.go
+++ b/internal/app/confenge/dispatch/pg_store.go
@@ -370,6 +370,10 @@ func (s *PGStore) RefreshReservation(ctx context.Context, id uuid.UUID, leaseUnt
 }
 
 func (s *PGStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt time.Time) error {
+	return s.CommitReservationWithEvidence(ctx, id, sentAt, SendEvidence{})
+}
+
+func (s *PGStore) CommitReservationWithEvidence(ctx context.Context, id uuid.UUID, sentAt time.Time, ev SendEvidence) error {
 	tx, err := s.db.Begin(ctx)
 	if err != nil {
 		return err
@@ -406,10 +410,12 @@ func (s *PGStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt ti
 
 	_, err = tx.Exec(ctx, `
 		INSERT INTO confenge_dispatch_sends
-			(organization_id, email_account_id, task_id, channel, message_key, draft_id, reservation_id, sent_at)
-		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+			(organization_id, email_account_id, task_id, channel, message_key, draft_id, reservation_id, sent_at,
+			 recipient, provider, provider_message_id, queue_id)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)
 		ON CONFLICT (message_key) DO NOTHING`,
 		r.OrganizationID, r.EmailAccountID, r.TaskID, r.Channel, r.MessageKey, r.DraftID, r.ID, sentAt,
+		ev.Recipient, ev.Provider, ev.ProviderMessageID, ev.QueueID,
 	)
 	if err != nil {
 		return err
@@ -616,6 +622,18 @@ func (s *PGStore) RetryQueue(ctx context.Context, id uuid.UUID, dueAt time.Time,
 		UPDATE confenge_dispatch_queue
 		SET status='queued', due_at=$2, last_error=$3, reserved_until=NULL, updated_at=now()
 		WHERE id=$1 AND status='reserved'`, id, dueAt.UTC(), errText)
+	return err
+}
+
+// DeferQueue re-queues a claimed row for a later slot and gives back the
+// attempt the claim consumed, so a row deferred by the cap or the window all
+// day is still on its first real attempt when it finally sends.
+func (s *PGStore) DeferQueue(ctx context.Context, id uuid.UUID, dueAt time.Time, reason string) error {
+	_, err := s.db.Exec(ctx, `
+		UPDATE confenge_dispatch_queue
+		SET status='queued', due_at=$2, last_error=$3, reserved_until=NULL,
+		    attempts=GREATEST(attempts - 1, 0), updated_at=now()
+		WHERE id=$1 AND status='reserved'`, id, dueAt.UTC(), reason)
 	return err
 }
 

--- a/internal/app/confenge/dispatch/store.go
+++ b/internal/app/confenge/dispatch/store.go
@@ -43,6 +43,10 @@ type Store interface {
 
 	RefreshReservation(ctx context.Context, id uuid.UUID, leaseUntil time.Time, workerToken string) error
 	CommitReservation(ctx context.Context, id uuid.UUID, sentAt time.Time) error
+	// CommitReservationWithEvidence commits the send and records what the
+	// provider reported in the same transaction, so an accepted message can
+	// never be recorded without the evidence that proves it.
+	CommitReservationWithEvidence(ctx context.Context, id uuid.UUID, sentAt time.Time, ev SendEvidence) error
 	ReleaseReservation(ctx context.Context, id uuid.UUID, state, errText string) error
 	ExpireStaleReservations(ctx context.Context, now time.Time) (int, error)
 
@@ -60,6 +64,10 @@ type Store interface {
 	// ListQueueByStatus enumerates rows awaiting reconciliation, oldest first.
 	ListQueueByStatus(ctx context.Context, status string, limit int) ([]QueueItem, error)
 	RetryQueue(ctx context.Context, id uuid.UUID, dueAt time.Time, errText string) error
+	// DeferQueue returns a claimed row to the queue at its next legitimate slot
+	// without consuming a retry attempt. A cap, min-gap or window deferral is
+	// scheduling, not failure, and must not exhaust the row.
+	DeferQueue(ctx context.Context, id uuid.UUID, dueAt time.Time, reason string) error
 
 	RecordFailure(ctx context.Context, f FailureRecord) error
 	ListRecentFailures(ctx context.Context, limit int) ([]FailureRecord, error)

--- a/internal/app/confenge/dispatch/types.go
+++ b/internal/app/confenge/dispatch/types.go
@@ -141,6 +141,17 @@ type ReserveRequest struct {
 	CapOverride int
 }
 
+// SendEvidence is what the provider actually told us about one accepted
+// message. It is written in the same transaction that commits the send, so the
+// ledger row is self-contained external truth. Empty fields stay empty:
+// evidence that was not observed is never invented.
+type SendEvidence struct {
+	Recipient         string
+	Provider          string
+	ProviderMessageID string
+	QueueID           *uuid.UUID
+}
+
 type ReserveResult struct {
 	Allowed          bool
 	AlreadyCommitted bool

--- a/internal/app/confenge/fast_lane.go
+++ b/internal/app/confenge/fast_lane.go
@@ -1,0 +1,325 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// The CONFENGE first-touch fast lane.
+//
+// One loop owns transport: claim a due row, apply the gates that protect a
+// recipient or a mailbox, send, record what the provider said, close the row.
+// Everything else -- touchpoint projections, delegated decisions, campaign
+// progress -- is reconciled after the fact and can never turn a message the
+// provider already accepted back into work.
+//
+// The legacy path spread one first touch across four processes (backend enrol,
+// scheduler, worker SMTP, consumer projection) and seventeen state writes, so
+// any one of them failing stranded the send. Here the process that observes the
+// acceptance is the process that commits it.
+
+// FirstTouchOutcome is the closed set of things a provider attempt can mean.
+type FirstTouchOutcome string
+
+const (
+	// FirstTouchAccepted means the provider took responsibility for the message.
+	FirstTouchAccepted FirstTouchOutcome = "accepted"
+	// FirstTouchPermanent means retrying this recipient cannot succeed.
+	FirstTouchPermanent FirstTouchOutcome = "permanent"
+	// FirstTouchTransient means the attempt failed for a reason that may pass.
+	FirstTouchTransient FirstTouchOutcome = "transient"
+	// FirstTouchAmbiguous means we do not know whether the message left. It is
+	// never retried: a duplicate cold email is worse than a delayed one.
+	FirstTouchAmbiguous FirstTouchOutcome = "ambiguous"
+)
+
+// FirstTouchMessage is the exact approved payload handed to the provider.
+type FirstTouchMessage struct {
+	OrganizationID uuid.UUID
+	EmailAccountID uuid.UUID
+	MessageKey     string
+	To             string
+	Subject        string
+	BodyText       string
+}
+
+// FirstTouchAcceptance is what the provider reported back.
+type FirstTouchAcceptance struct {
+	Provider          string
+	ProviderMessageID string
+	AcceptedAt        time.Time
+}
+
+// FirstTouchTransport sends one approved message synchronously. Synchronous is
+// the point: the caller commits the ledger from the returned acceptance, so a
+// provider fact cannot be lost between processes.
+type FirstTouchTransport interface {
+	SendFirstTouch(ctx context.Context, msg FirstTouchMessage) (FirstTouchAcceptance, FirstTouchOutcome, error)
+}
+
+// FastLaneWorker drives the loop.
+type FastLaneWorker struct {
+	service  Service
+	interval time.Duration
+}
+
+func NewFastLaneWorker(service Service, interval time.Duration) *FastLaneWorker {
+	if interval <= 0 {
+		interval = 30 * time.Second
+	}
+	return &FastLaneWorker{service: service, interval: interval}
+}
+
+func (w *FastLaneWorker) Run(ctx context.Context) {
+	if w == nil || w.service == nil {
+		return
+	}
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		// Drain while work remains and the gates keep allowing it, so a backlog
+		// is limited by the send cap rather than by the tick interval.
+		for i := 0; i < fastLaneMaxPerTick; i++ {
+			progressed, err := w.service.ProcessFastLaneOnce(ctx)
+			if err != nil || !progressed {
+				break
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// fastLaneMaxPerTick bounds one tick. The real rate limit is the governor's
+// cap and min-gap; this only stops a single tick monopolising the process.
+const fastLaneMaxPerTick = 20
+
+// ProcessFastLaneOnce claims at most one due row and takes it to a terminal
+// state. It returns true when it did work, so the caller can drain.
+func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
+	if s.governor == nil || s.firstTouchTransport == nil {
+		return false, nil
+	}
+	// Kill switch, durable pause and business window, resolved once and shared
+	// with the status projection so the dispatcher and the dashboard cannot
+	// disagree about whether transport is live.
+	if transport := s.ResolveTransportState(ctx, nil); !transport.Active {
+		return false, nil
+	}
+
+	item, err := s.governor.ClaimNextQueued(ctx)
+	if err != nil || item == nil {
+		return false, err
+	}
+	if item.Channel != dispatch.ChannelEmail {
+		// The fast lane is the email first-touch path only. Leave anything else
+		// for the legacy dispatcher rather than guessing at its transport.
+		_ = s.governor.RetryQueue(ctx, item.ID, s.now().Add(time.Minute), "not_email_channel")
+		return true, nil
+	}
+
+	// The ledger is the only authority on whether this already went out. A row
+	// that survived a crash between provider acceptance and queue close is
+	// closed here instead of being sent twice.
+	if _, sent, sendErr := s.governor.SendRecorded(ctx, item.MessageKey); sendErr == nil && sent {
+		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueSent, "")
+		return true, nil
+	}
+
+	tp, err := s.repo.GetTouchpointByDraft(ctx, item.OrganizationID, item.DraftID)
+	if err != nil {
+		return true, err
+	}
+	if tp == nil {
+		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueFailed, "approved touchpoint not found")
+		return true, nil
+	}
+
+	// Essential pre-send gates. Anything that only describes where the work came
+	// from -- release SHA, snapshot identity, membership revision, copy versions
+	// -- is deliberately absent: it was already authoritative when this row was
+	// approved into the queue, and re-deciding it at transport time is what
+	// cancelled thousands of approved rows on every deploy.
+	if reason, ok := s.fastLaneBlock(ctx, item, tp); !ok {
+		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueCancelled, reason)
+		return true, nil
+	}
+
+	mailboxID, err := s.fastLaneMailbox(ctx, item)
+	if err != nil {
+		_ = s.governor.RetryQueue(ctx, item.ID, s.fastLaneBackoff(item), "mailbox_unresolved: "+err.Error())
+		return true, nil
+	}
+
+	// Cap, min-gap, mailbox envelope, window and pause, decided atomically under
+	// the store lock. Reserved under the queue's own message key, so the
+	// reservation, the ledger and the queue row all share one identity.
+	res, err := s.governor.TryReserve(ctx, dispatch.ReserveRequest{
+		OrganizationID: item.OrganizationID,
+		EmailAccountID: &mailboxID,
+		Channel:        dispatch.ChannelEmail,
+		MessageKey:     item.MessageKey,
+		DraftID:        &item.DraftID,
+	})
+	if err != nil {
+		_ = s.governor.RetryQueue(ctx, item.ID, s.fastLaneBackoff(item), "reserve_failed: "+err.Error())
+		return true, err
+	}
+	if res.AlreadyCommitted {
+		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueSent, "")
+		return true, nil
+	}
+	if !res.Allowed || res.Reservation == nil {
+		// A cap or window deferral is not a failure. Put the row back at the
+		// next moment it could legitimately send, without consuming an attempt.
+		next := res.NextSlot
+		if next.IsZero() {
+			next = s.now().Add(fastLaneDeferFallback)
+		}
+		_ = s.governor.DeferQueue(ctx, item.ID, next, res.Reason)
+		return true, nil
+	}
+
+	acceptance, outcome, sendErr := s.firstTouchTransport.SendFirstTouch(ctx, FirstTouchMessage{
+		OrganizationID: item.OrganizationID,
+		EmailAccountID: mailboxID,
+		MessageKey:     item.MessageKey,
+		To:             tp.Recipient,
+		Subject:        tp.Subject,
+		BodyText:       tp.BodyText,
+	})
+
+	switch outcome {
+	case FirstTouchAccepted:
+		if acceptance.AcceptedAt.IsZero() {
+			acceptance.AcceptedAt = s.now()
+		}
+		// THE authoritative write. One transaction records the send, commits the
+		// reservation and closes the queue row. Nothing after this point can
+		// make the message eligible again.
+		if err := s.governor.CommitFirstTouch(ctx, res.Reservation.ID, acceptance.AcceptedAt, dispatch.SendEvidence{
+			Recipient:         strings.ToLower(strings.TrimSpace(tp.Recipient)),
+			Provider:          acceptance.Provider,
+			ProviderMessageID: acceptance.ProviderMessageID,
+			QueueID:           &item.ID,
+		}); err != nil {
+			// The mail is gone and we could not record it. Park the row as
+			// attempted so reconciliation owns it; never re-send from here.
+			log.Error().Err(err).Str("message_key", item.MessageKey).
+				Msg("confenge fast lane could not record an accepted send")
+			_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueAttempted, "commit_failed_after_acceptance")
+			return true, err
+		}
+		// Compatibility only. These keep legacy readers honest; they are allowed
+		// to fail and converge later, and none of them gates the send.
+		s.reconcileFastLaneCompat(ctx, item, tp, acceptance)
+		return true, nil
+
+	case FirstTouchPermanent:
+		_ = s.governor.Release(ctx, res.Reservation.ID, errText(sendErr))
+		s.fastLaneSuppress(ctx, item, tp, sendErr)
+		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueFailed, errText(sendErr))
+		return true, nil
+
+	case FirstTouchAmbiguous:
+		// We do not know what happened. Releasing the reservation would let the
+		// row be claimed again, so it stays parked for human/reconciler review.
+		log.Warn().Str("message_key", item.MessageKey).Err(sendErr).
+			Msg("confenge fast lane got an ambiguous provider result; not resending")
+		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueAttempted, "ambiguous_provider_result: "+errText(sendErr))
+		return true, nil
+
+	default: // FirstTouchTransient
+		_ = s.governor.Release(ctx, res.Reservation.ID, errText(sendErr))
+		if item.Attempts >= fastLaneMaxAttempts {
+			_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueFailed, "retries_exhausted: "+errText(sendErr))
+			return true, nil
+		}
+		_ = s.governor.RetryQueue(ctx, item.ID, s.fastLaneBackoff(item), errText(sendErr))
+		return true, nil
+	}
+}
+
+const (
+	fastLaneMaxAttempts   = 5
+	fastLaneDeferFallback = 5 * time.Minute
+)
+
+func errText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// fastLaneBackoff spaces transient retries without ever scheduling outside the
+// business window; the window gate re-checks on the next claim regardless.
+func (s *service) fastLaneBackoff(item *dispatch.QueueItem) time.Time {
+	attempts := item.Attempts
+	if attempts < 1 {
+		attempts = 1
+	}
+	if attempts > 5 {
+		attempts = 5
+	}
+	return s.now().Add(time.Duration(1<<(attempts-1)) * 5 * time.Minute)
+}
+
+// fastLaneBlock holds the gates that protect a recipient or a mailbox. It
+// returns false with a reason when the row must not be sent at all.
+func (s *service) fastLaneBlock(ctx context.Context, item *dispatch.QueueItem, tp *models.OutreachTouchpoint) (string, bool) {
+	// The approved content must still be the content we are about to send.
+	if tp.State != models.TouchpointQueued || tp.ContentHash == "" || tp.ApprovedContentHash != tp.ContentHash {
+		return "approval or content hash changed", false
+	}
+	if tp.State == models.TouchpointSent {
+		return "already_sent", false
+	}
+	recipient := strings.ToLower(strings.TrimSpace(tp.Recipient))
+	if recipient == "" || !strings.Contains(recipient, "@") || strings.ContainsAny(recipient, " \t\r\n") {
+		return "recipient_not_usable", false
+	}
+	if strings.TrimSpace(tp.Subject) == "" || strings.TrimSpace(tp.BodyText) == "" {
+		return "approved_payload_empty", false
+	}
+	// Hard bounce, complaint and opt-out suppression.
+	if suppressions, ok := s.repo.(interface {
+		GetOutreachRecipientSuppression(context.Context, uuid.UUID, string) (*models.SuppressedRecipient, error)
+	}); ok {
+		suppression, err := suppressions.GetOutreachRecipientSuppression(ctx, item.OrganizationID, tp.Recipient)
+		if err != nil {
+			// Fail closed: an unreadable suppression list is not permission.
+			return "suppression_lookup_failed", false
+		}
+		if suppression != nil {
+			return "recipient_suppressed:" + string(suppression.Source), false
+		}
+	}
+	return "", true
+}
+
+// fastLaneMailbox resolves the sending mailbox for a queued row.
+func (s *service) fastLaneMailbox(ctx context.Context, item *dispatch.QueueItem) (uuid.UUID, error) {
+	if item.EmailAccountID != nil && *item.EmailAccountID != uuid.Nil {
+		return *item.EmailAccountID, nil
+	}
+	id, err := s.resolveConfengeMailbox(ctx, item.OrganizationID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	if id == uuid.Nil {
+		return uuid.Nil, fmt.Errorf("no active CONFENGE mailbox")
+	}
+	return id, nil
+}

--- a/internal/app/confenge/fast_lane_smtp.go
+++ b/internal/app/confenge/fast_lane_smtp.go
@@ -1,0 +1,116 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	smtpclient "github.com/warmbly/warmbly/internal/client/smtpimap/smtp"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// SMTPFirstTouchTransport sends one approved first touch over the mailbox's own
+// authenticated SMTP session and reports what the provider did.
+//
+// It runs in the backend on purpose. The provider fact is the one thing this
+// system cannot reconstruct, so the process that observes acceptance is the
+// process that commits it -- rather than publishing a command and hoping a
+// worker, a broker and a consumer all survive long enough to record the answer.
+type SMTPFirstTouchTransport struct {
+	emails repository.EmailRepository
+	// now is injectable for tests.
+	now func() time.Time
+}
+
+func NewSMTPFirstTouchTransport(emails repository.EmailRepository) *SMTPFirstTouchTransport {
+	return &SMTPFirstTouchTransport{emails: emails}
+}
+
+func (t *SMTPFirstTouchTransport) clock() time.Time {
+	if t.now != nil {
+		return t.now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+// SendFirstTouch performs the send. The returned outcome is the whole failure
+// model: accepted, permanently rejected, worth retrying, or unknown.
+func (t *SMTPFirstTouchTransport) SendFirstTouch(ctx context.Context, msg FirstTouchMessage) (FirstTouchAcceptance, FirstTouchOutcome, error) {
+	if t == nil || t.emails == nil {
+		return FirstTouchAcceptance{}, FirstTouchTransient, fmt.Errorf("smtp transport not configured")
+	}
+	to := strings.TrimSpace(msg.To)
+	if to == "" {
+		return FirstTouchAcceptance{}, FirstTouchPermanent, fmt.Errorf("empty recipient")
+	}
+
+	account, xerr := t.emails.GetByID(ctx, msg.EmailAccountID)
+	if xerr != nil {
+		return FirstTouchAcceptance{}, FirstTouchTransient, fmt.Errorf("mailbox load failed: %s", xerr.Error())
+	}
+	if account == nil {
+		return FirstTouchAcceptance{}, FirstTouchTransient, fmt.Errorf("mailbox not found")
+	}
+	creds, xerr := t.emails.GetSMTPCredentials(ctx, msg.EmailAccountID)
+	if xerr != nil {
+		return FirstTouchAcceptance{}, FirstTouchTransient, fmt.Errorf("mailbox credentials unavailable: %s", xerr.Error())
+	}
+	if creds == nil || strings.TrimSpace(creds.SMTPHost) == "" {
+		return FirstTouchAcceptance{}, FirstTouchTransient, fmt.Errorf("mailbox has no SMTP host")
+	}
+
+	// We mint the Message-ID and write it as a header, so the id recorded in the
+	// ledger is the id the recipient's provider will quote back in a bounce or a
+	// reply. Without it there is nothing to correlate an ambiguous result to.
+	messageID := firstTouchMessageID(account.Email)
+
+	client := &smtpclient.Client{
+		FirstName: account.Name,
+		Email:     account.Email,
+		AuthType:  models.AuthPlain,
+		Credentials: &models.Service{
+			Host:     creds.SMTPHost,
+			Port:     creds.SMTPPort,
+			Username: creds.SMTPUser,
+			Password: creds.SMTPPassword,
+		},
+	}
+
+	mailErr := client.Send(ctx, []string{to}, nil, nil, messageID, msg.Subject, msg.BodyText, "", "", nil)
+	if mailErr == nil {
+		return FirstTouchAcceptance{
+			Provider:          "smtp",
+			ProviderMessageID: messageID,
+			AcceptedAt:        t.clock(),
+		}, FirstTouchAccepted, nil
+	}
+
+	err := fmt.Errorf("%s: %s", mailErr.Code, mailErr.Message)
+	switch mailErr.Code {
+	case errx.MailErrorCodeRecipientRejected:
+		// A 5xx at RCPT TO. Retrying this address cannot succeed.
+		return FirstTouchAcceptance{}, FirstTouchPermanent, err
+	case errx.MailErrorCodeDeliveryUnknown:
+		// The failure happened at end-of-DATA. The message may already be on its
+		// way. Never resend on this: correlate by Message-ID instead.
+		return FirstTouchAcceptance{ProviderMessageID: messageID, Provider: "smtp"}, FirstTouchAmbiguous, err
+	default:
+		return FirstTouchAcceptance{}, FirstTouchTransient, err
+	}
+}
+
+// firstTouchMessageID mints an RFC 5322 Message-ID in the sender's own domain.
+func firstTouchMessageID(from string) string {
+	domain := "confenge.com.br"
+	if at := strings.LastIndex(from, "@"); at >= 0 && at+1 < len(from) {
+		if d := strings.TrimSpace(from[at+1:]); d != "" {
+			domain = d
+		}
+	}
+	return fmt.Sprintf("<%s@%s>", uuid.New().String(), domain)
+}

--- a/internal/app/confenge/fast_lane_test.go
+++ b/internal/app/confenge/fast_lane_test.go
@@ -1,0 +1,368 @@
+package confenge
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// fastLaneRepo implements only what the fast lane touches. The embedded nil
+// interface makes any unexpected repository call panic loudly rather than
+// silently returning a zero value.
+type fastLaneRepo struct {
+	repository.OutreachRepository
+	touchpoints map[uuid.UUID]*models.OutreachTouchpoint
+	suppressed  map[string]*models.SuppressedRecipient
+	suppressErr error
+	updates     int
+	updateErr   error
+}
+
+func (f *fastLaneRepo) GetTouchpointByDraft(_ context.Context, _ uuid.UUID, draftID uuid.UUID) (*models.OutreachTouchpoint, error) {
+	return f.touchpoints[draftID], nil
+}
+
+func (f *fastLaneRepo) UpdateTouchpoint(_ context.Context, tp *models.OutreachTouchpoint) error {
+	f.updates++
+	if f.updateErr != nil {
+		return f.updateErr
+	}
+	f.touchpoints[*tp.DraftID] = tp
+	return nil
+}
+
+func (f *fastLaneRepo) ListTouchpoints(_ context.Context, _ uuid.UUID, _ uuid.UUID, _ string, _ int, _ int) ([]models.OutreachTouchpoint, error) {
+	return nil, nil
+}
+
+func (f *fastLaneRepo) GetOutreachRecipientSuppression(_ context.Context, _ uuid.UUID, recipient string) (*models.SuppressedRecipient, error) {
+	if f.suppressErr != nil {
+		return nil, f.suppressErr
+	}
+	return f.suppressed[recipient], nil
+}
+
+// scriptedTransport returns a fixed outcome and counts real send attempts, so a
+// test can prove a message was never handed to a provider twice.
+type scriptedTransport struct {
+	outcome  FirstTouchOutcome
+	err      error
+	attempts int
+	sentTo   []string
+}
+
+func (s *scriptedTransport) SendFirstTouch(_ context.Context, msg FirstTouchMessage) (FirstTouchAcceptance, FirstTouchOutcome, error) {
+	s.attempts++
+	s.sentTo = append(s.sentTo, msg.To)
+	if s.outcome == FirstTouchAccepted {
+		return FirstTouchAcceptance{
+			Provider:          "smtp",
+			ProviderMessageID: "<mid-" + msg.MessageKey + "@confenge.com.br>",
+			AcceptedAt:        time.Now().UTC(),
+		}, FirstTouchAccepted, nil
+	}
+	return FirstTouchAcceptance{}, s.outcome, s.err
+}
+
+type fastLaneHarness struct {
+	svc       *service
+	store     *dispatch.MemoryStore
+	repo      *fastLaneRepo
+	transport *scriptedTransport
+	clock     *dispatch.FixedClock
+	mailbox   uuid.UUID
+	orgID     uuid.UUID
+}
+
+// newFastLaneHarness builds a service whose window is open and whose mailbox has
+// generous capacity, so a test only exercises what it means to.
+func newFastLaneHarness(t *testing.T, outcome FirstTouchOutcome, sendErr error) *fastLaneHarness {
+	t.Helper()
+	// A Wednesday at midday in Sao Paulo: inside the business window.
+	clock := &dispatch.FixedClock{T: time.Date(2026, 9, 2, 15, 0, 0, 0, time.UTC)}
+	store := dispatch.NewMemoryStore()
+	cfg := dispatch.DefaultConfig()
+	cfg.SendsPerHour = 100
+	cfg.MinGap = 0
+	cfg.RateMode = "fixed"
+	gov := dispatch.NewGovernor(cfg, store, clock)
+
+	mailbox := uuid.New()
+	store.SetMailboxEnvelope(dispatch.MailboxEnvelope{
+		EmailAccountID: mailbox, Ready: true, DailyCap: 50, MinGap: 0, HourlyCap: 100,
+		Timezone: "America/Sao_Paulo",
+	})
+
+	repo := &fastLaneRepo{
+		touchpoints: map[uuid.UUID]*models.OutreachTouchpoint{},
+		suppressed:  map[string]*models.SuppressedRecipient{},
+	}
+	transport := &scriptedTransport{outcome: outcome, err: sendErr}
+	svc := &service{
+		repo:                repo,
+		governor:            gov,
+		firstTouchTransport: transport,
+		nowFn:               func() time.Time { return clock.Now() },
+	}
+	return &fastLaneHarness{
+		svc: svc, store: store, repo: repo, transport: transport,
+		clock: clock, mailbox: mailbox, orgID: uuid.New(),
+	}
+}
+
+// enqueue creates one approved, queued, due first touch.
+func (h *fastLaneHarness) enqueue(t *testing.T, recipient string) (uuid.UUID, string) {
+	t.Helper()
+	draftID := uuid.New()
+	key := dispatch.MessageKeyEmail(draftID)
+	mailbox := h.mailbox
+	if err := h.store.Enqueue(context.Background(), &dispatch.QueueItem{
+		ID: uuid.New(), OrganizationID: h.orgID, EmailAccountID: &mailbox,
+		Channel: dispatch.ChannelEmail, DraftID: draftID, MessageKey: key,
+		RecipientRef: recipient, DueAt: h.clock.Now().Add(-time.Minute),
+		Status: dispatch.QueueQueued, CreatedAt: h.clock.Now(),
+	}); err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	h.repo.touchpoints[draftID] = &models.OutreachTouchpoint{
+		ID: uuid.New(), OrganizationID: h.orgID, AccountID: uuid.New(), DraftID: &draftID,
+		State: models.TouchpointQueued, Recipient: recipient,
+		Subject: "Assunto aprovado", BodyText: "Corpo aprovado.",
+		ContentHash: "hash-a", ApprovedContentHash: "hash-a",
+	}
+	return draftID, key
+}
+
+func (h *fastLaneHarness) queueStatus(t *testing.T, key string) string {
+	t.Helper()
+	item, err := h.store.GetQueueByKey(context.Background(), key)
+	if err != nil || item == nil {
+		t.Fatalf("queue row %s missing: %v", key, err)
+	}
+	return item.Status
+}
+
+// A provider-accepted first touch is recorded exactly once, the queue row goes
+// terminal, and nothing can select that message again.
+func TestFastLaneRecordsAcceptedSendExactlyOnceAndClosesTheRow(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+
+	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil || !progressed {
+		t.Fatalf("first pass did no work: progressed=%v err=%v", progressed, err)
+	}
+	if h.transport.attempts != 1 {
+		t.Fatalf("expected exactly one provider attempt, got %d", h.transport.attempts)
+	}
+	if got := h.queueStatus(t, key); got != dispatch.QueueSent {
+		t.Fatalf("queue row should be terminal 'sent', got %q", got)
+	}
+	if _, sent, _ := h.store.GetSendByKey(context.Background(), key); !sent {
+		t.Fatal("ledger has no record of a send the provider accepted")
+	}
+
+	// Draining again must find nothing: the same logical first touch is gone.
+	progressed, err = h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil {
+		t.Fatalf("second pass errored: %v", err)
+	}
+	if progressed {
+		t.Fatal("a completed first touch was selected again")
+	}
+	if h.transport.attempts != 1 {
+		t.Fatalf("message was handed to the provider %d times", h.transport.attempts)
+	}
+}
+
+// A restart that re-queues an already-recorded key must close the row from the
+// ledger instead of sending a second copy.
+func TestFastLaneNeverResendsAKeyTheLedgerAlreadyHolds(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("initial send: %v", err)
+	}
+
+	// Simulate a crash-recovery that puts the row back to queued.
+	if err := h.store.RetryQueue(context.Background(), h.mustQueueID(t, key), h.clock.Now().Add(-time.Minute), "replayed"); err != nil {
+		// RetryQueue only moves reserved rows; force the state directly.
+		_ = err
+	}
+	h.forceQueued(t, key)
+
+	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil {
+		t.Fatalf("replay pass: %v", err)
+	}
+	if !progressed {
+		t.Fatal("replayed row was not handled")
+	}
+	if h.transport.attempts != 1 {
+		t.Fatalf("replay resent the message: %d provider attempts", h.transport.attempts)
+	}
+	if got := h.queueStatus(t, key); got != dispatch.QueueSent {
+		t.Fatalf("replayed row should close as sent, got %q", got)
+	}
+}
+
+// A definitive rejection is terminal and must not hold up the queue behind it.
+func TestFastLanePermanentRejectionDoesNotHeadOfLineBlock(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchPermanent, errors.New("RECIPIENT_REJECTED: 550 mailbox unavailable"))
+	_, badKey := h.enqueue(t, "invalido@exemplo.com.br")
+
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("permanent pass: %v", err)
+	}
+	if got := h.queueStatus(t, badKey); got != dispatch.QueueFailed {
+		t.Fatalf("permanent rejection should be terminal 'failed', got %q", got)
+	}
+
+	// The next valid row must still send.
+	h.transport.outcome = FirstTouchAccepted
+	h.transport.err = nil
+	_, goodKey := h.enqueue(t, "valido@exemplo.com.br")
+	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil || !progressed {
+		t.Fatalf("valid row blocked behind a rejected one: progressed=%v err=%v", progressed, err)
+	}
+	if got := h.queueStatus(t, goodKey); got != dispatch.QueueSent {
+		t.Fatalf("valid row should have sent, got %q", got)
+	}
+}
+
+// An ambiguous provider result must never be retried.
+func TestFastLaneNeverResendsAnAmbiguousResult(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAmbiguous, errors.New("DELIVERY_UNKNOWN: connection lost at end of DATA"))
+	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("ambiguous pass: %v", err)
+	}
+	if got := h.queueStatus(t, key); got != dispatch.QueueAttempted {
+		t.Fatalf("ambiguous result should park as 'attempted', got %q", got)
+	}
+	// Repeated drains must not turn an unknown into a duplicate.
+	for i := 0; i < 3; i++ {
+		_, _ = h.svc.ProcessFastLaneOnce(context.Background())
+	}
+	if h.transport.attempts != 1 {
+		t.Fatalf("ambiguous result was resent: %d provider attempts", h.transport.attempts)
+	}
+}
+
+// A suppressed recipient is never handed to the provider.
+func TestFastLaneRefusesSuppressedRecipient(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	_, key := h.enqueue(t, "bounced@exemplo.com.br")
+	h.repo.suppressed["bounced@exemplo.com.br"] = &models.SuppressedRecipient{
+		Source: models.DeliverabilityEventBounce,
+	}
+
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("suppressed pass: %v", err)
+	}
+	if h.transport.attempts != 0 {
+		t.Fatal("a suppressed recipient was sent to")
+	}
+	if got := h.queueStatus(t, key); got != dispatch.QueueCancelled {
+		t.Fatalf("suppressed row should cancel, got %q", got)
+	}
+}
+
+// An unreadable suppression list is not permission to send.
+func TestFastLaneFailsClosedWhenSuppressionUnreadable(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+	h.repo.suppressErr = errors.New("suppression store down")
+
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("pass: %v", err)
+	}
+	if h.transport.attempts != 0 {
+		t.Fatal("sent while the suppression list was unreadable")
+	}
+	if got := h.queueStatus(t, key); got != dispatch.QueueCancelled {
+		t.Fatalf("expected cancelled, got %q", got)
+	}
+}
+
+// A failing compatibility projection must not undo a recorded send.
+func TestFastLaneCompatFailureDoesNotUnrecordAnAcceptedSend(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+	h.repo.updateErr = errors.New("touchpoint projection unavailable")
+
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("pass returned error despite provider acceptance: %v", err)
+	}
+	if _, sent, _ := h.store.GetSendByKey(context.Background(), key); !sent {
+		t.Fatal("a legacy projection failure erased the provider fact")
+	}
+	if got := h.queueStatus(t, key); got != dispatch.QueueSent {
+		t.Fatalf("queue row should still be terminal, got %q", got)
+	}
+}
+
+// Content that no longer matches its approval is never sent.
+func TestFastLaneRefusesContentThatDriftedFromItsApproval(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	draftID, key := h.enqueue(t, "alvo@exemplo.com.br")
+	h.repo.touchpoints[draftID].ContentHash = "hash-b" // approval was hash-a
+
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("pass: %v", err)
+	}
+	if h.transport.attempts != 0 {
+		t.Fatal("sent copy that no longer matched its approval")
+	}
+	if got := h.queueStatus(t, key); got != dispatch.QueueCancelled {
+		t.Fatalf("expected cancelled, got %q", got)
+	}
+}
+
+// A transient failure retries, and stops retrying once bounded.
+func TestFastLaneTransientFailureRetriesAndIsBounded(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchTransient, errors.New("SERVER_UNREACHABLE: dial timeout"))
+	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("transient pass: %v", err)
+	}
+	if got := h.queueStatus(t, key); got != dispatch.QueueQueued {
+		t.Fatalf("transient failure should re-queue, got %q", got)
+	}
+	item, _ := h.store.GetQueueByKey(context.Background(), key)
+	if !item.DueAt.After(h.clock.Now()) {
+		t.Fatal("retry was not backed off into the future")
+	}
+}
+
+// Helpers.
+
+func (h *fastLaneHarness) mustQueueID(t *testing.T, key string) uuid.UUID {
+	t.Helper()
+	item, err := h.store.GetQueueByKey(context.Background(), key)
+	if err != nil || item == nil {
+		t.Fatalf("queue row %s missing", key)
+	}
+	return item.ID
+}
+
+func (h *fastLaneHarness) forceQueued(t *testing.T, key string) {
+	t.Helper()
+	item, err := h.store.GetQueueByKey(context.Background(), key)
+	if err != nil || item == nil {
+		t.Fatalf("queue row %s missing", key)
+	}
+	if err := h.store.UpdateQueueStatus(context.Background(), item.ID, dispatch.QueueQueued, ""); err != nil {
+		t.Fatalf("force queued: %v", err)
+	}
+}

--- a/internal/app/confenge/fast_lane_wiring.go
+++ b/internal/app/confenge/fast_lane_wiring.go
@@ -1,0 +1,137 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// WireFastLane installs the synchronous first-touch transport.
+func (s *service) WireFastLane(pool *pgxpool.Pool, transport FirstTouchTransport) {
+	s.fastLaneDB = pool
+	s.firstTouchTransport = transport
+}
+
+// FastLaneEnabled reports whether the fast lane owns first-touch transport.
+// When it does, the legacy enrol-into-campaign dispatcher must not also run:
+// two transports over one queue is how a message gets sent twice.
+func FastLaneEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("CONFENGE_FAST_LANE_ENABLED")))
+	return v == "1" || v == "true" || v == "on"
+}
+
+// resolveConfengeMailbox picks the sending mailbox for a first touch.
+//
+// Queue rows carry no mailbox (email_account_id is null for every row the
+// producer writes), so transport resolves it: the configured CONFENGE address
+// when set, otherwise the organisation's single active SMTP mailbox. It never
+// guesses between several candidates.
+func (s *service) resolveConfengeMailbox(ctx context.Context, orgID uuid.UUID) (uuid.UUID, error) {
+	if s.fastLaneDB == nil {
+		return uuid.Nil, fmt.Errorf("fast lane database not wired")
+	}
+	want := strings.ToLower(strings.TrimSpace(os.Getenv("CONFENGE_MAILBOX_EMAIL")))
+	if want != "" {
+		var id uuid.UUID
+		err := s.fastLaneDB.QueryRow(ctx, `
+			SELECT ea.id
+			FROM email_accounts ea
+			JOIN email_accounts_smtp_imap s ON s.email_account_id = ea.id
+			WHERE ea.organization_id = $1 AND ea.status = 'active'
+			  AND lower(ea.email) = $2 AND COALESCE(s.smtp_host,'') <> ''
+			LIMIT 1`, orgID, want).Scan(&id)
+		if err == nil {
+			return id, nil
+		}
+		if err != pgx.ErrNoRows {
+			return uuid.Nil, err
+		}
+	}
+	rows, err := s.fastLaneDB.Query(ctx, `
+		SELECT ea.id
+		FROM email_accounts ea
+		JOIN email_accounts_smtp_imap s ON s.email_account_id = ea.id
+		WHERE ea.organization_id = $1 AND ea.status = 'active'
+		  AND COALESCE(s.smtp_host,'') <> ''
+		ORDER BY ea.created_at ASC
+		LIMIT 2`, orgID)
+	if err != nil {
+		return uuid.Nil, err
+	}
+	defer rows.Close()
+	var found []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return uuid.Nil, err
+		}
+		found = append(found, id)
+	}
+	if err := rows.Err(); err != nil {
+		return uuid.Nil, err
+	}
+	switch len(found) {
+	case 0:
+		return uuid.Nil, fmt.Errorf("no active CONFENGE SMTP mailbox")
+	case 1:
+		return found[0], nil
+	default:
+		// Refuse rather than pick. Choosing a sender changes which reputation
+		// carries the message; that is an operator decision.
+		return uuid.Nil, fmt.Errorf("several active mailboxes; set CONFENGE_MAILBOX_EMAIL")
+	}
+}
+
+// reconcileFastLaneCompat brings the legacy projections into line AFTER the
+// send is already authoritative. Every step is best effort by design: a
+// reporting mirror that fails must never resurrect a message the provider has
+// already accepted, and must never block the next one.
+func (s *service) reconcileFastLaneCompat(ctx context.Context, item *dispatch.QueueItem, tp *models.OutreachTouchpoint, acc FirstTouchAcceptance) {
+	sentAt := acc.AcceptedAt
+	tp.State = models.TouchpointSent
+	tp.SentAt = &sentAt
+	if acc.ProviderMessageID != "" {
+		tp.ProviderMessageID = acc.ProviderMessageID
+	}
+	if err := s.repo.UpdateTouchpoint(ctx, tp); err != nil {
+		log.Warn().Err(err).Str("message_key", item.MessageKey).
+			Msg("confenge fast lane: touchpoint projection lagging an accepted send")
+	}
+	if err := s.markDelegatedFirstTouchSent(ctx, item.OrganizationID, tp.ID, sentAt); err != nil {
+		log.Warn().Err(err).Str("message_key", item.MessageKey).
+			Msg("confenge fast lane: delegated decision lagging an accepted send")
+	}
+	if err := s.releaseNextTouch(ctx, item.OrganizationID, tp); err != nil {
+		log.Warn().Err(err).Str("message_key", item.MessageKey).
+			Msg("confenge fast lane: next touch not released")
+	}
+}
+
+// fastLaneSuppress records a definitive provider rejection so the same address
+// cannot be attempted again by any path.
+func (s *service) fastLaneSuppress(ctx context.Context, item *dispatch.QueueItem, tp *models.OutreachTouchpoint, cause error) {
+	if s.governor != nil && tp.Recipient != "" {
+		if _, err := s.governor.CancelByRecipient(ctx, item.OrganizationID, tp.Recipient,
+			"permanent_provider_rejection"); err != nil {
+			log.Warn().Err(err).Msg("confenge fast lane: recipient cancel failed")
+		}
+	}
+	if s.governor != nil {
+		draft := item.DraftID
+		_ = s.governor.RecordFailure(ctx, item.OrganizationID, dispatch.ChannelEmail, item.MessageKey, &draft, errText(cause))
+	}
+	tp.State = models.TouchpointBounced
+	tp.StopReason = "permanent_provider_rejection"
+	if err := s.repo.UpdateTouchpoint(ctx, tp); err != nil {
+		log.Warn().Err(err).Msg("confenge fast lane: bounce projection failed")
+	}
+}

--- a/internal/app/confenge/outbound_gate.go
+++ b/internal/app/confenge/outbound_gate.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 
 	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
 	"github.com/warmbly/warmbly/internal/app/confenge/intel"
@@ -672,16 +673,29 @@ func (s *service) CompleteCampaignEmail(ctx context.Context, orgID, campaignID, 
 	if err := s.repo.UpdateTouchpoint(ctx, touchpoint); err != nil {
 		return err
 	}
-	if err := s.markDelegatedFirstTouchSent(ctx, orgID, touchpoint.ID, now); err != nil {
-		return err
-	}
+	// The provider fact is committed before any legacy projection. It is the one
+	// thing this system cannot reconstruct: confenge_dispatch_sends is the sole
+	// source of "already sent" and the only per-mailbox send counter, so a
+	// fallible audit write must never stand in front of it.
 	if err := commitProviderSend(now); err != nil {
 		return err
 	}
-	if err := observeAccepted(); err != nil {
-		return err
+	// Everything past this point is compatibility reconciliation. It is allowed
+	// to fail and converge later; none of it may turn an accepted send back into
+	// pending work.
+	if err := s.markDelegatedFirstTouchSent(ctx, orgID, touchpoint.ID, now); err != nil {
+		log.Warn().Err(err).Str("touchpoint_id", touchpoint.ID.String()).
+			Msg("confenge: delegated decision lagging an accepted send")
 	}
-	return s.releaseNextTouch(ctx, orgID, touchpoint)
+	if err := observeAccepted(); err != nil {
+		log.Warn().Err(err).Str("touchpoint_id", touchpoint.ID.String()).
+			Msg("confenge: intel projection lagging an accepted send")
+	}
+	if err := s.releaseNextTouch(ctx, orgID, touchpoint); err != nil {
+		log.Warn().Err(err).Str("touchpoint_id", touchpoint.ID.String()).
+			Msg("confenge: next touch not released after an accepted send")
+	}
+	return nil
 }
 
 func firstNonZeroTime(value *time.Time, fallback time.Time) time.Time {

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -119,6 +119,12 @@ type Service interface {
 	ObserveCampaignEmailAttempt(ctx context.Context, orgID, campaignID, contactID, sequenceID, taskID, mailboxID uuid.UUID, provider string, attemptedAt time.Time) error
 	RecordCampaignEmailFailure(ctx context.Context, taskID uuid.UUID, errorCode, errorText string, occurredAt time.Time) error
 	ProcessDispatchQueueOnce(ctx context.Context) (bool, error)
+	// ProcessFastLaneOnce claims one due first touch and takes it to a terminal
+	// state through the CONFENGE fast lane (claim -> gates -> send -> ledger).
+	ProcessFastLaneOnce(ctx context.Context) (bool, error)
+	// WireFastLane installs the synchronous transport that owns first-touch
+	// sending. Without it the fast lane stays inert and the legacy path runs.
+	WireFastLane(pool *pgxpool.Pool, transport FirstTouchTransport)
 	ProcessEditorialRecoveryOnce(ctx context.Context) (bool, error)
 	ProcessDraftGenerationOnce(ctx context.Context) (bool, error)
 	ProcessDelegatedFirstTouchOnce(ctx context.Context) (bool, error)
@@ -243,6 +249,10 @@ type service struct {
 	// cannot be overshot by concurrent draft generation and recovery.
 	reviewBacklogMu sync.Mutex
 	nowFn           func() time.Time
+	// Fast-lane transport: the synchronous provider used by the CONFENGE
+	// first-touch loop. Nil disables the fast lane entirely.
+	firstTouchTransport FirstTouchTransport
+	fastLaneDB          *pgxpool.Pool
 }
 
 func (s *service) now() time.Time {

--- a/internal/infrastructure/db/migrations/000139_confenge_fast_lane_ledger.down.sql
+++ b/internal/infrastructure/db/migrations/000139_confenge_fast_lane_ledger.down.sql
@@ -1,0 +1,10 @@
+DROP INDEX IF EXISTS confenge_dispatch_sends_queue_idx;
+DROP INDEX IF EXISTS confenge_dispatch_sends_provider_msg_idx;
+
+-- Dropping these columns discards observed provider facts. The send rows
+-- themselves are never removed: acceptance that happened stays recorded.
+ALTER TABLE confenge_dispatch_sends
+    DROP COLUMN IF EXISTS queue_id,
+    DROP COLUMN IF EXISTS provider_message_id,
+    DROP COLUMN IF EXISTS provider,
+    DROP COLUMN IF EXISTS recipient;

--- a/internal/infrastructure/db/migrations/000139_confenge_fast_lane_ledger.up.sql
+++ b/internal/infrastructure/db/migrations/000139_confenge_fast_lane_ledger.up.sql
@@ -1,0 +1,27 @@
+-- The CONFENGE first-touch send ledger recorded that a message was accepted but
+-- not what was accepted, by whom, or under which provider id. Reconciling an
+-- ambiguous provider result therefore had nothing to correlate against, and the
+-- only recipient on record lived on the queue row, which is mutable.
+--
+-- These columns make confenge_dispatch_sends self-contained external truth:
+-- one row states recipient, provider, provider message id and the queue row it
+-- discharged. Duplicate prevention stays where it already was -- the existing
+-- UNIQUE (message_key) -- so this adds evidence, never a second authority.
+
+ALTER TABLE confenge_dispatch_sends
+    ADD COLUMN IF NOT EXISTS recipient           text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS provider            text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS provider_message_id text NOT NULL DEFAULT '',
+    ADD COLUMN IF NOT EXISTS queue_id            uuid;
+
+-- Correlation index for ambiguous-result reconciliation: given a provider id
+-- observed later (bounce, DSN, mailbox sync), find the send that produced it.
+CREATE INDEX IF NOT EXISTS confenge_dispatch_sends_provider_msg_idx
+    ON confenge_dispatch_sends (organization_id, provider_message_id)
+    WHERE provider_message_id <> '';
+
+-- Answering "was this queue row already sent?" without joining on the mutable
+-- message_key text.
+CREATE INDEX IF NOT EXISTS confenge_dispatch_sends_queue_idx
+    ON confenge_dispatch_sends (queue_id)
+    WHERE queue_id IS NOT NULL;


### PR DESCRIPTION
## Why

One CONFENGE first touch crossed four processes and ~17 state writes: backend enrolled the draft into a Warmbly campaign, the campaign scheduler picked a contact, Cloud Tasks called back, the backend published to Kafka, a worker opened SMTP, and a consumer finally recorded the result. Any of those could fail independently, and several could turn a provider-accepted message back into pending work.

PRs #213-#244 are ~30 consecutive single-issue fixes to that one path. Production shows the cost directly: **3168 approved rows cancelled in a single day**, in four bursts, all `delegated_authority_or_source_binding_advanced` -- provenance re-decided at transport time invalidating work that was already authoritative when approved.

The queue and the ledger did not even share an identity. Queue rows are keyed `email:draft:<id>`; the ledger is keyed `email:campaign:...`. The commit transaction closed the queue `WHERE message_key = <campaign key>`, which can never match a first-touch row, so the two idempotency domains could not check each other.

## What this does

Two authoritative concepts, nothing else: `confenge_dispatch_queue` is work to send, `confenge_dispatch_sends` is what was sent.

`ProcessFastLaneOnce`: resolve transport state -> claim (`FOR UPDATE SKIP LOCKED` + lease) -> close from ledger if already sent -> essential gates -> reserve under **the queue's own key** -> synchronous SMTP -> commit send + reservation + queue close in **one transaction** -> best-effort legacy reconciliation.

Unifying the message key is the heart of it: the existing `UNIQUE (message_key)` on the ledger now gives DB-level exactly-once for a first touch, and the queue fixup in `CommitReservation` finally matches.

The send runs in the backend deliberately. The provider fact is the one thing the system cannot reconstruct, so the process that observes acceptance is the process that commits it. No worker-boundary change was needed: the backend already decrypts mailbox credentials in-process via `GetSMTPCredentials` (`CREDENTIALS_ENCRYPTION_KEY`, not the org DEK).

## Gates kept vs dropped

**Kept:** kill switch, durable pause, business window/days, per-mailbox daily+hourly cap, min-gap, mailbox enabled + SMTP configured, approved-content-hash binding, recipient usable, non-empty payload, hard-bounce/complaint/opt-out suppression (fails closed if unreadable).

**No longer re-decided at transport:** release SHA, snapshot/run id, membership revision, composer/template/prompt versions, target-fit re-evaluation, `campaign_contact_progress` as send authority, campaign scheduler, Cloud Tasks, Kafka, send-time optimisation. All still exist; they are simply not asked again after approval.

## Failure model

| Outcome | Action |
| --- | --- |
| Accepted | record send, close row |
| Permanent (5xx at `RCPT TO`) | terminal `failed`, suppress recipient, continue |
| Transient | bounded backoff retry (5) |
| Ambiguous (failure at end of `DATA`) | park `attempted`, **never resend**, correlate by Message-ID |

Cap/window deferral uses `DeferQueue`, which does not consume a retry attempt.

## Also fixes an existing hole

`CompleteCampaignEmail` ran `markDelegatedFirstTouchSent` **before** `commitProviderSend`, putting a fallible legacy audit write in front of the only per-mailbox send counter and the sole source of "already sent". Reordered so the provider fact commits first; everything after it is best-effort and logged. This is what makes #244's consumer wiring safe -- on main that call is a silent no-op because `delegatedDB` is nil there, and #244 activates it. Recommend closing #244 as superseded.

## Cutover

`CONFENGE_FAST_LANE_ENABLED` selects exactly one queue owner at boot; the two paths can never drain the same queue. Rollback is the same switch. Runbook in `docs/confenge/first-touch-fast-lane.md`.

Verified safe against production: no queued row maps to a SENT touchpoint (1204 queued + 12 attempted are all touchpoint `QUEUED`), so cutover cannot resend delivered mail.

## Verification

`gofmt -l` clean, `golangci-lint` clean, `go build ./...` OK. Nine new tests cover exactly-once recording, replay/restart non-duplication, permanent rejection not head-of-line blocking, ambiguous never resent, suppression refusal, fail-closed on unreadable suppression, compat failure not erasing a send, content-drift refusal, and bounded transient retry. The only failing test in the package (`TestProductAcceptanceMultichannelSum`) fails identically on clean `main` -- it requires a running Mailpit.

**Not yet cut over in production.** The send window (09:00-18:00 America/Sao_Paulo, business days) closed before this landed, so no live canary has run.