### PR TITLE
fix: CONFENGE fast-lane flag passthrough

### DIFF
--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -60,6 +60,9 @@ x-confenge-env: &confenge-env
   CONFENGE_SEND_WINDOW_END: ${CONFENGE_SEND_WINDOW_END:-18:00}
   CONFENGE_SEND_TIMEZONE: ${CONFENGE_SEND_TIMEZONE:-America/Sao_Paulo}
   CONFENGE_SEND_BUSINESS_DAYS_ONLY: ${CONFENGE_SEND_BUSINESS_DAYS_ONLY:-true}
+  # Selects the sole first-touch transport owner at boot; without this the .env
+  # setting never reaches the backend and the legacy dispatcher keeps the queue.
+  CONFENGE_FAST_LANE_ENABLED: ${CONFENGE_FAST_LANE_ENABLED:-false}
   CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT: ${CONFENGE_DEFAULT_CAMPAIGN_DAILY_LIMIT:-200}
   # Documentation / inventory only in this PR (governor core unchanged).
   HOSTINGER_PLAN_CLASS: ${HOSTINGER_PLAN_CLASS:-BUSINESS_EMAIL_STARTER}

--- a/docs/confenge/first-touch-fast-lane.md
+++ b/docs/confenge/first-touch-fast-lane.md
@@ -107,6 +107,57 @@ Rollback is the same switch: pause, set `CONFENGE_FAST_LANE_ENABLED=false`,
 recreate the backend, resume. The queue is untouched by the flag, so no work is
 lost in either direction.
 
+## Steady state
+
+The fast lane runs continuously. Business hours are a scheduling gate inside a
+running process, not an operational pause, so nothing about nights or weekends
+needs an operator.
+
+Normal production state, at every hour of every day:
+
+```
+CONFENGE_FAST_LANE_ENABLED=true
+durable dispatch pause = false
+file kill switch = absent
+backend container up and healthy
+```
+
+Outside 09:00-18:00 America/Sao_Paulo on a business day, `ProcessFastLaneOnce`
+resolves transport state before it claims anything, sees `send_window` blocking,
+and returns having done nothing. No row is claimed, no lease is taken, no
+attempt is consumed, no failure is recorded, and no campaign is auto-paused.
+Queued rows simply stay queued with their `due_at` intact and are claimed on the
+next tick that falls inside the window.
+
+At Friday 18:00 the correct state is therefore "running, window closed, next
+eligible slot Monday 09:00", not "paused". Read it as:
+
+```
+state    = PAUSED
+blockers = ["send_window:outside_send_window"]
+```
+
+`state` is the resolved answer to "may a message leave right now?", and the
+resolver labels any non-sending state `PAUSED`. The single `send_window` blocker
+is what distinguishes automatic window gating from an operator stop: an
+operator stop also lists `durable_control` or `file_kill_switch`. If
+`send_window` is the only blocker, the system is healthy and unattended.
+
+Monday at 09:00 the window source flips to ACTIVE on its own and sending
+resumes with no human action.
+
+### When to actually pause
+
+`pause.sh` and `resume.sh` are for emergency stop, deliberate maintenance or
+cutover, deployment safety, and explicit operator intervention. They are not a
+weekly schedule. Do not add cron jobs, timers, or an evening/weekend pause
+habit around them: doing so replaces an authoritative gate with a manual one
+and creates a Monday morning where sending silently does not start.
+
+After any maintenance pause, clear it as soon as the maintenance is done, even
+if that is outside the business window. Clearing it outside the window produces
+zero sends by construction.
+
 ## Runway
 
 Queue generation is unchanged. The delegated first-touch producer continues to

--- a/docs/confenge/vps-execution-plane.md
+++ b/docs/confenge/vps-execution-plane.md
@@ -238,6 +238,15 @@ deploy/confenge-vps/resume.sh
 
 Independent of extra-cli/AI. UI dispatch pause remains available when logged in.
 
+These are exceptional controls: emergency stop, deliberate maintenance or
+cutover, deployment safety, explicit operator intervention. The steady state is
+the stack running 24/7 with the pause cleared and the kill switch absent, and
+the business window (09:00-18:00 America/Sao_Paulo, business days) gating sends
+automatically from inside the running process. Never use pause/resume as an
+evening or weekend schedule, and never wire them to cron. See
+`docs/confenge/first-touch-fast-lane.md` for what "running, window closed" looks
+like in the transport-state projection.
+
 ## Human approve → later send
 
 1. Message generated/imported on VPS.


### PR DESCRIPTION
The fast-lane cutover switch was inert on the VPS.

`CONFENGE_FAST_LANE_ENABLED` was added to every env example in #245 but never to the `deploy/confenge-vps/docker-compose.override.yml` environment block, which is the only place VPS backend env is enumerated. Setting it in `.env` therefore changed nothing: the backend booted without the variable, `FastLaneEnabled()` returned false, and the legacy dispatch queue worker kept ownership of the queue. Confirmed live on ec-prod: flag set in `.env`, absent from the running container's environment, and no `fast lane owns transport` log line.

Also documents the steady-state operating model: the stack runs 24/7 with pause cleared and kill switch absent, and the business window gates sends from inside the running process. Pause and resume are for emergency stop, maintenance, cutover and explicit operator action only, never a nightly or weekend schedule.

Verification: `docker compose config` resolves the variable on the VPS; backend env shows `CONFENGE_FAST_LANE_ENABLED=true` after recreate.