### PR TITLE
fix: eliminate the CONFENGE VPS deploy/disk failure mode

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -49,3 +49,51 @@ logs/
 docs
 *.md
 !README.md
+
+# ─── runtime / operational data ───────────────────────────────────────────
+#
+# The root-context images (backend, consumer, worker) compile Go from source
+# and copy scripts/install-worker.sh. No Dockerfile reads anything below, but
+# without these rules `docker compose build` shipped the whole runtime tree to
+# BuildKit: on ec-prod that was data/backups at 4.3G inside a 4.7G context, and
+# every rebuild snapshotted it again until the root filesystem hit 100% and
+# Postgres could no longer extend files.
+#
+# Operational data is bind-mounted at runtime (GeoIP db, feed CA, confenge ops),
+# which .dockerignore does not affect. Excluding the whole tree is safe.
+data
+backups
+ops
+ops-evidence
+.worktrees
+
+# Local agent/editor state. Nothing in an image reads these and they grow fast.
+.claude
+.codex
+.cursor
+.agentd
+
+# Backup and release archives, wherever they land.
+*.tar
+*.tar.gz
+*.tar.zst
+*.tgz
+*.zip
+*.dump
+*.sql.gz
+*.bak
+*.bak.*
+
+# Dependency trees. The root pnpm workspace installs into ./node_modules, which
+# no root-context image needs.
+node_modules
+**/node_modules
+**/.vite
+**/dist
+**/.next
+**/.turbo
+**/target
+
+# Private env files (compose reads these from the host via --env-file).
+.env*
+**/.env*

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       service:
-        description: "Service to build (all, backend, consumer, worker, tracking, realtime)"
+        description: "Service to build (all, backend, consumer, worker, tracking, realtime, web, admin)"
         required: false
         default: "all"
 
@@ -23,83 +23,60 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      # JSON lists consumed as matrix inputs. `go` services cross-compile both
-      # arches on one runner; `native` services (Rust, Elixir) have no
-      # cross-compiler, so each arch builds on a native runner and the digests
-      # are merged into one manifest.
+      # JSON lists consumed as matrix inputs. `go` and `static` services
+      # cross-compile or emit arch-independent output on one runner; `native`
+      # services (Rust, Elixir) have no cross-compiler, so each arch builds on a
+      # native runner and the digests are merged into one manifest.
       go: ${{ steps.matrix.outputs.go }}
       native: ${{ steps.matrix.outputs.native }}
+      static: ${{ steps.matrix.outputs.static }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        if: github.event_name == 'push'
-        id: filter
-        with:
-          filters: |
-            backend:
-              - 'go.mod'
-              - 'go.sum'
-              - 'internal/**'
-              - 'cmd/backend/**'
-              - 'deploy/docker/backend.Dockerfile'
-            consumer:
-              - 'go.mod'
-              - 'go.sum'
-              - 'internal/**'
-              - 'cmd/consumer/**'
-              - 'deploy/docker/consumer.Dockerfile'
-            worker:
-              - 'go.mod'
-              - 'go.sum'
-              - 'internal/**'
-              - 'cmd/worker/**'
-              - 'deploy/docker/worker.Dockerfile'
-            tracking:
-              - 'tracking/**'
-            realtime:
-              - 'realtime/**'
-              - 'deploy/docker/realtime.Dockerfile'
       - name: Assemble build matrices
         id: matrix
         env:
           EVENT: ${{ github.event_name }}
           SELECTED: ${{ github.event.inputs.service }}
-          BACKEND: ${{ steps.filter.outputs.backend }}
-          CONSUMER: ${{ steps.filter.outputs.consumer }}
-          WORKER: ${{ steps.filter.outputs.worker }}
-          TRACKING: ${{ steps.filter.outputs.tracking }}
-          REALTIME: ${{ steps.filter.outputs.realtime }}
         run: |
+          # A push to main builds every service. The CONFENGE VPS deploys by
+          # pulling one image per service tagged with the release SHA, so a
+          # partial build would leave a commit with no deployable image for an
+          # unchanged service and force a local rebuild on production. GHA cache
+          # makes an unchanged service a near no-op.
           go=""
           native=""
-          if [ "$EVENT" = "workflow_dispatch" ]; then
-            sel="${SELECTED:-all}"
-            for s in backend consumer worker; do
-              if [ "$sel" = "all" ] || [ "$sel" = "$s" ]; then go="$go\"$s\","; fi
-            done
-            for s in tracking realtime; do
-              if [ "$sel" = "all" ] || [ "$sel" = "$s" ]; then native="$native\"$s\","; fi
-            done
-          else
-            if [ "$BACKEND" = "true" ]; then go="$go\"backend\","; fi
-            if [ "$CONSUMER" = "true" ]; then go="$go\"consumer\","; fi
-            if [ "$WORKER" = "true" ]; then go="$go\"worker\","; fi
-            if [ "$TRACKING" = "true" ]; then native="$native\"tracking\","; fi
-            if [ "$REALTIME" = "true" ]; then native="$native\"realtime\","; fi
-          fi
+          static=""
+          sel="all"
+          if [ "$EVENT" = "workflow_dispatch" ]; then sel="${SELECTED:-all}"; fi
+          for s in backend consumer worker; do
+            if [ "$sel" = "all" ] || [ "$sel" = "$s" ]; then go="$go\"$s\","; fi
+          done
+          for s in tracking realtime; do
+            if [ "$sel" = "all" ] || [ "$sel" = "$s" ]; then native="$native\"$s\","; fi
+          done
+          for s in web admin; do
+            if [ "$sel" = "all" ] || [ "$sel" = "$s" ]; then static="$static\"$s\","; fi
+          done
           echo "go=[${go%,}]" >> "$GITHUB_OUTPUT"
           echo "native=[${native%,}]" >> "$GITHUB_OUTPUT"
+          echo "static=[${static%,}]" >> "$GITHUB_OUTPUT"
 
   # Go services: the Dockerfiles build on $BUILDPLATFORM and cross-compile to
   # each target arch, so one amd64 runner produces both platforms without QEMU.
   build-go:
-    name: Build ${{ matrix.service }}
+    name: Build ${{ matrix.service }}${{ matrix.profile != '' && ' (minprofile)' || '' }}
     needs: changes
     if: needs.changes.outputs.go != '[]'
     strategy:
       fail-fast: false
       matrix:
         service: ${{ fromJSON(needs.changes.outputs.go) }}
+        # Two compile profiles per service. The default image serves self-host;
+        # the `-minprofile` image is what the CONFENGE VPS pins, keeping the
+        # contract that Stripe, the AWS SDK, GCP Tasks/PubSub and Kafka are not
+        # compile-linked on the execution plane. Building it here is what lets
+        # production stop compiling locally without weakening that contract.
+        profile: ["", "minprofile"]
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -123,9 +100,65 @@ jobs:
           context: .
           file: deploy/docker/${{ matrix.service }}.Dockerfile
           push: true
+          build-args: |
+            GO_TAGS=${{ matrix.profile }}
+          tags: |
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.sha }}${{ matrix.profile != '' && format('-{0}', matrix.profile) || '' }}
+            ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:dev${{ matrix.profile != '' && format('-{0}', matrix.profile) || '' }}
+          # deploy/verify-release.sh reconciles repo SHA -> image label ->
+          # running container. Without this label a pulled image cannot prove
+          # which commit it was built from.
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            br.com.confenge.service=warmbly-${{ matrix.service }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha,scope=${{ matrix.service }}${{ matrix.profile != '' && format('-{0}', matrix.profile) || '' }}
+          cache-to: type=gha,mode=max,scope=${{ matrix.service }}${{ matrix.profile != '' && format('-{0}', matrix.profile) || '' }}
+
+  # web and admin: stage 1 builds the SPA on $BUILDPLATFORM and the output is
+  # arch-independent, so one runner produces both platforms. The CONFENGE VPS
+  # runs both, so both must exist in the registry or production still builds.
+  build-static:
+    name: Build ${{ matrix.service }}
+    needs: changes
+    if: needs.changes.outputs.static != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        service: ${{ fromJSON(needs.changes.outputs.static) }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./${{ matrix.service }}
+          file: ./${{ matrix.service }}/Dockerfile
+          push: true
           tags: |
             ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:${{ github.sha }}
             ${{ env.IMAGE_PREFIX }}/${{ matrix.service }}:dev
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            br.com.confenge.service=warmbly-${{ matrix.service }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
@@ -175,6 +208,11 @@ jobs:
           platforms: ${{ matrix.platform }}
           cache-from: type=gha,scope=${{ matrix.service }}-${{ steps.prep.outputs.pair }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}-${{ steps.prep.outputs.pair }}
+          labels: |
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ github.sha }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            br.com.confenge.service=warmbly-${{ matrix.service }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.service }},push-by-digest=true,name-canonical=true,push=true
 
       - name: Export digest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,14 @@ jobs:
               - 'deploy/verify-release.sh'
               - 'docker-compose.yml'
 
+  build-context:
+    name: Docker build context budget
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Measure root build context
+        run: python3 scripts/build_context_size.py . --max-mb 150
+
   confenge-vps-pack:
     name: CONFENGE VPS pack
     needs: changes
@@ -78,6 +86,7 @@ jobs:
           python3 -m unittest
           deploy.confenge-vps.test_vps_pack
           deploy.confenge-vps.test_backup
+          deploy.confenge-vps.test_deploy_disk_safety
           deploy/confenge-vps/asaas-adapter/test_adapter.py
 
       - name: Validate deployment pack
@@ -622,7 +631,7 @@ jobs:
   ci-status:
     name: CI Status
     runs-on: ubuntu-latest
-    needs: [changes, go-ci, web-ci, confenge-product-acceptance, confenge-vps-pack, admin-ci, site-ci, make-ci, rust-ci, elixir-ci, ios-ci, frontend-images, security]
+    needs: [changes, build-context, go-ci, web-ci, confenge-product-acceptance, confenge-vps-pack, admin-ci, site-ci, make-ci, rust-ci, elixir-ci, ios-ci, frontend-images, security]
     if: always()
     steps:
       - name: Check CI status
@@ -650,6 +659,10 @@ jobs:
           if [[ "${{ needs.changes.outputs.confenge-vps }}" == "true" ]] && \
              [[ "$vps_result" != "success" ]]; then
             echo "CONFENGE VPS pack did not pass (result=$vps_result)"
+            vps_failed=1
+          fi
+          if [[ "${{ needs.build-context.result }}" != "success" ]]; then
+            echo "Docker build context budget did not pass (result=${{ needs.build-context.result }})"
             vps_failed=1
           fi
           if [[ "${{ needs.go-ci.result }}" == "failure" ]] || \

--- a/deploy/confenge-vps/README.md
+++ b/deploy/confenge-vps/README.md
@@ -7,6 +7,68 @@ Go images build with `GO_TAGS=minprofile`: postgres, redis, nats, filesystem
 blobs, and local KMS only. Stripe, AWS, GCP Cloud Tasks/PubSub, and Kafka are
 not compile-linked and fail closed if selected.
 
+## Deployment model
+
+Production consumes immutable images that CI already built. The VPS does not
+compile. `deploy/confenge-vps/docker-compose.release.yml` pins every application
+service to `ghcr.io/tjsasakifln/warmbly/<service>:<release-sha>` (the Go services
+to the `-minprofile` variant) and resets each `build:` section, so a missing
+image is a loud failure instead of a silent local build.
+
+```bash
+deploy/confenge-vps/release-deploy.sh            # roll onto origin/main
+deploy/confenge-vps/release-deploy.sh <full-sha> # roll onto a specific release
+```
+
+`up.sh` runs the deploy in this order and stops at the first failure:
+
+1. disk preflight, before any mutation
+2. bounded cleanup of reconstructible artifacts if headroom is short
+3. pull the images pinned to the release SHA
+4. verify each image carries `org.opencontainers.image.revision=<sha>`
+5. write the `deploy_preflight` kill switch (outbound cannot fail open)
+6. `compose up -d --no-build --remove-orphans`
+7. backend health, `pg_isready`, and `verify-release.sh` per service
+8. clear the deploy kill switch automatically
+9. bounded retention sweep
+
+Step 8 clears only a switch whose reason is `deploy_preflight`. An operator
+pause from `pause.sh` has a different reason and survives a deploy. After a
+successful deploy the business send window is the only outbound gate, at any
+hour.
+
+Set `CONFENGE_RELEASE_MODE=build` only if GHCR is unreachable. Local production
+builds are what filled the root filesystem.
+
+## Disk safety
+
+`data/backups` reached 4.3 GB inside a 4.7 GB Docker build context, every
+rebuild snapshotted it, builder cache grew to ~174 GB, and Postgres could no
+longer extend files. Three things prevent a repeat:
+
+- `.dockerignore` excludes `data`, `ops`, `ops-evidence`, `backups`, archives
+  and dependency trees. `scripts/build_context_size.py` is the CI gate (150 MB
+  budget); no Dockerfile copies any excluded tree.
+- `disk-guard.sh preflight` refuses a deploy below `20 GB` deploy budget plus a
+  `20 GB` Postgres reserve (and 12% free), after trying a bounded reclaim of
+  reconstructible artifacts only.
+- `disk-guard.sh retain` runs after every deploy and daily via
+  `confenge-docker-gc.timer`: builder cache capped at 8 GB / 168 h, dangling
+  images pruned, Warmbly release images older than the current and previous
+  release removed without `-f`. Named volumes, Postgres data, `confenge_ops`,
+  `confenge_keys` and `blobs` are never touched.
+
+```bash
+deploy/confenge-vps/disk-guard.sh report      # thresholds and current usage
+deploy/confenge-vps/host-disk-report.sh       # shared-host picture, read-only
+sudo deploy/confenge-vps/docker-gc-install.sh # timer + host BuildKit cache cap
+```
+
+Backups keep the newest `CONFENGE_BACKUP_KEEP` (default 10) archives with their
+manifests, checksums and key bundles. Co-tenant data (Extra Consultoria, the
+control center, host Postgres) is reported and never deleted by Warmbly
+automation.
+
 Full docs:
 
 - [vps-execution-plane.md](../../docs/confenge/vps-execution-plane.md)

--- a/deploy/confenge-vps/backup.sh
+++ b/deploy/confenge-vps/backup.sh
@@ -243,6 +243,31 @@ PY
 fi
 COMPLETE=true
 
+# ── retention ───────────────────────────────────────────────────────────────
+# These archives are Postgres dumps plus sealed key bundles, so loss semantics
+# are real: retention is count-based with a floor, applies only after this
+# backup succeeded, and never deletes the newest archives. It ran unbounded
+# until now, reaching 4.3 GB on ec-prod inside the Docker build context.
+# An archive is only removed together with its manifest, checksum and key
+# bundle, so a surviving backup is never left half-referenced.
+BACKUP_KEEP="${CONFENGE_BACKUP_KEEP:-10}"
+if [[ "$BACKUP_KEEP" =~ ^[0-9]+$ ]] && [[ "$BACKUP_KEEP" -ge 3 ]]; then
+  mapfile -t OLD_ARCHIVES < <(
+    find "$OUT_DIR" -maxdepth 1 -name 'warmbly-confenge-*.tar.gz' -printf '%f\n' 2>/dev/null |
+      sort -r | tail -n "+$((BACKUP_KEEP + 1))"
+  )
+  for old in "${OLD_ARCHIVES[@]:-}"; do
+    [[ -z "$old" ]] && continue
+    stamp="${old#warmbly-confenge-}"
+    stamp="${stamp%.tar.gz}"
+    echo "Retention: removing superseded backup $old (keeping newest $BACKUP_KEEP)"
+    rm -f -- "$OUT_DIR/$old" "$OUT_DIR/$old.manifest.json" "$OUT_DIR/$old.sha256"
+    rm -f -- "$SECRETS_DIR/keys-$stamp.env" "$SECRETS_DIR/keys-$stamp.env.sha256"
+  done
+else
+  echo "Retention: skipped (CONFENGE_BACKUP_KEEP=$BACKUP_KEEP is not an integer >= 3)"
+fi
+
 echo "Backup archive: $ARCHIVE"
 echo "Manifest: $MANIFEST_SIDECAR"
 echo "Archive checksum: $CHECKSUM_SIDECAR"

--- a/deploy/confenge-vps/disk-guard.sh
+++ b/deploy/confenge-vps/disk-guard.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# CONFENGE VPS disk safety: preflight, bounded cleanup, retention.
+#
+# Postgres and Docker share the root filesystem. A deploy that eats the last
+# free gigabytes stops Postgres extending files and the backend enters a
+# migration restart loop, so the measurement runs BEFORE production mutates and
+# fails the deploy instead of the database.
+#
+# Usage:
+#   disk-guard.sh report
+#   disk-guard.sh preflight [release-sha]
+#   disk-guard.sh retain [release-sha]
+set -euo pipefail
+
+# Deploy may consume this much; Postgres headroom below is never part of the budget.
+DEPLOY_BUDGET_GB="${CONFENGE_DISK_DEPLOY_BUDGET_GB:-20}"
+PG_RESERVED_GB="${CONFENGE_DISK_PG_RESERVED_GB:-20}"
+MIN_FREE_PCT="${CONFENGE_DISK_MIN_FREE_PCT:-12}"
+WARN_FREE_GB="${CONFENGE_DISK_WARN_FREE_GB:-80}"
+# Build cache is fully reconstructible: capped in steady state, dropped when a
+# deploy would otherwise not fit.
+BUILDER_CACHE_MAX_GB="${CONFENGE_BUILDER_CACHE_MAX_GB:-8}"
+BUILDER_CACHE_MAX_AGE="${CONFENGE_BUILDER_CACHE_MAX_AGE:-168h}"
+BUILDER_CACHE_EMERGENCY_GB="${CONFENGE_BUILDER_CACHE_EMERGENCY_GB:-0}"
+# Current release plus this many previous releases stay pullable-free for rollback.
+RELEASE_KEEP="${CONFENGE_RELEASE_KEEP:-2}"
+IMAGE_PREFIX="${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}"
+
+_dg_root() { cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd; }
+
+release_state_file() {
+  local dir="${CONFENGE_RELEASE_STATE_DIR:-/var/lib/confenge}"
+  if mkdir -p "$dir" 2>/dev/null && [[ -w "$dir" ]]; then
+    echo "$dir/release-history"
+  else
+    echo "$(_dg_root)/deploy/confenge-vps/.release-history"
+  fi
+}
+
+docker_root() {
+  local root
+  root="$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)"
+  [[ -n "$root" && -d "$root" ]] && { echo "$root"; return; }
+  echo /
+}
+
+# df in MB so a sub-GB reading never rounds to zero.
+_df_field() {
+  df -P -k "$1" 2>/dev/null | awk 'NR==2 {print $2, $3, $4}'
+}
+
+fs_free_mb()  { local f; f="$(_df_field "$1")"; echo $(( $(echo "$f" | awk '{print $3}') / 1024 )); }
+fs_total_mb() { local f; f="$(_df_field "$1")"; echo $(( $(echo "$f" | awk '{print $1}') / 1024 )); }
+
+free_floor_mb() { echo $(( (DEPLOY_BUDGET_GB + PG_RESERVED_GB) * 1024 )); }
+
+docker_usage() {
+  docker system df 2>/dev/null || echo "docker system df unavailable"
+}
+
+builder_cache_bytes() {
+  # `docker buildx du` totals are human strings; the reclaimable line is enough
+  # for reporting and the prune below is what actually bounds the cache.
+  docker buildx du 2>/dev/null | awk '/^Total:/ {print $2}' | tail -1
+}
+
+report() {
+  local path free_mb total_mb pct_free floor_mb
+  path="$(docker_root)"
+  free_mb="$(fs_free_mb "$path")"
+  total_mb="$(fs_total_mb "$path")"
+  floor_mb="$(free_floor_mb)"
+  pct_free=0
+  [[ "$total_mb" -gt 0 ]] && pct_free=$(( free_mb * 100 / total_mb ))
+  echo "DISK_PATH=$path"
+  echo "DISK_TOTAL_GB=$(( total_mb / 1024 ))"
+  echo "DISK_FREE_GB=$(( free_mb / 1024 ))"
+  echo "DISK_FREE_PCT=$pct_free"
+  echo "DISK_USED_PCT=$(( 100 - pct_free ))"
+  echo "DISK_REQUIRED_FREE_GB=$(( floor_mb / 1024 ))"
+  echo "DISK_PG_RESERVED_GB=$PG_RESERVED_GB"
+  echo "DISK_DEPLOY_BUDGET_GB=$DEPLOY_BUDGET_GB"
+  echo "BUILDER_CACHE_TOTAL=$(builder_cache_bytes)"
+  echo "BUILDER_CACHE_MAX_GB=$BUILDER_CACHE_MAX_GB"
+  if [[ "$free_mb" -lt "$floor_mb" ]]; then
+    echo "DISK_STATE=CRITICAL"
+  elif [[ "$free_mb" -lt $(( WARN_FREE_GB * 1024 )) ]]; then
+    echo "DISK_STATE=WARN"
+  else
+    echo "DISK_STATE=OK"
+  fi
+  echo "--- docker system df ---"
+  docker_usage
+}
+
+# Reconstructible artifacts only. Named volumes, Postgres data, the CONFENGE ops
+# and key volumes, and blobs are never arguments to anything below: this script
+# contains no `volume rm`, no `volume prune`, and no `system prune`.
+clean_reconstructible() {
+  local keep_gb="${1:-$BUILDER_CACHE_MAX_GB}" sha="${2:-}"
+  echo "cleanup: builder cache -> keep ${keep_gb}GB, drop older than ${BUILDER_CACHE_MAX_AGE}"
+  docker builder prune --force --keep-storage "${keep_gb}GB" --filter "until=${BUILDER_CACHE_MAX_AGE}" >/dev/null 2>&1 ||
+    docker builder prune --force --keep-storage "${keep_gb}GB" >/dev/null 2>&1 || true
+  echo "cleanup: dangling images (daemon refuses any image a container references)"
+  docker image prune --force >/dev/null 2>&1 || true
+  prune_stale_release_images "$sha"
+}
+
+# Delete Warmbly release images outside the keep set. `docker image rm` without
+# -f refuses an image any container references, so the running release and the
+# rollback release cannot be removed even if the keep set were wrong.
+prune_stale_release_images() {
+  local current="${1:-}" keep line repo tag sha
+  keep=" $current "
+  if [[ -f "$(release_state_file)" ]]; then
+    while read -r line; do
+      [[ -n "$line" ]] && keep+="$line "
+    done < <(tail -n "$RELEASE_KEEP" "$(release_state_file)" | awk '{print $1}')
+  fi
+  while read -r repo tag; do
+    [[ -z "$repo" || "$tag" == "<none>" ]] && continue
+    sha="${tag%-minprofile}"
+    [[ "$sha" == *[!0-9a-f]* || ${#sha} -ne 40 ]] && continue
+    if [[ "$keep" == *" $sha "* ]]; then continue; fi
+    echo "cleanup: removing superseded release image $repo:$tag"
+    docker image rm "$repo:$tag" >/dev/null 2>&1 || true
+  done < <(docker image ls --format '{{.Repository}} {{.Tag}}' 2>/dev/null | grep -F "$IMAGE_PREFIX/" || true)
+}
+
+record_release() {
+  local sha="$1" file
+  file="$(release_state_file)"
+  printf '%s %s\n' "$sha" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"$file"
+  # Bounded history; the file is the rollback keep list, not an audit log.
+  tail -n 20 "$file" >"$file.tmp" && mv "$file.tmp" "$file"
+}
+
+preflight() {
+  local sha="${1:-}" path free_mb total_mb floor_mb pct_free
+  path="$(docker_root)"
+  floor_mb="$(free_floor_mb)"
+  echo "== disk preflight =="
+  report
+  free_mb="$(fs_free_mb "$path")"
+  total_mb="$(fs_total_mb "$path")"
+  pct_free=0
+  [[ "$total_mb" -gt 0 ]] && pct_free=$(( free_mb * 100 / total_mb ))
+
+  if [[ "$free_mb" -ge "$floor_mb" && "$pct_free" -ge "$MIN_FREE_PCT" ]]; then
+    echo "DISK_PREFLIGHT=PASS free=$(( free_mb / 1024 ))GB floor=$(( floor_mb / 1024 ))GB"
+    return 0
+  fi
+
+  echo "DISK_PREFLIGHT=RECLAIM free=$(( free_mb / 1024 ))GB below floor=$(( floor_mb / 1024 ))GB"
+  clean_reconstructible "$BUILDER_CACHE_EMERGENCY_GB" "$sha"
+
+  free_mb="$(fs_free_mb "$path")"
+  pct_free=0
+  [[ "$total_mb" -gt 0 ]] && pct_free=$(( free_mb * 100 / total_mb ))
+  if [[ "$free_mb" -ge "$floor_mb" && "$pct_free" -ge "$MIN_FREE_PCT" ]]; then
+    echo "DISK_PREFLIGHT=PASS after reclaim free=$(( free_mb / 1024 ))GB"
+    return 0
+  fi
+
+  echo "REFUSE: insufficient disk headroom for a safe deploy." >&2
+  echo "  free=$(( free_mb / 1024 ))GB free_pct=${pct_free}% required=$(( floor_mb / 1024 ))GB (${DEPLOY_BUDGET_GB}GB deploy + ${PG_RESERVED_GB}GB Postgres reserve, min ${MIN_FREE_PCT}%)" >&2
+  echo "  No service was recreated. Reclaim space by hand and retry; persistent volumes were not touched." >&2
+  return 4
+}
+
+retain() {
+  local sha="${1:-}"
+  echo "== retention sweep =="
+  [[ -n "$sha" ]] && record_release "$sha"
+  clean_reconstructible "$BUILDER_CACHE_MAX_GB" "$sha"
+  report
+}
+
+case "${1:-report}" in
+  report)    report ;;
+  preflight) preflight "${2:-}" ;;
+  retain)    retain "${2:-}" ;;
+  *) echo "usage: disk-guard.sh {report|preflight|retain} [release-sha]" >&2; exit 2 ;;
+esac

--- a/deploy/confenge-vps/docker-compose.release.yml
+++ b/deploy/confenge-vps/docker-compose.release.yml
@@ -1,0 +1,50 @@
+# CONFENGE immutable release overlay.
+#
+# Production consumes images CI already built for the exact release SHA. The
+# `build: !reset null` on every application service is the point of this file:
+# with a build section present, `docker compose up` silently falls back to
+# compiling on the VPS when an image is missing, which is how ec-prod
+# accumulated 174 GB of builder cache and filled the root filesystem until
+# Postgres could no longer extend files. Resetting it makes a missing image a
+# loud failure instead of a local build.
+#
+# WARMBLY_RELEASE_SHA is required and has no default on purpose: a mutable
+# `:dev` or `:latest` must never be the deployment authority.
+#
+# The Go services pin the `-minprofile` variant, keeping the execution-plane
+# contract that Stripe, the AWS SDK, GCP Tasks/PubSub and Kafka are not
+# compile-linked.
+
+services:
+  backend:
+    build: !reset null
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/backend:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}-minprofile
+
+  consumer:
+    build: !reset null
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/consumer:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}-minprofile
+
+  worker:
+    build: !reset null
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/worker:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}-minprofile
+
+  tracking:
+    build: !reset null
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/tracking:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}
+
+  realtime:
+    build: !reset null
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/realtime:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}
+
+  web:
+    build: !reset null
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/web:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}
+
+  admin:
+    build: !reset null
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/admin:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}
+
+  # Same binary set as the backend image; seed runs from it under the `seed` profile.
+  seed:
+    build: !reset null
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/backend:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}-minprofile

--- a/deploy/confenge-vps/docker-gc-install.sh
+++ b/deploy/confenge-vps/docker-gc-install.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Install the bounded Docker GC timer and the host-level BuildKit cache cap.
+#
+# Without this, nothing bounds Docker growth between deploys and the operator
+# has to remember to prune. That is how ec-prod reached 100% root usage with
+# ~174 GB of builder cache.
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+PACK="$ROOT/deploy/confenge-vps"
+
+BUILDER_KEEP_GB="${CONFENGE_HOST_BUILDER_KEEP_GB:-10}"
+DAEMON_JSON="${CONFENGE_DOCKER_DAEMON_JSON:-/etc/docker/daemon.json}"
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "REFUSE: run as root (installs systemd units and /etc/docker config)" >&2
+  exit 3
+fi
+
+echo "== bounded GC timer =="
+install -m 0644 "$PACK/systemd/confenge-docker-gc.service" /etc/systemd/system/
+install -m 0644 "$PACK/systemd/confenge-docker-gc.timer" /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now confenge-docker-gc.timer
+systemctl list-timers confenge-docker-gc.timer --no-pager || true
+
+echo "== host BuildKit cache cap =="
+# Host-level, not Warmbly-level: Warmbly, Extra Consultoria and the control
+# center share one root filesystem, so the cap has to sit on the daemon or one
+# stack's builds can still consume the whole host.
+python3 - "$DAEMON_JSON" "$BUILDER_KEEP_GB" <<'PY'
+import json, os, sys
+
+path, keep_gb = sys.argv[1], int(sys.argv[2])
+cfg = {}
+if os.path.exists(path):
+    with open(path, encoding="utf-8") as fh:
+        text = fh.read().strip()
+    if text:
+        cfg = json.loads(text)
+
+builder = cfg.setdefault("builder", {})
+gc = builder.setdefault("gc", {})
+gc["enabled"] = True
+gc["defaultKeepStorage"] = f"{keep_gb}GB"
+gc["policy"] = [
+    {"keepStorage": "2GB", "filter": ["unused-for=24h"]},
+    {"keepStorage": f"{keep_gb}GB", "all": True},
+]
+# Cap container logs host-wide; the Warmbly compose files already do this per
+# service, but co-tenant stacks may not.
+cfg.setdefault("log-driver", "json-file")
+cfg.setdefault("log-opts", {"max-size": "20m", "max-file": "5"})
+
+os.makedirs(os.path.dirname(path), exist_ok=True)
+tmp = path + ".confenge-tmp"
+with open(tmp, "w", encoding="utf-8") as fh:
+    json.dump(cfg, fh, indent=2, sort_keys=True)
+    fh.write("\n")
+os.replace(tmp, path)
+print(f"wrote {path}: builder.gc.defaultKeepStorage={keep_gb}GB")
+PY
+
+echo
+echo "NOTE: the BuildKit GC policy applies when dockerd next starts. This script"
+echo "does not restart Docker, because that would restart every container on the"
+echo "host including production. The daily timer bounds the cache meanwhile."
+echo "Apply at the next maintenance window with: systemctl restart docker"

--- a/deploy/confenge-vps/host-disk-report.sh
+++ b/deploy/confenge-vps/host-disk-report.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Read-only shared-host storage report. Deletes nothing, ever.
+#
+# Warmbly is a minority tenant on this root filesystem. Any automatic cleanup
+# is scoped to artifacts Warmbly created and can reconstruct; everything else is
+# reported so a human can decide, because "large" is not the same as "safe to
+# delete" and co-tenant outputs have loss semantics we do not own.
+set -euo pipefail
+
+TOP="${CONFENGE_HOST_REPORT_TOP:-12}"
+
+echo "== filesystem =="
+df -h / | sed -n '1p;2p'
+echo
+
+echo "== largest trees =="
+du -shx /var/lib/* /opt/* 2>/dev/null | sort -rh | head -n "$TOP"
+echo
+
+echo "== docker =="
+docker system df 2>/dev/null || echo "docker unavailable"
+echo
+
+echo "== classification =="
+cat <<'TXT'
+Warmbly-owned, bounded automatically by this pack:
+  /var/lib/docker builder cache   reconstructible  disk-guard.sh retain (daily timer)
+  dangling images                 reconstructible  disk-guard.sh retain
+  superseded warmbly release imgs reconstructible  disk-guard.sh retain, keeps current + previous
+  data/backups/confenge-vps       BACKUP           backup.sh keeps newest CONFENGE_BACKUP_KEEP (default 10)
+
+Warmbly-owned, deliberately never touched:
+  docker named volumes            PERSISTENT       postgres data, confenge_ops, confenge_keys, blobs
+  data/GeoLite2-City.mmdb         runtime input    bind-mounted by the backend
+  ops/feed-tls                    credential       private CA for the same-host feed
+
+Co-tenant, NOT touched by any Warmbly automation. Retention is the owning
+stack's decision; this report only surfaces size and count:
+  /var/lib/extra-consultoria      unknown semantics; largest consumer on the host
+  /var/lib/postgresql             host Postgres data (not the Warmbly container's)
+  /opt/extra-consultoria-releases release trees, one per SHA; likely duplicated across releases
+  /opt/confenge-plane             feed/plane payloads
+  /opt/*-releases                 per-SHA checkouts; count grows without bound
+  /swapfile, /swapfile2           fixed allocation, not reclaimable by cleanup
+TXT
+echo
+
+echo "== per-SHA release trees (count and size; nothing is removed) =="
+for d in /opt/*-releases; do
+  [[ -d "$d" ]] || continue
+  printf '%-45s %6s entries  %s\n' "$d" "$(find "$d" -mindepth 1 -maxdepth 1 | wc -l)" "$(du -shx "$d" 2>/dev/null | cut -f1)"
+done

--- a/deploy/confenge-vps/lib.sh
+++ b/deploy/confenge-vps/lib.sh
@@ -54,6 +54,13 @@ bind_release_identity() {
   export WARMBLY_RELEASE_SHA CONFENGE_REPOSITORY_SHA
 }
 
+# registry: production runs CI-built images pinned to the release SHA and never
+# compiles on the VPS. `build` is the legacy local-compile path, kept only for
+# an emergency where the registry is unreachable; it is not the normal deploy.
+release_mode() {
+  echo "${CONFENGE_RELEASE_MODE:-registry}"
+}
+
 compose_cmd() {
   local root
   root="$(confenge_repo_root)"
@@ -64,10 +71,44 @@ compose_cmd() {
   args=(docker compose)
   args+=(-f "$root/docker-compose.yml")
   args+=(-f "$root/deploy/confenge-vps/docker-compose.override.yml")
+  if [[ "$(release_mode)" == "registry" ]]; then
+    args+=(-f "$root/deploy/confenge-vps/docker-compose.release.yml")
+  fi
   if [[ -f "$envf" ]]; then
     args+=(--env-file "$envf")
   fi
   COMPOSE_PROJECT_NAME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}" "${args[@]}" "$@"
+}
+
+# Services whose image carries application code. Anything here must exist in the
+# registry for the release SHA before production mutates.
+release_services() {
+  echo "${CONFENGE_RELEASE_SERVICES:-backend consumer worker tracking realtime web}"
+}
+
+# Profile-gated services. Their image is pinned the same way, but a missing one
+# must not block a deploy of the always-on stack.
+release_optional_services() {
+  echo "${CONFENGE_RELEASE_OPTIONAL_SERVICES:-admin}"
+}
+
+image_prefix() {
+  echo "${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}"
+}
+
+# The Go services pin the minprofile variant; the rest have a single build.
+release_image_ref() {
+  local svc="$1" sha="${2:-$WARMBLY_RELEASE_SHA}"
+  case "$svc" in
+    backend|consumer|worker|seed)
+      echo "$(image_prefix)/${svc/seed/backend}:${sha}-minprofile" ;;
+    *)
+      echo "$(image_prefix)/${svc}:${sha}" ;;
+  esac
+}
+
+disk_guard() {
+  bash "$_CONFENGE_VPS_DIR/disk-guard.sh" "$@"
 }
 
 api_base() {

--- a/deploy/confenge-vps/release-deploy.sh
+++ b/deploy/confenge-vps/release-deploy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Roll the warmbly-confenge stack onto a release and prove which commit runs.
+#
+# Replaces the ad-hoc /root/deploy-warmbly.sh: that script ran
+# `compose build backend consumer worker` on the VPS, which shipped the whole
+# worktree (4.7 GB, mostly data/backups) into BuildKit on every deploy and
+# eventually filled the root filesystem. This path pulls CI-built images pinned
+# to the release SHA and never compiles here.
+#
+# Usage: release-deploy.sh [sha|origin/main]
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+# shellcheck source=lib.sh
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+cd "$ROOT"
+
+TARGET="${1:-origin/main}"
+
+echo "== fetching =="
+git fetch --quiet origin
+if [[ "$TARGET" == "origin/main" ]]; then
+  git checkout --quiet main
+  git reset --quiet --hard origin/main
+else
+  git checkout --quiet "$TARGET"
+fi
+NEW_SHA="$(git rev-parse HEAD)"
+echo "== release $NEW_SHA =="
+
+ENVF="${CONFENGE_VPS_ENV:-$ROOT/deploy/confenge-vps/.env}"
+if [[ ! -f "$ENVF" ]]; then
+  echo "REFUSE: missing $ENVF" >&2
+  exit 2
+fi
+cp -a "$ENVF" "$ENVF.bak.$(date -u +%Y%m%dT%H%M%SZ)"
+if grep -q '^CONFENGE_REPOSITORY_SHA=' "$ENVF"; then
+  sed -i "s|^CONFENGE_REPOSITORY_SHA=.*|CONFENGE_REPOSITORY_SHA=$NEW_SHA|" "$ENVF"
+else
+  printf 'CONFENGE_REPOSITORY_SHA=%s\n' "$NEW_SHA" >>"$ENVF"
+fi
+chmod 600 "$ENVF"
+
+# up.sh runs the disk preflight, pulls and verifies the pinned images, recreates
+# the stack, checks Postgres and the running SHA, and clears its own deploy pause.
+WARMBLY_RELEASE_SHA="$NEW_SHA" bash "$ROOT/deploy/confenge-vps/up.sh"
+
+printf '%s\n' "$NEW_SHA" >"$ROOT/.deployed_sha"
+
+echo "== migrations =="
+compose_cmd exec -T postgres psql -U "${POSTGRES_USER:-warmbly}" -d "${POSTGRES_DB:-warmbly_dev}" \
+  -c 'select version, dirty from schema_migrations' || true
+
+echo "== health =="
+curl -sS http://127.0.0.1:8080/health; echo
+curl -sS -o /dev/null -w 'ready:%{http_code}\n' http://127.0.0.1:8080/ready
+echo "== deployed $NEW_SHA =="

--- a/deploy/confenge-vps/systemd/confenge-docker-gc.service
+++ b/deploy/confenge-vps/systemd/confenge-docker-gc.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=CONFENGE bounded Docker GC (build cache, dangling images, superseded releases)
+Documentation=file:/opt/warmbly-confenge/deploy/confenge-vps/README.md
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+# Bounded and idempotent. Never touches named volumes, Postgres data, the
+# CONFENGE ops or key volumes, or any image a container references.
+ExecStart=/opt/warmbly-confenge/deploy/confenge-vps/disk-guard.sh retain
+Nice=15
+IOSchedulingClass=idle
+TimeoutStartSec=900
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/confenge-vps/systemd/confenge-docker-gc.timer
+++ b/deploy/confenge-vps/systemd/confenge-docker-gc.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run the CONFENGE bounded Docker GC daily
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=30m
+Persistent=true
+Unit=confenge-docker-gc.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/confenge-vps/test_deploy_disk_safety.py
+++ b/deploy/confenge-vps/test_deploy_disk_safety.py
@@ -1,0 +1,460 @@
+#!/usr/bin/env python3
+"""Tests for the CONFENGE VPS deploy/disk failure mode.
+
+ec-prod filled its root filesystem during a deploy: the build context carried
+4.3 GB of data/backups, the VPS rebuilt images locally on every deploy, builder
+cache grew to ~174 GB unbounded, Postgres could not extend files and the backend
+restart-looped on migrations.
+
+These drive the real shipped scripts with stubbed `docker`/`df` so the policy is
+tested, not a reimplementation of it.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+PACK = Path(__file__).resolve().parent
+ROOT = PACK.parent.parent
+
+DOCKER_STUB = r"""#!/usr/bin/env bash
+echo "$*" >> "$DOCKER_LOG"
+case "$1 $2" in
+  "info --format") echo "${STUB_DOCKER_ROOT:-/}" ;;
+  "system df")     echo "Build Cache 90 0 17.83GB 17.83GB" ;;
+  "buildx du")     echo "Total:		${STUB_BUILDER_TOTAL:-17.83GB}" ;;
+  "image ls")      printf '%s\n' "${STUB_IMAGES:-}" ;;
+  "image inspect") exit "${STUB_INSPECT_RC:-0}" ;;
+esac
+exit 0
+"""
+
+DF_STUB = r"""#!/usr/bin/env bash
+# df -P -k <path>
+echo "Filesystem 1024-blocks Used Available Capacity Mounted on"
+total="${STUB_TOTAL_KB:-527000000}"
+avail="${STUB_AVAIL_KB:-152000000}"
+echo "/dev/vda4 $total $((total - avail)) $avail 71% /"
+"""
+
+
+
+def strip_comments(text: str) -> str:
+    """Policy assertions target executable lines, not the prose documenting them."""
+    return "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    )
+
+
+def stub_env(tmp: Path, **overrides: str) -> dict[str, str]:
+    bindir = tmp / "bin"
+    bindir.mkdir(exist_ok=True)
+    (bindir / "docker").write_text(DOCKER_STUB)
+    (bindir / "df").write_text(DF_STUB)
+    for name in ("docker", "df"):
+        (bindir / name).chmod(0o755)
+    env = dict(os.environ)
+    env["PATH"] = f"{bindir}:{env['PATH']}"
+    env["DOCKER_LOG"] = str(tmp / "docker.log")
+    env["CONFENGE_RELEASE_STATE_DIR"] = str(tmp / "state")
+    (tmp / "docker.log").write_text("")
+    env.update(overrides)
+    return env
+
+
+def run_guard(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(PACK / "disk-guard.sh"), *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+        check=False,
+    )
+
+
+def docker_log(env: dict[str, str]) -> str:
+    return Path(env["DOCKER_LOG"]).read_text()
+
+
+class TestDiskPreflight(unittest.TestCase):
+    def test_insufficient_disk_fails_before_service_mutation(self) -> None:
+        """The whole point: refuse while the healthy release is still running."""
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            # 5 GB free against a 20 GB deploy budget + 20 GB Postgres reserve.
+            env = stub_env(tmp, STUB_AVAIL_KB=str(5 * 1024 * 1024))
+            proc = run_guard(env, "preflight", "a" * 40)
+
+            self.assertEqual(proc.returncode, 4, proc.stdout + proc.stderr)
+            self.assertIn("REFUSE: insufficient disk headroom", proc.stderr)
+            self.assertIn("No service was recreated", proc.stderr)
+
+            log = docker_log(env)
+            for mutation in ("up ", "stop ", "restart ", "rm -f", "compose"):
+                self.assertNotIn(
+                    mutation, log, f"preflight touched production via: {mutation}"
+                )
+
+    def test_sufficient_disk_passes_without_cleanup(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            env = stub_env(tmp, STUB_AVAIL_KB=str(145 * 1024 * 1024))
+            proc = run_guard(env, "preflight", "a" * 40)
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+            self.assertIn("DISK_PREFLIGHT=PASS", proc.stdout)
+            self.assertNotIn("prune", docker_log(env))
+
+    def test_reserved_postgres_headroom_is_not_part_of_the_deploy_budget(self) -> None:
+        """25 GB free clears a 20 GB deploy on its own, but not once Postgres'
+        20 GB reserve is excluded. Postgres must never be the thing that runs
+        out of space because a deploy took the last gigabytes."""
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            env = stub_env(tmp, STUB_AVAIL_KB=str(25 * 1024 * 1024))
+            proc = run_guard(env, "preflight", "a" * 40)
+            self.assertEqual(proc.returncode, 4)
+            self.assertIn("Postgres reserve", proc.stderr)
+
+
+class TestCleanupSafety(unittest.TestCase):
+    FORBIDDEN = [
+        "volume rm",
+        "volume prune",
+        "system prune",
+        "image prune -a",
+        "image prune --all",
+        "builder prune -af",
+        "builder prune -a ",
+        "-v --rmi",
+        "down --volumes",
+    ]
+
+    def test_cleanup_never_targets_persistent_volumes(self) -> None:
+        source = strip_comments((PACK / "disk-guard.sh").read_text())
+        for bad in self.FORBIDDEN:
+            self.assertNotIn(
+                bad,
+                source,
+                f"disk-guard.sh must never issue `{bad}`: postgres data, the "
+                "CONFENGE ops and key volumes and blobs live in named volumes",
+            )
+
+    def test_cleanup_run_issues_no_volume_command(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            env = stub_env(tmp, STUB_AVAIL_KB=str(2 * 1024 * 1024))
+            run_guard(env, "preflight", "a" * 40)
+            log = docker_log(env)
+            self.assertIn("builder prune", log)
+            for line in log.splitlines():
+                self.assertNotIn("volume", line, f"cleanup touched volumes: {line}")
+
+    def test_cleanup_policy_is_bounded_not_blanket(self) -> None:
+        """`docker builder prune -af` is the manual emergency, not the policy."""
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            env = stub_env(tmp)
+            run_guard(env, "retain", "a" * 40)
+            log = docker_log(env)
+            prunes = [ln for ln in log.splitlines() if ln.startswith("builder prune")]
+            self.assertTrue(prunes, "retention must bound the builder cache")
+            for line in prunes:
+                self.assertIn("--keep-storage", line)
+                self.assertNotRegex(line, r"(^|\s)-af(\s|$)")
+
+    def test_dangling_prune_is_never_the_all_variant(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            env = stub_env(tmp)
+            run_guard(env, "retain", "a" * 40)
+            for line in docker_log(env).splitlines():
+                if line.startswith("image prune"):
+                    self.assertNotIn("-a", line)
+                    self.assertNotIn("--all", line)
+
+
+class TestReleaseRetention(unittest.TestCase):
+    PREFIX = "ghcr.io/tjsasakifln/warmbly"
+
+    def _images(self, *shas: str) -> str:
+        out = []
+        for sha in shas:
+            out += [
+                f"{self.PREFIX}/backend {sha}-minprofile",
+                f"{self.PREFIX}/consumer {sha}-minprofile",
+                f"{self.PREFIX}/worker {sha}-minprofile",
+            ]
+        return "\n".join(out)
+
+    def test_rollback_image_remains_available(self) -> None:
+        current, previous, ancient = "a" * 40, "b" * 40, "c" * 40
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            state = tmp / "state"
+            state.mkdir()
+            (state / "release-history").write_text(
+                f"{ancient} 2026-08-01T00:00:00Z\n{previous} 2026-08-27T00:00:00Z\n"
+            )
+            env = stub_env(tmp, STUB_IMAGES=self._images(current, previous, ancient))
+            proc = run_guard(env, "retain", current)
+            self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+            removed = [
+                ln for ln in docker_log(env).splitlines() if ln.startswith("image rm")
+            ]
+            joined = "\n".join(removed)
+            self.assertNotIn(current, joined, "removed the running release")
+            self.assertNotIn(previous, joined, "removed the rollback release")
+            self.assertIn(ancient, joined, "kept an image beyond the retention window")
+
+    def test_release_removal_is_never_forced(self) -> None:
+        """Without -f the daemon refuses an image any container references, so a
+        wrong keep set still cannot yank the running release."""
+        source = (PACK / "disk-guard.sh").read_text()
+        self.assertRegex(source, r"docker image rm \"\$repo:\$tag\"")
+        self.assertNotRegex(source, r"docker image rm\s+(-f|--force)")
+
+    def test_history_is_bounded(self) -> None:
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            env = stub_env(tmp)
+            for i in range(30):
+                run_guard(env, "retain", f"{i:040x}")
+            history = (tmp / "state" / "release-history").read_text().splitlines()
+            self.assertLessEqual(len(history), 20)
+
+    def test_non_warmbly_images_are_never_considered(self) -> None:
+        """Extra Consultoria and the control center share this daemon."""
+        with tempfile.TemporaryDirectory() as d:
+            tmp = Path(d)
+            env = stub_env(
+                tmp,
+                STUB_IMAGES=(
+                    "confenge-control-center-web 5fdda4f1b8fbe18243375614fb9b330d95cc2364\n"
+                    "extra-consultoria-api deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+                ),
+            )
+            run_guard(env, "retain", "a" * 40)
+            for line in docker_log(env).splitlines():
+                if line.startswith("image rm"):
+                    self.fail(f"cleanup reached a co-tenant image: {line}")
+
+
+class TestImmutableRelease(unittest.TestCase):
+    def _lib(self, script: str, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            ["bash", "-c", f'source "$1"; shift; {script}', "t", str(PACK / "lib.sh"), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    def test_correct_immutable_release_is_selected(self) -> None:
+        sha = "a" * 40
+        proc = self._lib(f'WARMBLY_RELEASE_SHA={sha}; for s in $(release_services); do release_image_ref "$s"; done')
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        refs = proc.stdout.split()
+        self.assertIn(f"ghcr.io/tjsasakifln/warmbly/backend:{sha}-minprofile", refs)
+        self.assertIn(f"ghcr.io/tjsasakifln/warmbly/consumer:{sha}-minprofile", refs)
+        self.assertIn(f"ghcr.io/tjsasakifln/warmbly/worker:{sha}-minprofile", refs)
+        self.assertIn(f"ghcr.io/tjsasakifln/warmbly/web:{sha}", refs)
+        for ref in refs:
+            self.assertNotIn(":dev", ref, "a mutable tag is not a release authority")
+            self.assertNotIn(":latest", ref)
+
+    def test_release_overlay_pins_every_application_service(self) -> None:
+        text = (PACK / "docker-compose.release.yml").read_text()
+        code = strip_comments(text)
+        for svc in ("backend", "consumer", "worker", "tracking", "realtime", "web", "admin", "seed"):
+            self.assertRegex(
+                text,
+                rf"\n  {svc}:\n    build: !reset null\n    image: ",
+                f"{svc} must pin an image and reset its build section",
+            )
+        self.assertNotIn(":dev", code)
+        self.assertNotIn(":latest", code)
+        # No default: a deploy without an explicit release SHA must fail loudly.
+        self.assertIn("WARMBLY_RELEASE_SHA:?", code)
+        self.assertNotIn("WARMBLY_RELEASE_SHA:-", code)
+
+    def test_go_services_keep_the_minprofile_contract(self) -> None:
+        text = (PACK / "docker-compose.release.yml").read_text()
+        for svc in ("backend", "consumer", "worker", "seed"):
+            self.assertRegex(text, rf"\n  {svc}:\n.*\n    image: .*-minprofile\n")
+
+    def test_ci_publishes_every_image_the_vps_pins(self) -> None:
+        wf = (ROOT / ".github/workflows/build-push.yml").read_text()
+        for svc in ("backend", "consumer", "worker", "tracking", "realtime", "web", "admin"):
+            self.assertIn(svc, wf, f"CI must publish {svc} or the VPS has to build it")
+        self.assertIn('profile: ["", "minprofile"]', wf)
+        self.assertIn("org.opencontainers.image.revision=${{ github.sha }}", wf)
+
+
+class TestDeployPath(unittest.TestCase):
+    def test_no_build_on_normal_production_deploy(self) -> None:
+        up = (PACK / "up.sh").read_text()
+        self.assertIn("compose_cmd up -d --no-build --remove-orphans", up)
+        self.assertNotIn("up -d --build", up)
+
+    def test_preflight_precedes_every_mutation(self) -> None:
+        up = (PACK / "up.sh").read_text()
+        preflight = up.index("disk_guard preflight")
+        for mutation in (
+            "docker volume create",
+            "compose_cmd up -d",
+            "compose_cmd --profile seed run",
+        ):
+            self.assertLess(
+                preflight,
+                up.index(mutation),
+                f"`{mutation}` runs before the disk preflight",
+            )
+
+    def test_release_is_acquired_and_verified_before_recreate(self) -> None:
+        up = (PACK / "up.sh").read_text()
+        self.assertLess(up.index("compose_cmd pull"), up.index("compose_cmd up -d --no-build"))
+        self.assertLess(
+            up.index("carries revision"), up.index("compose_cmd up -d --no-build")
+        )
+
+    def test_running_sha_is_validated_after_deploy(self) -> None:
+        up = (PACK / "up.sh").read_text()
+        self.assertIn("deploy/verify-release.sh", up)
+        self.assertLess(up.index("compose_cmd up -d --no-build"), up.index("verify-release.sh"))
+        self.assertIn("pg_isready", up)
+
+    def test_deploy_clears_only_its_own_pause(self) -> None:
+        """An operator emergency pause must survive a deploy; the deploy's own
+        preflight pause must not require a human to remember to clear it."""
+        up = (PACK / "up.sh").read_text()
+        self.assertIn("reason=deploy_preflight", up)
+        self.assertIn("DISPATCH_PAUSE=cleared", up)
+        self.assertIn("DISPATCH_PAUSE=held", up)
+        self.assertLess(up.index("verify-release.sh"), up.index("DISPATCH_PAUSE=cleared"))
+
+    def test_retention_runs_without_an_operator_remembering(self) -> None:
+        up = (PACK / "up.sh").read_text()
+        self.assertIn("disk_guard retain", up)
+        timer = (PACK / "systemd/confenge-docker-gc.timer").read_text()
+        self.assertIn("OnCalendar=daily", timer)
+        service = (PACK / "systemd/confenge-docker-gc.service").read_text()
+        self.assertIn("disk-guard.sh retain", service)
+
+    def test_legacy_local_build_driver_is_replaced(self) -> None:
+        driver = (PACK / "release-deploy.sh").read_text()
+        self.assertNotIn("compose.sh build", driver)
+        self.assertIn("up.sh", driver)
+
+
+class TestBuildContext(unittest.TestCase):
+    MAX_MB = 150
+
+    def test_build_context_stays_small(self) -> None:
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(ROOT / "scripts/build_context_size.py"),
+                str(ROOT),
+                "--max-mb",
+                str(self.MAX_MB),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=300,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stdout + proc.stderr)
+
+    def test_runtime_data_trees_are_excluded(self) -> None:
+        """data/backups reached 4.3 GB inside a 4.7 GB context on ec-prod."""
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.path.insert(0, %r); "
+                "from build_context_size import load_rules, excluded; "
+                "from pathlib import Path; "
+                "rules = load_rules(Path(%r)); "
+                "print('\\n'.join('%%s=%%s' %% (p, excluded(p, rules)) for p in sys.argv[1:]))"
+                % (str(ROOT / "scripts"), str(ROOT)),
+                "data/backups/confenge-vps/warmbly-confenge-20260827T005102Z.tar.gz",
+                "data/GeoLite2-City.mmdb",
+                "ops/feed-tls/ca-bundle.crt",
+                "ops-evidence/x.json",
+                "node_modules/left-pad/index.js",
+                "web/node_modules/react/index.js",
+                ".worktrees/x/internal/a.go",
+                "backups/dump.sql.gz",
+                "release.tar.gz",
+                "internal/api/routes.go",
+                "cmd/backend/main.go",
+                "scripts/install-worker.sh",
+                "go.mod",
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        verdicts = dict(
+            line.split("=") for line in proc.stdout.strip().splitlines() if "=" in line
+        )
+        for path in (
+            "data/backups/confenge-vps/warmbly-confenge-20260827T005102Z.tar.gz",
+            "data/GeoLite2-City.mmdb",
+            "ops/feed-tls/ca-bundle.crt",
+            "ops-evidence/x.json",
+            "node_modules/left-pad/index.js",
+            "web/node_modules/react/index.js",
+            ".worktrees/x/internal/a.go",
+            "backups/dump.sql.gz",
+            "release.tar.gz",
+        ):
+            self.assertEqual(verdicts[path], "True", f"{path} must not enter the context")
+        # The Go images still need their source and the worker installer.
+        for path in ("internal/api/routes.go", "cmd/backend/main.go", "scripts/install-worker.sh", "go.mod"):
+            self.assertEqual(verdicts[path], "False", f"{path} must stay in the context")
+
+    def test_no_dockerfile_consumes_the_excluded_trees(self) -> None:
+        """The exclusions are only safe because nothing copies these at build."""
+        dockerfiles = list((ROOT / "deploy/docker").glob("*.Dockerfile"))
+        dockerfiles += [ROOT / "tracking/Dockerfile", ROOT / "web/Dockerfile", ROOT / "admin/Dockerfile"]
+        pattern = re.compile(r"^\s*(COPY|ADD)\s+(?!--from)(.*)$", re.MULTILINE)
+        for df in dockerfiles:
+            if not df.is_file():
+                continue
+            for _, args in pattern.findall(df.read_text()):
+                for token in args.split():
+                    if token.startswith("--"):
+                        continue
+                    self.assertFalse(
+                        token.startswith(("data/", "ops/", "backups/", "ops-evidence/")),
+                        f"{df.name} copies an excluded runtime tree: {token}",
+                    )
+
+
+class TestBackupRetention(unittest.TestCase):
+    def test_backup_retention_is_bounded_with_a_floor(self) -> None:
+        text = (PACK / "backup.sh").read_text()
+        self.assertIn("CONFENGE_BACKUP_KEEP", text)
+        self.assertIn("-ge 3", text)
+        # Retention must only run after the archive is complete.
+        self.assertLess(text.index('mv "$ARCHIVE_TMP" "$ARCHIVE"'), text.index("BACKUP_KEEP="))
+
+    def test_co_tenant_data_is_reported_not_deleted(self) -> None:
+        report = (PACK / "host-disk-report.sh").read_text()
+        self.assertIn("Deletes nothing", report)
+        for bad in ("rm -rf", "rm -f", "prune", "docker volume"):
+            self.assertNotIn(bad, report)
+        self.assertIn("extra-consultoria", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/deploy/confenge-vps/test_vps_pack.py
+++ b/deploy/confenge-vps/test_vps_pack.py
@@ -53,6 +53,13 @@ class TestConfengeVpsPack(unittest.TestCase):
             "inbound-edge-monitor.sh",
             "asaas-adapter-install.sh",
             "asaas-adapter.env.example",
+            "disk-guard.sh",
+            "docker-gc-install.sh",
+            "host-disk-report.sh",
+            "release-deploy.sh",
+            "docker-compose.release.yml",
+            "systemd/confenge-docker-gc.service",
+            "systemd/confenge-docker-gc.timer",
         ]
         for name in required:
             path = PACK / name
@@ -146,17 +153,23 @@ class TestConfengeVpsPack(unittest.TestCase):
             )
         self.assertIn("VALIDATE=PASS", proc.stdout)
 
-    def test_up_rebuilds_release_images(self) -> None:
-        """A new checkout must not silently reuse the previous app images."""
+    def test_up_deploys_the_pinned_release_images(self) -> None:
+        """A new checkout must not silently reuse the previous app images. The
+        release SHA is bound before the images are pulled and the pull is pinned
+        to that SHA, so the guarantee the old `--build` gave is preserved
+        without compiling on the VPS."""
         text = (PACK / "up.sh").read_text(encoding="utf-8")
-        self.assertIn("compose_cmd up -d --build --remove-orphans", text)
+        self.assertIn("compose_cmd up -d --no-build --remove-orphans", text)
+        self.assertNotIn("up -d --build", text)
         env_load = text.index('set -a; . "$ENVF"; set +a')
         identity_bind = text.index(
             'bind_release_identity "$RELEASE_SHA_RESOLVED"'
         )
-        compose_up = text.index("compose_cmd up -d --build --remove-orphans")
+        pull = text.index("compose_cmd pull")
+        compose_up = text.index("compose_cmd up -d --no-build --remove-orphans")
         self.assertLess(env_load, identity_bind)
-        self.assertLess(identity_bind, compose_up)
+        self.assertLess(identity_bind, pull)
+        self.assertLess(pull, compose_up)
 
     def test_release_identity_binding_overrides_stale_audit_sha(self) -> None:
         release_sha = "a" * 40

--- a/deploy/confenge-vps/up.sh
+++ b/deploy/confenge-vps/up.sh
@@ -59,8 +59,63 @@ if [[ "${CONFENGE_OPERATOR_MODE:-true}" == "true" ]]; then
   esac
 fi
 
-# Every deploy and first boot starts paused. This is written before any app or
-# worker container starts, so a new/empty Docker volume cannot fail open.
+# ── 1. disk preflight ───────────────────────────────────────────────────────
+# Runs before the first mutation of any kind, including creating the ops volume.
+# Postgres shares the root filesystem with Docker: when a deploy ate the last
+# free gigabytes, the first symptom was Postgres failing to extend files and the
+# backend restart-looping on migrations. Refusing here leaves the healthy
+# release running and untouched.
+if ! disk_guard preflight "$WARMBLY_RELEASE_SHA"; then
+  echo "REFUSE: aborting before any service was stopped or recreated" >&2
+  exit 4
+fi
+
+# ── 2. acquire the release ──────────────────────────────────────────────────
+RELEASE_MODE="$(release_mode)"
+echo "Release mode: $RELEASE_MODE"
+if [[ "$RELEASE_MODE" == "registry" ]]; then
+  echo "Pulling immutable images for $WARMBLY_RELEASE_SHA ..."
+  if ! compose_cmd pull --quiet $(release_services); then
+    echo "REFUSE: could not pull the release images for $WARMBLY_RELEASE_SHA" >&2
+    echo "  CI publishes one image per service per commit on main; check that Build and Push succeeded for this SHA." >&2
+    echo "  Production was not touched and the current release is still running." >&2
+    exit 5
+  fi
+
+  # ── 3. verify the artifacts exist and carry this revision ─────────────────
+  # A pull that resolved a stale local tag, or an image built from another
+  # commit, is caught here rather than after production has been recreated.
+  for svc in $(release_services); do
+    ref="$(release_image_ref "$svc")"
+    if ! docker image inspect "$ref" >/dev/null 2>&1; then
+      echo "REFUSE: release image missing after pull: $ref" >&2
+      exit 5
+    fi
+    rev="$(docker image inspect "$ref" --format '{{index .Config.Labels "org.opencontainers.image.revision"}}' 2>/dev/null || true)"
+    if [[ "$rev" != "$WARMBLY_RELEASE_SHA" ]]; then
+      echo "REFUSE: $ref carries revision '${rev:-<none>}', expected $WARMBLY_RELEASE_SHA" >&2
+      exit 5
+    fi
+    echo "  ok $svc -> $ref"
+  done
+
+  # Profile-gated extras: pinned the same way, but never a deploy blocker.
+  for svc in $(release_optional_services); do
+    if compose_cmd --profile "$svc" pull --quiet "$svc" >/dev/null 2>&1; then
+      echo "  ok $svc -> $(release_image_ref "$svc")"
+    else
+      echo "  skip $svc (optional profile image not available for this release)"
+    fi
+  done
+else
+  echo "WARNING: CONFENGE_RELEASE_MODE=$RELEASE_MODE compiles on this host."
+  echo "  Local production builds are what filled the root filesystem; use registry mode unless GHCR is unreachable."
+  compose_cmd build $(release_services)
+fi
+
+# ── 4. engage the deploy safety pause ───────────────────────────────────────
+# Written before any app or worker container starts, so a new/empty Docker
+# volume cannot fail open. Cleared automatically once the release verifies.
 OPS_VOLUME="${COMPOSE_PROJECT_NAME:-warmbly-confenge}_confenge_ops"
 docker volume create "$OPS_VOLUME" >/dev/null
 docker run --rm -v "$OPS_VOLUME:/data" alpine \
@@ -68,7 +123,7 @@ docker run --rm -v "$OPS_VOLUME:/data" alpine \
 
 if [[ "${CONFENGE_VPS_SEED:-false}" == "true" ]]; then
   echo "Preparing first boot with operator mode temporarily disabled..."
-  CONFENGE_OPERATOR_MODE=false compose_cmd up -d postgres redis nats mailpit backend
+  CONFENGE_OPERATOR_MODE=false compose_cmd up -d --no-build postgres redis nats mailpit backend
   for i in $(seq 1 60); do
     if curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:8080/health" 2>/dev/null | grep -q 200; then
       break
@@ -82,17 +137,18 @@ if [[ "${CONFENGE_VPS_SEED:-false}" == "true" ]]; then
   CONFENGE_OPERATOR_MODE=false compose_cmd --profile seed run --rm --no-deps seed
 fi
 
+# ── 5. recreate the affected services ───────────────────────────────────────
 echo "Bringing up project=$COMPOSE_PROJECT_NAME ..."
-# A release checkout is not a release deployment until the local application
-# images have been rebuilt from that checkout.  Compose otherwise reuses the
-# previous tag and can report healthy containers that still run the prior SHA.
-compose_cmd up -d --build --remove-orphans
+# --no-build is the guarantee: in registry mode compose cannot quietly fall back
+# to compiling here, which is the behaviour that accumulated the builder cache.
+compose_cmd up -d --no-build --remove-orphans
 
 
 # Keep the kill-switch volume private and writable by the backend user (uid 1000).
 docker run --rm -v "${COMPOSE_PROJECT_NAME:-warmbly-confenge}_confenge_ops:/data" alpine \
   sh -c "chown 1000:1000 /data && chmod 700 /data" >/dev/null 2>&1 || true
 
+# ── 6. verify backend health ────────────────────────────────────────────────
 echo "Waiting for backend health..."
 for i in $(seq 1 60); do
   if curl -sS -o /dev/null -w '%{http_code}' --max-time 2 "http://127.0.0.1:8080/health" 2>/dev/null | grep -q 200; then
@@ -106,6 +162,44 @@ for i in $(seq 1 60); do
     exit 1
   fi
 done
+
+# ── 7. verify Postgres and the exact running release ────────────────────────
+echo "Verifying database..."
+if ! compose_cmd exec -T postgres pg_isready -U "${POSTGRES_USER:-warmbly}" >/dev/null 2>&1; then
+  echo "REFUSE: postgres is not accepting connections after deploy" >&2
+  exit 1
+fi
+echo "  postgres accepting connections"
+
+echo "Verifying running release $WARMBLY_RELEASE_SHA ..."
+for svc in backend consumer worker; do
+  if ! bash "$ROOT/deploy/verify-release.sh" "$WARMBLY_RELEASE_SHA" "${COMPOSE_PROJECT_NAME}-${svc}-1"; then
+    echo "REFUSE: $svc is not running the expected release" >&2
+    exit 1
+  fi
+done
+
+# ── 8. clear the deploy pause immediately ───────────────────────────────────
+# Only a switch this deploy wrote is cleared. An operator emergency pause has a
+# different reason and survives, so a deploy can never silently re-arm sending
+# that a human deliberately stopped. Outbound is then gated by the business
+# send window alone, which is the intended steady state at any hour.
+KS="$(docker run --rm -v "$OPS_VOLUME:/data:ro" alpine cat /data/kill-switch 2>/dev/null || true)"
+if [[ -z "$KS" ]]; then
+  echo "DISPATCH_PAUSE=absent"
+elif grep -q '^reason=deploy_preflight$' <<<"$KS"; then
+  docker run --rm -v "$OPS_VOLUME:/data" alpine sh -c 'rm -f /data/kill-switch' >/dev/null
+  if docker run --rm -v "$OPS_VOLUME:/data:ro" alpine test -f /data/kill-switch; then
+    echo "REFUSE: deploy pause could not be cleared" >&2
+    exit 1
+  fi
+  echo "DISPATCH_PAUSE=cleared (deploy_preflight)"
+else
+  echo "DISPATCH_PAUSE=held (operator pause, not this deploy; clear with resume.sh)"
+fi
+
+# ── 9. bounded retention, so nobody has to remember to prune ────────────────
+disk_guard retain "$WARMBLY_RELEASE_SHA" || echo "WARNING: retention sweep did not complete"
 
 echo "Stack up. Operator UI via SSH tunnel (see docs/confenge/vps-execution-plane.md):"
 if [[ "${CONFENGE_OPERATOR_MODE:-true}" == "true" ]]; then

--- a/deploy/confenge-vps/validate.sh
+++ b/deploy/confenge-vps/validate.sh
@@ -14,7 +14,10 @@ for f in \
   prove-hostinger-net.sh prove-restart.sh self-smoke.sh post-smtp-unlock.sh validate.sh \
   inbound-edge-install.sh inbound-edge-monitor.sh \
   nginx/http-params.conf nginx/proxy-params.conf nginx/site-http.conf nginx/site-https.conf \
-  systemd/confenge-inbound-edge-monitor.service systemd/confenge-inbound-edge-monitor.timer
+  systemd/confenge-inbound-edge-monitor.service systemd/confenge-inbound-edge-monitor.timer \
+  disk-guard.sh docker-gc-install.sh host-disk-report.sh release-deploy.sh \
+  docker-compose.release.yml \
+  systemd/confenge-docker-gc.service systemd/confenge-docker-gc.timer
 do
   if [[ -f "$PACK/$f" ]]; then
     echo "OK $f"
@@ -23,6 +26,33 @@ do
     fail=1
   fi
 done
+
+echo "== deploy consumes immutable images, never builds here =="
+if grep -qF 'compose_cmd up -d --no-build --remove-orphans' "$PACK/up.sh" &&
+   ! grep -qF 'up -d --build' "$PACK/up.sh"; then
+  echo "OK production deploy does not build on the VPS"
+else
+  echo "FAIL production deploy still builds locally"
+  fail=1
+fi
+if grep -qF 'disk_guard preflight' "$PACK/up.sh"; then
+  echo "OK deploy runs a disk preflight before mutating production"
+else
+  echo "FAIL deploy has no disk preflight"
+  fail=1
+fi
+if grep -qE '^(data|ops|ops-evidence|backups)$' "$ROOT/.dockerignore" >/dev/null; then
+  echo "OK runtime data trees are excluded from the build context"
+else
+  echo "FAIL .dockerignore does not exclude the runtime data trees"
+  fail=1
+fi
+if python3 "$ROOT/scripts/build_context_size.py" "$ROOT" --max-mb "${CONFENGE_MAX_BUILD_CONTEXT_MB:-150}" >/dev/null; then
+  echo "OK build context within budget"
+else
+  echo "FAIL build context exceeds budget"
+  fail=1
+fi
 
 if grep -qF 'reason=deploy_preflight' "$PACK/up.sh" &&
    grep -qF 'chmod 600 /data/kill-switch' "$PACK/up.sh"; then

--- a/docs/confenge/vps-execution-plane.md
+++ b/docs/confenge/vps-execution-plane.md
@@ -31,8 +31,52 @@ Directory: `deploy/confenge-vps/`
 | `prove-restart.sh` | Durable state after container restart |
 | `self-smoke.sh` | Requires explicit `CONFENGE_SELF_SMOKE_TO` |
 | `validate.sh` | Offline pack checks |
+| `release-deploy.sh` | Roll onto a release SHA using CI-built images |
+| `disk-guard.sh` | Disk preflight, bounded cleanup, retention |
+| `docker-gc-install.sh` | Daily GC timer + host BuildKit cache cap |
+| `host-disk-report.sh` | Shared-host storage picture, read-only |
 
-Compose: root `docker-compose.yml` + `deploy/confenge-vps/docker-compose.override.yml`, project name `warmbly-confenge`.
+Compose: root `docker-compose.yml` + `deploy/confenge-vps/docker-compose.override.yml`
++ `deploy/confenge-vps/docker-compose.release.yml`, project name `warmbly-confenge`.
+
+## Release model
+
+The VPS does not compile. CI publishes one image per service per commit on main,
+tagged with the commit SHA, and the release overlay pins every application
+service to `ghcr.io/tjsasakifln/warmbly/<service>:<release-sha>` (Go services to
+the `-minprofile` variant). Each `build:` section is reset, so compose cannot
+fall back to building here. Mutable `:dev` and `:latest` are never the
+deployment authority.
+
+`up.sh` order: disk preflight, bounded cleanup if needed, pull, verify each
+image's `org.opencontainers.image.revision`, write the `deploy_preflight` kill
+switch, `up -d --no-build`, backend health, `pg_isready`, `verify-release.sh`
+per service, clear the deploy kill switch, retention sweep. It refuses before
+recreating anything if any step fails, so a bad release leaves the healthy one
+running.
+
+Step 8 clears only a `deploy_preflight` switch. An operator pause from
+`pause.sh` survives a deploy and still needs `resume.sh`.
+
+## Disk safety
+
+The root filesystem is shared with Postgres and with co-tenant stacks. A deploy
+once consumed the last free space, Postgres could not extend files and the
+backend restart-looped on migrations. Guards:
+
+- build context: `.dockerignore` excludes `data`, `ops`, `ops-evidence`,
+  `backups`, archives and dependency trees. CI enforces a 150 MB budget with
+  `scripts/build_context_size.py`.
+- preflight: `disk-guard.sh preflight` needs a 20 GB deploy budget plus a 20 GB
+  Postgres reserve and 12% free, and reclaims only reconstructible artifacts
+  before refusing.
+- retention: `disk-guard.sh retain` runs after every deploy and daily via
+  `confenge-docker-gc.timer`. Builder cache capped at 8 GB / 168 h, dangling
+  images pruned, Warmbly release images beyond the current and previous release
+  removed without `-f`. Named volumes, Postgres data, `confenge_ops`,
+  `confenge_keys` and `blobs` are never touched, and no co-tenant data is.
+- backups: `backup.sh` keeps the newest `CONFENGE_BACKUP_KEEP` (default 10)
+  archives with their manifests, checksums and key bundles.
 
 ## Safety profile (fixed)
 

--- a/scripts/build_context_size.py
+++ b/scripts/build_context_size.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Measure a Docker build context after applying .dockerignore.
+
+A multi-gigabyte context is what put ec-prod on the floor: data/backups was
+4.3 GB, .dockerignore did not exclude it, and every `docker compose build`
+shipped and snapshotted the whole tree. This is the regression gate, so it runs
+without a Docker daemon.
+
+Usage:
+  build_context_size.py [context_dir] [--max-mb N] [--json] [--top N]
+
+Exits 1 when the context exceeds --max-mb.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def compile_pattern(pattern: str) -> re.Pattern[str]:
+    """Translate one .dockerignore pattern to a regex.
+
+    Follows moby/patternmatcher: `*` does not cross a separator, `**` does,
+    `?` matches one non-separator character.
+    """
+    parts = pattern.strip("/").split("/")
+    out: list[str] = []
+    for i, part in enumerate(parts):
+        if part == "**":
+            # `**` swallows this and any following segments.
+            out.append("(?:.*)" if i else "(?:.*)")
+            continue
+        seg = ""
+        for ch in part:
+            if ch == "*":
+                seg += "[^/]*"
+            elif ch == "?":
+                seg += "[^/]"
+            else:
+                seg += re.escape(ch)
+        out.append(seg)
+    # Join, collapsing the separator that follows a `**`.
+    joined = ""
+    for i, seg in enumerate(out):
+        if i:
+            joined += "/" if not out[i - 1].startswith("(?:.*)") else "/?"
+        joined += seg
+    return re.compile("^" + joined + "$")
+
+
+def load_rules(context: Path) -> list[tuple[re.Pattern[str], bool]]:
+    ignore = context / ".dockerignore"
+    rules: list[tuple[re.Pattern[str], bool]] = []
+    if not ignore.is_file():
+        return rules
+    for raw in ignore.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        negated = line.startswith("!")
+        if negated:
+            line = line[1:].strip()
+        if not line:
+            continue
+        rules.append((compile_pattern(line), negated))
+    return rules
+
+
+def excluded(rel: str, rules: list[tuple[re.Pattern[str], bool]]) -> bool:
+    """Last matching rule wins; a matching ancestor excludes the whole subtree."""
+    verdict = False
+    candidates = [rel]
+    parent = os.path.dirname(rel)
+    while parent:
+        candidates.append(parent)
+        parent = os.path.dirname(parent)
+    for pattern, negated in rules:
+        if negated:
+            if pattern.match(rel):
+                verdict = False
+        elif any(pattern.match(c) for c in candidates):
+            verdict = True
+    return verdict
+
+
+def measure(context: Path) -> tuple[int, int, dict[str, int]]:
+    rules = load_rules(context)
+    total = 0
+    files = 0
+    by_top: dict[str, int] = {}
+    for dirpath, dirnames, filenames in os.walk(context, followlinks=False):
+        rel_dir = os.path.relpath(dirpath, context)
+        rel_dir = "" if rel_dir == "." else rel_dir
+        # Prune excluded directories so a 4 GB tree is never walked.
+        kept = []
+        for d in dirnames:
+            rel = os.path.join(rel_dir, d) if rel_dir else d
+            if not excluded(rel, rules):
+                kept.append(d)
+        dirnames[:] = kept
+        for f in filenames:
+            rel = os.path.join(rel_dir, f) if rel_dir else f
+            if excluded(rel, rules):
+                continue
+            try:
+                size = os.lstat(os.path.join(dirpath, f)).st_size
+            except OSError:
+                continue
+            total += size
+            files += 1
+            top = rel.split("/", 1)[0] if "/" in rel else rel
+            by_top[top] = by_top.get(top, 0) + size
+    return total, files, by_top
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("context", nargs="?", default=".")
+    ap.add_argument("--max-mb", type=float, default=0)
+    ap.add_argument("--top", type=int, default=10)
+    ap.add_argument("--json", action="store_true")
+    args = ap.parse_args()
+
+    context = Path(args.context).resolve()
+    total, files, by_top = measure(context)
+    mb = total / (1024 * 1024)
+
+    if args.json:
+        print(json.dumps({"bytes": total, "mb": round(mb, 2), "files": files}))
+    else:
+        print(f"context   : {context}")
+        print(f"size      : {mb:.1f} MB ({total} bytes) across {files} files")
+        for name, size in sorted(by_top.items(), key=lambda kv: -kv[1])[: args.top]:
+            print(f"  {size / (1024 * 1024):8.1f} MB  {name}")
+
+    if args.max_mb and mb > args.max_mb:
+        print(
+            f"FAIL: build context {mb:.1f} MB exceeds the {args.max_mb} MB budget.\n"
+            "Add the offending tree to .dockerignore; a multi-gigabyte context "
+            "fills the production root filesystem one build at a time.",
+            file=sys.stderr,
+        )
+        return 1
+    if args.max_mb:
+        print(f"OK: within the {args.max_mb} MB budget")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Root cause

The ec-prod root filesystem hit 100% during a deploy. Postgres could not extend files and the backend restart-looped on migrations. Three compounding causes:

1. **Build context.** `data/backups` was 4.3 GB of a 4.7 GB context and `.dockerignore` did not exclude it. Every `docker compose build` shipped and snapshotted the whole tree.
2. **Local production builds.** `up.sh` ran `compose up -d --build` on every deploy, so builder cache grew unbounded (~174 GB reclaimed by hand).
3. **No retention and no preflight.** Nothing bounded Docker growth between deploys, and a deploy could not tell it was about to take Postgres' last headroom.

The damage was still live: `warmbly-confenge-backend-1` ran an image labelled `eaef2fda` while its env claimed `b3fcbb5c`, because the failed build left compose recreating the container with the new env and the old image.

## Changes

**Build context** — `.dockerignore` excludes `data`, `ops`, `ops-evidence`, `backups`, archives, dependency trees and agent state. Verified no Dockerfile copies any of them. Measured on the real ec-prod tree: **4488.8 MB → 27.3 MB**. `scripts/build_context_size.py` applies dockerignore semantics without a daemon and is an always-on CI gate at 150 MB.

**Immutable releases** — CI now builds every service on every push to main (so each SHA has a complete image set), adds `web` and `admin`, stamps `org.opencontainers.image.revision`, and publishes a `-minprofile` variant for the Go services so the VPS keeps its compile-time contract. `docker-compose.release.yml` pins each service to `ghcr.io/…/<svc>:<sha>` and uses `build: !reset null`, so compose cannot silently fall back to building. `up.sh` uses `--no-build`.

**Deploy order** — preflight, bounded cleanup, pull, verify each image's revision label, engage the deploy kill switch, recreate, backend health + `pg_isready` + `verify-release.sh` per service, clear the deploy kill switch, retention sweep. A failed pull or a short disk leaves the healthy release running.

**Disk guard** — refuses below a 20 GB deploy budget plus a 20 GB Postgres reserve (and 12% free), after reclaiming only reconstructible artifacts. Contains no `volume rm`, `volume prune` or `system prune`.

**Retention** — after every deploy and daily via `confenge-docker-gc.timer`: builder cache capped at 8 GB / 168 h, dangling images pruned, Warmbly release images beyond the current and previous release removed without `-f`. Backups keep the newest 10. Co-tenant data is reported by `host-disk-report.sh` and never deleted.

## Send-path safety

No first-touch transport, qualification, scheduling, cadence, queue or fast-lane behavior is touched. The deploy clears only a kill switch whose reason is `deploy_preflight`; an operator pause survives a deploy. The business send window remains the only outbound gate.

## Tests

27 new tests in `deploy/confenge-vps/test_deploy_disk_safety.py` (47 total in the pack): insufficient disk fails before service mutation, Postgres reserve is excluded from the deploy budget, cleanup never issues a volume command, retention is bounded rather than blanket, the rollback image survives, co-tenant images are never considered, the correct immutable release is selected, running-SHA validation, no `--build` on a normal deploy, and the build-context budget.