### PR TITLE
fix: carry the release identity through the CONFENGE deploy driver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,7 @@ data/backups/
 data/confenge-evidence/
 data/confenge-artifacts/
 data/confenge-backend.env
+
+# Python bytecode
+__pycache__/
+*.pyc

--- a/deploy/confenge-vps/README.md
+++ b/deploy/confenge-vps/README.md
@@ -40,6 +40,12 @@ hour.
 Set `CONFENGE_RELEASE_MODE=build` only if GHCR is unreachable. Local production
 builds are what filled the root filesystem.
 
+Rollback pulls the previous release the same way. Releases published before the
+`-minprofile` variant existed need `CONFENGE_GO_IMAGE_SUFFIX=` to select the
+plain tag; the local `warmbly-confenge-*` images from the pre-registry era are
+left in place as the rollback path for those releases and are never pruned by
+the retention sweep.
+
 ## Disk safety
 
 `data/backups` reached 4.3 GB inside a 4.7 GB Docker build context, every

--- a/deploy/confenge-vps/docker-compose.release.yml
+++ b/deploy/confenge-vps/docker-compose.release.yml
@@ -13,20 +13,22 @@
 #
 # The Go services pin the `-minprofile` variant, keeping the execution-plane
 # contract that Stripe, the AWS SDK, GCP Tasks/PubSub and Kafka are not
-# compile-linked.
+# compile-linked. CONFENGE_GO_IMAGE_SUFFIX exists for one case: rolling back to
+# a release published before that variant existed, with
+# CONFENGE_GO_IMAGE_SUFFIX= to select the plain tag.
 
 services:
   backend:
     build: !reset null
-    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/backend:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}-minprofile
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/backend:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}${CONFENGE_GO_IMAGE_SUFFIX--minprofile}
 
   consumer:
     build: !reset null
-    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/consumer:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}-minprofile
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/consumer:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}${CONFENGE_GO_IMAGE_SUFFIX--minprofile}
 
   worker:
     build: !reset null
-    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/worker:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}-minprofile
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/worker:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}${CONFENGE_GO_IMAGE_SUFFIX--minprofile}
 
   tracking:
     build: !reset null
@@ -47,4 +49,4 @@ services:
   # Same binary set as the backend image; seed runs from it under the `seed` profile.
   seed:
     build: !reset null
-    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/backend:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}-minprofile
+    image: ${CONFENGE_IMAGE_PREFIX:-ghcr.io/tjsasakifln/warmbly}/backend:${WARMBLY_RELEASE_SHA:?release sha required for an immutable deploy}${CONFENGE_GO_IMAGE_SUFFIX--minprofile}

--- a/deploy/confenge-vps/lib.sh
+++ b/deploy/confenge-vps/lib.sh
@@ -97,11 +97,17 @@ image_prefix() {
 }
 
 # The Go services pin the minprofile variant; the rest have a single build.
+# Must stay in step with docker-compose.release.yml, including the rollback
+# override for releases published before the minprofile variant existed.
+go_image_suffix() {
+  echo "${CONFENGE_GO_IMAGE_SUFFIX--minprofile}"
+}
+
 release_image_ref() {
   local svc="$1" sha="${2:-$WARMBLY_RELEASE_SHA}"
   case "$svc" in
     backend|consumer|worker|seed)
-      echo "$(image_prefix)/${svc/seed/backend}:${sha}-minprofile" ;;
+      echo "$(image_prefix)/${svc/seed/backend}:${sha}$(go_image_suffix)" ;;
     *)
       echo "$(image_prefix)/${svc}:${sha}" ;;
   esac

--- a/deploy/confenge-vps/release-deploy.sh
+++ b/deploy/confenge-vps/release-deploy.sh
@@ -25,6 +25,10 @@ else
   git checkout --quiet "$TARGET"
 fi
 NEW_SHA="$(git rev-parse HEAD)"
+# Export before any compose_cmd: the release overlay interpolates this and
+# compose_cmd rebinds the decision-audit identity from it. Passing it only as a
+# prefix to up.sh left the post-deploy migration check without an identity.
+export WARMBLY_RELEASE_SHA="$NEW_SHA"
 echo "== release $NEW_SHA =="
 
 ENVF="${CONFENGE_VPS_ENV:-$ROOT/deploy/confenge-vps/.env}"
@@ -42,7 +46,7 @@ chmod 600 "$ENVF"
 
 # up.sh runs the disk preflight, pulls and verifies the pinned images, recreates
 # the stack, checks Postgres and the running SHA, and clears its own deploy pause.
-WARMBLY_RELEASE_SHA="$NEW_SHA" bash "$ROOT/deploy/confenge-vps/up.sh"
+bash "$ROOT/deploy/confenge-vps/up.sh"
 
 printf '%s\n' "$NEW_SHA" >"$ROOT/.deployed_sha"
 

--- a/deploy/confenge-vps/test_deploy_disk_safety.py
+++ b/deploy/confenge-vps/test_deploy_disk_safety.py
@@ -285,9 +285,23 @@ class TestImmutableRelease(unittest.TestCase):
         self.assertNotIn("WARMBLY_RELEASE_SHA:-", code)
 
     def test_go_services_keep_the_minprofile_contract(self) -> None:
+        """Defaults to the variant with Stripe/AWS/GCP/Kafka not compile-linked."""
         text = (PACK / "docker-compose.release.yml").read_text()
         for svc in ("backend", "consumer", "worker", "seed"):
-            self.assertRegex(text, rf"\n  {svc}:\n.*\n    image: .*-minprofile\n")
+            self.assertRegex(
+                text,
+                rf"\n  {svc}:\n.*\n    image: .*\$\{{CONFENGE_GO_IMAGE_SUFFIX--minprofile\}}\n",
+            )
+        sha = "a" * 40
+        proc = self._lib(
+            f'WARMBLY_RELEASE_SHA={sha}; release_image_ref backend; '
+            f'CONFENGE_GO_IMAGE_SUFFIX= release_image_ref backend'
+        )
+        self.assertEqual(proc.returncode, 0, proc.stderr)
+        default_ref, rollback_ref = proc.stdout.split()
+        self.assertTrue(default_ref.endswith("-minprofile"))
+        # Rolling back to a release published before the variant existed.
+        self.assertTrue(rollback_ref.endswith(sha))
 
     def test_ci_publishes_every_image_the_vps_pins(self) -> None:
         wf = (ROOT / ".github/workflows/build-push.yml").read_text()
@@ -351,6 +365,14 @@ class TestDeployPath(unittest.TestCase):
         driver = (PACK / "release-deploy.sh").read_text()
         self.assertNotIn("compose.sh build", driver)
         self.assertIn("up.sh", driver)
+
+    def test_driver_exports_the_release_before_any_compose_call(self) -> None:
+        """compose_cmd rebinds the decision-audit identity from this variable,
+        so a post-deploy compose call without it refuses instead of reporting."""
+        driver = strip_comments((PACK / "release-deploy.sh").read_text())
+        export = driver.index('export WARMBLY_RELEASE_SHA="$NEW_SHA"')
+        self.assertLess(export, driver.index("up.sh"))
+        self.assertLess(export, driver.index("compose_cmd"))
 
 
 class TestBuildContext(unittest.TestCase):


### PR DESCRIPTION
Follow-up to #247, found during the live production deploy of `b45b940d`.

**Deploy driver identity.** `release-deploy.sh` passed `WARMBLY_RELEASE_SHA` only as a prefix to `up.sh`, so its own post-deploy migration check ran `compose_cmd` without it and printed `REFUSE: immutable release SHA must be a full 40- or 64-character lowercase hex digest` before the result. Exported before any compose call instead.

**Rollback to a pre-cutover release.** The overlay hardcoded `-minprofile`, which only exists for releases built after #247. `CONFENGE_GO_IMAGE_SUFFIX` (default `-minprofile`) lets a rollback select the plain tag. `release_image_ref` honours the same variable so the preflight verification and the overlay stay in step.

The pre-registry local `warmbly-confenge-*` images are documented as the rollback path for older releases and are outside the retention sweep, which only matches the GHCR prefix.

Also adds `__pycache__/` to `.gitignore`.

48 pack tests and `validate.sh` pass.