### PR TITLE
fix: make the CONFENGE builder-cache cap actually bind

### DIFF
--- a/deploy/confenge-vps/disk-guard.sh
+++ b/deploy/confenge-vps/disk-guard.sh
@@ -98,9 +98,13 @@ report() {
 # contains no `volume rm`, no `volume prune`, and no `system prune`.
 clean_reconstructible() {
   local keep_gb="${1:-$BUILDER_CACHE_MAX_GB}" sha="${2:-}"
-  echo "cleanup: builder cache -> keep ${keep_gb}GB, drop older than ${BUILDER_CACHE_MAX_AGE}"
-  docker builder prune --force --keep-storage "${keep_gb}GB" --filter "until=${BUILDER_CACHE_MAX_AGE}" >/dev/null 2>&1 ||
-    docker builder prune --force --keep-storage "${keep_gb}GB" >/dev/null 2>&1 || true
+  echo "cleanup: builder cache -> drop older than ${BUILDER_CACHE_MAX_AGE}, then cap at ${keep_gb}GB"
+  # Two passes, in this order. Combining them into one call makes the age filter
+  # gate the size cap: entries younger than the age are then exempt from the cap
+  # and the cache sits above it indefinitely, which is what an earlier version
+  # did (17.83 GB against an 8 GB cap after a sweep reported success).
+  docker builder prune --force --filter "until=${BUILDER_CACHE_MAX_AGE}" >/dev/null 2>&1 || true
+  docker builder prune --force --keep-storage "${keep_gb}GB" >/dev/null 2>&1 || true
   echo "cleanup: dangling images (daemon refuses any image a container references)"
   docker image prune --force >/dev/null 2>&1 || true
   prune_stale_release_images "$sha"

--- a/deploy/confenge-vps/test_deploy_disk_safety.py
+++ b/deploy/confenge-vps/test_deploy_disk_safety.py
@@ -166,8 +166,19 @@ class TestCleanupSafety(unittest.TestCase):
             prunes = [ln for ln in log.splitlines() if ln.startswith("builder prune")]
             self.assertTrue(prunes, "retention must bound the builder cache")
             for line in prunes:
-                self.assertIn("--keep-storage", line)
                 self.assertNotRegex(line, r"(^|\s)-af(\s|$)")
+
+            # The size cap must not be gated by the age filter: entries younger
+            # than the age would then be exempt and the cache would sit above
+            # the cap forever while the sweep still reported success.
+            capped = [ln for ln in prunes if "--keep-storage" in ln]
+            self.assertTrue(capped, "retention must cap the builder cache size")
+            for line in capped:
+                self.assertNotIn("--filter", line)
+            self.assertTrue(
+                any("--filter" in ln and "until=" in ln for ln in prunes),
+                "retention must also drop stale cache by age",
+            )
 
     def test_dangling_prune_is_never_the_all_variant(self) -> None:
         with tempfile.TemporaryDirectory() as d:


### PR DESCRIPTION
Found while validating the retention sweep on ec-prod after #247.

`docker builder prune --keep-storage 8GB --filter until=168h` reported success and left the cache at 17.83 GB. Combining the two makes the age filter *gate* the size cap: entries younger than 168h are exempt, so the cap never binds and the sweep looks healthy while the cache grows.

Split into two passes, age sweep then size cap. Verified on ec-prod: **17.83 GB → 7.50 GB**, root filesystem 68% → 65%.

Regression test asserts the `--keep-storage` call carries no `--filter`, and that an age-filtered pass still runs.