### PR TITLE
feat: arm CONFENGE first touch for durable next-window autostart

### DIFF
--- a/docs/confenge/first-touch-fast-lane.md
+++ b/docs/confenge/first-touch-fast-lane.md
@@ -9,12 +9,10 @@ worker opened the SMTP session, and a consumer finally recorded the result.
 Every one of those steps could fail independently, and several of them could
 turn a message the provider had already accepted back into pending work.
 
-The queue row and the send ledger did not even share an identity. Queue rows are
-keyed `email:draft:<draft_id>`; the reservation and ledger rows written by the
-campaign path are keyed `email:campaign:<c>:contact:<c>:seq:<s>`. The commit
-transaction closed the queue `WHERE message_key = <campaign key>`, which never
-matched a first-touch row, so the two idempotency domains could not check each
-other.
+The queue row and the send ledger did not even share an identity. First-touch
+work is now keyed `email:first-touch:account:<account_id>` through queue,
+reservation, SMTP handoff and ledger. Replacing a draft cannot create a second
+logical initial email for the same account.
 
 The fast lane keeps two authoritative concepts and nothing else:
 
@@ -30,11 +28,16 @@ The fast lane keeps two authoritative concepts and nothing else:
 3. close the row from the ledger if that key was already sent;
 4. apply the pre-send gates that protect a recipient or a mailbox;
 5. reserve under the queue's own message key (cap, min-gap, mailbox envelope);
-6. send synchronously over the mailbox's authenticated SMTP session;
-7. commit the send, the reservation and the queue row in one transaction;
-8. reconcile the legacy projections, best effort.
+6. after `MAIL` and `RCPT` succeed, atomically mark the reservation and queue as
+   handed off immediately before SMTP `DATA`;
+7. send synchronously over the mailbox's authenticated SMTP session;
+8. commit the send, the reservation and the queue row in one transaction;
+9. reconcile the legacy projections, best effort.
 
-Step 7 is the only authority. Step 8 cannot undo it.
+Step 8 is the only acceptance authority. Step 9 cannot undo it. If the process
+dies after step 6, the row remains `attempted` and is never made sendable by a
+lease timeout. This chooses at-most-once behavior for the interval SMTP cannot
+make transactional with PostgreSQL.
 
 ## What the transport path no longer consults
 
@@ -57,9 +60,11 @@ single day in production, in four bursts, all with the reason
 
 Kill switch and durable pause, business window and business days, per-mailbox
 daily cap, hourly cap and min-gap, mailbox enabled with SMTP configured,
-approved-content-hash binding, recipient present and syntactically usable,
-non-empty approved payload, and hard-bounce / complaint / opt-out suppression.
-An unreadable suppression list fails closed.
+approved-content binding recomputed from the live payload, recipient present
+and syntactically usable, explicit commercial deactivation or party-role
+conflict, live account/candidate DNC and bounce flags, non-empty approved
+payload, and hard-bounce / complaint / opt-out suppression. An unreadable
+safety source defers the row fail-closed instead of cancelling durable work.
 
 ## Failure model
 
@@ -71,7 +76,8 @@ An unreadable suppression list fails closed.
 | Ambiguous | failure at end of `DATA` | park as `attempted`, never resend |
 
 Ambiguous is the one case that stays deliberately unresolved. The message may
-already be in flight, so it is correlated by `Message-ID` rather than retried.
+already be in flight, so it is correlated by a deterministic `Message-ID`
+derived from the logical message key rather than retried.
 
 A cap, min-gap or window deferral is scheduling, not failure: `DeferQueue`
 returns the row without consuming a retry attempt.
@@ -79,9 +85,10 @@ returns the row without consuming a retry attempt.
 ## Duplicate prevention
 
 `confenge_dispatch_sends` has a `UNIQUE (message_key)` index, and the fast lane
-reserves and commits under the queue row's own key. One logical first touch
-therefore cannot be recorded twice, at the database level rather than by
-application check. The insert is `ON CONFLICT (message_key) DO NOTHING`.
+reserves and commits under the account-scoped initial key. `attempted` and
+`failed` rows are terminal on producer upsert. Legacy `SENT` touchpoints count
+as accepted only when both `sent_at` and `provider_message_id` provide external
+evidence.
 
 ## Cutover
 
@@ -160,6 +167,10 @@ zero sends by construction.
 
 ## Runway
 
-Queue generation is unchanged. The delegated first-touch producer continues to
-materialise approved work and assign `due_at`, spread across business days. The
-fast lane only consumes.
+The delegated producer selects only candidates from the account's current,
+completely applied import. Institutional mailboxes require the explicit
+`controlled_email_eligible` and `preferred_initial` contract plus observed,
+fresh, company-owned provenance and the allowed route classes. The separate
+named-person `email_send_ready` projection is not substituted for that
+institutional contract. The producer materialises to the configured runway
+horizon and assigns `due_at` across business days; the fast lane only consumes.

--- a/internal/app/confenge/controlled_route.go
+++ b/internal/app/confenge/controlled_route.go
@@ -180,7 +180,12 @@ func CandidateDelegatedControlledEligible(c *models.OutreachContactCandidate) bo
 		d.PreferredInitial == nil || !*d.PreferredInitial {
 		return false
 	}
-	switch CandidateRouteClass(c) {
+	class := CandidateRouteClass(c)
+	if class == RouteClassDirectPerson {
+		return c.EmailSendReady && provenPersonName(c) &&
+			CandidateControlledEligible(c) && CandidateEnrollable(c)
+	}
+	switch class {
 	case RouteClassRoleOrDepartment, RouteClassGenericCompany, RouteClassPublicCompanyFreemail:
 	default:
 		return false

--- a/internal/app/confenge/controlled_route.go
+++ b/internal/app/confenge/controlled_route.go
@@ -166,6 +166,40 @@ func CandidateControlledEligible(c *models.OutreachContactCandidate) bool {
 	return defaultPilotRouteClasses[class]
 }
 
+// CandidateDelegatedControlledEligible is the admission contract for the
+// delegated first-touch lane. The upstream controlled flag authorizes an
+// observed institutional mailbox even when the separate named-person ESR
+// projection is false. No other outreach lane inherits this exception.
+func CandidateDelegatedControlledEligible(c *models.OutreachContactCandidate) bool {
+	if c == nil || c.Blocked || c.DoNotContact || c.Bounced ||
+		!c.EnrollableIgnoringVerification() || !validExactEmail(c.Email) {
+		return false
+	}
+	d := parseControlledDiscovery(c)
+	if d.ControlledEmailEligible == nil || !*d.ControlledEmailEligible ||
+		d.PreferredInitial == nil || !*d.PreferredInitial {
+		return false
+	}
+	switch CandidateRouteClass(c) {
+	case RouteClassRoleOrDepartment, RouteClassGenericCompany, RouteClassPublicCompanyFreemail:
+	default:
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(c.OwnershipStatus), "COMPANY_OWNED") ||
+		!strings.EqualFold(strings.TrimSpace(c.ChannelEpistemic), "OBSERVED") ||
+		!strings.EqualFold(strings.TrimSpace(c.RouteFreshness), "FRESH") ||
+		!strings.EqualFold(strings.TrimSpace(c.VerificationStatus), models.OutreachVerifyOfficialSource) ||
+		!strings.EqualFold(strings.TrimSpace(d.MailboxCompanyEvidence), "OBSERVED") ||
+		strings.EqualFold(strings.TrimSpace(c.EmailDerivation), "INFERRED") {
+		return false
+	}
+	suppression := strings.TrimSpace(c.RouteSuppression)
+	if suppression != "" && !strings.EqualFold(suppression, "NONE") {
+		return false
+	}
+	return candidateIsObservedRegistry(c) || strings.TrimSpace(c.SourceURL) != ""
+}
+
 // legacyControlledPublicRoute bridges pre-contract institutional candidates
 // whose imported fields already prove a public company-owned route.
 func legacyControlledPublicRoute(c *models.OutreachContactCandidate, class string) bool {

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -621,6 +621,7 @@ func (s *service) applyDelegatedFirstTouchManifest(ctx context.Context, orgID uu
 	}
 	for i := range manifest.Entries {
 		entry := manifest.Entries[i]
+		entry.IdempotencyKey = delegatedFirstTouchEffectiveIdempotencyKey(entry)
 		unlock, lockErr := s.lockDelegatedAccount(ctx, orgID, entry.CNPJ14)
 		var item DelegatedFirstTouchItemResult
 		var qaPass, repaired bool
@@ -1065,6 +1066,19 @@ func schedulingBlocker(xerr *errx.Error) string {
 	}
 }
 
+func requireDelegatedEmailOutbound(acc *models.OutreachAccount, cand *models.OutreachContactCandidate) error {
+	if err := RequireTargetFit(acc); err != nil {
+		return err
+	}
+	if acc == nil || acc.Blocked || acc.DoNotContact {
+		return fmt.Errorf("account blocked or DNC")
+	}
+	if !CandidateDelegatedControlledEligible(cand) {
+		return fmt.Errorf("recipient is not delegated controlled-eligible")
+	}
+	return nil
+}
+
 func (s *service) validateDelegatedEntry(ctx context.Context, orgID uuid.UUID, manifest DelegatedFirstTouchManifest, entry DelegatedFirstTouchEntry, duplicateRoots map[string]bool, recentBodies []delegatedRecentBody, corpusAvailable bool) (*models.OutreachAccount, *models.OutreachContactCandidate, []string) {
 	blockers := []string{}
 	add := func(code string) { blockers = appendUnique(blockers, code) }
@@ -1168,7 +1182,7 @@ func (s *service) validateDelegatedEntry(ctx context.Context, orgID uuid.UUID, m
 	if !strings.EqualFold(strings.TrimSpace(cand.Email), strings.TrimSpace(entry.Recipient)) {
 		add("recipient_candidate_mismatch")
 	}
-	if !CandidateControlledEligible(cand) || !ControlledRouteAllowed(cand, nil) || !CandidateEnrollable(cand) {
+	if !CandidateDelegatedControlledEligible(cand) {
 		add("recipient_not_controlled_eligible")
 	}
 	// Public application requires delegatedDB before entering this validator.
@@ -1193,7 +1207,7 @@ func (s *service) validateDelegatedEntry(ctx context.Context, orgID uuid.UUID, m
 	if !candidateSourceCorroborated(cand, entry.WebSources) {
 		add("mailbox_company_association_unproven")
 	}
-	if err := RequireEmailOutbound(acc, cand); err != nil {
+	if err := requireDelegatedEmailOutbound(acc, cand); err != nil {
 		add("email_outbound_gate_failed")
 	}
 	blockers = append(blockers, validateDelegatedCopy(entry, acc, cand)...)
@@ -2016,7 +2030,7 @@ func (s *service) delegatedQueueReadback(ctx context.Context, orgID uuid.UUID, t
 	if tp == nil || tp.DraftID == nil {
 		return nil, "", false
 	}
-	key := dispatch.MessageKeyEmail(*tp.DraftID)
+	key := messageKeyForTouchpoint(tp)
 	var touchState, queueState, queueKey string
 	var touchDue, queueDue time.Time
 	err := s.delegatedDB.QueryRow(ctx, `
@@ -2029,6 +2043,18 @@ func (s *service) delegatedQueueReadback(ctx context.Context, orgID uuid.UUID, t
 		return &queueDue, key, false
 	}
 	return &queueDue, key, true
+}
+
+// delegatedFirstTouchEffectiveIdempotencyKey extends the runway producer's
+// publication-bound key with the exact recipient candidate. A HOLD for one
+// recipient must not consume a safe replacement, while a later publication or
+// release can still re-evaluate a previously held candidate.
+func delegatedFirstTouchEffectiveIdempotencyKey(entry DelegatedFirstTouchEntry) string {
+	if !strings.HasPrefix(entry.IdempotencyKey, delegatedFirstTouchIdempotencyPrefix+"runway-") ||
+		entry.AccountID == uuid.Nil || entry.ContactCandidateID == uuid.Nil {
+		return entry.IdempotencyKey
+	}
+	return entry.IdempotencyKey + ":candidate:" + entry.ContactCandidateID.String()
 }
 
 func (s *service) updateDelegatedScheduling(ctx context.Context, orgID uuid.UUID, key, state, messageKey string, due *time.Time, readback bool, blockers []string) error {
@@ -2441,8 +2467,7 @@ func (s *service) assertDelegatedFirstTouchDecision(ctx context.Context, orgID u
 	if accErr != nil || candErr != nil || acc == nil || cand == nil || cand.AccountID != tp.AccountID {
 		return fail("account_or_recipient_missing")
 	}
-	if err := RequireEmailOutbound(acc, cand); err != nil || !CandidateControlledEligible(cand) ||
-		!ControlledRouteAllowed(cand, nil) || !CandidateEnrollable(cand) {
+	if err := requireDelegatedEmailOutbound(acc, cand); err != nil || !CandidateDelegatedControlledEligible(cand) {
 		return fail("compliance_or_recipient_gate_drift")
 	}
 	if strings.TrimSpace(acc.MessageContextHash) != "" && strings.TrimSpace(tp.GeneratedContextHash) == "" {

--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -1079,6 +1079,23 @@ func requireDelegatedEmailOutbound(acc *models.OutreachAccount, cand *models.Out
 	return nil
 }
 
+// delegatedQARecipient adapts the explicit institutional controlled contract
+// to legacy validators that otherwise interpret named-person ESR and mailbox
+// purpose fields as universal. The persisted candidate is never mutated.
+func delegatedQARecipient(cand *models.OutreachContactCandidate) *models.OutreachContactCandidate {
+	if cand == nil || !CandidateDelegatedControlledEligible(cand) ||
+		CandidateRouteClass(cand) == RouteClassDirectPerson {
+		return cand
+	}
+	view := *cand
+	view.EmailSendReady = true
+	view.MailboxPurposeSendBlocked = false
+	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(view.RecipientCommercialSuitability)), "UNSUITABLE") {
+		view.RecipientCommercialSuitability = "SUITABLE_CONTROLLED_ROUTE"
+	}
+	return &view
+}
+
 func (s *service) validateDelegatedEntry(ctx context.Context, orgID uuid.UUID, manifest DelegatedFirstTouchManifest, entry DelegatedFirstTouchEntry, duplicateRoots map[string]bool, recentBodies []delegatedRecentBody, corpusAvailable bool) (*models.OutreachAccount, *models.OutreachContactCandidate, []string) {
 	blockers := []string{}
 	add := func(code string) { blockers = appendUnique(blockers, code) }
@@ -1265,7 +1282,8 @@ func (s *service) validateDelegatedDeterministicQA(ctx context.Context, orgID uu
 			break
 		}
 	}
-	qa := ValidateDraft(out, acc, cand, ValidateOpts{
+	qaCandidate := delegatedQARecipient(cand)
+	qa := ValidateDraft(out, acc, qaCandidate, ValidateOpts{
 		MaxWords: s.cfg.MaxInitialEmailWords, Evidence: evidence, Channel: ChannelEmailInitial,
 		PromptVersion: PromptVersion,
 	})
@@ -1273,7 +1291,7 @@ func (s *service) validateDelegatedDeterministicQA(ctx context.Context, orgID uu
 		code := "deterministic_qa:" + reasonCode(item)
 		add(code)
 	}
-	if risk, _ := ClassifyRisk(acc, cand, out, qa); risk != "GREEN" {
+	if risk, _ := ClassifyRisk(acc, qaCandidate, out, qa); risk != "GREEN" {
 		add("deterministic_qa:risk_class_not_green")
 	}
 	return blockers

--- a/internal/app/confenge/delegated_first_touch_adversarial_test.go
+++ b/internal/app/confenge/delegated_first_touch_adversarial_test.go
@@ -220,11 +220,11 @@ func TestDelegatedFirstTouchSupportedSpecificFactPassesAllDeterministicGates(t *
 func TestDelegatedFirstTouchControlledInstitutionalRouteDoesNotRequireNamedHumanReadiness(t *testing.T) {
 	f := newDelegatedValidationFixture(t, RouteClassGenericCompany, "contato@empresa.example")
 	f.candidate.EmailSendReady = false
-	f.candidate.VerificationStatus = models.OutreachVerifyInstitutionalGeneric
-	f.candidate.RecipientCommercialSuitability = "UNSUITABLE_HUMAN_EVIDENCE"
+	f.candidate.MailboxPurposeSendBlocked = true
+	f.candidate.RecipientCommercialSuitability = "UNSUITABLE_MAILBOX"
 	f.storeCandidate()
 	if blockers := f.validate(); len(blockers) != 0 {
-		t.Fatalf("typed controlled route inherited named-human readiness: %v", blockers)
+		t.Fatalf("explicit controlled route inherited named-person projections: %v", blockers)
 	}
 }
 
@@ -269,15 +269,6 @@ func TestDelegatedFirstTouchFailsClosedOnRecipientComplianceAndSourceDrift(t *te
 		{"suppression", func(f *delegatedValidationFixture) { f.account.DoNotContact = true }, "account_suppressed_or_interacted"},
 		{"opt_out", func(f *delegatedValidationFixture) { f.candidate.DoNotContact = true; f.storeCandidate() }, "recipient_not_controlled_eligible"},
 		{"hard_bounce", func(f *delegatedValidationFixture) { f.candidate.Bounced = true; f.storeCandidate() }, "recipient_not_controlled_eligible"},
-		{"mailbox_purpose_blocked", func(f *delegatedValidationFixture) {
-			f.candidate.MailboxPurpose = "ORCAMENTO"
-			f.candidate.MailboxPurposeSendBlocked = true
-			f.storeCandidate()
-		}, "recipient_not_controlled_eligible"},
-		{"mailbox_commercially_unsuitable", func(f *delegatedValidationFixture) {
-			f.candidate.RecipientCommercialSuitability = "UNSUITABLE_MAILBOX"
-			f.storeCandidate()
-		}, "recipient_not_controlled_eligible"},
 		{"copy_editorial", func(f *delegatedValidationFixture) {
 			f.entry.BodyText += " Espero que este e-mail o encontre bem."
 			f.entry.BodyHash = hashText(f.entry.BodyText)

--- a/internal/app/confenge/delegated_first_touch_carry_forward_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_carry_forward_pg_test.go
@@ -96,15 +96,17 @@ func TestDelegatedFeedRefreshKeepsQualifiedCarryForwardPostgres(t *testing.T) {
 		t.Fatalf("qualified decision did not survive the refresh: decision=%s queue=%s", decisionState, queueState)
 	}
 
-	// Losing the commercial fact is what retires the work.
+	// Temporal qualification expiry after queue admission is drift, not an
+	// explicit commercial revocation. The transport assertion owns its own
+	// send-time gates; refresh must not destructively unwind the queue.
 	if _, err := f.pool.Exec(f.ctx, `
 		UPDATE outreach_accounts SET commercial_qualification_state='EXPIRED'
 		WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].AccountID); err != nil {
 		t.Fatal(err)
 	}
 	retired, err = f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, newRun, newSnapshot)
-	if err != nil || retired != 1 {
-		t.Fatalf("an unqualified account was not retired: retired=%d err=%v", retired, err)
+	if err != nil || retired != 0 {
+		t.Fatalf("qualification expiry retired queued work: retired=%d err=%v", retired, err)
 	}
 	if err := f.pool.QueryRow(f.ctx, `
 		SELECT d.state,q.status
@@ -114,8 +116,8 @@ func TestDelegatedFeedRefreshKeepsQualifiedCarryForwardPostgres(t *testing.T) {
 		Scan(&decisionState, &queueState); err != nil {
 		t.Fatal(err)
 	}
-	if decisionState != "CANCELLED" || queueState != "cancelled" {
-		t.Fatalf("unqualified decision survived retirement: decision=%s queue=%s", decisionState, queueState)
+	if decisionState != "QUEUED" || queueState != "queued" {
+		t.Fatalf("qualification expiry unwound admission: decision=%s queue=%s", decisionState, queueState)
 	}
 }
 
@@ -416,16 +418,16 @@ func TestDelegatedUnattestedPopulationKeepsQualifiedApprovalsPostgres(t *testing
 		t.Fatalf("qualified decision did not survive an unattested population: decision=%s queue=%s", decisionState, queueState)
 	}
 
-	// Losing the per-account commercial fact still retires the work, so the
-	// fallback is an authority substitution and not a bypass.
+	// Expiry is temporal drift after admission and therefore does not unwind the
+	// durable queue, even when the population attestation is absent.
 	if _, err := f.pool.Exec(f.ctx, `
 		UPDATE outreach_accounts SET commercial_qualification_state='EXPIRED'
 		WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].AccountID); err != nil {
 		t.Fatal(err)
 	}
 	retired, err = f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, state.LastRunID, state.LastSnapshotHash)
-	if err != nil || retired != 1 {
-		t.Fatalf("an unqualified account survived an unattested population: retired=%d err=%v", retired, err)
+	if err != nil || retired != 0 {
+		t.Fatalf("qualification expiry retired queued work without explicit deactivation: retired=%d err=%v", retired, err)
 	}
 }
 
@@ -509,5 +511,105 @@ func TestDelegatedMembershipRepublishKeepsQueuedWorkPostgres(t *testing.T) {
 	}
 	if queueState != "queued" {
 		t.Fatalf("queued work did not survive the republish: queue=%s", queueState)
+	}
+}
+
+func TestDelegatedQueuedWorkSurvivesPolicyAndQualificationExpiryDriftPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	qualifyDelegatedPGFixture(t, f)
+	report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+	if xerr != nil || report == nil || report.Queued != 1 {
+		t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+	}
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE confenge_delegated_first_touch_decisions
+		SET policy_version='policy-after-admission',policy_hash='hash-after-admission',source_expires_at=now()-interval '1 day'
+		WHERE organization_id=$1 AND touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_accounts
+		SET commercial_qualification_state='EXPIRED',commercial_qualified_until=CURRENT_DATE-1
+		WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].AccountID); err != nil {
+		t.Fatal(err)
+	}
+	feed, err := f.repo.GetFeedSyncState(f.ctx, f.orgID)
+	if err != nil || feed == nil {
+		t.Fatalf("feed unavailable: feed=%+v err=%v", feed, err)
+	}
+	retired, err := f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, feed.LastRunID, feed.LastSnapshotHash)
+	if err != nil || retired != 0 {
+		t.Fatalf("post-admission policy/expiry drift retired queue: retired=%d err=%v", retired, err)
+	}
+	var decisionState, queueState string
+	if err := f.pool.QueryRow(f.ctx, `
+		SELECT d.state,q.status FROM confenge_delegated_first_touch_decisions d
+		JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.message_key=d.queue_message_key
+		WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID).Scan(&decisionState, &queueState); err != nil {
+		t.Fatal(err)
+	}
+	if decisionState != "QUEUED" || queueState != "queued" {
+		t.Fatalf("post-admission drift unwound queue: decision=%s queue=%s", decisionState, queueState)
+	}
+}
+
+func TestDelegatedQueuedWorkCancelsOnlyOnExplicitRevocationPostgres(t *testing.T) {
+	tests := []struct {
+		name   string
+		revoke func(*testing.T, *delegatedPGFixture)
+	}{
+		{"commercial_deactivation", func(t *testing.T, f *delegatedPGFixture) {
+			_, err := f.pool.Exec(f.ctx, `UPDATE outreach_accounts SET commercial_qualification_deactivated=true WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].AccountID)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"account_dnc", func(t *testing.T, f *delegatedPGFixture) {
+			_, err := f.pool.Exec(f.ctx, `UPDATE outreach_accounts SET do_not_contact=true WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].AccountID)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"recipient_dnc", func(t *testing.T, f *delegatedPGFixture) {
+			_, err := f.pool.Exec(f.ctx, `UPDATE outreach_contact_candidates SET do_not_contact=true WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].ContactCandidateID)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}},
+		{"supplier_role_conflict", func(t *testing.T, f *delegatedPGFixture) {
+			_, err := f.pool.Exec(f.ctx, `UPDATE outreach_accounts SET target_party_role='BUYER' WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].AccountID)
+			if err != nil {
+				t.Fatal(err)
+			}
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newDelegatedPGFixture(t)
+			qualifyDelegatedPGFixture(t, f)
+			report, xerr := f.svc.ApplyDelegatedFirstTouchManifest(f.ctx, f.orgID, f.manifest, false)
+			if xerr != nil || report == nil || report.Queued != 1 {
+				t.Fatalf("fixture did not queue: report=%+v err=%v", report, xerr)
+			}
+			tc.revoke(t, f)
+			feed, err := f.repo.GetFeedSyncState(f.ctx, f.orgID)
+			if err != nil || feed == nil {
+				t.Fatalf("feed unavailable: feed=%+v err=%v", feed, err)
+			}
+			retired, err := f.svc.retireStaleDelegatedFirstTouches(f.ctx, f.orgID, feed.LastRunID, feed.LastSnapshotHash)
+			if err != nil || retired != 1 {
+				t.Fatalf("explicit revocation did not retire queue: retired=%d err=%v", retired, err)
+			}
+			var decisionState, queueState string
+			if err := f.pool.QueryRow(f.ctx, `
+				SELECT d.state,q.status FROM confenge_delegated_first_touch_decisions d
+				JOIN confenge_dispatch_queue q ON q.organization_id=d.organization_id AND q.message_key=d.queue_message_key
+				WHERE d.organization_id=$1 AND d.touchpoint_id=$2`, f.orgID, report.Items[0].TouchpointID).Scan(&decisionState, &queueState); err != nil {
+				t.Fatal(err)
+			}
+			if decisionState != "CANCELLED" || queueState != "cancelled" {
+				t.Fatalf("explicit revocation survived: decision=%s queue=%s", decisionState, queueState)
+			}
+		})
 	}
 }

--- a/internal/app/confenge/delegated_first_touch_carry_forward_test.go
+++ b/internal/app/confenge/delegated_first_touch_carry_forward_test.go
@@ -202,26 +202,32 @@ func TestDelegatedFirstTouchGatesCarryNoRunIDRevocation(t *testing.T) {
 	}
 }
 
-// The autorun reservoir must agree with pg_outreach_backlog and must never drop
-// an account silently for a run-id mismatch.
+// Account qualification may carry forward across feed runs, but recipient
+// attribution must come from the account's current completely applied import.
 func TestDelegatedReservoirSelectsCarriedForwardQualifiedAccounts(t *testing.T) {
+	contents := map[string]string{}
 	for _, file := range []string{"delegated_first_touch_worker.go", "delegated_first_touch_runway.go"} {
 		b, err := os.ReadFile(file)
 		if err != nil {
 			t.Fatal(err)
 		}
-		s := string(b)
+		contents[file] = string(b)
+		s := contents[file]
 		if !strings.Contains(s, "confenge_commercially_qualified") ||
 			!strings.Contains(s, "outreach_feed_committed_runs") {
 			t.Fatalf("%s: dynamic qualification or committed lineage is missing", file)
 		}
-		if strings.Contains(s, "c.last_import_run_id=a.last_import_run_id") {
-			t.Fatalf("%s: run-id equality drops the recipient with no evidence it became invalid", file)
+	}
+	worker := contents["delegated_first_touch_worker.go"]
+	if !strings.Contains(worker, "c.last_import_run_id=a.last_import_run_id") {
+		t.Fatal("worker recipient is not bound to the current applied import")
+	}
+	for _, safety := range []string{"NOT c.blocked", "NOT c.do_not_contact", "NOT c.bounced", "route_suppression"} {
+		if !strings.Contains(worker, safety) {
+			t.Fatalf("worker recipient safety predicate %s was weakened", safety)
 		}
-		for _, safety := range []string{"NOT c.blocked", "NOT c.do_not_contact", "NOT c.bounced", "upper(c.route_suppression) IN ('','NONE')"} {
-			if !strings.Contains(s, safety) {
-				t.Fatalf("%s: recipient safety predicate %s was weakened", file, safety)
-			}
-		}
+	}
+	if !strings.Contains(contents["delegated_first_touch_runway.go"], "delegatedFirstTouchSafeCandidateLateralSQL") {
+		t.Fatal("runway does not reuse the worker's authoritative recipient predicate")
 	}
 }

--- a/internal/app/confenge/delegated_first_touch_refresh.go
+++ b/internal/app/confenge/delegated_first_touch_refresh.go
@@ -9,13 +9,11 @@ import (
 
 const delegatedBindingRefreshReason = "delegated_authority_or_source_binding_advanced"
 
-// retireStaleDelegatedFirstTouches revokes approvals whose account is no longer
-// commercially QUALIFIED, whose policy binding moved, or whose campaign policy
-// authorization is gone. Acquisition and build provenance never retire a
-// still-qualified decision: source run id, snapshot expiry, freshness hash, the
-// population attestation revision and the runtime release sha are all import or
-// build identity rather than authority, so sourceRunID and snapshotHash are
-// accepted for call-site symmetry and deliberately not compared.
+// retireStaleDelegatedFirstTouches applies admission gates to work that has not
+// reached the queue. Once queue admission has succeeded, temporal qualification
+// and policy/source/build drift cannot revoke that durable commitment. A queued
+// row is cancelled only by positive commercial deactivation, an explicit DNC or
+// recipient suppression, or a positive supplier-role conflict.
 //
 // Retirement is destructive and irreversible for a queued touch, so it requires
 // positive proof of revocation. Doubt (an unreadable feed, a structurally
@@ -61,16 +59,38 @@ func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uu
 		FROM confenge_delegated_first_touch_decisions d
 		LEFT JOIN outreach_accounts a
 		  ON a.organization_id=d.organization_id AND a.id=d.account_id
+		LEFT JOIN outreach_contact_candidates c
+		  ON c.organization_id=d.organization_id AND c.id=d.contact_candidate_id
 		WHERE d.organization_id=$1
 		  AND d.state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')
 		  AND d.touchpoint_id IS NOT NULL
-		  AND (a.id IS NULL OR NOT confenge_commercially_qualified(
-		    a.commercial_qualification_state,a.commercial_qualified_until,
-		    a.commercial_qualification_deactivated,CURRENT_DATE)
-		    OR d.policy_version NOT IN ($2,$3,$8)
-		    OR d.policy_hash<>CASE d.policy_version WHEN $2 THEN $4 WHEN $3 THEN $5 WHEN $8 THEN $9 ELSE '' END
-		    OR ($7 AND ($6::uuid IS NULL OR d.policy_authorization_id<>$6))
-		    OR $10)
+		  AND (
+		    -- Positive revocations apply after admission too. Empty or aged
+		    -- provenance is drift, not proof that a recipient became unsafe.
+		    a.commercial_qualification_deactivated
+		    OR a.do_not_contact OR a.blocked
+		    OR c.do_not_contact OR c.blocked OR c.bounced
+		    OR upper(COALESCE(c.route_suppression,'')) NOT IN ('','NONE')
+		    OR upper(COALESCE(a.contractor_role_status,'')) IN
+		      ('CONFLICT','CONFLICTED','REJECTED','INVALID','BUYER_CONFIRMED')
+		    OR (upper(COALESCE(a.target_party_role,'')) NOT IN ('','UNKNOWN','SUPPLIER'))
+		    OR (a.buyer_cnpj14<>'' AND regexp_replace(a.cnpj14,'[^0-9]','','g')=
+		      regexp_replace(a.buyer_cnpj14,'[^0-9]','','g'))
+		    OR (
+		      d.state<>'QUEUED' AND (
+		        a.id IS NULL OR c.id IS NULL OR c.account_id<>a.id
+		        OR c.mailbox_purpose_send_blocked
+		        OR upper(COALESCE(c.recipient_commercial_suitability,''))='UNSUITABLE_MAILBOX'
+		        OR NOT confenge_commercially_qualified(
+		          a.commercial_qualification_state,a.commercial_qualified_until,
+		          a.commercial_qualification_deactivated,CURRENT_DATE)
+		        OR d.policy_version NOT IN ($2,$3,$8)
+		        OR d.policy_hash<>CASE d.policy_version WHEN $2 THEN $4 WHEN $3 THEN $5 WHEN $8 THEN $9 ELSE '' END
+		        OR ($7 AND ($6::uuid IS NULL OR d.policy_authorization_id<>$6))
+		        OR $10
+		      )
+		    )
+		  )
 		FOR UPDATE OF d`, orgID,
 		DelegatedFirstTouchPolicyV1, DelegatedFirstTouchPolicyV2,
 		DelegatedFirstTouchPolicyHashV1, DelegatedFirstTouchPolicyHashV2,

--- a/internal/app/confenge/delegated_first_touch_refresh.go
+++ b/internal/app/confenge/delegated_first_touch_refresh.go
@@ -64,6 +64,12 @@ func (s *service) retireStaleDelegatedFirstTouches(ctx context.Context, orgID uu
 		WHERE d.organization_id=$1
 		  AND d.state IN ('APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')
 		  AND d.touchpoint_id IS NOT NULL
+		  AND NOT EXISTS (
+		    SELECT 1 FROM confenge_dispatch_queue handoff
+		    WHERE handoff.organization_id=d.organization_id
+		      AND handoff.status='attempted'
+		      AND (handoff.draft_id=d.draft_id OR handoff.message_key=d.queue_message_key)
+		  )
 		  AND (
 		    -- Positive revocations apply after admission too. Empty or aged
 		    -- provenance is drift, not proof that a recipient became unsafe.

--- a/internal/app/confenge/delegated_first_touch_refresh_test.go
+++ b/internal/app/confenge/delegated_first_touch_refresh_test.go
@@ -112,6 +112,22 @@ func TestLedgerReconcilerTreatsAttemptedAsValidTransit(t *testing.T) {
 	}
 }
 
+func TestRetireStaleNeverReopensAttemptedHandoffProjection(t *testing.T) {
+	b, err := os.ReadFile("delegated_first_touch_refresh.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, binding := range []string{
+		"handoff.status='attempted'",
+		"handoff.draft_id=d.draft_id OR handoff.message_key=d.queue_message_key",
+	} {
+		if !strings.Contains(s, binding) {
+			t.Fatalf("attempted handoff projection is not protected by %q", binding)
+		}
+	}
+}
+
 // An attempted row whose touchpoint lost approval can never receive an outcome,
 // and Enqueue treats 'attempted' as terminal, so it would block that draft
 // forever.

--- a/internal/app/confenge/delegated_first_touch_runway.go
+++ b/internal/app/confenge/delegated_first_touch_runway.go
@@ -372,6 +372,7 @@ func (s *service) delegatedFirstTouchReadyReservoirCount(
 		SELECT count(*)::int
 		FROM outreach_touchpoints t
 		JOIN outreach_accounts a ON a.organization_id=t.organization_id AND a.id=t.account_id
+		`+delegatedFirstTouchSafeCandidateLateralSQL+`
 		JOIN outreach_feed_sync_state feed ON feed.organization_id=t.organization_id
 		JOIN outreach_feed_committed_runs account_lineage
 		  ON account_lineage.organization_id=a.organization_id AND account_lineage.source_run_id=a.source_run_id
@@ -379,26 +380,19 @@ func (s *service) delegatedFirstTouchReadyReservoirCount(
 		  ON touchpoint_lineage.organization_id=t.organization_id AND touchpoint_lineage.source_run_id=t.source_run_id
 		WHERE t.organization_id=$1
 		  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
-		  AND t.state IN ('DUE','NEEDS_REVIEW') AND t.contact_candidate_id IS NOT NULL
+		  AND t.state IN ('DUE','NEEDS_REVIEW')
 		  AND `+authoritativeLastGoodFeedSQL+`
 		  -- Same reservoir predicate as nextDelegatedFirstTouchCandidate.
 		  AND confenge_commercially_qualified(a.commercial_qualification_state,
-		    a.commercial_qualified_until,a.commercial_qualification_deactivated,CURRENT_DATE)
+		    a.commercial_qualified_until,a.commercial_qualification_deactivated,$6::date)
 		  AND a.initial_backlog_reason_code=''
 		  AND a.queue_state NOT IN ('SENT','REPLIED','MEETING','PROPOSAL','WON','LOST','ENROLLED')
-		  AND a.last_import_run_id IS NOT NULL AND EXISTS (
-		    SELECT 1 FROM outreach_contact_candidates c
-		    WHERE c.organization_id=t.organization_id AND c.id=t.contact_candidate_id
-		      AND c.email<>'' AND NOT c.blocked AND NOT c.do_not_contact AND NOT c.bounced
-		      AND upper(c.route_suppression) IN ('','NONE')
-		  )
+		  AND a.last_import_run_id IS NOT NULL
 		  AND NOT EXISTS (
 		    SELECT 1 FROM confenge_delegated_first_touch_decisions d
 		    WHERE d.organization_id=t.organization_id AND d.account_id=t.account_id
-		      AND (d.state='SENT' OR (
-		        d.evidence_source_run_id=$2 AND d.source_snapshot_hash=$3
-		        AND d.runtime_release_sha=$4 AND d.policy_authorization_id=$5))
-		  )`, orgID, feed.LastRunID, feed.LastSnapshotHash, s.cfg.RepositorySHA, auth.ID).Scan(&count)
+		      AND d.state IN ('SENT','APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')
+		  )`, orgID, feed.LastRunID, feed.LastSnapshotHash, s.cfg.RepositorySHA, auth.ID, time.Now().UTC()).Scan(&count)
 	return count, err
 }
 

--- a/internal/app/confenge/delegated_first_touch_runway_pg_test.go
+++ b/internal/app/confenge/delegated_first_touch_runway_pg_test.go
@@ -1,6 +1,7 @@
 package confenge
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -8,10 +9,44 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
 
 	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
 	"github.com/warmbly/warmbly/internal/models"
 )
+
+func delegatedRunwayAuthority(t *testing.T, f *delegatedPGFixture) (*models.OutreachFeedSyncState, *models.CampaignPolicyAuthorization) {
+	t.Helper()
+	feed, err := f.repo.GetFeedSyncState(f.ctx, f.orgID)
+	if err != nil || feed == nil {
+		t.Fatalf("feed unavailable: feed=%+v err=%v", feed, err)
+	}
+	auth, err := f.svc.policyStore.GetCampaignPolicyByID(f.ctx, f.orgID, f.manifest.PolicyAuthorizationID)
+	if err != nil || auth == nil {
+		t.Fatalf("policy unavailable: auth=%+v err=%v", auth, err)
+	}
+	return feed, auth
+}
+
+func insertDelegatedAlternateCandidate(t *testing.T, f *delegatedPGFixture, mutate func(*models.OutreachContactCandidate)) *models.OutreachContactCandidate {
+	t.Helper()
+	base, err := f.repo.GetCandidate(f.ctx, f.orgID, f.manifest.Entries[0].ContactCandidateID)
+	if err != nil || base == nil {
+		t.Fatalf("base candidate unavailable: candidate=%+v err=%v", base, err)
+	}
+	alternate := *base
+	alternate.ID = uuid.New()
+	alternate.SourceContactID = "alternate-" + alternate.ID.String()
+	alternate.Email = "alternate-" + alternate.ID.String() + "@empresa.example"
+	alternate.SourceURL = "https://empresa.example/alternate/" + alternate.ID.String()
+	if mutate != nil {
+		mutate(&alternate)
+	}
+	if _, err := f.repo.UpsertCandidate(f.ctx, &alternate); err != nil {
+		t.Fatal(err)
+	}
+	return &alternate
+}
 
 func enableDelegatedRunwayFixture(t *testing.T, f *delegatedPGFixture, days, dailyLimit int) {
 	t.Helper()
@@ -467,5 +502,97 @@ func TestDelegatedFirstTouchRunwayNeverSelectsFollowupsPostgres(t *testing.T) {
 	}
 	if touchpointID != base.ID {
 		t.Fatalf("runway selected non-first-touch row: got=%s first=%s followup=%s", touchpointID, base.ID, followup.ID)
+	}
+}
+
+func TestDelegatedFirstTouchRunwayRebindsOnlyToCurrentControlledCandidatePostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	qualifyDelegatedPGFixture(t, f)
+	prepareDelegatedRunwayCandidates(t, f, 1)
+
+	// Institutional controlled routes intentionally do not inherit the strict
+	// named-person EMAIL_SEND_READY bit.
+	alternate := insertDelegatedAlternateCandidate(t, f, func(c *models.OutreachContactCandidate) {
+		c.EmailSendReady = false
+	})
+	if _, err := f.pool.Exec(f.ctx, `
+		UPDATE outreach_contact_candidates SET blocked=true
+		WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].ContactCandidateID); err != nil {
+		t.Fatal(err)
+	}
+	feed, auth := delegatedRunwayAuthority(t, f)
+	touchpointID, _, candidateID, err := f.svc.nextDelegatedFirstTouchCandidate(f.ctx, f.orgID, feed, auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidateID != alternate.ID {
+		t.Fatalf("selected candidate=%s want current controlled alternate=%s", candidateID, alternate.ID)
+	}
+	reserved, err := f.repo.GetTouchpoint(f.ctx, f.orgID, touchpointID)
+	if err != nil || reserved == nil || reserved.ContactCandidateID == nil {
+		t.Fatalf("reserved touchpoint unavailable: touchpoint=%+v err=%v", reserved, err)
+	}
+	if *reserved.ContactCandidateID != f.manifest.Entries[0].ContactCandidateID {
+		t.Fatalf("reservation rebound recipient before prepare: got=%s want old=%s", *reserved.ContactCandidateID, f.manifest.Entries[0].ContactCandidateID)
+	}
+}
+
+func TestDelegatedFirstTouchRunwayRejectsHistoricalAndUnsafeAlternatesPostgres(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*models.OutreachContactCandidate)
+	}{
+		{"historical_import", func(c *models.OutreachContactCandidate) { id := uuid.New(); c.LastImportRunID = &id }},
+		{"not_controlled", func(c *models.OutreachContactCandidate) {
+			c.DiscoveryJSON = []byte(`{"route_class":"GENERIC_COMPANY","preferred_initial":true}`)
+		}},
+		{"company_evidence_missing", func(c *models.OutreachContactCandidate) {
+			c.DiscoveryJSON = []byte(`{"route_class":"GENERIC_COMPANY","controlled_email_eligible":true,"preferred_initial":true}`)
+		}},
+		{"inferred", func(c *models.OutreachContactCandidate) { c.EmailDerivation = "INFERRED" }},
+		{"suppressed", func(c *models.OutreachContactCandidate) { c.RouteSuppression = "DNC" }},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newDelegatedPGFixture(t)
+			qualifyDelegatedPGFixture(t, f)
+			prepareDelegatedRunwayCandidates(t, f, 1)
+			if _, err := f.pool.Exec(f.ctx, `
+				UPDATE outreach_contact_candidates SET blocked=true
+				WHERE organization_id=$1 AND id=$2`, f.orgID, f.manifest.Entries[0].ContactCandidateID); err != nil {
+				t.Fatal(err)
+			}
+			insertDelegatedAlternateCandidate(t, f, tc.mutate)
+			feed, auth := delegatedRunwayAuthority(t, f)
+			if _, _, _, err := f.svc.nextDelegatedFirstTouchCandidate(f.ctx, f.orgID, feed, auth); !errors.Is(err, pgx.ErrNoRows) {
+				t.Fatalf("unsafe alternate became selectable: %v", err)
+			}
+			ready, err := f.svc.delegatedFirstTouchReadyReservoirCount(f.ctx, f.orgID, feed, auth)
+			if err != nil || ready != 0 {
+				t.Fatalf("reservoir drifted from selector: ready=%d err=%v", ready, err)
+			}
+		})
+	}
+}
+
+func TestDelegatedFirstTouchRunwayHoldConsumesCandidateNotAccountPostgres(t *testing.T) {
+	f := newDelegatedPGFixture(t)
+	qualifyDelegatedPGFixture(t, f)
+	prepareDelegatedRunwayCandidates(t, f, 1)
+	alternate := insertDelegatedAlternateCandidate(t, f, nil)
+
+	manifest := f.manifest
+	entry := manifest.Entries[0]
+	entry.IdempotencyKey = "old-candidate-hold-" + uuid.NewString()
+	if err := f.svc.persistDelegatedHold(f.ctx, f.orgID, manifest, entry, []string{"recipient_not_controlled_eligible"}); err != nil {
+		t.Fatal(err)
+	}
+	feed, auth := delegatedRunwayAuthority(t, f)
+	_, _, candidateID, err := f.svc.nextDelegatedFirstTouchCandidate(f.ctx, f.orgID, feed, auth)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if candidateID != alternate.ID {
+		t.Fatalf("old candidate HOLD blocked safe alternate: got=%s want=%s", candidateID, alternate.ID)
 	}
 }

--- a/internal/app/confenge/delegated_first_touch_test.go
+++ b/internal/app/confenge/delegated_first_touch_test.go
@@ -92,6 +92,24 @@ func TestDelegatedDraftIdentityIsStableWithinRunAndDistinctAcrossRuns(t *testing
 	}
 }
 
+func TestDelegatedRunwayIdempotencyPreservesPublicationBindingAndAddsCandidate(t *testing.T) {
+	accountID, oldCandidateID, safeCandidateID := uuid.New(), uuid.New(), uuid.New()
+	old := DelegatedFirstTouchEntry{
+		IdempotencyKey: "delegated-first-touch:runway-v1:old-binding:" + accountID.String(),
+		AccountID:      accountID, ContactCandidateID: oldCandidateID,
+	}
+	safe := old
+	safe.ContactCandidateID = safeCandidateID
+	oldKey := delegatedFirstTouchEffectiveIdempotencyKey(old)
+	safeKey := delegatedFirstTouchEffectiveIdempotencyKey(safe)
+	if oldKey == safeKey {
+		t.Fatalf("old HOLD would still block safe replacement candidate: %q", oldKey)
+	}
+	if !strings.HasPrefix(oldKey, old.IdempotencyKey+":candidate:") || !strings.Contains(oldKey, oldCandidateID.String()) {
+		t.Fatalf("runway key must preserve publication binding and identify candidate: %q", oldKey)
+	}
+}
+
 func TestDelegatedPolicyBindsTemplateAndExplicitGreenTemplateAuthority(t *testing.T) {
 	now := time.Now().UTC()
 	orgID, founderID := uuid.New(), uuid.New()

--- a/internal/app/confenge/delegated_first_touch_worker.go
+++ b/internal/app/confenge/delegated_first_touch_worker.go
@@ -21,6 +21,65 @@ const (
 	delegatedFirstTouchRetryDelay        = 15 * time.Minute
 )
 
+// delegatedFirstTouchSafeCandidateLateralSQL is the authoritative recipient
+// selector shared by the worker and the runway readback. It deliberately does
+// not trust the candidate currently attached to an unadmitted touchpoint: a
+// later import may have replaced that route with a safer one. Conversely, a
+// historical candidate can never be revived merely because its email still
+// looks usable; current import lineage and the complete controlled-route
+// provenance are required.
+const delegatedFirstTouchSafeCandidateLateralSQL = `
+		JOIN LATERAL (
+			SELECT c.id
+			FROM outreach_contact_candidates c
+			WHERE c.organization_id=t.organization_id AND c.account_id=t.account_id
+			  AND a.last_import_run_id IS NOT NULL
+			  AND c.last_import_run_id=a.last_import_run_id
+			  AND c.email<>'' AND c.email ~* '^[^[:space:]@]+@[^[:space:]@]+[.][^[:space:]@]+$'
+			  AND NOT c.blocked AND NOT c.do_not_contact AND NOT c.bounced
+			  AND upper(COALESCE(c.ownership_status,''))='COMPANY_OWNED'
+			  AND upper(COALESCE(c.channel_epistemic_class,''))='OBSERVED'
+			  AND upper(COALESCE(c.route_freshness,''))='FRESH'
+			  AND upper(COALESCE(c.email_derivation,''))<>'INFERRED'
+			  AND upper(COALESCE(c.route_suppression,'')) IN ('','NONE')
+			  AND c.discovery_json @> '{"controlled_email_eligible":true}'::jsonb
+			  AND c.discovery_json @> '{"preferred_initial":true}'::jsonb
+			  AND upper(COALESCE(c.discovery_json->>'mailbox_company_evidence',''))='OBSERVED'
+			  AND upper(COALESCE(c.discovery_json->>'route_class','')) IN
+			    ('ROLE_OR_DEPARTMENT','GENERIC_COMPANY','PUBLIC_COMPANY_FREEMAIL')
+			  AND upper(COALESCE(c.verification_status,''))='OFFICIAL_SOURCE'
+			  AND c.source_date IS NOT NULL
+			  AND (
+			    (c.source_url ~* '^https?://[^/[:space:]]+' AND lower(c.source_url) !~
+			      'google[.]|bing[.]|duckduckgo[.]|search[.]yahoo[.]')
+			    OR (c.source_url='' AND upper(c.verification_status)='OFFICIAL_SOURCE')
+			  )
+			  AND lower(btrim(c.email)) NOT LIKE 'fixture@%'
+			  AND lower(btrim(c.email)) NOT LIKE 'synthetic@%'
+			  AND NOT (lower(btrim(c.email)) LIKE '%@demo%' AND lower(btrim(c.email)) LIKE '%obra.com.br')
+			  AND lower(COALESCE(c.block_reason,'')) NOT LIKE '%provenance_taint%'
+			  AND lower(COALESCE(c.block_reason,'')) NOT LIKE '%provenance_chain%'
+			  AND upper(COALESCE(c.block_reason,'')) NOT LIKE '%PROVENANCE_CONTAMINATION%'
+			  -- A terminal HOLD/CANCELLED consumes this recipient binding, not
+			  -- every other current-safe recipient on the same account.
+			  AND NOT EXISTS (
+			    SELECT 1 FROM confenge_delegated_first_touch_decisions candidate_decision
+			    WHERE candidate_decision.organization_id=c.organization_id
+			      AND candidate_decision.account_id=c.account_id
+			      AND candidate_decision.contact_candidate_id=c.id
+			      AND candidate_decision.evidence_source_run_id=$2
+			      AND candidate_decision.source_snapshot_hash=$3
+			      AND candidate_decision.runtime_release_sha=$4
+			      AND candidate_decision.policy_authorization_id=$5
+			  )
+			ORDER BY
+			  CASE WHEN c.recommended THEN 0 ELSE 1 END,
+			  CASE upper(COALESCE(c.discovery_json->>'route_class',''))
+			    WHEN 'ROLE_OR_DEPARTMENT' THEN 0 WHEN 'GENERIC_COMPANY' THEN 1 ELSE 2 END,
+			  lower(btrim(c.email)),c.id
+			LIMIT 1
+		) selected_candidate ON true`
+
 type delegatedFirstTouchProcessor interface {
 	ProcessDelegatedFirstTouchOnce(context.Context) (bool, error)
 }
@@ -186,11 +245,10 @@ func (s *service) nextDelegatedFirstTouchCandidate(ctx context.Context, orgID uu
 	now := time.Now().UTC()
 	err := s.delegatedDB.QueryRow(ctx, `
 		WITH next AS (
-			SELECT t.id
+			SELECT t.id,selected_candidate.id AS candidate_id
 			FROM outreach_touchpoints t
 			JOIN outreach_accounts a ON a.organization_id=t.organization_id AND a.id=t.account_id
-			JOIN outreach_contact_candidates c
-			  ON c.organization_id=t.organization_id AND c.id=t.contact_candidate_id
+			`+delegatedFirstTouchSafeCandidateLateralSQL+`
 			JOIN outreach_feed_sync_state feed ON feed.organization_id=t.organization_id
 			JOIN outreach_feed_committed_runs account_lineage
 			  ON account_lineage.organization_id=a.organization_id AND account_lineage.source_run_id=a.source_run_id
@@ -198,25 +256,19 @@ func (s *service) nextDelegatedFirstTouchCandidate(ctx context.Context, orgID uu
 			  ON touchpoint_lineage.organization_id=t.organization_id AND touchpoint_lineage.source_run_id=t.source_run_id
 			WHERE t.organization_id=$1
 			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
-			  AND t.state IN ('DUE','NEEDS_REVIEW') AND t.contact_candidate_id IS NOT NULL
+			  AND t.state IN ('DUE','NEEDS_REVIEW')
 			  AND `+authoritativeLastGoodFeedSQL+`
 			  AND confenge_commercially_qualified(a.commercial_qualification_state,
 			    a.commercial_qualified_until,a.commercial_qualification_deactivated,$6::date)
 			  AND a.initial_backlog_reason_code=''
 			  AND a.last_import_run_id IS NOT NULL
 			  AND a.queue_state NOT IN ('SENT','REPLIED','MEETING','PROPOSAL','WON','LOST','ENROLLED')
-			  -- Recipient safety is real invalidity, not run-id equality; a
-			  -- silent drop leaves no evidence the mailbox became unusable.
-			  AND c.email<>'' AND NOT c.blocked AND NOT c.do_not_contact AND NOT c.bounced
-			  AND upper(c.route_suppression) IN ('','NONE')
 			  AND t.delegated_retry_at <= $6
 			  AND (t.delegated_reserved_until IS NULL OR t.delegated_reserved_until <= $6)
 			  AND NOT EXISTS (
 			    SELECT 1 FROM confenge_delegated_first_touch_decisions d
 			    WHERE d.organization_id=t.organization_id AND d.account_id=t.account_id
-			      AND (d.state='SENT'
-			        OR (d.evidence_source_run_id=$2 AND d.source_snapshot_hash=$3
-			          AND d.runtime_release_sha=$4 AND d.policy_authorization_id=$5))
+			      AND d.state IN ('SENT','APPROVED','QUEUED','APPROVED_NOT_SCHEDULED')
 			  )
 			ORDER BY t.delegated_retry_at,t.due_at,t.created_at,t.id
 			LIMIT 1 FOR UPDATE OF t SKIP LOCKED
@@ -225,7 +277,7 @@ func (s *service) nextDelegatedFirstTouchCandidate(ctx context.Context, orgID uu
 		SET delegated_reserved_until=$7,delegated_attempts=t.delegated_attempts+1,
 			delegated_last_error='',updated_at=$6
 		FROM next WHERE t.id=next.id
-		RETURNING t.id,t.account_id,t.contact_candidate_id`, orgID, feed.LastRunID, feed.LastSnapshotHash,
+		RETURNING t.id,t.account_id,next.candidate_id`, orgID, feed.LastRunID, feed.LastSnapshotHash,
 		s.cfg.RepositorySHA, auth.ID, now, now.Add(delegatedFirstTouchLease)).Scan(&touchpointID, &accountID, &candidateID)
 	return touchpointID, accountID, candidateID, err
 }

--- a/internal/app/confenge/dispatch/governor.go
+++ b/internal/app/confenge/dispatch/governor.go
@@ -184,6 +184,16 @@ func (g *Governor) Commit(ctx context.Context, reservationID uuid.UUID) error {
 	return g.store.CommitReservation(ctx, reservationID, g.clock.Now().UTC())
 }
 
+// StartHandoff creates the durable no-resend fence immediately before the
+// transport enters SMTP DATA.
+func (g *Governor) StartHandoff(ctx context.Context, reservationID, queueID uuid.UUID) error {
+	return g.store.StartHandoff(ctx, reservationID, queueID, g.clock.Now().UTC())
+}
+
+func (g *Governor) FinalizeHandoff(ctx context.Context, reservationID uuid.UUID, errText string) (bool, error) {
+	return g.store.FinalizeHandoff(ctx, reservationID, StateFailed, errText)
+}
+
 // CommitByMessageKey records provider-confirmed delivery for an async transport.
 func (g *Governor) CommitByMessageKey(ctx context.Context, messageKey string) error {
 	if g == nil {

--- a/internal/app/confenge/dispatch/memory_store.go
+++ b/internal/app/confenge/dispatch/memory_store.go
@@ -90,7 +90,7 @@ func (m *MemoryStore) SetPaused(ctx context.Context, paused bool, reason string,
 
 func (m *MemoryStore) expireLocked(now time.Time) {
 	for _, r := range m.reservations {
-		if r.State == StateReserved && !r.LeaseUntil.After(now) {
+		if r.State == StateReserved && r.AttemptedAt == nil && !r.LeaseUntil.After(now) {
 			r.State = StateReleased
 			r.LastError = "lease_expired"
 		}
@@ -110,13 +110,19 @@ func (m *MemoryStore) occupiedLocked(now time.Time, window time.Duration) ([]tim
 		}
 	}
 	for _, r := range m.reservations {
-		if r.State != StateReserved || !r.LeaseUntil.After(now) {
+		attempted := r.AttemptedAt != nil && r.State != StateCommitted
+		reserved := r.State == StateReserved && r.AttemptedAt == nil && r.LeaseUntil.After(now)
+		if !attempted && !reserved {
 			continue
 		}
-		if !r.ReservedAt.Before(cutoff) && !r.ReservedAt.After(now) {
-			times = append(times, r.ReservedAt)
-			if r.ReservedAt.After(last) {
-				last = r.ReservedAt
+		observed := r.ReservedAt
+		if r.AttemptedAt != nil {
+			observed = *r.AttemptedAt
+		}
+		if !observed.Before(cutoff) && !observed.After(now) {
+			times = append(times, observed)
+			if observed.After(last) {
+				last = observed
 			}
 		}
 	}
@@ -148,6 +154,10 @@ func (m *MemoryStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInpu
 
 	if existing := m.reservations[in.Req.MessageKey]; existing != nil &&
 		existing.State == StateReserved && existing.LeaseUntil.After(now) {
+		if existing.AttemptedAt != nil {
+			out.Reason = "handoff_already_started"
+			return out, nil
+		}
 		mailboxConflict := in.Req.Channel == ChannelEmail && in.Req.EmailAccountID != nil &&
 			(existing.EmailAccountID == nil || *existing.EmailAccountID != *in.Req.EmailAccountID)
 		taskConflict := in.Req.TaskID != nil && (existing.TaskID == nil || *existing.TaskID != *in.Req.TaskID)
@@ -164,6 +174,10 @@ func (m *MemoryStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInpu
 		out.SentLastHour = countTimes(m.sendTimes, now.Add(-window), now)
 		return out, nil
 	}
+	if existing := m.reservations[in.Req.MessageKey]; existing != nil && existing.AttemptedAt != nil {
+		out.Reason = "handoff_already_started"
+		return out, nil
+	}
 
 	if in.Req.Channel == ChannelEmail && in.Mailbox != nil {
 		var mailboxTimes []time.Time
@@ -177,8 +191,9 @@ func (m *MemoryStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInpu
 			}
 		}
 		for _, reservation := range m.reservations {
-			if reservation.EmailAccountID == nil || *reservation.EmailAccountID != in.Mailbox.EmailAccountID ||
-				reservation.State != StateReserved || !reservation.LeaseUntil.After(now) {
+			attempted := reservation.AttemptedAt != nil && reservation.State != StateCommitted
+			reserved := reservation.State == StateReserved && reservation.AttemptedAt == nil && reservation.LeaseUntil.After(now)
+			if reservation.EmailAccountID == nil || *reservation.EmailAccountID != in.Mailbox.EmailAccountID || (!attempted && !reserved) {
 				continue
 			}
 			observed := reservation.ReservedAt
@@ -311,19 +326,63 @@ func (m *MemoryStore) RefreshReservation(ctx context.Context, id uuid.UUID, leas
 	return nil
 }
 
+func (m *MemoryStore) StartHandoff(_ context.Context, reservationID, queueID uuid.UUID, attemptedAt time.Time) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.byResID[reservationID]
+	q := m.queueByID[queueID]
+	if r == nil || q == nil || r.MessageKey != q.MessageKey {
+		return fmt.Errorf("dispatch handoff binding not found")
+	}
+	if r.State == StateCommitted || q.Status == QueueSent {
+		return nil
+	}
+	if r.State != StateReserved || q.Status != QueueReserved {
+		return fmt.Errorf("dispatch handoff is not reserved")
+	}
+	value := attemptedAt.UTC()
+	if value.IsZero() {
+		value = time.Now().UTC()
+	}
+	r.AttemptedAt = &value
+	q.Status = QueueAttempted
+	q.ReservedUntil = nil
+	return nil
+}
+
+func (m *MemoryStore) FinalizeHandoff(_ context.Context, reservationID uuid.UUID, state, errText string) (bool, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	r := m.byResID[reservationID]
+	if r == nil {
+		return false, fmt.Errorf("dispatch reservation not found")
+	}
+	if r.AttemptedAt == nil || r.State == StateCommitted {
+		return false, nil
+	}
+	if state == "" {
+		state = StateFailed
+	}
+	r.State = state
+	r.LastError = errText
+	return true, nil
+}
+
 func (m *MemoryStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt time.Time) error {
 	return m.CommitReservationWithEvidence(ctx, id, sentAt, SendEvidence{})
 }
 
 // CommitReservationWithEvidence mirrors the PG behaviour; the in-memory store
 // keeps no evidence columns, so the evidence is accepted and ignored.
-func (m *MemoryStore) CommitReservationWithEvidence(ctx context.Context, id uuid.UUID, sentAt time.Time, _ SendEvidence) error {
-	m.closeQueueForKey(id)
+func (m *MemoryStore) CommitReservationWithEvidence(ctx context.Context, id uuid.UUID, sentAt time.Time, ev SendEvidence) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	r := m.byResID[id]
 	if r == nil {
 		return fmt.Errorf("reservation not found")
+	}
+	if ev.QueueID != nil && r.AttemptedAt == nil {
+		return fmt.Errorf("provider acceptance cannot commit before durable handoff")
 	}
 	if r.State == StateCommitted {
 		current, sent := m.sends[r.MessageKey]
@@ -354,6 +413,13 @@ func (m *MemoryStore) CommitReservationWithEvidence(ctx context.Context, id uuid
 		m.sendMailboxes[r.MessageKey] = *r.EmailAccountID
 	}
 	m.sendTimes = append(m.sendTimes, sentAt)
+	if q := m.queue[r.MessageKey]; q != nil {
+		switch q.Status {
+		case QueueQueued, QueueReserved, QueueAttempted:
+			q.Status = QueueSent
+			q.ReservedUntil = nil
+		}
+	}
 	return nil
 }
 
@@ -365,6 +431,9 @@ func (m *MemoryStore) ReleaseReservation(ctx context.Context, id uuid.UUID, stat
 		return fmt.Errorf("reservation not found")
 	}
 	if r.State == StateCommitted {
+		return nil
+	}
+	if r.AttemptedAt != nil {
 		return nil
 	}
 	if state == "" {
@@ -389,7 +458,7 @@ func (m *MemoryStore) ExpireStaleReservations(ctx context.Context, now time.Time
 	defer m.mu.Unlock()
 	n := 0
 	for _, r := range m.reservations {
-		if r.State == StateReserved && !r.LeaseUntil.After(now) {
+		if r.State == StateReserved && r.AttemptedAt == nil && !r.LeaseUntil.After(now) {
 			r.State = StateReleased
 			r.LastError = "lease_expired"
 			n++
@@ -405,7 +474,7 @@ func (m *MemoryStore) Enqueue(ctx context.Context, item *QueueItem) error {
 		// 'attempted' is terminal for enqueue: the message is already with the
 		// transport and its acceptance is merely unobserved. Re-queueing it would
 		// dispatch the same message a second time.
-		if existing.Status == QueueAttempted || existing.Status == QueueSent || existing.Status == QueueCancelled {
+		if existing.Status == QueueAttempted || existing.Status == QueueSent || existing.Status == QueueCancelled || existing.Status == QueueFailed {
 			return nil
 		}
 		existing.DueAt = item.DueAt
@@ -487,6 +556,13 @@ func (m *MemoryStore) CountQueued(ctx context.Context, orgID *uuid.UUID) (int, e
 func (m *MemoryStore) ClaimNextQueued(ctx context.Context, now time.Time) (*QueueItem, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	for _, q := range m.queue {
+		if q.Status == QueueReserved && q.ReservedUntil != nil && !q.ReservedUntil.After(now) {
+			q.Status = QueueQueued
+			q.ReservedUntil = nil
+			q.LastError = "claim_lease_expired"
+		}
+	}
 	var candidates []*QueueItem
 	for _, q := range m.queue {
 		if q.Status != QueueQueued || q.DueAt.After(now) {
@@ -510,6 +586,8 @@ func (m *MemoryStore) ClaimNextQueued(ctx context.Context, now time.Time) (*Queu
 	chosen := candidates[0]
 	chosen.Status = QueueReserved
 	chosen.Attempts++
+	leaseUntil := now.Add(DefaultLeaseTTL)
+	chosen.ReservedUntil = &leaseUntil
 	cp := *chosen
 	return &cp, nil
 }
@@ -521,7 +599,14 @@ func (m *MemoryStore) UpdateQueueStatus(ctx context.Context, id uuid.UUID, statu
 	if q == nil {
 		return fmt.Errorf("queue item not found")
 	}
+	if (q.Status == QueueAttempted || q.Status == QueueSent || q.Status == QueueFailed) &&
+		(status == QueueQueued || status == QueueReserved) {
+		return nil
+	}
 	q.Status = status
+	if status != QueueReserved {
+		q.ReservedUntil = nil
+	}
 	if errText != "" {
 		q.LastError = errText
 	}
@@ -530,25 +615,6 @@ func (m *MemoryStore) UpdateQueueStatus(ctx context.Context, id uuid.UUID, statu
 
 // GetQueueByKey returns a copy of the queue row for a message key. It exists
 // for inspection and tests; the Store interface does not expose it.
-// closeQueueForKey mirrors the PG commit transaction, which closes the queue
-// row sharing the reservation's message key.
-func (m *MemoryStore) closeQueueForKey(reservationID uuid.UUID) {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	r := m.byResID[reservationID]
-	if r == nil {
-		return
-	}
-	q := m.queue[r.MessageKey]
-	if q == nil {
-		return
-	}
-	switch q.Status {
-	case QueueQueued, QueueReserved, QueueAttempted:
-		q.Status = QueueSent
-	}
-}
-
 func (m *MemoryStore) GetQueueByKey(_ context.Context, messageKey string) (*QueueItem, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -596,9 +662,13 @@ func (m *MemoryStore) RetryQueue(ctx context.Context, id uuid.UUID, dueAt time.T
 	if q == nil {
 		return fmt.Errorf("queue item not found")
 	}
+	if q.Status != QueueReserved {
+		return nil
+	}
 	q.Status = QueueQueued
 	q.DueAt = dueAt.UTC()
 	q.LastError = errText
+	q.ReservedUntil = nil
 	return nil
 }
 
@@ -635,7 +705,7 @@ func (m *MemoryStore) CountActiveLeases(ctx context.Context, now time.Time) (int
 	defer m.mu.Unlock()
 	n := 0
 	for _, r := range m.reservations {
-		if r.State == StateReserved && r.LeaseUntil.After(now) {
+		if r.State == StateReserved && (r.AttemptedAt != nil || r.LeaseUntil.After(now)) {
 			n++
 		}
 	}

--- a/internal/app/confenge/dispatch/pg_store.go
+++ b/internal/app/confenge/dispatch/pg_store.go
@@ -73,9 +73,11 @@ func (s *PGStore) ListOccupied(ctx context.Context, now time.Time, window time.D
 		SELECT sent_at FROM confenge_dispatch_sends
 		WHERE sent_at >= $1 AND sent_at <= $2
 		UNION ALL
-		SELECT reserved_at FROM confenge_dispatch_reservations
-		WHERE state = 'reserved' AND lease_until > $2
-		  AND reserved_at >= $1 AND reserved_at <= $2`,
+		SELECT COALESCE(attempted_at, reserved_at) FROM confenge_dispatch_reservations
+		WHERE ((attempted_at IS NOT NULL AND state <> 'committed')
+		       OR (attempted_at IS NULL AND state = 'reserved' AND lease_until > $2))
+		  AND COALESCE(attempted_at, reserved_at) >= $1
+		  AND COALESCE(attempted_at, reserved_at) <= $2`,
 		cutoff, now,
 	)
 	if err != nil {
@@ -158,7 +160,7 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 	_, _ = tx.Exec(ctx, `
 		UPDATE confenge_dispatch_reservations
 		SET state = 'released', last_error = 'lease_expired'
-			WHERE state = 'reserved' AND lease_until <= $1`, now)
+			WHERE state = 'reserved' AND attempted_at IS NULL AND lease_until <= $1`, now)
 
 	// Provider-confirmed replays remain final after later mailbox disablement.
 	var sentAt time.Time
@@ -216,6 +218,13 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 	).Scan(&existing.ID, &existing.OrganizationID, &existing.EmailAccountID, &existing.TaskID, &existing.Channel, &existing.MessageKey,
 		&draftID, &existing.State, &existing.ReservedAt, &existing.AttemptedAt, &existing.LeaseUntil)
 	if err == nil && existing.State == StateReserved && existing.LeaseUntil.After(now) {
+		if existing.AttemptedAt != nil {
+			out.Reason = "handoff_already_started"
+			if err := tx.Commit(ctx); err != nil {
+				return out, err
+			}
+			return out, nil
+		}
 		mailboxConflict := in.Req.Channel == ChannelEmail && in.Req.EmailAccountID != nil &&
 			(existing.EmailAccountID == nil || *existing.EmailAccountID != *in.Req.EmailAccountID)
 		taskConflict := in.Req.TaskID != nil && (existing.TaskID == nil || *existing.TaskID != *in.Req.TaskID)
@@ -242,6 +251,13 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 	}
 	if err != nil && !errors.Is(err, pgx.ErrNoRows) {
 		return out, err
+	}
+	if err == nil && existing.AttemptedAt != nil {
+		out.Reason = "handoff_already_started"
+		if err := tx.Commit(ctx); err != nil {
+			return out, err
+		}
+		return out, nil
 	}
 
 	if in.Req.Channel == ChannelEmail && in.Mailbox != nil {
@@ -285,9 +301,11 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 		SELECT sent_at FROM confenge_dispatch_sends
 		WHERE sent_at >= $1 AND sent_at <= $2
 		UNION ALL
-		SELECT reserved_at FROM confenge_dispatch_reservations
-		WHERE state = 'reserved' AND lease_until > $2
-		  AND reserved_at >= $1 AND reserved_at <= $2`,
+		SELECT COALESCE(attempted_at, reserved_at) FROM confenge_dispatch_reservations
+		WHERE ((attempted_at IS NOT NULL AND state <> 'committed')
+		       OR (attempted_at IS NULL AND state = 'reserved' AND lease_until > $2))
+		  AND COALESCE(attempted_at, reserved_at) >= $1
+		  AND COALESCE(attempted_at, reserved_at) <= $2`,
 		now.Add(-window), now,
 	)
 	if err != nil {
@@ -330,8 +348,8 @@ func (s *PGStore) TryReserveAtomic(ctx context.Context, in AtomicReserveInput) (
 	_, _ = tx.Exec(ctx, `
 		DELETE FROM confenge_dispatch_reservations
 		WHERE message_key = $1 AND (
-			state IN ('released', 'failed')
-			OR (state = 'reserved' AND lease_until <= $2)
+			(state IN ('released', 'failed') AND attempted_at IS NULL)
+			OR (state = 'reserved' AND attempted_at IS NULL AND lease_until <= $2)
 		)`, in.Req.MessageKey, now)
 
 	resID := uuid.New()
@@ -365,8 +383,55 @@ func (s *PGStore) RefreshReservation(ctx context.Context, id uuid.UUID, leaseUnt
 	_, err := s.db.Exec(ctx, `
 		UPDATE confenge_dispatch_reservations
 		SET lease_until = $2, worker_token = COALESCE(NULLIF($3,''), worker_token)
-		WHERE id = $1 AND state = 'reserved'`, id, leaseUntil, workerToken)
+		WHERE id = $1 AND state = 'reserved' AND attempted_at IS NULL`, id, leaseUntil, workerToken)
 	return err
+}
+
+func (s *PGStore) StartHandoff(ctx context.Context, reservationID, queueID uuid.UUID, attemptedAt time.Time) error {
+	if attemptedAt.IsZero() {
+		attemptedAt = time.Now().UTC()
+	}
+	tx, err := s.db.Begin(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+	var messageKey string
+	err = tx.QueryRow(ctx, `
+		UPDATE confenge_dispatch_reservations
+		SET attempted_at = COALESCE(attempted_at, $2)
+		WHERE id = $1 AND state = 'reserved'
+		RETURNING message_key`, reservationID, attemptedAt.UTC()).Scan(&messageKey)
+	if err != nil {
+		return fmt.Errorf("start dispatch handoff reservation: %w", err)
+	}
+	tag, err := tx.Exec(ctx, `
+		UPDATE confenge_dispatch_queue
+		SET status='attempted', reserved_until=NULL,
+		    last_error='handoff_started', updated_at=now()
+		WHERE id=$1 AND message_key=$2 AND status IN ('reserved','attempted')`, queueID, messageKey)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() != 1 {
+		return fmt.Errorf("start dispatch handoff queue binding not found")
+	}
+	return tx.Commit(ctx)
+}
+
+func (s *PGStore) FinalizeHandoff(ctx context.Context, reservationID uuid.UUID, state, errText string) (bool, error) {
+	if state == "" {
+		state = StateFailed
+	}
+	tag, err := s.db.Exec(ctx, `
+		UPDATE confenge_dispatch_reservations
+		SET state=$2, last_error=$3
+		WHERE id=$1 AND attempted_at IS NOT NULL AND state <> 'committed'`,
+		reservationID, state, errText)
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
 }
 
 func (s *PGStore) CommitReservation(ctx context.Context, id uuid.UUID, sentAt time.Time) error {
@@ -383,13 +448,16 @@ func (s *PGStore) CommitReservationWithEvidence(ctx context.Context, id uuid.UUI
 	var r Reservation
 	var draftID *uuid.UUID
 	err = tx.QueryRow(ctx, `
-		SELECT id, organization_id, email_account_id, task_id, channel, message_key, draft_id, state
+		SELECT id, organization_id, email_account_id, task_id, channel, message_key, draft_id, state, attempted_at
 		FROM confenge_dispatch_reservations WHERE id = $1 FOR UPDATE`, id,
-	).Scan(&r.ID, &r.OrganizationID, &r.EmailAccountID, &r.TaskID, &r.Channel, &r.MessageKey, &draftID, &r.State)
+	).Scan(&r.ID, &r.OrganizationID, &r.EmailAccountID, &r.TaskID, &r.Channel, &r.MessageKey, &draftID, &r.State, &r.AttemptedAt)
 	if err != nil {
 		return err
 	}
 	r.DraftID = draftID
+	if ev.QueueID != nil && r.AttemptedAt == nil {
+		return fmt.Errorf("provider acceptance cannot commit before durable handoff")
+	}
 	if r.State == StateCommitted {
 		_, err = tx.Exec(ctx, `
 			UPDATE confenge_dispatch_sends
@@ -425,9 +493,11 @@ func (s *PGStore) CommitReservationWithEvidence(ctx context.Context, id uuid.UUI
 	if err != nil {
 		return err
 	}
-	_, _ = tx.Exec(ctx, `
+	if _, err = tx.Exec(ctx, `
 		UPDATE confenge_dispatch_queue SET status = 'sent', updated_at = now()
-		WHERE message_key = $1 AND status IN ('queued','reserved','attempted')`, r.MessageKey)
+		WHERE message_key = $1 AND status IN ('queued','reserved','attempted')`, r.MessageKey); err != nil {
+		return err
+	}
 	return tx.Commit(ctx)
 }
 
@@ -445,7 +515,7 @@ func (s *PGStore) ReleaseReservation(ctx context.Context, id uuid.UUID, state, e
 	var channel, messageKey string
 	err = tx.QueryRow(ctx, `
 		UPDATE confenge_dispatch_reservations SET state = $2, last_error = $3
-		WHERE id = $1 AND state = 'reserved'
+		WHERE id = $1 AND state = 'reserved' AND attempted_at IS NULL
 		RETURNING organization_id, email_account_id, task_id, channel, message_key, draft_id`,
 		id, state, errText).Scan(&orgID, &emailAccountID, &taskID, &channel, &messageKey, &draftID)
 	if errors.Is(err, pgx.ErrNoRows) {
@@ -471,7 +541,7 @@ func (s *PGStore) ExpireStaleReservations(ctx context.Context, now time.Time) (i
 	tag, err := s.db.Exec(ctx, `
 		UPDATE confenge_dispatch_reservations
 		SET state = 'released', last_error = 'lease_expired'
-		WHERE state = 'reserved' AND lease_until <= $1`, now)
+		WHERE state = 'reserved' AND attempted_at IS NULL AND lease_until <= $1`, now)
 	if err != nil {
 		return 0, err
 	}
@@ -500,7 +570,7 @@ func (s *PGStore) Enqueue(ctx context.Context, item *QueueItem) error {
 				-- 'attempted' is terminal for enqueue: the message is already with the
 				-- transport and its acceptance is merely unobserved. Re-queueing it
 				-- would dispatch the same message a second time.
-				WHEN confenge_dispatch_queue.status IN ('attempted','sent','cancelled') THEN confenge_dispatch_queue.status
+				WHEN confenge_dispatch_queue.status IN ('attempted','sent','cancelled','failed') THEN confenge_dispatch_queue.status
 				ELSE 'queued'
 			END,
 			cancel_reason = CASE
@@ -613,7 +683,8 @@ func (s *PGStore) UpdateQueueStatus(ctx context.Context, id uuid.UUID, status, e
 			last_error = CASE WHEN $3 <> '' THEN $3 ELSE last_error END,
 			reserved_until = CASE WHEN $2 = 'reserved' THEN reserved_until ELSE NULL END,
 			updated_at = now()
-		WHERE id = $1`, id, status, errText)
+		WHERE id = $1
+		  AND NOT (status IN ('attempted','sent','failed') AND $2 IN ('queued','reserved'))`, id, status, errText)
 	return err
 }
 
@@ -687,7 +758,7 @@ func firstNonEmptyString(value, fallback string) string {
 
 func (s *PGStore) CountActiveLeases(ctx context.Context, now time.Time) (int, error) {
 	var n int
-	err := s.db.QueryRow(ctx, `SELECT count(*) FROM confenge_dispatch_reservations WHERE state = 'reserved' AND lease_until > $1`, now).Scan(&n)
+	err := s.db.QueryRow(ctx, `SELECT count(*) FROM confenge_dispatch_reservations WHERE state = 'reserved' AND (attempted_at IS NOT NULL OR lease_until > $1)`, now).Scan(&n)
 	return n, err
 }
 

--- a/internal/app/confenge/dispatch/store.go
+++ b/internal/app/confenge/dispatch/store.go
@@ -42,6 +42,15 @@ type Store interface {
 	GetSendByKey(ctx context.Context, messageKey string) (sentAt time.Time, ok bool, err error)
 
 	RefreshReservation(ctx context.Context, id uuid.UUID, leaseUntil time.Time, workerToken string) error
+	// StartHandoff durably fences a message immediately before the transport's
+	// irreversible DATA phase. The reservation attempt timestamp and terminal
+	// queue state are changed atomically: once this succeeds, lease recovery may
+	// never make the message sendable again without provider evidence.
+	StartHandoff(ctx context.Context, reservationID, queueID uuid.UUID, attemptedAt time.Time) error
+	// FinalizeHandoff closes an attempted reservation without making it
+	// retryable. It returns false when DATA was never fenced and ordinary
+	// pre-handoff release/retry semantics still apply.
+	FinalizeHandoff(ctx context.Context, reservationID uuid.UUID, state, errText string) (bool, error)
 	CommitReservation(ctx context.Context, id uuid.UUID, sentAt time.Time) error
 	// CommitReservationWithEvidence commits the send and records what the
 	// provider reported in the same transaction, so an accepted message can

--- a/internal/app/confenge/dispatch/types.go
+++ b/internal/app/confenge/dispatch/types.go
@@ -176,6 +176,7 @@ type QueueItem struct {
 	Status         string
 	CancelReason   string
 	LastError      string
+	ReservedUntil  *time.Time
 	CreatedAt      time.Time
 }
 

--- a/internal/app/confenge/dispatch/window.go
+++ b/internal/app/confenge/dispatch/window.go
@@ -134,6 +134,13 @@ func MessageKeyEmail(draftID uuid.UUID) string {
 	return "email:draft:" + draftID.String()
 }
 
+// MessageKeyFirstTouch is the delivery identity of an account's initial email.
+// A draft is an editable rendering of that message, so it must not affect
+// exactly-once delivery.
+func MessageKeyFirstTouch(accountID uuid.UUID) string {
+	return "email:first-touch:account:" + accountID.String()
+}
+
 func MessageKeyWhatsApp(draftID uuid.UUID) string {
 	return "wa:draft:" + draftID.String()
 }

--- a/internal/app/confenge/dispatch/window_business_test.go
+++ b/internal/app/confenge/dispatch/window_business_test.go
@@ -60,3 +60,17 @@ func TestGovernorDefersWeekend(t *testing.T) {
 		t.Fatalf("reason=%s", res.Reason)
 	}
 }
+
+func TestMessageKeyFirstTouchUsesAccountNotDraftIdentity(t *testing.T) {
+	accountID, otherAccountID := uuid.New(), uuid.New()
+	firstDraft, replacementDraft := uuid.New(), uuid.New()
+	if MessageKeyEmail(firstDraft) == MessageKeyEmail(replacementDraft) {
+		t.Fatal("draft keys must remain distinct for non-initial compatibility")
+	}
+	if got, want := MessageKeyFirstTouch(accountID), MessageKeyFirstTouch(accountID); got != want {
+		t.Fatalf("same account must retain first-touch identity: %q != %q", got, want)
+	}
+	if MessageKeyFirstTouch(accountID) == MessageKeyFirstTouch(otherAccountID) {
+		t.Fatal("different accounts must not share a first-touch identity")
+	}
+}

--- a/internal/app/confenge/fast_lane.go
+++ b/internal/app/confenge/fast_lane.go
@@ -49,6 +49,9 @@ type FirstTouchMessage struct {
 	To             string
 	Subject        string
 	BodyText       string
+	// BeforeHandoff is invoked by the transport after MAIL/RCPT succeed and
+	// immediately before SMTP DATA. Success creates the durable no-resend fence.
+	BeforeHandoff func(context.Context) error
 }
 
 // FirstTouchAcceptance is what the provider reported back.
@@ -128,6 +131,12 @@ func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
 		_ = s.governor.RetryQueue(ctx, item.ID, s.now().Add(time.Minute), "not_email_channel")
 		return true, nil
 	}
+	// Attempts is incremented by claim. A row whose prior failures already used
+	// the budget must become terminal without touching the provider again.
+	if item.Attempts > fastLaneMaxAttempts {
+		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueFailed, "retries_exhausted_before_provider")
+		return true, nil
+	}
 
 	// The ledger is the only authority on whether this already went out. A row
 	// that survived a crash between provider acceptance and queue close is
@@ -151,8 +160,12 @@ func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
 	// -- is deliberately absent: it was already authoritative when this row was
 	// approved into the queue, and re-deciding it at transport time is what
 	// cancelled thousands of approved rows on every deploy.
-	if reason, ok := s.fastLaneBlock(ctx, item, tp); !ok {
-		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueCancelled, reason)
+	if reason, ok, retryable := s.fastLaneBlock(ctx, item, tp); !ok {
+		if retryable {
+			_ = s.governor.DeferQueue(ctx, item.ID, s.fastLaneBackoff(item), reason)
+		} else {
+			_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueCancelled, reason)
+		}
 		return true, nil
 	}
 
@@ -191,48 +204,79 @@ func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
 		return true, nil
 	}
 
-	// Qualification is time-dependent. Re-read it after the reservation and at
-	// the final boundary before the provider, so an approval that expired while
-	// queued cannot leave the system.
-	committedRun, lineageErr := s.repo.HasCommittedFeedRun(ctx, item.OrganizationID, tp.SourceRunID)
-	if lineageErr != nil || !committedRun {
-		reason := "feed_lineage_unavailable"
-		if lineageErr == nil {
-			reason = "feed_lineage_uncommitted"
-		}
+	// Re-read every live safety fact after capacity reservation. Admission facts
+	// stay committed, but a DNC/suppression/content mutation racing the claim must
+	// still win before the irreversible handoff.
+	liveTouchpoint, liveTouchpointErr := s.repo.GetTouchpointByDraft(ctx, item.OrganizationID, item.DraftID)
+	if liveTouchpointErr != nil || liveTouchpoint == nil {
+		reason := "touchpoint_safety_recheck_failed"
 		_ = s.governor.Release(ctx, res.Reservation.ID, reason)
-		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueCancelled, reason)
+		_ = s.governor.DeferQueue(ctx, item.ID, s.fastLaneBackoff(item), reason)
 		return true, nil
 	}
-	account, accountErr := s.repo.GetAccount(ctx, item.OrganizationID, tp.AccountID)
-	qualification := AccountCommercialQualification(account, s.now())
-	if accountErr != nil || !qualification.AllowsTransport() {
-		reason := "commercial_qualification_unavailable"
-		if accountErr == nil {
-			reason = firstNonEmpty(firstHold(qualification.ReasonCodes), ReasonQualificationMissing)
-		}
+	tp = liveTouchpoint
+	if reason, ok, retryable := s.fastLaneBlock(ctx, item, tp); !ok {
 		_ = s.governor.Release(ctx, res.Reservation.ID, reason)
-		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueCancelled, reason)
+		if retryable {
+			_ = s.governor.DeferQueue(ctx, item.ID, s.fastLaneBackoff(item), reason)
+		} else {
+			_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueCancelled, reason)
+		}
 		return true, nil
 	}
+	if transport := s.ResolveTransportState(ctx, nil); !transport.Active {
+		reason := "transport_blocked_after_reservation"
+		_ = s.governor.Release(ctx, res.Reservation.ID, reason)
+		_ = s.governor.DeferQueue(ctx, item.ID, s.now().Add(fastLaneDeferFallback), reason)
+		return true, nil
+	}
+	liveMailboxID, mailboxErr := s.fastLaneMailbox(ctx, item)
+	if mailboxErr != nil || liveMailboxID != mailboxID {
+		reason := "mailbox_changed_after_reservation"
+		if mailboxErr != nil {
+			reason = "mailbox_unavailable_after_reservation: " + mailboxErr.Error()
+		}
+		_ = s.governor.Release(ctx, res.Reservation.ID, reason)
+		_ = s.governor.DeferQueue(ctx, item.ID, s.fastLaneBackoff(item), reason)
+		return true, nil
+	}
+
+	// Feed lineage and temporal qualification were consumed at queue admission.
+	// Rechecking either here makes a durable authorization disappear on a feed
+	// pointer change or on the mere passage of time. Explicit live deactivation,
+	// role, recipient and content safety are enforced by fastLaneBlock above.
 	accepted, acceptedErr := s.repo.HasAcceptedInitialForAccount(ctx, item.OrganizationID, tp.AccountID)
-	if acceptedErr != nil || accepted {
+	if acceptedErr != nil {
 		reason := "accepted_initial_ledger_lookup_failed"
-		if acceptedErr == nil {
-			reason = "accepted_initial_already_recorded"
-		}
+		_ = s.governor.Release(ctx, res.Reservation.ID, reason)
+		_ = s.governor.DeferQueue(ctx, item.ID, s.fastLaneBackoff(item), reason)
+		return true, nil
+	}
+	if accepted {
+		reason := "accepted_initial_already_recorded"
 		_ = s.governor.Release(ctx, res.Reservation.ID, reason)
 		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueCancelled, reason)
 		return true, nil
 	}
 
-	acceptance, outcome, sendErr := s.firstTouchTransport.SendFirstTouch(ctx, FirstTouchMessage{
+	sendBudget := res.Reservation.LeaseUntil.Sub(s.now()) - fastLaneSMTPLeaseMargin
+	if sendBudget <= 0 {
+		_ = s.governor.Release(ctx, res.Reservation.ID, "smtp_budget_exhausted_before_handoff")
+		_ = s.governor.RetryQueue(ctx, item.ID, s.fastLaneBackoff(item), "smtp_budget_exhausted_before_handoff")
+		return true, nil
+	}
+	sendCtx, cancelSend := context.WithTimeout(ctx, sendBudget)
+	defer cancelSend()
+	acceptance, outcome, sendErr := s.firstTouchTransport.SendFirstTouch(sendCtx, FirstTouchMessage{
 		OrganizationID: item.OrganizationID,
 		EmailAccountID: mailboxID,
 		MessageKey:     item.MessageKey,
 		To:             tp.Recipient,
 		Subject:        tp.Subject,
 		BodyText:       tp.BodyText,
+		BeforeHandoff: func(handoffCtx context.Context) error {
+			return s.governor.StartHandoff(handoffCtx, res.Reservation.ID, item.ID)
+		},
 	})
 
 	switch outcome {
@@ -253,6 +297,7 @@ func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
 			// attempted so reconciliation owns it; never re-send from here.
 			log.Error().Err(err).Str("message_key", item.MessageKey).
 				Msg("confenge fast lane could not record an accepted send")
+			_, _ = s.governor.FinalizeHandoff(ctx, res.Reservation.ID, "commit_failed_after_acceptance")
 			_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueAttempted, "commit_failed_after_acceptance")
 			return true, err
 		}
@@ -272,10 +317,17 @@ func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
 		// row be claimed again, so it stays parked for human/reconciler review.
 		log.Warn().Str("message_key", item.MessageKey).Err(sendErr).
 			Msg("confenge fast lane got an ambiguous provider result; not resending")
+		_, _ = s.governor.FinalizeHandoff(ctx, res.Reservation.ID, "ambiguous_provider_result: "+errText(sendErr))
 		_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueAttempted, "ambiguous_provider_result: "+errText(sendErr))
 		return true, nil
 
 	default: // FirstTouchTransient
+		if finalized, finalizeErr := s.governor.FinalizeHandoff(ctx, res.Reservation.ID, "transient_after_handoff: "+errText(sendErr)); finalizeErr != nil {
+			return true, finalizeErr
+		} else if finalized {
+			_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueAttempted, "transient_after_handoff: "+errText(sendErr))
+			return true, nil
+		}
 		_ = s.governor.Release(ctx, res.Reservation.ID, errText(sendErr))
 		if item.Attempts >= fastLaneMaxAttempts {
 			_ = s.governor.MarkQueue(ctx, item.ID, dispatch.QueueFailed, "retries_exhausted: "+errText(sendErr))
@@ -289,6 +341,9 @@ func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
 const (
 	fastLaneMaxAttempts   = 5
 	fastLaneDeferFallback = 5 * time.Minute
+	// The socket deadline must fire while the reservation still belongs to this
+	// worker. This margin leaves time for the accepted-ledger transaction.
+	fastLaneSMTPLeaseMargin = 10 * time.Second
 )
 
 func errText(err error) string {
@@ -313,20 +368,82 @@ func (s *service) fastLaneBackoff(item *dispatch.QueueItem) time.Time {
 
 // fastLaneBlock holds the gates that protect a recipient or a mailbox. It
 // returns false with a reason when the row must not be sent at all.
-func (s *service) fastLaneBlock(ctx context.Context, item *dispatch.QueueItem, tp *models.OutreachTouchpoint) (string, bool) {
+func (s *service) fastLaneBlock(ctx context.Context, item *dispatch.QueueItem, tp *models.OutreachTouchpoint) (string, bool, bool) {
 	// The approved content must still be the content we are about to send.
-	if tp.State != models.TouchpointQueued || tp.ContentHash == "" || tp.ApprovedContentHash != tp.ContentHash {
-		return "approval or content hash changed", false
+	liveHash := TouchpointBindingHash(tp)
+	if tp.State != models.TouchpointQueued || liveHash == "" || tp.ContentHash != liveHash || tp.ApprovedContentHash != liveHash {
+		return "approval or content binding hash changed", false, false
 	}
 	if tp.State == models.TouchpointSent {
-		return "already_sent", false
+		return "already_sent", false, false
 	}
 	recipient := strings.ToLower(strings.TrimSpace(tp.Recipient))
 	if recipient == "" || !strings.Contains(recipient, "@") || strings.ContainsAny(recipient, " \t\r\n") {
-		return "recipient_not_usable", false
+		return "recipient_not_usable", false, false
 	}
 	if strings.TrimSpace(tp.Subject) == "" || strings.TrimSpace(tp.BodyText) == "" {
-		return "approved_payload_empty", false
+		return "approved_payload_empty", false, false
+	}
+	queueRecipient := strings.ToLower(strings.TrimSpace(item.RecipientRef))
+	if queueRecipient == "" || queueRecipient != recipient {
+		return "recipient_binding_drift", false, false
+	}
+	account, err := s.repo.GetAccount(ctx, item.OrganizationID, tp.AccountID)
+	if err != nil || account == nil {
+		return "account_safety_lookup_failed", false, true
+	}
+	if account.Blocked || account.DoNotContact {
+		return "account_blocked_or_dnc", false, false
+	}
+	switch account.QueueState {
+	case models.OutreachQueueBlocked, models.OutreachQueueBounced, models.OutreachQueueDoNotContact,
+		models.OutreachQueueSent, models.OutreachQueueReplied, models.OutreachQueueMeeting,
+		models.OutreachQueueProposal, models.OutreachQueueWon, models.OutreachQueueLost:
+		return "account_terminal:" + account.QueueState, false, false
+	}
+	qualificationState := strings.ToUpper(strings.TrimSpace(account.CommercialQualificationState))
+	if account.CommercialQualificationDeactivated || qualificationState == CommercialRevoked {
+		return "commercial_qualification_deactivated", false, false
+	}
+	role := strings.ToUpper(strings.TrimSpace(account.TargetPartyRole))
+	leadCNPJ := NormalizeCNPJ14(account.CNPJ14)
+	buyerCNPJ := NormalizeCNPJ14(account.BuyerCNPJ14)
+	roleStatus := strings.ToUpper(strings.TrimSpace(account.ContractorRoleStatus))
+	roleConflict := role == ContractorRoleConflict || role == "BUYER_CONFLICT" || role == "BUYER" ||
+		roleStatus == ContractorRoleConflict || roleStatus == "PARTY_ROLE_CONFLICT"
+	identityConflict := leadCNPJ != "" && buyerCNPJ == leadCNPJ
+	if account.SupplierIdentityRef != "" && account.SupplierIdentityRef == account.BuyerIdentityRef {
+		identityConflict = true
+	}
+	if roleConflict || identityConflict {
+		return "target_party_role_conflict", false, false
+	}
+	if tp.ContactCandidateID != nil {
+		candidate, candidateErr := s.repo.GetCandidate(ctx, item.OrganizationID, *tp.ContactCandidateID)
+		if candidateErr != nil {
+			return "candidate_safety_lookup_failed", false, true
+		}
+		// A missing historical candidate is provenance loss, not a new safety
+		// fact. Positive live flags or a concrete binding drift still revoke.
+		if candidate != nil {
+			if candidate.OrganizationID != item.OrganizationID || candidate.AccountID != tp.AccountID {
+				return "candidate_account_binding_drift", false, false
+			}
+			candidateEmail := strings.ToLower(strings.TrimSpace(candidate.Email))
+			if candidateEmail != "" && candidateEmail != recipient {
+				return "candidate_recipient_binding_drift", false, false
+			}
+			if candidate.Blocked || candidate.DoNotContact || candidate.Bounced {
+				return "candidate_blocked_dnc_or_bounced", false, false
+			}
+			switch candidate.VerificationStatus {
+			case models.OutreachVerifyInvalid, models.OutreachVerifyBounced, models.OutreachVerifyDoNotContact:
+				return "candidate_terminal:" + candidate.VerificationStatus, false, false
+			}
+			if suppression := strings.ToUpper(strings.TrimSpace(candidate.RouteSuppression)); suppression != "" && suppression != "NONE" {
+				return "candidate_route_suppressed:" + suppression, false, false
+			}
+		}
 	}
 	// Hard bounce, complaint and opt-out suppression.
 	if suppressions, ok := s.repo.(interface {
@@ -335,22 +452,29 @@ func (s *service) fastLaneBlock(ctx context.Context, item *dispatch.QueueItem, t
 		suppression, err := suppressions.GetOutreachRecipientSuppression(ctx, item.OrganizationID, tp.Recipient)
 		if err != nil {
 			// Fail closed: an unreadable suppression list is not permission.
-			return "suppression_lookup_failed", false
+			return "suppression_lookup_failed", false, true
 		}
 		if suppression != nil {
-			return "recipient_suppressed:" + string(suppression.Source), false
+			return "recipient_suppressed:" + string(suppression.Source), false, false
 		}
+	} else {
+		return "suppression_lookup_unavailable", false, true
 	}
-	return "", true
+	return "", true, false
 }
 
 // fastLaneMailbox resolves the sending mailbox for a queued row.
 func (s *service) fastLaneMailbox(ctx context.Context, item *dispatch.QueueItem) (uuid.UUID, error) {
-	if item.EmailAccountID != nil && *item.EmailAccountID != uuid.Nil {
-		return *item.EmailAccountID, nil
-	}
+	// Resolve the configured/live sender every time. The queue binding is an
+	// admission hint, not permission to keep using a mailbox after configuration
+	// changed. The resolver fails closed on a missing explicit mailbox.
 	id, err := s.resolveConfengeMailbox(ctx, item.OrganizationID)
 	if err != nil {
+		// Unit/in-memory services have no live mailbox database. Production does,
+		// and must never turn a resolver error into permission to use a stale row.
+		if s.fastLaneDB == nil && item.EmailAccountID != nil && *item.EmailAccountID != uuid.Nil {
+			return *item.EmailAccountID, nil
+		}
 		return uuid.Nil, err
 	}
 	if id == uuid.Nil {

--- a/internal/app/confenge/fast_lane.go
+++ b/internal/app/confenge/fast_lane.go
@@ -275,6 +275,36 @@ func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
 		Subject:        tp.Subject,
 		BodyText:       tp.BodyText,
 		BeforeHandoff: func(handoffCtx context.Context) error {
+			if transport := s.ResolveTransportState(handoffCtx, nil); !transport.Active {
+				return fmt.Errorf("transport blocked immediately before SMTP DATA")
+			}
+			liveTP, liveErr := s.repo.GetTouchpointByDraft(handoffCtx, item.OrganizationID, item.DraftID)
+			if liveErr != nil {
+				return fmt.Errorf("touchpoint safety lookup before SMTP DATA: %w", liveErr)
+			}
+			if liveTP == nil {
+				return fmt.Errorf("touchpoint missing before SMTP DATA")
+			}
+			if TouchpointBindingHash(liveTP) != TouchpointBindingHash(tp) {
+				return fmt.Errorf("approved payload changed before SMTP DATA")
+			}
+			if reason, ok, _ := s.fastLaneBlock(handoffCtx, item, liveTP); !ok {
+				return fmt.Errorf("safety blocked before SMTP DATA: %s", reason)
+			}
+			lastMailboxID, mailboxErr := s.fastLaneMailbox(handoffCtx, item)
+			if mailboxErr != nil {
+				return fmt.Errorf("mailbox changed before SMTP DATA: %w", mailboxErr)
+			}
+			if lastMailboxID != mailboxID {
+				return fmt.Errorf("mailbox identity changed before SMTP DATA")
+			}
+			terminal, terminalErr := s.repo.HasAcceptedInitialForAccount(handoffCtx, item.OrganizationID, tp.AccountID)
+			if terminalErr != nil {
+				return fmt.Errorf("terminal initial appeared before SMTP DATA: %w", terminalErr)
+			}
+			if terminal {
+				return fmt.Errorf("terminal initial appeared before SMTP DATA")
+			}
 			return s.governor.StartHandoff(handoffCtx, res.Reservation.ID, item.ID)
 		},
 	})

--- a/internal/app/confenge/fast_lane_smtp.go
+++ b/internal/app/confenge/fast_lane_smtp.go
@@ -2,6 +2,7 @@ package confenge
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 	"time"
@@ -67,7 +68,7 @@ func (t *SMTPFirstTouchTransport) SendFirstTouch(ctx context.Context, msg FirstT
 	// We mint the Message-ID and write it as a header, so the id recorded in the
 	// ledger is the id the recipient's provider will quote back in a bounce or a
 	// reply. Without it there is nothing to correlate an ambiguous result to.
-	messageID := firstTouchMessageID(account.Email)
+	messageID := firstTouchMessageID(msg.OrganizationID, msg.MessageKey, account.Email)
 
 	client := &smtpclient.Client{
 		FirstName: account.Name,
@@ -79,6 +80,7 @@ func (t *SMTPFirstTouchTransport) SendFirstTouch(ctx context.Context, msg FirstT
 			Username: creds.SMTPUser,
 			Password: creds.SMTPPassword,
 		},
+		BeforeData: msg.BeforeHandoff,
 	}
 
 	mailErr := client.Send(ctx, []string{to}, nil, nil, messageID, msg.Subject, msg.BodyText, "", "", nil)
@@ -105,12 +107,15 @@ func (t *SMTPFirstTouchTransport) SendFirstTouch(ctx context.Context, msg FirstT
 }
 
 // firstTouchMessageID mints an RFC 5322 Message-ID in the sender's own domain.
-func firstTouchMessageID(from string) string {
+func firstTouchMessageID(orgID uuid.UUID, messageKey, from string) string {
 	domain := "confenge.com.br"
 	if at := strings.LastIndex(from, "@"); at >= 0 && at+1 < len(from) {
 		if d := strings.TrimSpace(from[at+1:]); d != "" {
-			domain = d
+			domain = strings.ToLower(d)
 		}
 	}
-	return fmt.Sprintf("<%s@%s>", uuid.New().String(), domain)
+	identity := strings.ToLower(strings.TrimSpace(orgID.String())) + "\x00" +
+		strings.TrimSpace(messageKey) + "\x00" + strings.ToLower(strings.TrimSpace(from))
+	digest := sha256.Sum256([]byte(identity))
+	return fmt.Sprintf("<confenge-%x@%s>", digest[:20], domain)
 }

--- a/internal/app/confenge/fast_lane_test.go
+++ b/internal/app/confenge/fast_lane_test.go
@@ -3,6 +3,7 @@ package confenge
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,6 +21,7 @@ type fastLaneRepo struct {
 	repository.OutreachRepository
 	touchpoints map[uuid.UUID]*models.OutreachTouchpoint
 	accounts    map[uuid.UUID]*models.OutreachAccount
+	candidates  map[uuid.UUID]*models.OutreachContactCandidate
 	accepted    map[uuid.UUID]bool
 	acceptedErr error
 	committed   map[string]bool
@@ -35,6 +37,10 @@ func (f *fastLaneRepo) GetTouchpointByDraft(_ context.Context, _ uuid.UUID, draf
 
 func (f *fastLaneRepo) GetAccount(_ context.Context, _ uuid.UUID, accountID uuid.UUID) (*models.OutreachAccount, error) {
 	return f.accounts[accountID], nil
+}
+
+func (f *fastLaneRepo) GetCandidate(_ context.Context, _ uuid.UUID, candidateID uuid.UUID) (*models.OutreachContactCandidate, error) {
+	return f.candidates[candidateID], nil
 }
 
 func (f *fastLaneRepo) HasAcceptedInitialForAccount(_ context.Context, _ uuid.UUID, accountID uuid.UUID) (bool, error) {
@@ -65,6 +71,15 @@ func (f *fastLaneRepo) GetOutreachRecipientSuppression(_ context.Context, _ uuid
 	return f.suppressed[recipient], nil
 }
 
+func (f *fastLaneRepo) UpsertOutreachRecipientSuppression(_ context.Context, value *models.SuppressedRecipient) error {
+	if value == nil {
+		return errors.New("suppression required")
+	}
+	copyValue := *value
+	f.suppressed[strings.ToLower(strings.TrimSpace(value.Email))] = &copyValue
+	return nil
+}
+
 // scriptedTransport returns a fixed outcome and counts real send attempts, so a
 // test can prove a message was never handed to a provider twice.
 type scriptedTransport struct {
@@ -72,9 +87,21 @@ type scriptedTransport struct {
 	err      error
 	attempts int
 	sentTo   []string
+	deadline time.Time
 }
 
-func (s *scriptedTransport) SendFirstTouch(_ context.Context, msg FirstTouchMessage) (FirstTouchAcceptance, FirstTouchOutcome, error) {
+func (s *scriptedTransport) SendFirstTouch(ctx context.Context, msg FirstTouchMessage) (FirstTouchAcceptance, FirstTouchOutcome, error) {
+	if deadline, ok := ctx.Deadline(); ok {
+		s.deadline = deadline
+	}
+	if s.outcome == FirstTouchAccepted || s.outcome == FirstTouchAmbiguous {
+		if msg.BeforeHandoff == nil {
+			return FirstTouchAcceptance{}, FirstTouchTransient, errors.New("missing handoff hook")
+		}
+		if err := msg.BeforeHandoff(context.Background()); err != nil {
+			return FirstTouchAcceptance{}, FirstTouchTransient, err
+		}
+	}
 	s.attempts++
 	s.sentTo = append(s.sentTo, msg.To)
 	if s.outcome == FirstTouchAccepted {
@@ -119,6 +146,7 @@ func newFastLaneHarness(t *testing.T, outcome FirstTouchOutcome, sendErr error) 
 	repo := &fastLaneRepo{
 		touchpoints: map[uuid.UUID]*models.OutreachTouchpoint{},
 		accounts:    map[uuid.UUID]*models.OutreachAccount{},
+		candidates:  map[uuid.UUID]*models.OutreachContactCandidate{},
 		accepted:    map[uuid.UUID]bool{},
 		committed:   map[string]bool{"run-committed": true},
 		suppressed:  map[string]*models.SuppressedRecipient{},
@@ -138,6 +166,32 @@ func newFastLaneHarness(t *testing.T, outcome FirstTouchOutcome, sendErr error) 
 
 // enqueue creates one approved, queued, due first touch.
 func (h *fastLaneHarness) enqueue(t *testing.T, recipient string) (uuid.UUID, string) {
+	return h.enqueueWithAttempts(t, recipient, 0)
+}
+
+type commitFailStore struct {
+	*dispatch.MemoryStore
+	err error
+}
+
+func (s *commitFailStore) CommitReservationWithEvidence(context.Context, uuid.UUID, time.Time, dispatch.SendEvidence) error {
+	return s.err
+}
+
+func TestFirstTouchMessageIDIsStableForLogicalSend(t *testing.T) {
+	orgID := uuid.New()
+	a := firstTouchMessageID(orgID, "email:draft:stable", "Sender@Confenge.COM.BR")
+	b := firstTouchMessageID(orgID, "email:draft:stable", "sender@confenge.com.br")
+	c := firstTouchMessageID(orgID, "email:draft:different", "sender@confenge.com.br")
+	if a != b {
+		t.Fatalf("same logical send produced different ids: %q != %q", a, b)
+	}
+	if a == c {
+		t.Fatal("different message keys produced the same Message-ID")
+	}
+}
+
+func (h *fastLaneHarness) enqueueWithAttempts(t *testing.T, recipient string, attempts int) (uuid.UUID, string) {
 	t.Helper()
 	draftID := uuid.New()
 	key := dispatch.MessageKeyEmail(draftID)
@@ -146,23 +200,42 @@ func (h *fastLaneHarness) enqueue(t *testing.T, recipient string) (uuid.UUID, st
 		ID: uuid.New(), OrganizationID: h.orgID, EmailAccountID: &mailbox,
 		Channel: dispatch.ChannelEmail, DraftID: draftID, MessageKey: key,
 		RecipientRef: recipient, DueAt: h.clock.Now().Add(-time.Minute),
-		Status: dispatch.QueueQueued, CreatedAt: h.clock.Now(),
+		Attempts: attempts, Status: dispatch.QueueQueued, CreatedAt: h.clock.Now(),
 	}); err != nil {
 		t.Fatalf("enqueue: %v", err)
 	}
 	accountID := uuid.New()
-	h.repo.touchpoints[draftID] = &models.OutreachTouchpoint{
+	tp := &models.OutreachTouchpoint{
 		ID: uuid.New(), OrganizationID: h.orgID, AccountID: accountID, DraftID: &draftID,
 		SourceRunID: "run-committed",
-		State:       models.TouchpointQueued, Recipient: recipient,
+		State:       models.TouchpointQueued, Channel: models.OutreachChannelEmail,
+		Purpose: "INITIAL", Ordinal: 1, Recipient: recipient,
 		Subject: "Assunto aprovado", BodyText: "Corpo aprovado.",
-		ContentHash: "hash-a", ApprovedContentHash: "hash-a",
 	}
+	tp.ContentHash = TouchpointBindingHash(tp)
+	tp.ApprovedContentHash = tp.ContentHash
+	h.repo.touchpoints[draftID] = tp
 	account := &models.OutreachAccount{ID: accountID, OrganizationID: h.orgID, CNPJRoot: "11222333", TargetPartyRole: PartyRoleSupplier}
 	qualification := testRootQualification(account.CNPJRoot, h.clock.Now().AddDate(-1, 0, 0))
 	applyCommercialQualificationToAccount(account, &qualification, h.clock.Now())
 	h.repo.accounts[accountID] = account
 	return draftID, key
+}
+
+func (h *fastLaneHarness) claimAndReserve(t *testing.T) (*dispatch.QueueItem, *dispatch.Reservation) {
+	t.Helper()
+	item, err := h.svc.governor.ClaimNextQueued(context.Background())
+	if err != nil || item == nil {
+		t.Fatalf("claim: item=%+v err=%v", item, err)
+	}
+	res, err := h.svc.governor.TryReserve(context.Background(), dispatch.ReserveRequest{
+		OrganizationID: item.OrganizationID, EmailAccountID: item.EmailAccountID,
+		Channel: item.Channel, MessageKey: item.MessageKey, DraftID: &item.DraftID,
+	})
+	if err != nil || !res.Allowed || res.Reservation == nil {
+		t.Fatalf("reserve: result=%+v err=%v", res, err)
+	}
+	return item, res.Reservation
 }
 
 func (h *fastLaneHarness) queueStatus(t *testing.T, key string) string {
@@ -207,7 +280,7 @@ func TestFastLaneRecordsAcceptedSendExactlyOnceAndClosesTheRow(t *testing.T) {
 	}
 }
 
-func TestFastLaneRechecksQualificationImmediatelyBeforeProvider(t *testing.T) {
+func TestFastLaneDoesNotRevokeAdmissionWhenQualificationTimeElapses(t *testing.T) {
 	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
 	draftID, key := h.enqueue(t, "alvo@exemplo.com.br")
 	tp := h.repo.touchpoints[draftID]
@@ -223,11 +296,11 @@ func TestFastLaneRechecksQualificationImmediatelyBeforeProvider(t *testing.T) {
 	if err != nil || !progressed {
 		t.Fatalf("expired row was not closed: progressed=%v err=%v", progressed, err)
 	}
-	if h.transport.attempts != 0 {
-		t.Fatalf("expired qualification reached provider: attempts=%d", h.transport.attempts)
+	if h.transport.attempts != 1 {
+		t.Fatalf("temporal expiry revoked durable admission: attempts=%d", h.transport.attempts)
 	}
-	if got := h.queueStatus(t, key); got != dispatch.QueueCancelled {
-		t.Fatalf("expired qualification queue state=%q", got)
+	if got := h.queueStatus(t, key); got != dispatch.QueueSent {
+		t.Fatalf("admitted row should send despite temporal expiry, state=%q", got)
 	}
 }
 
@@ -249,7 +322,7 @@ func TestFastLaneLedgerOnlyAcceptanceBlocksDifferentMessageKey(t *testing.T) {
 	}
 }
 
-func TestFastLaneBlocksLegacyQueuedUncommittedLineage(t *testing.T) {
+func TestFastLaneDoesNotRecheckFeedLineageAfterAdmission(t *testing.T) {
 	for _, sourceRunID := range []string{"", "legacy-uncommitted"} {
 		t.Run(firstNonEmpty(sourceRunID, "empty"), func(t *testing.T) {
 			h := newFastLaneHarness(t, FirstTouchAccepted, nil)
@@ -260,38 +333,39 @@ func TestFastLaneBlocksLegacyQueuedUncommittedLineage(t *testing.T) {
 			if err != nil || !progressed {
 				t.Fatalf("uncommitted legacy row was not closed: progressed=%v err=%v", progressed, err)
 			}
-			if h.transport.attempts != 0 {
-				t.Fatalf("uncommitted legacy row reached provider: attempts=%d", h.transport.attempts)
+			if h.transport.attempts != 1 {
+				t.Fatalf("lineage drift revoked durable admission: attempts=%d", h.transport.attempts)
 			}
-			if got := h.queueStatus(t, key); got != dispatch.QueueCancelled {
-				t.Fatalf("uncommitted legacy queue state=%q", got)
+			if got := h.queueStatus(t, key); got != dispatch.QueueSent {
+				t.Fatalf("admitted row should send after lineage drift, state=%q", got)
 			}
 		})
 	}
 }
 
-// A restart that re-queues an already-recorded key must close the row from the
-// ledger instead of sending a second copy.
-func TestFastLaneNeverResendsAKeyTheLedgerAlreadyHolds(t *testing.T) {
+// A producer replay after an accepted send must not reopen the terminal row.
+func TestFastLaneNeverRequeuesAKeyTheLedgerAlreadyHolds(t *testing.T) {
 	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
-	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+	draftID, key := h.enqueue(t, "alvo@exemplo.com.br")
 	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
 		t.Fatalf("initial send: %v", err)
 	}
 
-	// Simulate a crash-recovery that puts the row back to queued.
-	if err := h.store.RetryQueue(context.Background(), h.mustQueueID(t, key), h.clock.Now().Add(-time.Minute), "replayed"); err != nil {
-		// RetryQueue only moves reserved rows; force the state directly.
-		_ = err
+	mailbox := h.mailbox
+	if err := h.store.Enqueue(context.Background(), &dispatch.QueueItem{
+		OrganizationID: h.orgID, EmailAccountID: &mailbox, Channel: dispatch.ChannelEmail,
+		DraftID: draftID, MessageKey: key, RecipientRef: "alvo@exemplo.com.br",
+		DueAt: h.clock.Now().Add(-time.Minute), Status: dispatch.QueueQueued,
+	}); err != nil {
+		t.Fatalf("producer replay: %v", err)
 	}
-	h.forceQueued(t, key)
 
 	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
 	if err != nil {
 		t.Fatalf("replay pass: %v", err)
 	}
-	if !progressed {
-		t.Fatal("replayed row was not handled")
+	if progressed {
+		t.Fatal("accepted row became claimable after producer replay")
 	}
 	if h.transport.attempts != 1 {
 		t.Fatalf("replay resent the message: %d provider attempts", h.transport.attempts)
@@ -311,6 +385,9 @@ func TestFastLanePermanentRejectionDoesNotHeadOfLineBlock(t *testing.T) {
 	}
 	if got := h.queueStatus(t, badKey); got != dispatch.QueueFailed {
 		t.Fatalf("permanent rejection should be terminal 'failed', got %q", got)
+	}
+	if suppression := h.repo.suppressed["invalido@exemplo.com.br"]; suppression == nil || suppression.Source != models.DeliverabilityEventBounce {
+		t.Fatalf("permanent rejection did not persist suppression: %+v", suppression)
 	}
 
 	// The next valid row must still send.
@@ -377,8 +454,8 @@ func TestFastLaneFailsClosedWhenSuppressionUnreadable(t *testing.T) {
 	if h.transport.attempts != 0 {
 		t.Fatal("sent while the suppression list was unreadable")
 	}
-	if got := h.queueStatus(t, key); got != dispatch.QueueCancelled {
-		t.Fatalf("expected cancelled, got %q", got)
+	if got := h.queueStatus(t, key); got != dispatch.QueueQueued {
+		t.Fatalf("transient lookup failure should defer durable work, got %q", got)
 	}
 }
 
@@ -430,6 +507,167 @@ func TestFastLaneTransientFailureRetriesAndIsBounded(t *testing.T) {
 	item, _ := h.store.GetQueueByKey(context.Background(), key)
 	if !item.DueAt.After(h.clock.Now()) {
 		t.Fatal("retry was not backed off into the future")
+	}
+}
+
+func TestFastLaneAcceptedCommitFailureParksAndNeverResends(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	draftID, key := h.enqueue(t, "alvo@exemplo.com.br")
+	failing := &commitFailStore{MemoryStore: h.store, err: errors.New("ledger transaction unavailable")}
+	cfg := dispatch.DefaultConfig()
+	cfg.SendsPerHour = 100
+	cfg.MinGap = 0
+	cfg.RateMode = "fixed"
+	h.svc.governor = dispatch.NewGovernor(cfg, failing, h.clock)
+
+	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
+	if !progressed || err == nil {
+		t.Fatalf("accepted commit failure not surfaced: progressed=%v err=%v", progressed, err)
+	}
+	if h.transport.attempts != 1 || h.queueStatus(t, key) != dispatch.QueueAttempted {
+		t.Fatalf("accepted failure was not parked: attempts=%d status=%s", h.transport.attempts, h.queueStatus(t, key))
+	}
+	reservation, _ := h.store.GetReservationByKey(context.Background(), key)
+	if reservation == nil || reservation.AttemptedAt == nil || reservation.State != dispatch.StateFailed {
+		t.Fatalf("handoff reservation not terminal: %+v", reservation)
+	}
+	h.clock.Advance(dispatch.DefaultLeaseTTL + time.Second)
+	_, _ = h.store.ExpireStaleReservations(context.Background(), h.clock.Now())
+	mailbox := h.mailbox
+	_ = h.store.Enqueue(context.Background(), &dispatch.QueueItem{
+		OrganizationID: h.orgID, EmailAccountID: &mailbox, Channel: dispatch.ChannelEmail,
+		DraftID: draftID, MessageKey: key, RecipientRef: "alvo@exemplo.com.br", DueAt: h.clock.Now(),
+	})
+	progressed, err = h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil || progressed || h.transport.attempts != 1 {
+		t.Fatalf("parked acceptance was retried: progressed=%v attempts=%d err=%v", progressed, h.transport.attempts, err)
+	}
+}
+
+func TestFastLaneSMTPDeadlineIsShorterThanReservationLease(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	h.enqueue(t, "alvo@exemplo.com.br")
+	started := time.Now()
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if h.transport.deadline.IsZero() {
+		t.Fatal("transport context had no deadline")
+	}
+	if budget := h.transport.deadline.Sub(started); budget <= 0 || budget >= dispatch.DefaultLeaseTTL {
+		t.Fatalf("SMTP budget must be positive and shorter than lease: %s", budget)
+	}
+}
+
+func TestFastLaneCrashRecoveryBeforeHandoffRequeues(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+	h.claimAndReserve(t) // worker crashes before the transport invokes the hook
+	h.clock.Advance(dispatch.DefaultLeaseTTL + time.Second)
+
+	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil || !progressed {
+		t.Fatalf("pre-handoff recovery did not resume: progressed=%v err=%v", progressed, err)
+	}
+	if h.transport.attempts != 1 || h.queueStatus(t, key) != dispatch.QueueSent {
+		t.Fatalf("pre-handoff recovery result attempts=%d status=%s", h.transport.attempts, h.queueStatus(t, key))
+	}
+}
+
+func TestFastLaneCrashRecoveryAfterHandoffNeverRequeues(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	draftID, key := h.enqueue(t, "alvo@exemplo.com.br")
+	item, reservation := h.claimAndReserve(t)
+	if err := h.svc.governor.StartHandoff(context.Background(), reservation.ID, item.ID); err != nil {
+		t.Fatalf("start handoff: %v", err)
+	}
+	h.clock.Advance(dispatch.DefaultLeaseTTL + time.Second)
+	if expired, err := h.store.ExpireStaleReservations(context.Background(), h.clock.Now()); err != nil || expired != 0 {
+		t.Fatalf("post-handoff reservation expired: count=%d err=%v", expired, err)
+	}
+	mailbox := h.mailbox
+	_ = h.store.Enqueue(context.Background(), &dispatch.QueueItem{
+		OrganizationID: h.orgID, EmailAccountID: &mailbox, Channel: dispatch.ChannelEmail,
+		DraftID: draftID, MessageKey: key, RecipientRef: "alvo@exemplo.com.br", DueAt: h.clock.Now(),
+	})
+	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil || progressed {
+		t.Fatalf("post-handoff row became work again: progressed=%v err=%v", progressed, err)
+	}
+	if h.transport.attempts != 0 || h.queueStatus(t, key) != dispatch.QueueAttempted {
+		t.Fatalf("post-handoff recovery attempts=%d status=%s", h.transport.attempts, h.queueStatus(t, key))
+	}
+}
+
+func TestFastLaneLiveAccountAndCandidateSafety(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*models.OutreachAccount, *models.OutreachContactCandidate)
+	}{
+		{"account_dnc", func(a *models.OutreachAccount, _ *models.OutreachContactCandidate) { a.DoNotContact = true }},
+		{"account_blocked", func(a *models.OutreachAccount, _ *models.OutreachContactCandidate) { a.Blocked = true }},
+		{"account_bounced", func(a *models.OutreachAccount, _ *models.OutreachContactCandidate) {
+			a.QueueState = models.OutreachQueueBounced
+		}},
+		{"qualification_deactivated", func(a *models.OutreachAccount, _ *models.OutreachContactCandidate) {
+			a.CommercialQualificationDeactivated = true
+		}},
+		{"buyer_role_conflict", func(a *models.OutreachAccount, _ *models.OutreachContactCandidate) {
+			a.TargetPartyRole = "BUYER_CONFLICT"
+		}},
+		{"candidate_dnc", func(_ *models.OutreachAccount, c *models.OutreachContactCandidate) { c.DoNotContact = true }},
+		{"candidate_bounced", func(_ *models.OutreachAccount, c *models.OutreachContactCandidate) { c.Bounced = true }},
+		{"candidate_recipient_drift", func(_ *models.OutreachAccount, c *models.OutreachContactCandidate) { c.Email = "outro@exemplo.com.br" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+			draftID, key := h.enqueue(t, "alvo@exemplo.com.br")
+			tp := h.repo.touchpoints[draftID]
+			candidateID := uuid.New()
+			tp.ContactCandidateID = &candidateID
+			candidate := &models.OutreachContactCandidate{
+				ID: candidateID, OrganizationID: h.orgID, AccountID: tp.AccountID,
+				Email: "alvo@exemplo.com.br", VerificationStatus: models.OutreachVerifyVerified,
+			}
+			h.repo.candidates[candidateID] = candidate
+			tt.mutate(h.repo.accounts[tp.AccountID], candidate)
+			if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+				t.Fatalf("process: %v", err)
+			}
+			if h.transport.attempts != 0 || h.queueStatus(t, key) != dispatch.QueueCancelled {
+				t.Fatalf("unsafe binding reached provider: attempts=%d status=%s", h.transport.attempts, h.queueStatus(t, key))
+			}
+		})
+	}
+}
+
+func TestFastLaneRetryBudgetIsCheckedBeforeProvider(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	_, key := h.enqueueWithAttempts(t, "alvo@exemplo.com.br", fastLaneMaxAttempts)
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	if h.transport.attempts != 0 || h.queueStatus(t, key) != dispatch.QueueFailed {
+		t.Fatalf("exhausted row reached provider: attempts=%d status=%s", h.transport.attempts, h.queueStatus(t, key))
+	}
+}
+
+func TestFastLaneFailedRowCannotBeReenqueued(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchPermanent, errors.New("550 permanent"))
+	draftID, key := h.enqueue(t, "invalido@exemplo.com.br")
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	mailbox := h.mailbox
+	if err := h.store.Enqueue(context.Background(), &dispatch.QueueItem{
+		OrganizationID: h.orgID, EmailAccountID: &mailbox, Channel: dispatch.ChannelEmail,
+		DraftID: draftID, MessageKey: key, RecipientRef: "invalido@exemplo.com.br", DueAt: h.clock.Now(),
+	}); err != nil {
+		t.Fatalf("re-enqueue: %v", err)
+	}
+	if h.queueStatus(t, key) != dispatch.QueueFailed {
+		t.Fatalf("failed row was reopened: %s", h.queueStatus(t, key))
 	}
 }
 

--- a/internal/app/confenge/fast_lane_wiring.go
+++ b/internal/app/confenge/fast_lane_wiring.go
@@ -55,6 +55,7 @@ func (s *service) resolveConfengeMailbox(ctx context.Context, orgID uuid.UUID) (
 		if err != pgx.ErrNoRows {
 			return uuid.Nil, err
 		}
+		return uuid.Nil, fmt.Errorf("configured CONFENGE mailbox %q is not active with SMTP configured", want)
 	}
 	rows, err := s.fastLaneDB.Query(ctx, `
 		SELECT ea.id
@@ -119,6 +120,26 @@ func (s *service) reconcileFastLaneCompat(ctx context.Context, item *dispatch.Qu
 // fastLaneSuppress records a definitive provider rejection so the same address
 // cannot be attempted again by any path.
 func (s *service) fastLaneSuppress(ctx context.Context, item *dispatch.QueueItem, tp *models.OutreachTouchpoint, cause error) {
+	if suppressions, ok := s.repo.(interface {
+		UpsertOutreachRecipientSuppression(context.Context, *models.SuppressedRecipient) error
+	}); ok {
+		if err := suppressions.UpsertOutreachRecipientSuppression(ctx, &models.SuppressedRecipient{
+			OrganizationID: item.OrganizationID,
+			Email:          strings.ToLower(strings.TrimSpace(tp.Recipient)),
+			Reason:         firstNonEmpty(errText(cause), "permanent provider rejection"),
+			Source:         models.DeliverabilityEventBounce,
+			Metadata: map[string]interface{}{
+				"message_key": item.MessageKey,
+				"source":      "confenge_fast_lane_smtp",
+			},
+		}); err != nil {
+			log.Error().Err(err).Str("message_key", item.MessageKey).
+				Msg("confenge fast lane: durable recipient suppression failed")
+		}
+	} else {
+		log.Error().Str("message_key", item.MessageKey).
+			Msg("confenge fast lane: repository cannot persist recipient suppression")
+	}
 	if s.governor != nil && tp.Recipient != "" {
 		if _, err := s.governor.CancelByRecipient(ctx, item.OrganizationID, tp.Recipient,
 			"permanent_provider_rejection"); err != nil {

--- a/internal/app/confenge/fast_lane_wiring.go
+++ b/internal/app/confenge/fast_lane_wiring.go
@@ -98,20 +98,41 @@ func (s *service) resolveConfengeMailbox(ctx context.Context, orgID uuid.UUID) (
 // already accepted, and must never block the next one.
 func (s *service) reconcileFastLaneCompat(ctx context.Context, item *dispatch.QueueItem, tp *models.OutreachTouchpoint, acc FirstTouchAcceptance) {
 	sentAt := acc.AcceptedAt
-	tp.State = models.TouchpointSent
-	tp.SentAt = &sentAt
+	projected := *tp
+	projected.State = models.TouchpointSent
+	projected.SentAt = &sentAt
 	if acc.ProviderMessageID != "" {
-		tp.ProviderMessageID = acc.ProviderMessageID
+		projected.ProviderMessageID = acc.ProviderMessageID
 	}
-	if err := s.repo.UpdateTouchpoint(ctx, tp); err != nil {
+	projectionUpdated := false
+	if s.fastLaneDB != nil {
+		tag, err := s.fastLaneDB.Exec(ctx, `
+			UPDATE outreach_touchpoints
+			SET state='SENT',sent_at=$3,
+			    provider_message_id=CASE WHEN $4<>'' THEN $4 ELSE provider_message_id END,
+			    stop_reason='',updated_at=now()
+			WHERE organization_id=$1 AND id=$2 AND state='QUEUED'`,
+			item.OrganizationID, tp.ID, sentAt.UTC(), acc.ProviderMessageID)
+		if err != nil {
+			log.Warn().Err(err).Str("message_key", item.MessageKey).
+				Msg("confenge fast lane: touchpoint projection lagging an accepted send")
+		} else {
+			projectionUpdated = tag.RowsAffected() == 1
+		}
+	} else if err := s.repo.UpdateTouchpoint(ctx, &projected); err != nil {
 		log.Warn().Err(err).Str("message_key", item.MessageKey).
 			Msg("confenge fast lane: touchpoint projection lagging an accepted send")
+	} else {
+		projectionUpdated = true
 	}
 	if err := s.markDelegatedFirstTouchSent(ctx, item.OrganizationID, tp.ID, sentAt); err != nil {
 		log.Warn().Err(err).Str("message_key", item.MessageKey).
 			Msg("confenge fast lane: delegated decision lagging an accepted send")
 	}
-	if err := s.releaseNextTouch(ctx, item.OrganizationID, tp); err != nil {
+	if !projectionUpdated {
+		return
+	}
+	if err := s.releaseNextTouch(ctx, item.OrganizationID, &projected); err != nil {
 		log.Warn().Err(err).Str("message_key", item.MessageKey).
 			Msg("confenge fast lane: next touch not released")
 	}
@@ -149,6 +170,15 @@ func (s *service) fastLaneSuppress(ctx context.Context, item *dispatch.QueueItem
 	if s.governor != nil {
 		draft := item.DraftID
 		_ = s.governor.RecordFailure(ctx, item.OrganizationID, dispatch.ChannelEmail, item.MessageKey, &draft, errText(cause))
+	}
+	if tp.ContactCandidateID != nil {
+		if candidate, err := s.repo.GetCandidate(ctx, item.OrganizationID, *tp.ContactCandidateID); err == nil && candidate != nil {
+			candidate.Bounced = true
+			candidate.VerificationStatus = models.OutreachVerifyBounced
+			if _, err = s.repo.UpsertCandidate(ctx, candidate); err != nil {
+				log.Warn().Err(err).Msg("confenge fast lane: candidate bounce projection failed")
+			}
+		}
 	}
 	tp.State = models.TouchpointBounced
 	tp.StopReason = "permanent_provider_rejection"

--- a/internal/app/confenge/touchpoint_test.go
+++ b/internal/app/confenge/touchpoint_test.go
@@ -38,6 +38,24 @@ func TestSendWithoutApprovalBlocked(t *testing.T) {
 	}
 }
 
+func TestMessageKeyForTouchpointUsesLogicalInitialIdentity(t *testing.T) {
+	accountID, firstDraft, secondDraft := uuid.New(), uuid.New(), uuid.New()
+	initial := func(draftID uuid.UUID) *models.OutreachTouchpoint {
+		return &models.OutreachTouchpoint{
+			AccountID: accountID, DraftID: &draftID, Ordinal: 1,
+			Channel: models.OutreachChannelEmail, Purpose: models.TouchpointPurposeInitial,
+		}
+	}
+	if got, want := messageKeyForTouchpoint(initial(firstDraft)), messageKeyForTouchpoint(initial(secondDraft)); got != want {
+		t.Fatalf("replacement draft changed initial identity: %q != %q", got, want)
+	}
+	nonInitial := initial(firstDraft)
+	nonInitial.Ordinal, nonInitial.Purpose = 2, "FOLLOW_UP"
+	if got := messageKeyForTouchpoint(nonInitial); got != "email:draft:"+firstDraft.String() {
+		t.Fatalf("non-initial email lost draft compatibility key: %q", got)
+	}
+}
+
 func TestEditAfterApproveInvalidates(t *testing.T) {
 	tp := sampleTouch(models.OutreachChannelEmail, "lead@example.com", "Hi", "Hello")
 	if err := ApplyHumanApproval(tp, uuid.New(), time.Now().UTC()); err != nil {

--- a/internal/app/confenge/touchpoints.go
+++ b/internal/app/confenge/touchpoints.go
@@ -1149,10 +1149,7 @@ func (s *service) scheduleApprovedTouchpointAt(ctx context.Context, orgID uuid.U
 		}
 		due = dispatch.NextEligibleSlot(candidate, cfg.Timezone, cfg.WindowStart, cfg.WindowEnd, cfg.BusinessDaysOnly)
 	}
-	messageKey := dispatch.MessageKeyEmail(*tp.DraftID)
-	if tp.Channel == models.OutreachChannelWhatsApp {
-		messageKey = dispatch.MessageKeyWhatsApp(*tp.DraftID)
-	}
+	messageKey := messageKeyForTouchpoint(tp)
 	queued, err := s.repo.CASScheduleTouchpoint(ctx, orgID, tp.ID, tp.ContentHash, messageKey, due)
 	if err != nil {
 		return nil, errx.New(errx.Internal, "schedule approved touchpoint: "+err.Error())
@@ -1165,6 +1162,19 @@ func (s *service) scheduleApprovedTouchpointAt(ctx context.Context, orgID uuid.U
 		return nil, errx.New(errx.Conflict, "touchpoint not schedulable (state or approved hash mismatch)")
 	}
 	return queued, nil
+}
+
+func messageKeyForTouchpoint(tp *models.OutreachTouchpoint) string {
+	if tp == nil || tp.DraftID == nil {
+		return ""
+	}
+	if tp.Channel == models.OutreachChannelWhatsApp {
+		return dispatch.MessageKeyWhatsApp(*tp.DraftID)
+	}
+	if tp.Channel == models.OutreachChannelEmail && tp.Ordinal == 1 && tp.Purpose == models.TouchpointPurposeInitial {
+		return dispatch.MessageKeyFirstTouch(tp.AccountID)
+	}
+	return dispatch.MessageKeyEmail(*tp.DraftID)
 }
 
 func (s *service) dispatchEmailTouch(ctx context.Context, orgID, userID uuid.UUID, tp *models.OutreachTouchpoint) *errx.Error {

--- a/internal/client/smtpimap/smtp/client.go
+++ b/internal/client/smtpimap/smtp/client.go
@@ -37,6 +37,10 @@ type Client struct {
 	// When nil, WORKER_BIND_IP is consulted; when still unset, the OS default
 	// route is used.
 	BindIP *net.TCPAddr
+
+	// BeforeData is an optional durable handoff hook. It runs after every RCPT
+	// succeeds and immediately before SMTP DATA. An error aborts before DATA.
+	BeforeData func(context.Context) error
 }
 
 // Attachment is a fully-resolved file to encode into an outbound message. Data
@@ -260,6 +264,8 @@ func (c *Client) sendRaw(ctx context.Context, from string, to []string, data []b
 		return errx.ErrMailServerUnreachable
 	}
 	defer conn.Close()
+	stopDeadlineWatch := applyContextDeadline(ctx, conn)
+	defer stopDeadlineWatch()
 
 	// Use the resolved host: c.Credentials is nil for OAuth2-configured clients.
 	client, err := smtp.NewClient(conn, host)
@@ -316,11 +322,32 @@ func (c *Client) sendRaw(ctx context.Context, from string, to []string, data []b
 			return classifySMTPFailure(err, true)
 		}
 	}
+	return sendSMTPData(ctx, client, data, c.BeforeData)
+}
+
+type smtpDataClient interface {
+	Data() (io.WriteCloser, error)
+}
+
+func sendSMTPData(ctx context.Context, client smtpDataClient, data []byte, beforeData func(context.Context) error) *errx.MailError {
+	handoffStarted := false
+	if beforeData != nil {
+		if err := beforeData(ctx); err != nil {
+			return errx.ErrMailServerUnreachable
+		}
+		handoffStarted = true
+	}
 	w, err := client.Data()
 	if err != nil {
+		if handoffStarted {
+			return errx.ErrMailDeliveryUnknown
+		}
 		return classifySMTPFailure(err, false)
 	}
 	if _, err := w.Write(data); err != nil {
+		if handoffStarted {
+			return errx.ErrMailDeliveryUnknown
+		}
 		return classifySMTPFailure(err, false)
 	}
 	if err := w.Close(); err != nil {
@@ -328,6 +355,24 @@ func (c *Client) sendRaw(ctx context.Context, from string, to []string, data []b
 	}
 
 	return nil
+}
+
+// applyContextDeadline extends DialContext cancellation to the rest of the
+// SMTP conversation, whose standard-library methods do not accept a context.
+// The caller-supplied fast-lane timeout is shorter than its durable lease.
+func applyContextDeadline(ctx context.Context, conn net.Conn) func() {
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			_ = conn.SetDeadline(time.Now())
+		case <-done:
+		}
+	}()
+	return func() { close(done) }
 }
 
 func classifySMTPFailure(err error, recipientStage bool) *errx.MailError {

--- a/internal/client/smtpimap/smtp/client_test.go
+++ b/internal/client/smtpimap/smtp/client_test.go
@@ -1,13 +1,33 @@
 package smtp
 
 import (
+	"bytes"
+	"context"
 	"errors"
+	"io"
 	"net/textproto"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/warmbly/warmbly/internal/errx"
 )
+
+type trackedDataClient struct {
+	events *[]string
+	err    error
+}
+
+func (c trackedDataClient) Data() (io.WriteCloser, error) {
+	*c.events = append(*c.events, "data")
+	if c.err != nil {
+		return nil, c.err
+	}
+	return nopWriteCloser{Writer: &bytes.Buffer{}}, nil
+}
+
+type nopWriteCloser struct{ io.Writer }
+
+func (nopWriteCloser) Close() error { return nil }
 
 func TestClassifySMTPFailureRecognizesMicrosoftAuthFailure(t *testing.T) {
 	mailErr := classifySMTPFailure(errors.New("535 5.7.515 Access denied, authentication unsuccessful"), true)
@@ -25,4 +45,34 @@ func TestClassifySMTPFailureRecordsOnlyPermanentRecipientFailures(t *testing.T) 
 func TestClassifySMTPFailureDoesNotTreatSenderStageAsRecipientBounce(t *testing.T) {
 	mailErr := classifySMTPFailure(&textproto.Error{Code: 550, Msg: "5.7.1 sender rejected"}, false)
 	require.Equal(t, errx.MailErrorCodeServerUnreachable, mailErr.Code)
+}
+
+func TestSendSMTPDataRunsDurableHookImmediatelyBeforeDATA(t *testing.T) {
+	events := []string{"rcpt"}
+	err := sendSMTPData(context.Background(), trackedDataClient{events: &events}, []byte("message"), func(context.Context) error {
+		events = append(events, "hook")
+		return nil
+	})
+	require.Nil(t, err)
+	require.Equal(t, []string{"rcpt", "hook", "data"}, events)
+}
+
+func TestSendSMTPDataHookFailureNeverStartsDATA(t *testing.T) {
+	events := []string{"rcpt"}
+	err := sendSMTPData(context.Background(), trackedDataClient{events: &events}, []byte("message"), func(context.Context) error {
+		events = append(events, "hook")
+		return errors.New("durable fence unavailable")
+	})
+	require.Equal(t, errx.MailErrorCodeServerUnreachable, err.Code)
+	require.Equal(t, []string{"rcpt", "hook"}, events)
+}
+
+func TestSendSMTPDataFailureAfterHookIsAmbiguous(t *testing.T) {
+	events := []string{"rcpt"}
+	err := sendSMTPData(context.Background(), trackedDataClient{events: &events, err: errors.New("connection lost")}, nil, func(context.Context) error {
+		events = append(events, "hook")
+		return nil
+	})
+	require.Equal(t, errx.MailErrorCodeDeliveryUnknown, err.Code)
+	require.Equal(t, []string{"rcpt", "hook", "data"}, events)
 }

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -110,8 +110,7 @@ func (r *outreachRepository) HasAcceptedInitialForAccount(ctx context.Context, o
 	var accepted bool
 	err := r.db.QueryRow(ctx, `
 		SELECT EXISTS (
-			SELECT 1
-			FROM confenge_dispatch_sends sent
+			SELECT 1 FROM confenge_dispatch_sends sent
 			JOIN outreach_touchpoints t
 			  ON t.organization_id=sent.organization_id AND (
 			    t.draft_id=sent.draft_id OR EXISTS (
@@ -120,6 +119,15 @@ func (r *outreachRepository) HasAcceptedInitialForAccount(ctx context.Context, o
 			    ))
 			WHERE sent.organization_id=$1 AND t.account_id=$2 AND sent.channel='EMAIL'
 			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+			UNION ALL
+			-- Old sends predate the authoritative ledger. Treat them as accepted
+			-- only with all three independent provider-evidence fields present;
+			-- a queued/enrolled or attempted row is never enough to suppress work.
+			SELECT 1 FROM outreach_touchpoints t
+			WHERE t.organization_id=$1 AND t.account_id=$2
+			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+			  AND t.state='SENT' AND COALESCE(t.provider_message_id,'') <> ''
+			  AND t.sent_at IS NOT NULL
 		)`, orgID, accountID).Scan(&accepted)
 	return accepted, err
 }

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -128,6 +128,17 @@ func (r *outreachRepository) HasAcceptedInitialForAccount(ctx context.Context, o
 			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
 			  AND t.state='SENT' AND COALESCE(t.provider_message_id,'') <> ''
 			  AND t.sent_at IS NOT NULL
+			UNION ALL
+			-- An old draft-scoped queue can predate the account-scoped message
+			-- key. Attempted is an ambiguous external handoff and failed is an
+			-- exhausted/permanent terminal outcome; neither may be auto-resendable
+			-- through a replacement draft.
+			SELECT 1 FROM confenge_dispatch_queue q
+			JOIN outreach_touchpoints t
+			  ON t.organization_id=q.organization_id AND t.draft_id=q.draft_id
+			WHERE q.organization_id=$1 AND t.account_id=$2
+			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+			  AND q.status IN ('attempted','failed','sent')
 		)`, orgID, accountID).Scan(&accepted)
 	return accepted, err
 }

--- a/internal/repository/pg_outreach_backlog.go
+++ b/internal/repository/pg_outreach_backlog.go
@@ -101,6 +101,14 @@ func (r *outreachRepository) materializeCurrentInitialBacklog(ctx context.Contex
 			    ))
 			WHERE sent.organization_id=$1 AND sent.channel='EMAIL'
 			UNION
+			SELECT t.account_id
+			FROM confenge_dispatch_queue q
+			JOIN outreach_touchpoints t
+			  ON t.organization_id=q.organization_id AND t.draft_id=q.draft_id
+			WHERE q.organization_id=$1 AND q.channel='EMAIL'
+			  AND q.status IN ('attempted','failed','sent')
+			  AND t.ordinal=1 AND t.purpose='INITIAL' AND t.channel='EMAIL'
+			UNION
 			SELECT account_id
 			FROM outreach_touchpoints
 			WHERE organization_id=$1 AND ordinal=1 AND purpose='INITIAL' AND channel='EMAIL'

--- a/internal/repository/pg_outreach_schedule_terminal_pg_test.go
+++ b/internal/repository/pg_outreach_schedule_terminal_pg_test.go
@@ -1,0 +1,100 @@
+package repository
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestCASScheduleTouchpointNeverReopensTerminalInitialQueue(t *testing.T) {
+	dsn := os.Getenv("WARMBLY_TEST_POSTGRES_DSN")
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN is not set")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+
+	userID, orgID := uuid.New(), uuid.New()
+	if _, err = pool.Exec(ctx, `INSERT INTO users (id,first_name,last_name,email) VALUES($1,'Terminal','Schedule',$2)`, userID, fmt.Sprintf("terminal-schedule-%s@example.test", userID)); err != nil {
+		t.Fatal(err)
+	}
+	if _, err = pool.Exec(ctx, `INSERT INTO organizations (id,name,slug,owner_user_id) VALUES($1,'Terminal Schedule',$2,$3)`, orgID, "terminal-schedule-"+orgID.String(), userID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, done := context.WithTimeout(context.Background(), 10*time.Second)
+		defer done()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM organizations WHERE id=$1`, orgID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM users WHERE id=$1`, userID)
+	})
+
+	for _, terminalStatus := range []string{"attempted", "failed", "sent"} {
+		t.Run(terminalStatus, func(t *testing.T) {
+			accountID, oldDraftID, newDraftID, touchpointID := uuid.New(), uuid.New(), uuid.New(), uuid.New()
+			oldRecipient := terminalStatus + "-old@fornecedor.example"
+			newRecipient := terminalStatus + "-new@fornecedor.example"
+			messageKey := "email:first-touch:account:" + accountID.String()
+			if _, err = pool.Exec(ctx, `INSERT INTO outreach_accounts
+				(id,organization_id,source_lead_id,cnpj14,razao_social,queue_state,source_system)
+				VALUES($1,$2,$3,$4,'Fornecedor Terminal Ltda','APPROVED','extra-cli')`,
+				accountID, orgID, "terminal-"+terminalStatus, fmt.Sprintf("%014d", 52000000000000+len(terminalStatus))); err != nil {
+				t.Fatal(err)
+			}
+			for _, draft := range []struct {
+				id        uuid.UUID
+				recipient string
+			}{{oldDraftID, oldRecipient}, {newDraftID, newRecipient}} {
+				if _, err = pool.Exec(ctx, `INSERT INTO outreach_drafts
+					(id,organization_id,account_id,recipient_email,subject,body_text,status)
+					VALUES($1,$2,$3,$4,'Assunto','Mensagem','APPROVED')`,
+					draft.id, orgID, accountID, draft.recipient); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if _, err = pool.Exec(ctx, `INSERT INTO outreach_touchpoints
+				(id,organization_id,account_id,ordinal,purpose,channel,state,draft_id,recipient,subject,body_text,
+				 content_hash,approved_content_hash,approved_by,approved_at)
+				VALUES($1,$2,$3,1,'INITIAL','EMAIL','APPROVED',$4,$5,'Assunto','Mensagem','hash','hash',$6,now())`,
+				touchpointID, orgID, accountID, newDraftID, newRecipient, userID); err != nil {
+				t.Fatal(err)
+			}
+			if _, err = pool.Exec(ctx, `INSERT INTO confenge_dispatch_queue
+				(organization_id,channel,draft_id,message_key,recipient_ref,status,last_error)
+				VALUES($1,'EMAIL',$2,$3,$4,$5,'terminal evidence')`,
+				orgID, oldDraftID, messageKey, oldRecipient, terminalStatus); err != nil {
+				t.Fatal(err)
+			}
+
+			repo := NewOutreachRepository(pool)
+			queued, scheduleErr := repo.CASScheduleTouchpoint(ctx, orgID, touchpointID, "hash", messageKey, time.Now().UTC().Add(time.Hour))
+			if scheduleErr != nil {
+				t.Fatal(scheduleErr)
+			}
+			if queued != nil {
+				t.Fatalf("terminal queue was reported scheduled: %+v", queued)
+			}
+			var gotStatus, gotRecipient, touchState string
+			var gotDraft uuid.UUID
+			if err = pool.QueryRow(ctx, `SELECT status,draft_id,recipient_ref FROM confenge_dispatch_queue WHERE message_key=$1`, messageKey).
+				Scan(&gotStatus, &gotDraft, &gotRecipient); err != nil {
+				t.Fatal(err)
+			}
+			if err = pool.QueryRow(ctx, `SELECT state FROM outreach_touchpoints WHERE id=$1`, touchpointID).Scan(&touchState); err != nil {
+				t.Fatal(err)
+			}
+			if gotStatus != terminalStatus || gotDraft != oldDraftID || gotRecipient != oldRecipient || touchState != "APPROVED" {
+				t.Fatalf("terminal binding changed: status=%s draft=%s recipient=%s touchpoint=%s", gotStatus, gotDraft, gotRecipient, touchState)
+			}
+		})
+	}
+}

--- a/internal/repository/pg_outreach_touchpoints.go
+++ b/internal/repository/pg_outreach_touchpoints.go
@@ -344,21 +344,50 @@ func (r *outreachRepository) CASScheduleTouchpoint(ctx context.Context, orgID, i
 	if tp.DraftID == nil {
 		return nil, errors.New("approved touchpoint has no draft")
 	}
-	_, err = tx.Exec(ctx, `
+	var queueStatus string
+	var queueDraftID uuid.UUID
+	var queueRecipient string
+	err = tx.QueryRow(ctx, `
 		INSERT INTO confenge_dispatch_queue (
 			organization_id, channel, draft_id, message_key, recipient_ref,
 			due_at, priority, status, created_at, updated_at
 		) VALUES ($1,$2,$3,$4,$5,$6,0,'queued',$7,$7)
 		ON CONFLICT (message_key) DO UPDATE SET
-			due_at=EXCLUDED.due_at, recipient_ref=EXCLUDED.recipient_ref,
+			draft_id=CASE
+				WHEN confenge_dispatch_queue.status='cancelled'
+				  AND confenge_dispatch_queue.cancel_reason IN (
+					'delegated_authority_or_source_binding_advanced',
+					'source_run_superseded'
+				  ) THEN EXCLUDED.draft_id
+				ELSE confenge_dispatch_queue.draft_id
+			END,
+			due_at=CASE
+				WHEN confenge_dispatch_queue.status='cancelled'
+				  AND confenge_dispatch_queue.cancel_reason IN (
+					'delegated_authority_or_source_binding_advanced',
+					'source_run_superseded'
+				  ) THEN EXCLUDED.due_at
+				WHEN confenge_dispatch_queue.status IN ('queued','reserved')
+				  AND confenge_dispatch_queue.draft_id=EXCLUDED.draft_id
+				  AND COALESCE(confenge_dispatch_queue.recipient_ref,'')=COALESCE(EXCLUDED.recipient_ref,'')
+				  THEN EXCLUDED.due_at
+				ELSE confenge_dispatch_queue.due_at
+			END,
+			recipient_ref=CASE
+				WHEN confenge_dispatch_queue.status='cancelled'
+				  AND confenge_dispatch_queue.cancel_reason IN (
+					'delegated_authority_or_source_binding_advanced',
+					'source_run_superseded'
+				  ) THEN EXCLUDED.recipient_ref
+				ELSE confenge_dispatch_queue.recipient_ref
+			END,
 			status=CASE
 				WHEN confenge_dispatch_queue.status='cancelled'
 				  AND confenge_dispatch_queue.cancel_reason IN (
 					'delegated_authority_or_source_binding_advanced',
 					'source_run_superseded'
 				  ) THEN 'queued'
-				WHEN confenge_dispatch_queue.status IN ('sent','cancelled') THEN confenge_dispatch_queue.status
-				ELSE 'queued'
+				ELSE confenge_dispatch_queue.status
 			END,
 			cancel_reason=CASE
 				WHEN confenge_dispatch_queue.status='cancelled'
@@ -374,10 +403,39 @@ func (r *outreachRepository) CASScheduleTouchpoint(ctx context.Context, orgID, i
 					'source_run_superseded'
 				  )
 				  THEN confenge_dispatch_queue.last_error ELSE '' END,
-			reserved_until=NULL, updated_at=EXCLUDED.updated_at`,
-		orgID, tp.Channel, *tp.DraftID, messageKey, strings.ToLower(strings.TrimSpace(tp.Recipient)), dueAt.UTC(), now)
+			reserved_until=CASE
+				WHEN confenge_dispatch_queue.status='cancelled'
+				  AND confenge_dispatch_queue.cancel_reason IN (
+					'delegated_authority_or_source_binding_advanced',
+					'source_run_superseded'
+				  ) THEN NULL
+				ELSE confenge_dispatch_queue.reserved_until
+			END,
+			updated_at=CASE
+				WHEN confenge_dispatch_queue.status='cancelled'
+				  AND confenge_dispatch_queue.cancel_reason IN (
+					'delegated_authority_or_source_binding_advanced',
+					'source_run_superseded'
+				  ) THEN EXCLUDED.updated_at
+				WHEN confenge_dispatch_queue.status IN ('queued','reserved')
+				  AND confenge_dispatch_queue.draft_id=EXCLUDED.draft_id
+				  AND COALESCE(confenge_dispatch_queue.recipient_ref,'')=COALESCE(EXCLUDED.recipient_ref,'')
+				  THEN EXCLUDED.updated_at
+				ELSE confenge_dispatch_queue.updated_at
+			END
+		RETURNING status,draft_id,COALESCE(recipient_ref,'')`,
+		orgID, tp.Channel, *tp.DraftID, messageKey, strings.ToLower(strings.TrimSpace(tp.Recipient)), dueAt.UTC(), now).
+		Scan(&queueStatus, &queueDraftID, &queueRecipient)
 	if err != nil {
 		return nil, err
+	}
+	wantRecipient := strings.ToLower(strings.TrimSpace(tp.Recipient))
+	if (queueStatus != "queued" && queueStatus != "reserved") ||
+		queueDraftID != *tp.DraftID || queueRecipient != wantRecipient {
+		// Roll back the touchpoint's QUEUED transition as well. Attempted,
+		// failed, sent and safety-cancelled work is terminal unless an explicit
+		// audited recovery operation reopens it.
+		return nil, nil
 	}
 	if err := tx.Commit(ctx); err != nil {
 		return nil, err

--- a/internal/repository/pg_outreach_touchpoints_test.go
+++ b/internal/repository/pg_outreach_touchpoints_test.go
@@ -17,10 +17,10 @@ func TestOutreachTouchpointSelectQualifiesJoinedColumns(t *testing.T) {
 	}
 }
 
-func TestAcceptedInitialQueryRequiresTerminalProviderEvidenceForLegacyRows(t *testing.T) {
+func TestAcceptedInitialQueryRecognizesProviderEvidenceAndTerminalLegacyQueue(t *testing.T) {
 	// The send ledger branch is authoritative. The legacy branch is deliberately
-	// stricter so an attempted, queued, or merely enrolled initial is not treated
-	// as provider acceptance.
+	// strict for SENT projections, while attempted/failed queue rows are a
+	// conservative no-resend fence rather than provider acceptance.
 	source, err := os.ReadFile("pg_outreach.go")
 	if err != nil {
 		t.Fatal(err)
@@ -29,6 +29,7 @@ func TestAcceptedInitialQueryRequiresTerminalProviderEvidenceForLegacyRows(t *te
 	for _, required := range []string{
 		"FROM confenge_dispatch_sends sent",
 		"t.state='SENT'", "COALESCE(t.provider_message_id,'') <> ''", "t.sent_at IS NOT NULL",
+		"FROM confenge_dispatch_queue q", "q.status IN ('attempted','failed','sent')",
 	} {
 		if !strings.Contains(query, required) {
 			t.Fatalf("accepted-initial query missing %q", required)

--- a/internal/repository/pg_outreach_touchpoints_test.go
+++ b/internal/repository/pg_outreach_touchpoints_test.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -12,6 +13,25 @@ func TestOutreachTouchpointSelectQualifiesJoinedColumns(t *testing.T) {
 	} {
 		if !strings.Contains(outreachTouchpointSelect, "t."+column) {
 			t.Fatalf("touchpoint select must qualify %s for joined queries", column)
+		}
+	}
+}
+
+func TestAcceptedInitialQueryRequiresTerminalProviderEvidenceForLegacyRows(t *testing.T) {
+	// The send ledger branch is authoritative. The legacy branch is deliberately
+	// stricter so an attempted, queued, or merely enrolled initial is not treated
+	// as provider acceptance.
+	source, err := os.ReadFile("pg_outreach.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	query := string(source)
+	for _, required := range []string{
+		"FROM confenge_dispatch_sends sent",
+		"t.state='SENT'", "COALESCE(t.provider_message_id,'') <> ''", "t.sent_at IS NOT NULL",
+	} {
+		if !strings.Contains(query, required) {
+			t.Fatalf("accepted-initial query missing %q", required)
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- make SMTP handoff durable before DATA so crash/lease recovery cannot resend ambiguous first touches
- use account-scoped initial message keys, stable Message-IDs, terminal failed/attempted rows, live recipient/content safety, and durable permanent suppression
- keep feed lineage and temporal qualification at queue admission rather than re-deciding them before SMTP
- refill from current-import institutional recipients carrying the explicit controlled-email contract, while preserving DNC, suppression, provenance, party-role, and accepted-ledger gates
- preserve queued work across source/release/policy drift and document the operational boundary

## Production evidence behind the change
- current controlled recoverable reservoir: 5,037 accounts (read-only query)
- current queue: 0 queued/reserved; 4,396 cancelled by provenance/context drift
- immutable runtime before change: 43ec021, schema 140, fast lane enabled, SMTP/IMAP reachable
- dispatch remains deliberately paused under outbound_recovery_20260831 during review/deploy

## Verification
- gofmt on every changed Go file
- go test ./internal/app/confenge/dispatch ./internal/client/smtpimap/smtp -count=1
- focused CONFENGE fast-lane/delegated/controlled tests
- go test -c ./internal/app/confenge
- go test -c ./internal/repository
- git diff --check