### PR TITLE
feat: bind CONFENGE refill to the claimed touchpoint

### DIFF
--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -1653,9 +1653,21 @@ func (s *service) prepareDelegatedTouchpoint(ctx context.Context, orgID uuid.UUI
 	if err != nil {
 		return nil, nil, fmt.Errorf("first_touch_lookup_failed")
 	}
+	var selectedTouchpointID uuid.UUID
+	runwayEntry := strings.HasPrefix(entry.IdempotencyKey, delegatedFirstTouchIdempotencyPrefix+"runway-")
+	if runwayEntry {
+		raw := strings.TrimPrefix(strings.TrimSpace(entry.CorrelationID), "touchpoint:")
+		selectedTouchpointID, err = uuid.Parse(raw)
+		if err != nil || selectedTouchpointID == uuid.Nil {
+			return nil, nil, fmt.Errorf("selected_first_touch_binding_invalid")
+		}
+	}
 	var tp *models.OutreachTouchpoint
 	var legacy *models.OutreachTouchpoint
 	for i := range all {
+		if runwayEntry && all[i].ID != selectedTouchpointID {
+			continue
+		}
 		if all[i].Ordinal != 1 || all[i].Purpose != models.TouchpointPurposeInitial ||
 			all[i].Channel != models.OutreachChannelEmail {
 			continue
@@ -1673,6 +1685,9 @@ func (s *service) prepareDelegatedTouchpoint(ctx context.Context, orgID uuid.UUI
 		}
 		row := all[i]
 		tp = &row
+	}
+	if runwayEntry && tp == nil {
+		return nil, nil, fmt.Errorf("selected_first_touch_missing")
 	}
 	if tp == nil {
 		tp = legacy

--- a/internal/app/confenge/delegated_first_touch_test.go
+++ b/internal/app/confenge/delegated_first_touch_test.go
@@ -110,6 +110,38 @@ func TestDelegatedRunwayIdempotencyPreservesPublicationBindingAndAddsCandidate(t
 	}
 }
 
+func TestDelegatedRunwayPreparesExactlyTheClaimedTouchpoint(t *testing.T) {
+	f := newDelegatedValidationFixture(t, RouteClassGenericCompany, "contato@empresa.example")
+	selectedID := uuid.New()
+	for i, state := range []string{models.TouchpointCancelled, models.TouchpointCancelled, models.TouchpointDue} {
+		id := uuid.New()
+		if i == 2 {
+			id = selectedID
+		}
+		f.repo.touchpoints[id] = &models.OutreachTouchpoint{
+			ID: id, OrganizationID: f.orgID, AccountID: f.account.ID,
+			ContactCandidateID: &f.candidate.ID, Ordinal: 1, CadenceStep: "INITIAL",
+			Channel: models.OutreachChannelEmail, Purpose: models.TouchpointPurposeInitial,
+			DueAt: time.Now().UTC(), State: state, SourceRunID: f.manifest.SourceRunID,
+		}
+	}
+	entry := f.entry
+	entry.IdempotencyKey = delegatedFirstTouchIdempotencyPrefix + "runway-v1:binding:" + f.account.ID.String()
+	entry.CorrelationID = "touchpoint:" + selectedID.String()
+	tp, _, err := f.service.prepareDelegatedTouchpoint(context.Background(), f.orgID, f.account, &f.candidate, f.manifest, entry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if tp == nil || tp.ID != selectedID || tp.State != models.TouchpointNeedsReview {
+		t.Fatalf("prepared wrong touchpoint: %+v", tp)
+	}
+	for id, stored := range f.repo.touchpoints {
+		if id != selectedID && stored.State != models.TouchpointCancelled {
+			t.Fatalf("terminal sibling %s was mutated to %s", id, stored.State)
+		}
+	}
+}
+
 func TestDelegatedPolicyBindsTemplateAndExplicitGreenTemplateAuthority(t *testing.T) {
 	now := time.Now().UTC()
 	orgID, founderID := uuid.New(), uuid.New()


### PR DESCRIPTION
## Summary
- make delegated runway materialization consume the exact touchpoint id already claimed by the selector
- stop a second source-run scan from choosing one of the two terminal historical siblings instead
- preserve the selected current recipient rebind and all admission/safety gates

## Production evidence
117 sampled blocked accounts each have exactly three INITIAL rows: two CANCELLED historical siblings and one DUE current row. The old preparer ignored the claimed id and returned first_touch_already_authorized_or_terminal.

## Verification
- focused unit test with two CANCELLED siblings and one claimed DUE row
- gofmt
- git diff --check