### PR TITLE
feat: admit committed CONFENGE carryover through refill

### DIFF
--- a/internal/app/confenge/delegated_first_touch.go
+++ b/internal/app/confenge/delegated_first_touch.go
@@ -1672,6 +1672,14 @@ func (s *service) prepareDelegatedTouchpoint(ctx context.Context, orgID uuid.UUI
 			all[i].Channel != models.OutreachChannelEmail {
 			continue
 		}
+		if runwayEntry {
+			// The selector already proved committed lineage for this exact row.
+			// Carryover may legitimately come from an older run; admission below
+			// rebinds it to the current manifest before queue commit.
+			row := all[i]
+			tp = &row
+			break
+		}
 		if all[i].SourceRunID == "" {
 			row := all[i]
 			legacy = &row

--- a/internal/app/confenge/delegated_first_touch_test.go
+++ b/internal/app/confenge/delegated_first_touch_test.go
@@ -118,11 +118,15 @@ func TestDelegatedRunwayPreparesExactlyTheClaimedTouchpoint(t *testing.T) {
 		if i == 2 {
 			id = selectedID
 		}
+		sourceRunID := f.manifest.SourceRunID
+		if i == 2 {
+			sourceRunID = "committed-carryover-run"
+		}
 		f.repo.touchpoints[id] = &models.OutreachTouchpoint{
 			ID: id, OrganizationID: f.orgID, AccountID: f.account.ID,
 			ContactCandidateID: &f.candidate.ID, Ordinal: 1, CadenceStep: "INITIAL",
 			Channel: models.OutreachChannelEmail, Purpose: models.TouchpointPurposeInitial,
-			DueAt: time.Now().UTC(), State: state, SourceRunID: f.manifest.SourceRunID,
+			DueAt: time.Now().UTC(), State: state, SourceRunID: sourceRunID,
 		}
 	}
 	entry := f.entry


### PR DESCRIPTION
## Summary
- allow the exact touchpoint claimed by runway refill to carry committed lineage from an older source run
- remove the preparer's redundant current-run equality after the SQL selector already proved both account and touchpoint committed lineage
- rebind the selected row to the current manifest before queue admission

## Production evidence
The first hotfix replaced first_touch_already_authorized_or_terminal with selected_first_touch_missing. The selected DUE rows are committed carryover; the two terminal siblings are current-run projections. Source-run equality in the second selector was the remaining false gate.

## Verification
- focused carryover unit test
- gofmt
- git diff --check