### PR TITLE
CONFENGE_WEB contract, real INTEL_WATCH EventProducer, engine_lane attribution, INTEL_SEED cap

### DIFF
--- a/cmd/backend/main.go
+++ b/cmd/backend/main.go
@@ -268,6 +268,8 @@ func main() {
 	var organizationRepoForHandler repository.OrganizationRepository
 	var warmupRoutingRepoForHandler repository.WarmupRoutingRepository
 	var intelWatchRepoForHandler repository.IntelWatchRepository
+	var intelWatchInboxRepo repository.IntelWatchInboxRepository
+	var intelSeedRepo repository.IntelSeedRepository
 	var webhookServiceForHandler webhook.Service
 	var integrationServiceForHandler integration.Service
 	var oauthService *oauth.Service
@@ -584,6 +586,8 @@ func main() {
 		crmRepository := repository.NewCRMRepository(primaryDB.Pool)
 		advancedRepository := repository.NewAdvancedOutreachRepository(primaryDB.Pool)
 		intelWatchRepoForHandler = repository.NewIntelWatchRepository(primaryDB.Pool)
+		intelWatchInboxRepo = repository.NewIntelWatchInboxRepository(primaryDB.Pool)
+		intelSeedRepo = repository.NewIntelSeedRepository(primaryDB.Pool)
 		// INTEL_WATCH is an opt-in side lane. It is checked here, loudly, so a
 		// missing opt-out signing secret is diagnosed at boot instead of at the
 		// first unusable unsubscribe link -- and it is only ever a log, never a
@@ -1146,26 +1150,46 @@ func main() {
 			// This worker is idle while paused or outside the business window.
 			go confenge.NewDispatchQueueWorker(confengeServiceForHandler, 30*time.Second).Run(ctx)
 		}
+		// Stores that must exist whether or not their lane is running.
+		// CONFENGE_WEB records consent while INTEL_WATCH delivery is dormant,
+		// and the opportunity-event inbox must accept a post the moment the
+		// upstream makes one: an event we refuse is an event nobody can replay.
+		confengeServiceForHandler.WireIntelWatchSubscriptions(intelWatchRepoForHandler)
+		confengeServiceForHandler.WireIntelWatchInbox(intelWatchInboxRepo)
+		confengeServiceForHandler.WireIntelSeed(intelSeedRepo)
 		// INTEL_WATCH side lane. Opt-in, and deliberately started after first
 		// touch: it shares the SMTP transport and the mailbox rules, never the
 		// send governor, the queue or the cap. A dormant or broken watch lane
 		// starts nothing and changes nothing about first-touch sending.
 		if watchEnabled, watchErr := liveintel.WatchStartupDecision(); watchEnabled && watchErr == nil {
 			confengeServiceForHandler.WireIntelWatch(primaryDB.Pool)
-			watchProducer, producerErr := liveintel.NewFixtureEventProducerFromEnv()
+			// The durable inbox is the production event source. The fixture
+			// producer stays available for rehearsal and tests, and is used only
+			// when an operator explicitly points at a file.
+			var watchProducer liveintel.EventProducer
+			var producerErr error
+			if fixturePath := strings.TrimSpace(os.Getenv(liveintel.EnvFixturePath)); fixturePath != "" {
+				var fixtureProducer *liveintel.FixtureEventProducer
+				fixtureProducer, producerErr = liveintel.NewFixtureEventProducerFromEnv()
+				if fixtureProducer != nil {
+					if orgID := confengeIntelWatchOrgID(); orgID != uuid.Nil {
+						fixtureProducer.BindOrganization(orgID)
+					}
+					watchProducer = fixtureProducer
+					log.Printf("confenge INTEL_WATCH replaying the rehearsal fixture at %s instead of the durable inbox", fixturePath)
+				}
+			} else if pgProducer := liveintel.NewPostgresEventProducer(confengeServiceForHandler.IntelWatchInbox()); pgProducer != nil {
+				if orgID := confengeIntelWatchOrgID(); orgID != uuid.Nil {
+					pgProducer.BindOrganization(orgID)
+				}
+				watchProducer = pgProducer
+			}
 			switch {
 			case producerErr != nil:
 				log.Printf("ERROR confenge INTEL_WATCH event source unusable, the watch lane will deliver nothing: %v", producerErr)
 			case watchProducer == nil:
-				log.Printf("confenge INTEL_WATCH enabled with no event source (set %s); the lane is idle", liveintel.EnvFixturePath)
+				log.Printf("confenge INTEL_WATCH enabled with no event source; the lane is idle")
 			default:
-				if orgRaw := strings.TrimSpace(os.Getenv("CONFENGE_INTEL_WATCH_ORG_ID")); orgRaw != "" {
-					if orgID, err := uuid.Parse(orgRaw); err == nil {
-						watchProducer.BindOrganization(orgID)
-					} else {
-						log.Printf("confenge INTEL_WATCH: invalid CONFENGE_INTEL_WATCH_ORG_ID %q", orgRaw)
-					}
-				}
 				if watchWorker := confengeServiceForHandler.NewIntelWatchReclaimWorker(
 					intelWatchRepoForHandler, confenge.NewSMTPFirstTouchTransport(emailRepostory),
 					watchProducer, 5*time.Minute); watchWorker != nil {
@@ -1173,6 +1197,16 @@ func main() {
 					log.Printf("confenge INTEL_WATCH reclaim worker started")
 				}
 			}
+		}
+		// INTEL_SEED. Its own loop, its own cap, its own counter: it claims no
+		// queue row and takes no dispatch reservation, so first touch behaves
+		// identically whether this is dormant, running, or fully capped out.
+		if confenge.IntelSeedEnabled() && confenge.IntelSeedDailyCap() > 0 {
+			go confenge.NewIntelSeedWorker(confengeServiceForHandler, time.Minute).Run(ctx)
+			log.Printf("confenge INTEL_SEED lane enabled with a dedicated daily cap of %d", confenge.IntelSeedDailyCap())
+		} else {
+			log.Printf("confenge INTEL_SEED lane dormant (set %s and %s to enable)",
+				confenge.EnvIntelSeedEnabled, confenge.EnvIntelSeedDailyCap)
 		}
 		// Suboptimal and explicitly rejected copy is recoverable. AI rewrites run
 		// asynchronously and always return to human review.
@@ -1994,4 +2028,21 @@ func (m advisorMembers) MemberPermissions(ctx context.Context, orgID, userID uui
 		return 0, errors.New("not a member of this organization")
 	}
 	return member.Permissions, nil
+}
+
+// confengeIntelWatchOrgID scopes the INTEL_WATCH event source to one
+// organization. Unset means every organization, which is the durable inbox's
+// natural shape: each row already carries the org Warmbly's webhook auth
+// resolved.
+func confengeIntelWatchOrgID() uuid.UUID {
+	raw := strings.TrimSpace(os.Getenv("CONFENGE_INTEL_WATCH_ORG_ID"))
+	if raw == "" {
+		return uuid.Nil
+	}
+	orgID, err := uuid.Parse(raw)
+	if err != nil {
+		log.Printf("confenge INTEL_WATCH: invalid CONFENGE_INTEL_WATCH_ORG_ID %q", raw)
+		return uuid.Nil
+	}
+	return orgID
 }

--- a/docs/confenge/acquisition-engines.md
+++ b/docs/confenge/acquisition-engines.md
@@ -4,8 +4,9 @@ Internal engineering notes for the four-engine acquisition surface. Operator and
 backend facing. The customer-visible behavior of these lanes is documented in
 `docs/content/docs/guides/confenge-outreach.mdx`; this page records the parts an
 operator or an engineer needs and a customer does not: the INTEL_WATCH
-replayability boundary, the `GET /confenge/interrupt-budget` contract, and what
-engine attribution does and does not currently claim.
+replayability boundary and the durable inbox that resolves it, the INTEL_SEED
+cap, the `GET /confenge/interrupt-budget` and `GET /confenge/sales-context`
+contracts, and what engine attribution does and does not claim.
 
 ## The four engines
 
@@ -22,18 +23,22 @@ INTEL_SEED is admitted on the cold-outreach basis (DNC, opt-out, bounce,
 recipient suppression, commercial authority, target fit) and never reads a
 subscription record. INTEL_WATCH is admitted on its subscription record and
 never reads cold-outreach admission. Nothing in the repo converts an accepted
-INTEL_SEED into a subscription automatically; `CreateOrReactivateSubscription`
-has no production caller, so consent can only arrive through an explicit act.
+INTEL_SEED into a subscription automatically. The one production caller of
+`CreateOrReactivateSubscription` is CONFENGE_WEB intake, which acts on a
+`MONITOR_COMPANY` or `MONITOR_OPPORTUNITY` envelope carrying its own consent
+provenance, so consent still arrives only through an explicit act by the person
+whose address it is.
 
 None of the additive lanes takes a dispatch reservation, a touchpoint, a cohort
 slot, or any first-touch queue state. Both intelligence lanes send through the
 same `FirstTouchTransport` and the same mailbox-resolution rules as first touch.
 There is one SMTP implementation in the system.
 
-## INTEL_WATCH replayability boundary
+## INTEL_WATCH replayability boundary, and how it is resolved
 
-This is the load-bearing caveat on the INTEL_WATCH recovery story. Read it
-before treating automatic reprocessing as a guarantee.
+This was the load-bearing caveat on the INTEL_WATCH recovery story. It is
+resolved by the durable inbox described at the end of this section. The
+distinction it rests on still matters and is stated first.
 
 **Dedup buys at-most-once. Replayability buys at-least-once. Only the first is
 source-independent.**
@@ -45,35 +50,56 @@ and a failure after the irreversible handoff is parked as `AMBIGUOUS` and never
 resent.
 
 Automatic resumption of a `PENDING` row is a different property. It is
-*completeness*, not safety, and it holds only because of the current event
-source. `WATCH_PENDING_HAS_AUTOMATIC_REPROCESSING=YES` means exactly this and
-nothing more:
+*completeness*, not safety, and it holds only if the event can still be
+obtained. The delivery ledger deliberately stores delivery identity, not event
+content, so it cannot rebuild a notification on its own.
 
-> The reclaim worker automatically resumes PENDING delivery ONLY because the
-> current event source (the fixture-backed `EventProducer` in
-> `internal/app/confenge/liveintel/events_fixture.go`) is replayable and
-> deterministic: it re-emits the same immutable event set on every `Subscribe`,
-> so a delivery identity can be re-derived from the source rather than read back
-> from the ledger. The ledger deliberately stores delivery identity, not event
-> content.
+The real upstream (extra-cli) posts once, over HTTP, and cannot be asked to post
+again. Warmbly therefore does not depend on the upstream being replayable. It
+persists the envelope itself.
 
-The contract with a real extra-cli producer has **not** been proven cross-repo.
-If the real upstream is at-most-once or otherwise non-replayable, a `PENDING`
-row whose event is never re-emitted is permanently undelivered, and the reclaim
-worker cannot detect it: there is nothing in the ledger to rebuild the message
-from. A durable event-payload inbox is required before the reprocessing
-guarantee holds against such an upstream.
+### The durable inbox
 
-That inbox is a **deliberate deferred decision** pending cross-repo convergence
-with the real extra-cli producer. It is not an oversight and not a known defect.
-Nothing in this repo should be read as a guarantee against an at-most-once
-upstream, and no comment, docstring, or doc page may be written to imply one.
+`confenge_intel_watch_inbox` (migration `000143`) stores every accepted
+`CONFENGE_OPPORTUNITY_EVENT/1.0` envelope at the moment of ingestion, before
+anything else happens to it, so a crash after the HTTP `200` cannot lose it.
+`PostgresEventProducer` in
+`internal/app/confenge/liveintel/events_postgres.go` is the production
+`EventProducer` and replays from that table.
 
-Boundary stated in code at:
+Two properties of the table are load bearing:
 
+- **Emission never consumes a row.** The inbox is append-only inside a bounded
+  replay window (24 hours by default). Marking a row consumed when it is handed
+  to the consumer would lose the event whenever the consumer failed straight
+  afterwards, which is precisely the failure the inbox exists to prevent.
+  Re-emission is free because the delivery ledger refuses a duplicate by primary
+  key.
+- **The organization comes from the column, not the payload.** The column is
+  what Warmbly's own webhook authentication resolved. Any `org_id` inside the
+  posted body is overwritten and never read, so an external caller cannot write
+  into another organization's watch pipeline.
+
+`emit_lease_until` bounds duplicate *work* between two producer instances. It is
+not a correctness boundary: with the lease cleared, the same rows are simply
+offered again and the ledger dedups them.
+
+`Subscribe` emits the currently replayable batch and closes the channel, exactly
+as the fixture producer does. That is the contract the reclaim worker was built
+against: it ranges to close, so a producer that held a live tail open would hold
+one reclaim pass open forever.
+
+`FixtureEventProducer` is unchanged and still available. It is selected only
+when an operator explicitly sets `CONFENGE_INTEL_WATCH_EVENTS_FILE`, which is a
+rehearsal and test path; otherwise the durable inbox is the source. With neither
+configured the lane is dormant: no producer is built, the reclaim worker is
+never started, and first-touch startup and sending are untouched.
+
+Stated in code at:
+
+- `internal/app/confenge/liveintel/events_postgres.go` (package doc block)
 - `internal/app/confenge/liveintel/watch_reclaim_worker.go` (package doc block)
-- `internal/app/confenge/liveintel/events_fixture.go` (package doc block and the
-  `FixtureEventProducer` doc)
+- `internal/app/confenge/liveintel/events_fixture.go` (package doc block)
 
 Related bounds, which are separate from the boundary above: a reclaim pass runs
 every five minutes while the lane is enabled, parks handoffs whose worker
@@ -158,30 +184,79 @@ Each item carries `action_id`, `account_id`, optional `candidate_id`, `bucket`,
 reader can distinguish "no hand-raisers from INTEL_SEED" from "INTEL_SEED is
 not a dimension this projection knows about".
 
-### Reading `by_engine` today
+### Reading `by_engine`
 
-Known limitation, stated here so the numbers are not misread. No production code
-path currently writes `engine_lane` on `outreach_commercial_actions`. The column
-exists (migration `000142`), the repository reads and writes it, and
-`ConvergeHandRaise` stamps it, but `ConvergeHandRaise` has no production caller
-yet and the existing first-touch action-creation paths were deliberately left
-untouched. In production today, therefore:
+`engine_lane` now has production writers. There is exactly one:
+`PersistHandRaise` in
+`internal/app/confenge/handraise_persist.go`, which converges every signal
+through `ConvergeHandRaise` and files it idempotently on
+`HandRaiseIdempotencyKey`. Stamping the lane in one place is why two engines
+cannot disagree about attribution.
 
-- every row reads back `engine_lane = ''`
-- `by_engine` is all zeros
-- `unattributed` equals `total`
+Its callers:
 
-`outbound_first_touch: 0` means "nothing stamps this lane yet", **not** "first
-touch produced no hand-raisers". The endpoint is honest about this because
-`unattributed` is its own field rather than a hidden remainder, but the zero is
-easy to misread. Wiring the writers means touching first-touch action creation,
-which is out of scope for the closure of this campaign.
+| Engine | Call site | Signal |
+| --- | --- | --- |
+| `confenge_web` | `IngestWebIntent`, on a `REQUEST_DEEP_DIVE` or `REQUEST_HUMAN_REVIEW` envelope | `REQUEST_DEEP_DIVE` / `REQUEST_HUMAN_REVIEW` |
+| `outbound_first_touch` | `convergeReplyHandRaise`, from `ProcessInboundHandoff` on a positive reply correlated to a first-touch touchpoint | `POSITIVE_REPLY_FIRST_TOUCH` |
+| `intel_seed` | the same reply path, when the caller declares `InboundHandoff.EngineLane` | `INTEL_SEED_RESPONSE` |
 
-The same applies on the intel side. `intel.Chain.EngineLane` is populated from
-`ObserveFromInbound` (which stamps `confenge_web`, the one engine knowable from
-the record's kind) and from `ObserveFromAction` (which inherits whatever the
-action row carries, so empty today). `ProjectEngineLaneProgression` has no
-production caller.
+Attribution is derived, never guessed. `ReplyEngineLane` uses the lane the
+caller declared; failing that, a correlated touchpoint, which is first-touch
+cadence state no other engine writes. With neither, the row stays unattributed
+and is counted in `unattributed` rather than assigned to whichever engine
+happens to be running.
+
+Two gaps remain, stated so a zero is not misread:
+
+- **`intel_watch` has no hand-raise signal.** The closed `HandRaiseSignal` set
+  has a first-touch reply and an INTEL_SEED response and nothing for
+  subscription mail. A reply to watch mail therefore cannot converge under a
+  signal that names it. Adding one is a policy decision, not something the
+  mapping may invent, so `by_engine["intel_watch"]` stays zero.
+- **`intel_seed` needs its caller to declare the lane.** Replies arrive through
+  the same IMAP path as first touch and carry no lane marker of their own. The
+  mapping is wired and tested; it fires once a caller populates
+  `InboundHandoff.EngineLane`.
+
+On the intel side, `intel.Chain.EngineLane` is populated from
+`ObserveFromInbound` (which stamps `confenge_web`) and from `ObserveFromAction`
+(which inherits whatever the action row carries, so it now inherits a real lane
+for hand-raiser rows). `ProjectEngineLaneProgression` still has no production
+caller.
+
+## `GET /confenge/sales-context`
+
+The `CONFENGE_SALES_CONTEXT/1.0` artifact. A flat, versioned projection of the
+hand-raisers the engines produced, so a downstream sales tool can pick a
+conversation up without a second data model and without calling back per row.
+
+Implementation: `internal/app/confenge/sales_context.go`
+(`ExportSalesContext`), handler `GetConfengeSalesContext`, same auth, gating and
+`limit` rules as the interrupt budget, and the same read-only guarantee: it
+reserves nothing, sends nothing and mutates no row.
+
+It reads the same open commercial actions the interrupt budget reads and keeps
+only the hand-raisers. Every field is copied from a row that already exists.
+Nothing here scores, ranks or infers intent, and where the underlying row has no
+answer the field is absent, because an empty field is honest and a filled one
+would not be.
+
+Per item: `acquisition_channel` (the engine lane), `company_ref` and
+`opportunity_id`, `company_name`, `person_name`, `intent_reason` (the converged
+signal, read back off the row's own idempotency key), `reply_reason`,
+`conversation_started`, a `facts` block carrying `why_now`, `factual_hook`,
+`evidence_ids` as provenance and `confidence` plus `stated_limits` as the limits
+travelling with them, the account's `touchpoints`, and the next action.
+
+There is no claim-safety field. No live claim-safety or attestation concept
+exists in the repo to source one from, and inventing one would be a claim the
+system cannot back.
+
+The subject a request pointed at is recorded as a `subject_key:` entry in the
+action's `evidence_ids`. The action row has no subject column, and overloading
+one that already means something else would corrupt it; provenance is where an
+identity the claim points at legitimately belongs.
 
 ## Engine attribution is not queue routing, and not a feedback dimension
 
@@ -206,14 +281,51 @@ An unknown value normalizes to unattributed rather than to a default engine. A
 wrong attribution makes a working engine look like it produced someone else's
 result, which is worse than a missing one.
 
+## INTEL_SEED cap
+
+INTEL_SEED takes no dispatch reservation, no queue row and no cohort slot, so
+before this change nothing counted an INTEL_SEED send at all.
+
+`confenge_intel_seed_sends` (migration `000143`) is the lane's own counter and
+its no-resend record at the same time. Two things follow:
+
+- **The cap is additional, never a carve-out.** A seed touch must pass every
+  first-touch admission predicate `GateIntelSeed` already applies AND fit inside
+  `CONFENGE_INTEL_SEED_DAILY_CAP` for its organization that UTC day. The cap
+  counts rows in this table. It never reads, spends or reduces the first-touch
+  dispatch governor's budget.
+- **The row is written before the handoff.** It is the fence as well as the
+  counter, so a crash between recording and sending cannot re-send the recipient
+  or under-count the cap.
+
+Both opt-ins are required and both fail closed. `CONFENGE_INTEL_SEED_ENABLED`
+stays `false` by default, and `CONFENGE_INTEL_SEED_DAILY_CAP` defaults to `0`,
+which sends nothing. A missing, malformed or negative cap is `0`; it never falls
+back to a first-touch number budgeted for a different lane. An unwired ledger is
+an uncountable cap, which is not a cap, so the lane stays dormant.
+`CONFENGE_INTEL_SEED_ORG_ID` scopes the loop to one organization; unset means
+the loop does not run.
+
+A contact this lane has written to is skipped for 90 days. A seed offer is a
+cold email and repeating it is the failure mode this lane must not have.
+
+Deliberate divergence from the fast lane, named here so it can be overruled: a
+non-accepted send keeps its ledger row, so a transient SMTP failure permanently
+spends that cap slot and that contact is not retried. A duplicate cold email is
+worse than a missed one, but this is stricter than how first touch treats a
+transient.
+
+`internal/app/confenge/intel_seed_worker.go` (`ProcessIntelSeedOnce`,
+`IntelSeedHeadroom`), gate in `internal/app/confenge/intel_seed.go`.
+
 ## Known boundaries, out of scope by decision
 
-- **Durable event-payload inbox.** See the replayability boundary above.
-  Deferred pending cross-repo convergence with the real extra-cli producer.
-- **INTEL_SEED cap policy.** `CONFENGE_INTEL_SEED_ENABLED` stays dormant and no
-  cap, window, admission, or queue default was changed for it. `GateIntelSeed`
-  has no production caller.
-- **No `engine_lane` writers.** See "Reading `by_engine` today".
+- **INTEL_WATCH hand-raise signal.** See "Reading `by_engine`". A reply to
+  subscription mail has no member of the closed signal set, so it cannot be
+  attributed. This is a deliberate refusal to invent a mapping, not a gap to
+  close silently.
+- **INTEL_SEED reply attribution.** The mapping exists; the reply path does not
+  yet declare the lane. See "Reading `by_engine`".
 - **Watch mail and cold-outreach suppression are separate.** The INTEL_WATCH
   dispatcher checks the subscription's own active state, not the cold-outreach
   suppression list, because consulting the cold-outreach list for subscription
@@ -221,5 +333,6 @@ result, which is worse than a missing one.
   terminates that one delivery as `WatchPermanent` but does not suppress future
   events for that address. Relevant to shared mailbox reputation, and a
   deliberate boundary rather than a gap to close silently.
-- **No frontend.** `GET /confenge/interrupt-budget` is an internal operator
-  endpoint with no dashboard surface yet.
+- **No frontend.** `GET /confenge/interrupt-budget` and
+  `GET /confenge/sales-context` are internal operator endpoints with no
+  dashboard surface yet.

--- a/docs/content/docs/api/endpoints.mdx
+++ b/docs/content/docs/api/endpoints.mdx
@@ -103,6 +103,7 @@ All paths below are relative to the versioned base URL `https://api.warmbly.com/
 | POST | `/confenge/dispatch/resume` | `WRITE_CONTACTS` |
 | GET | `/confenge/cockpit` | `READ_CONTACTS` |
 | GET | `/confenge/interrupt-budget` | `READ_CONTACTS` |
+| GET | `/confenge/sales-context` | `READ_CONTACTS` |
 | GET | `/confenge/inbound` | `READ_CONTACTS` |
 | POST | `/confenge/inbound/:leadId/outcome` | `WRITE_CONTACTS` |
 | POST | `/confenge/inbound/:leadId/acknowledge` | `WRITE_CONTACTS` |

--- a/docs/content/docs/api/error-codes.mdx
+++ b/docs/content/docs/api/error-codes.mdx
@@ -437,6 +437,65 @@ Retry-After: 60
 
 Use the `Retry-After` header to determine when to retry.
 
+## CONFENGE inbound intelligence envelopes
+
+`POST /webhooks/confenge/inbound` accepts several body schemas and branches on
+the envelope's `schema` field. Two of them are intelligence envelopes with their
+own stable rejection codes. Both fail closed on the whole envelope: a rejected
+body creates nothing, not even the part of it that was well formed.
+
+### `CONFENGE_WEB_INTENT/1.0`
+
+A person on the public site asking to be told about something, or asking for a
+human to look. `intent_kind` is a closed set: `MONITOR_COMPANY`,
+`MONITOR_OPPORTUNITY`, `REQUEST_DEEP_DIVE`, `REQUEST_HUMAN_REVIEW`. All
+rejections return `400`.
+
+| `code` | Meaning |
+| --- | --- |
+| `confenge_web_intent_schema_mismatch` | The body is not tagged `CONFENGE_WEB_INTENT/1.0` |
+| `confenge_web_intent_kind_unknown` | `intent_kind` is outside the closed set. There is no default |
+| `confenge_web_intent_lane_not_confenge_web` | `lane` is not `confenge_web`. The engine lane is verified, never chosen by the caller |
+| `confenge_web_intent_contact_email_missing` | `contact_email` is absent or not an address |
+| `confenge_web_intent_company_ref_missing` | `MONITOR_COMPANY`, `REQUEST_DEEP_DIVE` and `REQUEST_HUMAN_REVIEW` require a `company_ref` |
+| `confenge_web_intent_opportunity_id_missing` | `MONITOR_OPPORTUNITY` requires an `opportunity_id` |
+| `confenge_web_intent_correlation_key_is_cnpj` | A correlation key normalized to a CNPJ. A tax register number identifies a legal entity, not one company record or one opportunity, so it is never accepted as a correlation key |
+| `confenge_web_intent_correlation_key_is_share_token` | A correlation key is an `li_`-prefixed share token. A token identifies a link, not the subject the link points at |
+| `confenge_web_intent_consent_provenance_missing` | A `MONITOR_*` intent arrived without `consent_source`, `consent_at` and `consent_provenance_ok`. Only the monitor intents put an address on a standing mail list, so only they require consent provenance |
+| `confenge_web_intent_cadence_unknown` | `cadence` is not `immediate`, `daily` or `weekly` |
+| `confenge_web_intent_store_unavailable` | `503`. The subscription store is not wired, so consent could not be recorded |
+
+Accepted `MONITOR_*` envelopes return `201` with a `subscription_id` and a
+canonical `subject_key` of the form `company:<company_ref>` or
+`opportunity:<opportunity_id>`. No other subject-key shape is produced by this
+path. Accepted `REQUEST_*` envelopes return `201` with an `action_id`; when the
+contact does not resolve to a known account the response carries
+`matched: false` and `reason: contact_not_matched_to_account` instead, because
+a commercial action is filed against an account and inventing one would be
+worse than saying so.
+
+### `CONFENGE_OPPORTUNITY_EVENT/1.0`
+
+An upstream saying a watched subject changed. The envelope is stored durably
+before anything else happens to it. All rejections return `400` except the last,
+which is `503`.
+
+| `code` | Meaning |
+| --- | --- |
+| `confenge_opportunity_event_event_schema_mismatch` | The body is not tagged `CONFENGE_OPPORTUNITY_EVENT/1.0` |
+| `confenge_opportunity_event_event_id_missing` | `event_id` is empty. It is the replay identity, so there is no way to store the envelope without it |
+| `confenge_opportunity_event_event_type_not_in_closed_set` | `event_type` is outside `NEW_OPPORTUNITY`, `OPPORTUNITY_CHANGED`, `DEADLINE_CHANGED`, `FIT_BECAME_RELEVANT` |
+| `confenge_opportunity_event_event_organization_missing` | No organization is configured for inbound, so the event has no owner |
+| `confenge_opportunity_event_event_subject_key_missing` | `subject_key` is empty, so no watcher can be resolved |
+| `confenge_opportunity_event_event_payload_empty` | `payload` is empty. There is nothing to tell a watcher |
+| `confenge_opportunity_event_inbox_unavailable` | `503`. The durable inbox is not wired. The event is refused rather than accepted and dropped |
+
+The organization is always the one Warmbly's own webhook authentication
+resolved. An `org_id` inside the payload is overwritten and never consulted, so
+a caller cannot reach another organization's watch list by naming it in the
+body. A repeat post of the same `event_id` returns `200` and does not rewrite
+the stored envelope; a first post returns `201`.
+
 ## See also
 
 - [Authentication](/api/authentication/)

--- a/internal/api/handler/confenge.go
+++ b/internal/api/handler/confenge.go
@@ -1304,6 +1304,35 @@ func (h *Handler) GetConfengeInterruptBudget(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"data": budget})
 }
 
+// GetConfengeSalesContext — GET /confenge/sales-context
+//
+// The CONFENGE_SALES_CONTEXT/1.0 artifact: the hand-raisers the acquisition
+// engines produced, with their facts, provenance, stated limits and
+// touchpoints, so a downstream sales tool can pick a conversation up without a
+// second data model. Read-only, and a projection over the same commercial
+// actions the interrupt budget reads.
+func (h *Handler) GetConfengeSalesContext(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	limit := 50
+	if raw := strings.TrimSpace(c.Query("limit")); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 || n > 200 {
+			errx.JSON(c, errx.New(errx.BadRequest, "limit must be between 1 and 200"))
+			return
+		}
+		limit = n
+	}
+	export, xerr := h.ConfengeService.ExportSalesContext(c.Request.Context(), orgID, limit)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": export})
+}
+
 // GetConfengeAttention — GET /confenge/attention/:id
 func (h *Handler) GetConfengeAttention(c *gin.Context) {
 	orgID, ok := h.confengeOrg(c)

--- a/internal/api/handler/confenge_inbound.go
+++ b/internal/api/handler/confenge_inbound.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
 	"github.com/warmbly/warmbly/internal/errx"
 )
 
@@ -111,6 +112,40 @@ func (h *Handler) ConfengeInboundWebhook(c *gin.Context) {
 			status = http.StatusOK
 		}
 		c.JSON(status, gin.H{"data": res})
+		return
+	}
+	// Checked before the inbound-lead fallthrough, which would otherwise
+	// swallow both of these: neither carries a lead shape.
+	if intel.IsWebIntentEnvelope(body) {
+		env, err := intel.ParseWebIntentEnvelope(body)
+		if err != nil {
+			errx.JSON(c, errx.New(errx.BadRequest, err.Error()))
+			return
+		}
+		res, xerr := h.ConfengeService.IngestWebIntent(c.Request.Context(), orgID, env, time.Now().UTC())
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		c.JSON(http.StatusCreated, gin.H{"data": res})
+		return
+	}
+	if liveintel.IsOpportunityEventEnvelope(body) {
+		event, err := liveintel.ParseOpportunityEvent(body)
+		if err != nil {
+			errx.JSON(c, errx.New(errx.BadRequest, err.Error()))
+			return
+		}
+		receipt, xerr := h.ConfengeService.IngestOpportunityEvent(c.Request.Context(), orgID, event, time.Now().UTC())
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		status := http.StatusCreated
+		if receipt.Replay {
+			status = http.StatusOK
+		}
+		c.JSON(status, gin.H{"data": receipt})
 		return
 	}
 	res, xerr := h.ConfengeService.IngestInboundLead(c.Request.Context(), orgID, body, confenge.IngestOptions{

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -552,6 +552,7 @@ func Run(
 				confengeGroup.GET("/intel/commercial/:leadId", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeCommercialCanonical)
 				confengeGroup.GET("/attention", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeAttention)
 				confengeGroup.GET("/interrupt-budget", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeInterruptBudget)
+				confengeGroup.GET("/sales-context", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeSalesContext)
 				confengeGroup.GET("/attention/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeAttention)
 				confengeGroup.GET("/accounts", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeAccounts)
 				confengeGroup.GET("/accounts/:id", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeAccount)

--- a/internal/app/confenge/engine_lane_test.go
+++ b/internal/app/confenge/engine_lane_test.go
@@ -1,0 +1,228 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Engine-lane attribution proofs.
+//
+// G: a hand raise from each wired engine converges to the right engine_lane and
+//    shows up correctly in the interrupt budget's by_engine and in the
+//    CONFENGE_SALES_CONTEXT/1.0 export.
+
+// newWebIntentService builds a service over the in-memory repository with one
+// account and one contact already in the book, so intake has something to match.
+func newWebIntentService(t *testing.T) (*service, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	repo := newMemRepo()
+	orgID := uuid.New()
+	svc := NewService(Config{
+		Enabled: true, RequireHumanApproval: true, DefaultDailyLimit: 50,
+		FeedSchemaVersion: models.OutreachSchemaV1, EvidenceVersion: DefaultEvidenceVersion,
+	}, repo, nil).(*service)
+	acc := &models.OutreachAccount{
+		ID: uuid.New(), OrganizationID: orgID, CNPJ14: "12345678000190",
+		RazaoSocial: "Acme Holdings", QueueState: models.OutreachQueueNeedsContact,
+	}
+	if _, err := repo.UpsertAccount(ctx, acc); err != nil {
+		t.Fatal(err)
+	}
+	cand := &models.OutreachContactCandidate{
+		ID: uuid.New(), OrganizationID: orgID, AccountID: acc.ID,
+		Name: "Ana Souza", Email: "ana@example.com",
+	}
+	if _, err := repo.UpsertCandidate(ctx, cand); err != nil {
+		t.Fatal(err)
+	}
+	return svc, orgID
+}
+
+// A REQUEST_* intake converges onto the hand-raiser surface with the
+// confenge_web engine lane, and creates no watch subscription.
+func TestWebIntentRequestConvergesAsConfengeWebHandRaise(t *testing.T) {
+	for _, tc := range []struct {
+		kind       string
+		wantSignal HandRaiseSignal
+		wantLane   string
+	}{
+		{intel.WebIntentRequestDeepDive, SignalRequestDeepDive, models.LaneInboundNow},
+		{intel.WebIntentRequestHumanReview, SignalRequestHumanReview, models.LaneEmailNeedsReview},
+	} {
+		t.Run(tc.kind, func(t *testing.T) {
+			svc, orgID := newWebIntentService(t)
+			subs := &fakeWatchSubs{}
+			svc.WireIntelWatchSubscriptions(subs)
+
+			res, xerr := svc.IngestWebIntent(context.Background(), orgID, validWebIntent(tc.kind), time.Now().UTC())
+			if xerr != nil {
+				t.Fatalf("intake rejected: %v", xerr)
+			}
+			if len(subs.saved) != 0 {
+				t.Fatalf("a REQUEST_* intake created %d subscriptions", len(subs.saved))
+			}
+			if res.ActionID == nil {
+				t.Fatalf("no commercial action was persisted: %+v", res)
+			}
+			action, err := svc.actionStore().GetCommercialAction(context.Background(), orgID, *res.ActionID)
+			if err != nil || action == nil {
+				t.Fatalf("action not readable: %v", err)
+			}
+			if action.EngineLane != EngineLaneConfengeWeb {
+				t.Fatalf("engine_lane = %q, want %q", action.EngineLane, EngineLaneConfengeWeb)
+			}
+			if action.Lane != tc.wantLane {
+				t.Fatalf("cockpit lane = %q, want %q", action.Lane, tc.wantLane)
+			}
+			if got := HandRaiseSignalOf(action); got != string(tc.wantSignal) {
+				t.Fatalf("recorded signal = %q, want %q", got, tc.wantSignal)
+			}
+			if got := HandRaiseSubjectKeyOf(action); got != "company:acme-holdings" {
+				t.Fatalf("recorded subject key = %q", got)
+			}
+		})
+	}
+}
+
+// The same web request twice is one hand-raiser, not two.
+func TestWebIntentRequestConvergesOnce(t *testing.T) {
+	svc, orgID := newWebIntentService(t)
+	svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+	env := validWebIntent(intel.WebIntentRequestDeepDive)
+	first, xerr := svc.IngestWebIntent(context.Background(), orgID, env, time.Now().UTC())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	second, xerr := svc.IngestWebIntent(context.Background(), orgID, env, time.Now().UTC().Add(time.Hour))
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if first.ActionID == nil || second.ActionID == nil || *first.ActionID != *second.ActionID {
+		t.Fatalf("repeat request did not converge: %v vs %v", first.ActionID, second.ActionID)
+	}
+}
+
+// Proof G. Hand raises from three engines are attributed separately in
+// by_engine and carried through to the sales-context export.
+func TestInterruptBudgetAndSalesContextAttributeEachEngine(t *testing.T) {
+	ctx := context.Background()
+	svc, orgID := newWebIntentService(t)
+	accountID := uuid.New()
+
+	lanes := []struct {
+		lane   string
+		signal HandRaiseSignal
+	}{
+		{EngineLaneFirstTouch, SignalPositiveReplyFirstTouch},
+		{EngineLaneIntelSeed, SignalIntelSeedResponse},
+		{EngineLaneConfengeWeb, SignalRequestDeepDive},
+	}
+	for _, l := range lanes {
+		if _, xerr := svc.PersistHandRaise(ctx, HandRaise{
+			OrganizationID: orgID, AccountID: accountID, Signal: l.signal, EngineLane: l.lane,
+			OccurredAt: time.Now().UTC(), Evidence: "reply", SubjectKey: "company:acme-holdings",
+		}); xerr != nil {
+			t.Fatalf("%s did not converge: %v", l.lane, xerr)
+		}
+	}
+
+	budget, xerr := svc.FounderInterruptBudget(ctx, orgID, 50)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	for _, l := range lanes {
+		if budget.ByEngine[l.lane] != 1 {
+			t.Fatalf("by_engine[%s] = %d, want 1 (full map %v)", l.lane, budget.ByEngine[l.lane], budget.ByEngine)
+		}
+	}
+	if budget.ByEngine[EngineLaneIntelWatch] != 0 {
+		t.Fatalf("intel_watch attributed %d rows it did not produce", budget.ByEngine[EngineLaneIntelWatch])
+	}
+	if budget.Unattributed != 0 {
+		t.Fatalf("unattributed = %d, want 0 now that every writer stamps a lane", budget.Unattributed)
+	}
+
+	export, xerr := svc.ExportSalesContext(ctx, orgID, 50)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if export.Schema != SalesContextSchemaV1 {
+		t.Fatalf("schema = %q", export.Schema)
+	}
+	if export.Total != len(lanes) {
+		t.Fatalf("export total = %d, want %d", export.Total, len(lanes))
+	}
+	for _, l := range lanes {
+		if export.ByEngine[l.lane] != 1 {
+			t.Fatalf("export by_engine[%s] = %d, want 1", l.lane, export.ByEngine[l.lane])
+		}
+	}
+	for _, item := range export.Items {
+		if item.AcquisitionChannel == EngineLaneUnattributed {
+			t.Fatalf("export item has no acquisition channel: %+v", item)
+		}
+		if item.CompanyRef != "acme-holdings" {
+			t.Fatalf("export item company_ref = %q, want acme-holdings", item.CompanyRef)
+		}
+		if item.IntentReason == "" {
+			t.Fatalf("export item has no intent reason: %+v", item)
+		}
+	}
+}
+
+// An unattributed hand raise still round-trips its signal. This is the guard on
+// the idempotency-key split: an engine segment that is the empty string must
+// not shift the signal out from under the reader.
+func TestHandRaiseSignalRoundTripsWithoutAnEngine(t *testing.T) {
+	action := ConvergeHandRaise(HandRaise{
+		OrganizationID: uuid.New(), AccountID: uuid.New(),
+		Signal: SignalMeetingOrProposalRequest, EngineLane: "",
+	})
+	if action == nil {
+		t.Fatal("unattributed hand raise did not converge")
+	}
+	if action.EngineLane != EngineLaneUnattributed {
+		t.Fatalf("engine_lane = %q, want unattributed", action.EngineLane)
+	}
+	if got := HandRaiseSignalOf(action); got != string(SignalMeetingOrProposalRequest) {
+		t.Fatalf("signal = %q, want %q", got, SignalMeetingOrProposalRequest)
+	}
+}
+
+// Reply attribution never guesses. A correlated touchpoint is first touch; an
+// uncorrelated reply with no declared lane stays unattributed.
+func TestReplyEngineLaneIsDerivedNeverGuessed(t *testing.T) {
+	if got := ReplyEngineLane(InboundHandoff{}); got != EngineLaneUnattributed {
+		t.Fatalf("bare reply attributed to %q", got)
+	}
+	if got := ReplyEngineLane(InboundHandoff{TouchpointID: uuid.New()}); got != EngineLaneFirstTouch {
+		t.Fatalf("correlated touchpoint attributed to %q, want first touch", got)
+	}
+	if got := ReplyEngineLane(InboundHandoff{EngineLane: EngineLaneIntelSeed}); got != EngineLaneIntelSeed {
+		t.Fatalf("declared lane became %q", got)
+	}
+	if got := ReplyEngineLane(InboundHandoff{EngineLane: "not-an-engine"}); got != EngineLaneUnattributed {
+		t.Fatalf("unknown declared lane became %q, want unattributed", got)
+	}
+}
+
+func TestReplyHandRaiseSignalPerEngine(t *testing.T) {
+	if _, ok := ReplyHandRaiseSignal(IntentObjection, EngineLaneFirstTouch); ok {
+		t.Fatal("a non-positive reply converged as a hand raise")
+	}
+	sig, ok := ReplyHandRaiseSignal(IntentPositiveInterest, EngineLaneFirstTouch)
+	if !ok || sig != SignalPositiveReplyFirstTouch {
+		t.Fatalf("first touch positive reply = %q", sig)
+	}
+	sig, ok = ReplyHandRaiseSignal(IntentPositiveInterest, EngineLaneIntelSeed)
+	if !ok || sig != SignalIntelSeedResponse {
+		t.Fatalf("intel seed positive reply = %q", sig)
+	}
+}

--- a/internal/app/confenge/handraise_persist.go
+++ b/internal/app/confenge/handraise_persist.go
@@ -1,0 +1,41 @@
+package confenge
+
+import (
+	"context"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// PersistHandRaise converges one signal and files it on the commercial-action
+// surface the Control Center already reads.
+//
+// It is the single writer for every engine, so engine_lane is stamped in one
+// place. Convergence is idempotent on HandRaiseIdempotencyKey: the same person
+// raising their hand twice through the same engine is one row, and an existing
+// row is returned untouched rather than overwritten, because a human may
+// already have worked it.
+//
+// A nil action with a nil error means the signal did not converge (unknown
+// signal, or no organization/account to file against). That is a legible
+// no-op, never an invented row.
+func (s *service) PersistHandRaise(ctx context.Context, raise HandRaise) (*models.OutreachCommercialAction, *errx.Error) {
+	if s == nil {
+		return nil, errx.New(errx.Internal, "confenge service is not available")
+	}
+	action := ConvergeHandRaise(raise)
+	if action == nil {
+		return nil, nil
+	}
+	store := s.actionStore()
+	if store == nil {
+		return nil, errx.New(errx.Internal, "commercial action store is not wired")
+	}
+	if existing, err := store.GetCommercialActionByIdempotency(ctx, action.OrganizationID, action.IdempotencyKey); err == nil && existing != nil {
+		return existing, nil
+	}
+	if err := store.UpsertCommercialAction(ctx, action); err != nil {
+		return nil, errx.New(errx.Internal, "persist hand raise: "+err.Error())
+	}
+	return action, nil
+}

--- a/internal/app/confenge/handraiser.go
+++ b/internal/app/confenge/handraiser.go
@@ -105,6 +105,29 @@ type HandRaise struct {
 	Evidence   string
 	PersonName string
 	HumanNotes string
+	// SubjectKey is the canonical identity of the thing the person asked about,
+	// when the engine knows one. It is recorded as provenance, never as a
+	// routing input: nothing in the mapping reads it.
+	SubjectKey string
+}
+
+// handRaiseSubjectEvidencePrefix marks the subject key inside EvidenceIDs. The
+// action row has no subject column, and overloading one that already means
+// something else would corrupt it; provenance is where an identity the claim
+// points at legitimately belongs.
+const handRaiseSubjectEvidencePrefix = "subject_key:"
+
+// HandRaiseSubjectKeyOf reads a recorded subject key back off an action.
+func HandRaiseSubjectKeyOf(action *models.OutreachCommercialAction) string {
+	if action == nil {
+		return ""
+	}
+	for _, id := range action.EvidenceIDs {
+		if strings.HasPrefix(id, handRaiseSubjectEvidencePrefix) {
+			return strings.TrimPrefix(id, handRaiseSubjectEvidencePrefix)
+		}
+	}
+	return ""
 }
 
 // handRaiseMapping is the whole policy: signal -> (next action, cockpit lane,
@@ -203,6 +226,9 @@ func ConvergeHandRaise(raise HandRaise) *models.OutreachCommercialAction {
 		IdempotencyKey: HandRaiseIdempotencyKey(raise),
 		CreatedAt:      occurred,
 		UpdatedAt:      occurred,
+	}
+	if subject := strings.TrimSpace(raise.SubjectKey); subject != "" {
+		action.EvidenceIDs = append(action.EvidenceIDs, handRaiseSubjectEvidencePrefix+subject)
 	}
 	return action
 }

--- a/internal/app/confenge/inbound_receive.go
+++ b/internal/app/confenge/inbound_receive.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
 )
 
 const (
@@ -17,6 +18,14 @@ const (
 	InboundReasonSecretMissing = "inbound_secret_missing"
 	InboundReasonOrgMissing    = "inbound_org_missing"
 )
+
+// acceptedInboundEventVersions is the full capability list this endpoint
+// branches on. It is assembled here because the two intelligence schemas live
+// in sibling packages and the probe must not advertise a body the dispatch
+// cannot actually route.
+func acceptedInboundEventVersions() []string {
+	return append(intel.AcceptedEventVersions(), intel.WebIntentSchemaV1, liveintel.EventSchemaV1)
+}
 
 // InboundReceiveProbe is the PII-free, secret-free signal web-cfg uses
 // to decide whether to POST. Timeout is a client-side class (process
@@ -38,7 +47,7 @@ func EvaluateInboundReceive(cfg Config) InboundReceiveProbe {
 		AutoSendEnabled:       cfg.AutoSendEnabled,
 		Reasons:               nil,
 		DispatchAttempted:     false,
-		AcceptedEventVersions: intel.AcceptedEventVersions(),
+		AcceptedEventVersions: acceptedInboundEventVersions(),
 	}
 	if !cfg.Enabled {
 		p.Reasons = append(p.Reasons, InboundReasonOutreachOff)

--- a/internal/app/confenge/intel/web_intent.go
+++ b/internal/app/confenge/intel/web_intent.go
@@ -1,0 +1,95 @@
+package intel
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// The CONFENGE_WEB intent envelope.
+//
+// web-cfg posts this when a person asks, on the public site, to be told about
+// something or to have a human look. It is the inbound counterpart of the
+// outbound engines: the person is talking to us first, so the consent basis is
+// their own act, recorded on the envelope rather than inferred later.
+//
+// This file is syntax only. It recognises and decodes the body; it decides
+// nothing about whether the request may be acted on. Semantic validation and
+// routing live in the confenge package, which owns the correlation-key rules
+// and the subscription and hand-raise stores.
+
+// WebIntentSchemaV1 tags the envelope, following the same versioned-contract
+// convention as the other inbound bodies this endpoint accepts.
+const WebIntentSchemaV1 = "CONFENGE_WEB_INTENT/1.0"
+
+// The closed intent set. MONITOR_* asks for standing notification; REQUEST_*
+// asks for a person. The two REQUEST_* values are byte-identical to the
+// hand-raise signals they compose into, so no translation table exists.
+const (
+	WebIntentMonitorCompany     = "MONITOR_COMPANY"
+	WebIntentMonitorOpportunity = "MONITOR_OPPORTUNITY"
+	WebIntentRequestDeepDive    = "REQUEST_DEEP_DIVE"
+	WebIntentRequestHumanReview = "REQUEST_HUMAN_REVIEW"
+)
+
+// WebIntentKinds is the closed set in declaration order.
+var WebIntentKinds = []string{
+	WebIntentMonitorCompany,
+	WebIntentMonitorOpportunity,
+	WebIntentRequestDeepDive,
+	WebIntentRequestHumanReview,
+}
+
+// WebIntentEnvelope is the decoded body. Every field is carried as written;
+// nothing here trims, defaults or infers.
+type WebIntentEnvelope struct {
+	Schema     string `json:"schema"`
+	IntentKind string `json:"intent_kind"`
+	// Lane must be the confenge_web engine lane. It is checked, never trusted
+	// as a routing instruction: an external caller does not choose our lanes.
+	Lane          string `json:"lane"`
+	CompanyRef    string `json:"company_ref"`
+	OpportunityID string `json:"opportunity_id"`
+	ContactEmail  string `json:"contact_email"`
+	ContactName   string `json:"contact_name"`
+	Topic         string `json:"topic"`
+	Cadence       string `json:"cadence"`
+	// Consent provenance, in the same shape the subscription row stores.
+	ConsentSource       string     `json:"consent_source"`
+	ConsentAt           *time.Time `json:"consent_at"`
+	ConsentProvenanceOK bool       `json:"consent_provenance_ok"`
+	OccurredAt          *time.Time `json:"occurred_at"`
+	Evidence            string     `json:"evidence"`
+	Notes               string     `json:"notes"`
+}
+
+// IsWebIntentEnvelope reports a CONFENGE_WEB_INTENT/1.0 body. It is checked
+// before the inbound-lead fallthrough, which would otherwise swallow it.
+func IsWebIntentEnvelope(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var peek struct {
+		Schema  string `json:"schema"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return false
+	}
+	return strings.TrimSpace(peek.Schema) == WebIntentSchemaV1 ||
+		strings.TrimSpace(peek.Version) == WebIntentSchemaV1
+}
+
+// ParseWebIntentEnvelope decodes the body without judging it.
+func ParseWebIntentEnvelope(raw []byte) (WebIntentEnvelope, error) {
+	if !IsWebIntentEnvelope(raw) {
+		return WebIntentEnvelope{}, fmt.Errorf("not %s", WebIntentSchemaV1)
+	}
+	var env WebIntentEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return WebIntentEnvelope{}, fmt.Errorf("%s: %w", WebIntentSchemaV1, err)
+	}
+	env.Schema = WebIntentSchemaV1
+	return env, nil
+}

--- a/internal/app/confenge/intel_seed_worker.go
+++ b/internal/app/confenge/intel_seed_worker.go
@@ -1,0 +1,284 @@
+package confenge
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// The INTEL_SEED production loop.
+//
+// GateIntelSeed already answers "may this person receive a seed touch, and what
+// would it say". What was missing is something that asks. This is that caller,
+// and it is deliberately its own loop rather than a branch inside the
+// first-touch one: it claims no queue row, takes no dispatch reservation and
+// spends no first-touch budget, so first touch behaves identically whether this
+// loop runs, is dormant, or is enabled and fully capped out.
+//
+// The cap below is the one thing this lane adds on TOP of the shared admission
+// predicates. It is additional, never a carve-out: a seed send must pass every
+// first-touch gate GateIntelSeed already applies AND fit inside this lane's own
+// daily counter.
+
+// EnvIntelSeedDailyCap is the INTEL_SEED lane's own daily send ceiling, per
+// organization. Unset or zero means no seed is deliverable, which is the same
+// dormant answer an unset opt-in gives.
+const EnvIntelSeedDailyCap = "CONFENGE_INTEL_SEED_DAILY_CAP"
+
+// EnvIntelSeedOrgID scopes the loop to one organization. INTEL_SEED is an
+// operator-run experiment; it does not sweep every tenant by default.
+const EnvIntelSeedOrgID = "CONFENGE_INTEL_SEED_ORG_ID"
+
+// intelSeedMaxPerTick bounds one pass so a large book cannot turn a single tick
+// into an unbounded send burst.
+const intelSeedMaxPerTick = 10
+
+// intelSeedGateAttemptsPerPass bounds how many contacts one pass puts to the
+// gate before giving up. A refusal writes nothing, so without a bound a book
+// where nobody is admissible would never end its pass.
+const intelSeedGateAttemptsPerPass = 25
+
+// intelSeedContactCooldown is how long one contact stays out of the lane's
+// candidate pool after a seed touch. It is long on purpose: a seed offer is a
+// cold email, and repeating it is the failure mode this lane must not have.
+const intelSeedContactCooldown = 90 * 24 * time.Hour
+
+// IntelSeedDailyCap reads the lane's own ceiling. A missing, unparseable or
+// non-positive value is zero: fail closed, never fall back to a first-touch
+// number that was budgeted for a different lane.
+func IntelSeedDailyCap() int {
+	raw := strings.TrimSpace(os.Getenv(EnvIntelSeedDailyCap))
+	if raw == "" {
+		return 0
+	}
+	n, err := strconv.Atoi(raw)
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// IntelSeedLedger is the INTEL_SEED lane's own send record. It is what the
+// daily cap counts; nothing here reads or writes first-touch state.
+type IntelSeedLedger interface {
+	// CountSendsSince is the cap's counter.
+	CountSendsSince(ctx context.Context, orgID uuid.UUID, since time.Time) (int, error)
+	// RecordSend is idempotent on the message key, so a retry after a crash
+	// cannot double-count the cap or double-send the recipient.
+	RecordSend(ctx context.Context, send models.IntelSeedSend) (bool, error)
+	// AlreadySent reports whether this exact seed touch was already delivered.
+	AlreadySent(ctx context.Context, orgID uuid.UUID, messageKey string) (bool, error)
+	// SeededCandidateIDs is what stops the loop re-offering the same contact
+	// every tick. The message key depends on the subject, which is only known
+	// after admission, so the pre-filter has to dedupe on the contact instead.
+	SeededCandidateIDs(ctx context.Context, orgID uuid.UUID, since time.Time) (map[uuid.UUID]bool, error)
+}
+
+// WireIntelSeed installs the lane's own ledger. Without it the lane stays
+// dormant: an uncountable cap is not a cap, so nothing may be sent.
+func (s *service) WireIntelSeed(ledger IntelSeedLedger) {
+	if s == nil {
+		return
+	}
+	s.intelSeedLedger = ledger
+}
+
+// IntelSeedHeadroom reports how many seed touches this organization may still
+// send today. Zero is the dormant answer as well as the exhausted one, and the
+// caller does not need to tell them apart: both mean "send nothing".
+func (s *service) IntelSeedHeadroom(ctx context.Context, orgID uuid.UUID, now time.Time) int {
+	limit := IntelSeedDailyCap()
+	if limit <= 0 || s == nil || s.intelSeedLedger == nil || !IntelSeedEnabled() {
+		return 0
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	dayStart := now.UTC().Truncate(24 * time.Hour)
+	sent, err := s.intelSeedLedger.CountSendsSince(ctx, orgID, dayStart)
+	if err != nil {
+		// An unreadable counter is never permission to send.
+		return 0
+	}
+	if sent >= limit {
+		return 0
+	}
+	return limit - sent
+}
+
+// ProcessIntelSeedOnce sends at most one INTEL_SEED touch and reports whether
+// it did. It returns false without touching anything when the lane is dormant,
+// uncapped, exhausted, or has nothing admissible to say.
+func (s *service) ProcessIntelSeedOnce(ctx context.Context) (bool, error) {
+	if s == nil || !IntelSeedEnabled() || s.intelSeedLedger == nil || s.firstTouchTransport == nil {
+		return false, nil
+	}
+	orgID := intelSeedOrgID()
+	if orgID == uuid.Nil {
+		return false, nil
+	}
+	now := s.now()
+	if s.IntelSeedHeadroom(ctx, orgID, now) <= 0 {
+		return false, nil
+	}
+	// Several candidates are tried, not one. A refusal writes no ledger row, so
+	// a loop that stopped at the first refused contact would re-offer that same
+	// person on every tick and never reach anyone behind them. Bounded, because
+	// a book where nobody is admissible must still end the pass.
+	for _, candidate := range s.intelSeedCandidates(ctx, orgID, now, intelSeedGateAttemptsPerPass) {
+		// Admission and composition. Every predicate here is the first-touch
+		// one, applied by composition; none of it reserves anything.
+		decision := s.GateIntelSeed(ctx, orgID, candidate)
+		switch decision.Kind {
+		case IntelSeedProceed:
+			if decision.Message == nil {
+				continue
+			}
+			return s.deliverIntelSeed(ctx, decision.Message, now)
+		case IntelSeedPaused, IntelSeedDormant:
+			// Lane-wide, not contact-specific. Trying more contacts cannot
+			// change the answer, so stop rather than burning the pass.
+			return false, decision.Err
+		default:
+			continue
+		}
+	}
+	return false, nil
+}
+
+func (s *service) deliverIntelSeed(ctx context.Context, msg *IntelSeedMessage, now time.Time) (bool, error) {
+	sent, err := s.intelSeedLedger.AlreadySent(ctx, msg.OrganizationID, msg.MessageKey)
+	if err != nil {
+		return false, err
+	}
+	if sent {
+		return false, nil
+	}
+	mailboxID, err := s.ResolveOutboundMailbox(ctx, msg.OrganizationID)
+	if err != nil {
+		return false, err
+	}
+	// Record BEFORE the handoff. The ledger row is the no-resend fence and the
+	// cap's counter at the same time; writing it after the send would let a
+	// crash in between re-send the recipient and under-count the cap.
+	recorded, err := s.intelSeedLedger.RecordSend(ctx, models.IntelSeedSend{
+		OrganizationID: msg.OrganizationID, MessageKey: msg.MessageKey,
+		CandidateID: msg.CandidateID, AccountID: msg.AccountID,
+		Recipient: msg.To, SubjectKey: msg.SubjectKey, SentAt: now,
+	})
+	if err != nil {
+		return false, err
+	}
+	if !recorded {
+		// Another worker holds this exact touch. Not ours to send.
+		return false, nil
+	}
+	_, outcome, sendErr := s.firstTouchTransport.SendFirstTouch(ctx, FirstTouchMessage{
+		OrganizationID: msg.OrganizationID, EmailAccountID: mailboxID,
+		MessageKey: msg.MessageKey, To: msg.To,
+		Subject: msg.Subject, BodyText: msg.BodyText,
+	})
+	if outcome != FirstTouchAccepted {
+		// The ledger row stays. A seed touch is not worth a retry that risks a
+		// duplicate cold email, and the spent cap slot is the honest record of
+		// an attempt this lane made.
+		log.Warn().Str("org_id", msg.OrganizationID.String()).Str("outcome", string(outcome)).
+			Msg("confenge intel seed: touch not accepted, slot spent and not retried")
+		return false, sendErr
+	}
+	return true, nil
+}
+
+// intelSeedCandidates lists contacts worth putting to the gate. It reads only
+// accounts the shared admission rules already consider operational, and skips
+// contacts this lane already wrote to; GateIntelSeed re-checks every predicate
+// itself, so this is a cheap pre-filter and never the authority.
+func (s *service) intelSeedCandidates(ctx context.Context, orgID uuid.UUID, now time.Time, limit int) []uuid.UUID {
+	if s.repo == nil || s.intelSeedLedger == nil || limit <= 0 {
+		return nil
+	}
+	seeded, err := s.intelSeedLedger.SeededCandidateIDs(ctx, orgID, now.UTC().Add(-intelSeedContactCooldown))
+	if err != nil {
+		// An unreadable skip set would re-offer people this lane already wrote
+		// to. Send nothing instead.
+		return nil
+	}
+	accounts, err := s.repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{
+		Limit: limit * 10, ExcludeTerminal: true, RequireOperational: true,
+	})
+	if err != nil {
+		return nil
+	}
+	var out []uuid.UUID
+	for i := range accounts {
+		cands, candErr := s.repo.ListCandidates(ctx, orgID, accounts[i].ID)
+		if candErr != nil {
+			continue
+		}
+		for j := range cands {
+			if cands[j].DoNotContact || cands[j].Bounced || cands[j].Blocked || seeded[cands[j].ID] {
+				continue
+			}
+			out = append(out, cands[j].ID)
+			if len(out) >= limit {
+				return out
+			}
+		}
+	}
+	return out
+}
+
+func intelSeedOrgID() uuid.UUID {
+	raw := strings.TrimSpace(os.Getenv(EnvIntelSeedOrgID))
+	if raw == "" {
+		return uuid.Nil
+	}
+	id, err := uuid.Parse(raw)
+	if err != nil {
+		return uuid.Nil
+	}
+	return id
+}
+
+// IntelSeedWorker drives the loop on the same ticker shape every other CONFENGE
+// worker uses. It runs and does nothing while the lane is dormant.
+type IntelSeedWorker struct {
+	service  Service
+	interval time.Duration
+}
+
+func NewIntelSeedWorker(service Service, interval time.Duration) *IntelSeedWorker {
+	if interval <= 0 {
+		interval = time.Minute
+	}
+	return &IntelSeedWorker{service: service, interval: interval}
+}
+
+func (w *IntelSeedWorker) Run(ctx context.Context) {
+	if w == nil || w.service == nil {
+		return
+	}
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+	for {
+		for i := 0; i < intelSeedMaxPerTick; i++ {
+			progressed, err := w.service.ProcessIntelSeedOnce(ctx)
+			if err != nil || !progressed {
+				break
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/internal/app/confenge/intel_seed_worker_test.go
+++ b/internal/app/confenge/intel_seed_worker_test.go
@@ -1,0 +1,315 @@
+package confenge
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/dispatch"
+	"github.com/warmbly/warmbly/internal/config"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// INTEL_SEED cap and non-interference proofs.
+//
+// E: the lane has its own daily counter, enforced on top of the shared
+//    admission gates rather than carved out of them.
+// H: first-touch admission and queue drain are byte-identical with the lane
+//    unset, and with it enabled and its dedicated cap fully exhausted.
+
+// fakeSeedLedger is an in-memory IntelSeedLedger.
+type fakeSeedLedger struct {
+	sends []models.IntelSeedSend
+}
+
+func (f *fakeSeedLedger) CountSendsSince(_ context.Context, orgID uuid.UUID, since time.Time) (int, error) {
+	n := 0
+	for _, s := range f.sends {
+		if s.OrganizationID == orgID && !s.SentAt.Before(since) {
+			n++
+		}
+	}
+	return n, nil
+}
+
+func (f *fakeSeedLedger) RecordSend(_ context.Context, send models.IntelSeedSend) (bool, error) {
+	for _, s := range f.sends {
+		if s.OrganizationID == send.OrganizationID && s.MessageKey == send.MessageKey {
+			return false, nil
+		}
+	}
+	f.sends = append(f.sends, send)
+	return true, nil
+}
+
+func (f *fakeSeedLedger) AlreadySent(_ context.Context, orgID uuid.UUID, messageKey string) (bool, error) {
+	for _, s := range f.sends {
+		if s.OrganizationID == orgID && s.MessageKey == messageKey {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (f *fakeSeedLedger) SeededCandidateIDs(_ context.Context, orgID uuid.UUID, since time.Time) (map[uuid.UUID]bool, error) {
+	out := map[uuid.UUID]bool{}
+	for _, s := range f.sends {
+		if s.OrganizationID == orgID && !s.SentAt.Before(since) && s.CandidateID != uuid.Nil {
+			out[s.CandidateID] = true
+		}
+	}
+	return out, nil
+}
+
+// The cap defaults closed. Neither an unset value nor a malformed one may fall
+// back to a first-touch number budgeted for a different lane.
+func TestIntelSeedDailyCapFailsClosed(t *testing.T) {
+	for _, raw := range []string{"", "   ", "not-a-number", "-5"} {
+		t.Setenv(EnvIntelSeedDailyCap, raw)
+		if got := IntelSeedDailyCap(); got != 0 {
+			t.Fatalf("cap %q = %d, want 0", raw, got)
+		}
+	}
+	t.Setenv(EnvIntelSeedDailyCap, "3")
+	if got := IntelSeedDailyCap(); got != 3 {
+		t.Fatalf("cap = %d, want 3", got)
+	}
+}
+
+// Proof E. Headroom is the lane's OWN counter: it starts at the configured cap
+// and reaches zero after that many seed sends, with no reference to first
+// touch's budget.
+func TestIntelSeedHeadroomIsItsOwnCounter(t *testing.T) {
+	t.Setenv(EnvIntelSeedEnabled, "true")
+	t.Setenv(EnvIntelSeedDailyCap, "2")
+	ctx := context.Background()
+	svc, orgID := newWebIntentService(t)
+	ledger := &fakeSeedLedger{}
+	svc.WireIntelSeed(ledger)
+
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	if got := svc.IntelSeedHeadroom(ctx, orgID, now); got != 2 {
+		t.Fatalf("fresh headroom = %d, want 2", got)
+	}
+	for i := 0; i < 2; i++ {
+		if _, err := ledger.RecordSend(ctx, models.IntelSeedSend{
+			OrganizationID: orgID, MessageKey: fmt.Sprintf("email:intel_seed:contact:%d", i),
+			Recipient: "x@example.com", SentAt: now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := svc.IntelSeedHeadroom(ctx, orgID, now); got != 0 {
+		t.Fatalf("exhausted headroom = %d, want 0", got)
+	}
+	// The counter is daily. Yesterday's sends do not spend today's cap.
+	if got := svc.IntelSeedHeadroom(ctx, orgID, now.Add(48*time.Hour)); got != 2 {
+		t.Fatalf("headroom on a later day = %d, want 2", got)
+	}
+}
+
+// A dormant lane sends nothing regardless of the cap, and a capped-at-zero lane
+// sends nothing regardless of the opt-in. Both gates must pass.
+func TestIntelSeedStaysDormantWithoutBothOptIns(t *testing.T) {
+	ctx := context.Background()
+	svc, orgID := newWebIntentService(t)
+	svc.WireIntelSeed(&fakeSeedLedger{})
+	now := time.Now().UTC()
+
+	t.Setenv(EnvIntelSeedEnabled, "")
+	t.Setenv(EnvIntelSeedDailyCap, "10")
+	if got := svc.IntelSeedHeadroom(ctx, orgID, now); got != 0 {
+		t.Fatalf("headroom without the opt-in = %d, want 0", got)
+	}
+	t.Setenv(EnvIntelSeedEnabled, "true")
+	t.Setenv(EnvIntelSeedDailyCap, "0")
+	if got := svc.IntelSeedHeadroom(ctx, orgID, now); got != 0 {
+		t.Fatalf("headroom without a cap = %d, want 0", got)
+	}
+	// An unwired ledger is an uncountable cap, which is not a cap.
+	t.Setenv(EnvIntelSeedDailyCap, "10")
+	bare, bareOrg := newWebIntentService(t)
+	if got := bare.IntelSeedHeadroom(ctx, bareOrg, now); got != 0 {
+		t.Fatalf("headroom with no ledger = %d, want 0", got)
+	}
+}
+
+// A dormant or exhausted lane never reaches the transport.
+func TestProcessIntelSeedOnceDoesNothingWhileDormantOrExhausted(t *testing.T) {
+	ctx := context.Background()
+	svc, orgID := newWebIntentService(t)
+	ledger := &fakeSeedLedger{}
+	svc.WireIntelSeed(ledger)
+
+	t.Setenv(EnvIntelSeedEnabled, "")
+	t.Setenv(EnvIntelSeedDailyCap, "5")
+	t.Setenv(EnvIntelSeedOrgID, orgID.String())
+	if progressed, err := svc.ProcessIntelSeedOnce(ctx); progressed || err != nil {
+		t.Fatalf("dormant lane progressed=%v err=%v", progressed, err)
+	}
+	t.Setenv(EnvIntelSeedEnabled, "true")
+	t.Setenv(EnvIntelSeedDailyCap, "0")
+	if progressed, err := svc.ProcessIntelSeedOnce(ctx); progressed || err != nil {
+		t.Fatalf("uncapped lane progressed=%v err=%v", progressed, err)
+	}
+	if len(ledger.sends) != 0 {
+		t.Fatalf("a dormant lane recorded %d sends", len(ledger.sends))
+	}
+}
+
+// The loop advances instead of re-offering the same contact forever: a contact
+// this lane already wrote to is skipped by the pre-filter.
+func TestIntelSeedLoopSkipsAlreadySeededContacts(t *testing.T) {
+	ctx := context.Background()
+	svc, orgID := newWebIntentService(t)
+	ledger := &fakeSeedLedger{}
+	svc.WireIntelSeed(ledger)
+	now := time.Now().UTC()
+
+	offered := svc.intelSeedCandidates(ctx, orgID, now, 25)
+	if len(offered) == 0 {
+		t.Fatal("no candidate offered")
+	}
+	first := offered[0]
+	if _, err := ledger.RecordSend(ctx, models.IntelSeedSend{
+		OrganizationID: orgID, MessageKey: MessageKeyIntelSeed(first, "company:acme"),
+		CandidateID: first, Recipient: "ana@example.com", SentAt: now,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	for _, id := range svc.intelSeedCandidates(ctx, orgID, now, 25) {
+		if id == first {
+			t.Fatal("the loop re-offered a contact this lane already wrote to")
+		}
+	}
+}
+
+// A contact the gate refuses writes no ledger row, so the pre-filter cannot
+// skip them. The pass must still put the contacts behind them to the gate
+// rather than stopping at the first refusal and re-offering it every tick.
+func TestIntelSeedPassTriesPastAContactTheGateRefuses(t *testing.T) {
+	ctx := context.Background()
+	svc, orgID := newWebIntentService(t)
+	svc.WireIntelSeed(&fakeSeedLedger{})
+	now := time.Now().UTC()
+
+	acc, err := svc.repo.GetAccountByCNPJ(ctx, orgID, "12345678000190")
+	if err != nil || acc == nil {
+		t.Fatalf("seed account missing: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := svc.repo.UpsertCandidate(ctx, &models.OutreachContactCandidate{
+			ID: uuid.New(), OrganizationID: orgID, AccountID: acc.ID,
+			Name: fmt.Sprintf("Contato %d", i), Email: fmt.Sprintf("c%d@example.com", i),
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	offered := svc.intelSeedCandidates(ctx, orgID, now, intelSeedGateAttemptsPerPass)
+	if len(offered) < 3 {
+		t.Fatalf("one pass offered %d contacts, want the ones behind the first", len(offered))
+	}
+	seen := map[uuid.UUID]bool{}
+	for _, id := range offered {
+		if seen[id] {
+			t.Fatalf("the same contact was offered twice in one pass: %s", id)
+		}
+		seen[id] = true
+	}
+}
+
+// Proof H / E. First-touch admission and drain are identical with the lane off
+// and with it on and fully exhausted. The two runs share this one body, so a
+// difference is a real difference, not a difference in the harness.
+func TestFirstTouchUnchangedByIntelSeedState(t *testing.T) {
+	baseline := lane0FirstTouchFingerprint(t)
+
+	t.Run("intel seed enabled and its dedicated cap exhausted", func(t *testing.T) {
+		t.Setenv(EnvIntelSeedEnabled, "true")
+		t.Setenv(EnvIntelSeedDailyCap, "3")
+		t.Setenv(EnvIntelSeedOrgID, uuid.New().String())
+		// Exhaust the lane's own counter, then re-measure first touch.
+		ctx := context.Background()
+		svc, orgID := newWebIntentService(t)
+		ledger := &fakeSeedLedger{}
+		svc.WireIntelSeed(ledger)
+		now := time.Now().UTC()
+		for i := 0; i < 3; i++ {
+			if _, err := ledger.RecordSend(ctx, models.IntelSeedSend{
+				OrganizationID: orgID, MessageKey: fmt.Sprintf("email:intel_seed:contact:%d", i),
+				Recipient: "x@example.com", SentAt: now,
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}
+		if headroom := svc.IntelSeedHeadroom(ctx, orgID, now); headroom != 0 {
+			t.Fatalf("the seed cap was not exhausted: headroom = %d", headroom)
+		}
+		if got := lane0FirstTouchFingerprint(t); got != baseline {
+			t.Fatalf("first touch changed with INTEL_SEED enabled and exhausted:\n  off: %s\n   on: %s", baseline, got)
+		}
+	})
+}
+
+// lane0FirstTouchFingerprint re-runs the LANE 0 queue-drain measurement and
+// returns its result as a string, so two runs under different INTEL_SEED
+// environments can be compared as one value.
+//
+// It reuses the LANE 0 pack's own governor helper and cap rather than
+// duplicating the numbers, so a change to first-touch pacing shows up here as
+// a changed fingerprint instead of being silently re-asserted.
+func lane0FirstTouchFingerprint(t *testing.T) string {
+	t.Helper()
+	t.Setenv(EnvKillSwitchPath, filepath.Join(t.TempDir(), "absent"))
+	ctx := context.Background()
+	const capPerHour = 5
+	const queued = 12
+	store := dispatch.NewMemoryStore()
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	gov := newLane0Governor(store, capPerHour, now)
+	orgID := uuid.New()
+
+	for i := 0; i < queued; i++ {
+		draftID := uuid.New()
+		if err := store.Enqueue(ctx, &dispatch.QueueItem{
+			ID: uuid.New(), OrganizationID: orgID, Channel: dispatch.ChannelEmail,
+			DraftID: draftID, MessageKey: dispatch.MessageKeyEmail(draftID),
+			RecipientRef: fmt.Sprintf("lane0-%d@example.com", i),
+			DueAt:        now.Add(-time.Minute), Status: dispatch.QueueQueued, CreatedAt: now,
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	reserved, claimed, refused := 0, 0, 0
+	for i := 0; i < queued; i++ {
+		item, err := gov.ClaimNextQueued(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if item == nil {
+			break
+		}
+		claimed++
+		res, err := gov.TryReserve(ctx, dispatch.ReserveRequest{
+			OrganizationID: item.OrganizationID, Channel: item.Channel,
+			MessageKey: item.MessageKey, DraftID: &item.DraftID,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if res.Allowed {
+			reserved++
+			if err := gov.Commit(ctx, res.Reservation.ID); err != nil {
+				t.Fatal(err)
+			}
+		} else {
+			refused++
+		}
+	}
+	return fmt.Sprintf("claimed=%d reserved=%d refused=%d cap=%d default_daily=%d min_gap=%d",
+		claimed, reserved, refused, capPerHour, config.CampaignLimitDefault, config.MinWaitTimeDefault)
+}

--- a/internal/app/confenge/intel_watch_inbox.go
+++ b/internal/app/confenge/intel_watch_inbox.go
@@ -1,0 +1,84 @@
+package confenge
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
+	"github.com/warmbly/warmbly/internal/errx"
+)
+
+// Inbound opportunity-event ingestion.
+//
+// The envelope is persisted before anything else happens to it. That ordering
+// is the whole point: the upstream posts once and cannot be asked to post
+// again, so a crash after the 200 must not be able to lose the event. Delivery
+// is the reclaim worker's job, driven off the stored row, not off this request.
+
+// OpportunityEventReceipt is what one accepted envelope did.
+type OpportunityEventReceipt struct {
+	Schema     string `json:"schema"`
+	EventID    string `json:"event_id"`
+	EventType  string `json:"event_type"`
+	SubjectKey string `json:"subject_key"`
+	// Replay is true when this event id was already stored. The envelope is not
+	// rewritten: the first copy is the evidence of what the upstream said.
+	Replay bool `json:"replay"`
+}
+
+// WireIntelWatchInbox installs the durable opportunity-event inbox. Without it
+// inbound opportunity events are refused rather than accepted and dropped.
+func (s *service) WireIntelWatchInbox(inbox liveintel.EventInbox) {
+	if s == nil {
+		return
+	}
+	s.intelWatchInbox = inbox
+}
+
+// IntelWatchInbox returns the wired inbox, or nil. The caller uses it to build
+// the production EventProducer over the same store this endpoint writes.
+func (s *service) IntelWatchInbox() liveintel.EventInbox {
+	if s == nil {
+		return nil
+	}
+	return s.intelWatchInbox
+}
+
+// IngestOpportunityEvent validates and durably stores one inbound event.
+//
+// orgID is the organization Warmbly's webhook auth resolved. It is written onto
+// the event BEFORE validation and stored as its own column, so an external
+// caller cannot reach another organization's watch list by naming it in the
+// body. Any org id inside the payload is overwritten, never consulted.
+func (s *service) IngestOpportunityEvent(ctx context.Context, orgID uuid.UUID, event liveintel.OpportunityEvent, now time.Time) (*OpportunityEventReceipt, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if orgID == uuid.Nil {
+		return nil, errx.New(errx.ServiceUnavailable, "inbound org is not configured")
+	}
+	event.Schema = liveintel.EventSchemaV1
+	event.OrgID = orgID
+	if ok, reason := event.Validate(); !ok {
+		return nil, errx.NewWithIdentifier(errx.BadRequest, "confenge_opportunity_event_"+reason,
+			"opportunity event rejected: "+reason)
+	}
+	if s.intelWatchInbox == nil {
+		return nil, errx.NewWithIdentifier(errx.ServiceUnavailable, "confenge_opportunity_event_inbox_unavailable",
+			"opportunity event inbox is not wired")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	inserted, err := s.intelWatchInbox.AppendOpportunityEvent(ctx, liveintel.InboxRowFromEvent(orgID, event, now))
+	if err != nil {
+		return nil, errx.New(errx.Internal, "opportunity event inbox write: "+err.Error())
+	}
+	return &OpportunityEventReceipt{
+		Schema: liveintel.EventSchemaV1, EventID: event.EventID,
+		EventType: string(event.EventType), SubjectKey: event.SubjectKey,
+		Replay: !inserted,
+	}, nil
+}

--- a/internal/app/confenge/intel_watch_inbox_pg_test.go
+++ b/internal/app/confenge/intel_watch_inbox_pg_test.go
@@ -1,0 +1,161 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// Real-Postgres proofs for the durable opportunity-event inbox and the
+// INTEL_SEED send ledger. They exercise the actual SQL, the actual CHECK
+// constraints and the actual conflict handling, which no fake can stand in for.
+//
+// They skip without WARMBLY_TEST_POSTGRES_DSN, following the same pattern as
+// the rest of this package's _pg_test.go files.
+
+func inboxTestEvent(orgID uuid.UUID, id, subject string, at time.Time) models.IntelWatchInboxEvent {
+	return liveintel.InboxRowFromEvent(orgID, liveintel.OpportunityEvent{
+		Schema: liveintel.EventSchemaV1, EventID: id, EventType: liveintel.EventNewOpportunity,
+		SubjectKey: subject, OccurredAt: at,
+		Payload: map[string]string{"headline": "edital publicado", "public_url": "https://example.gov/e"},
+	}, at)
+}
+
+// The envelope survives a restart because it is a row. A fresh producer over a
+// fresh pool replays it.
+func TestPGInboxSurvivesRestartAndReplaysUnconsumedRows(t *testing.T) {
+	pool, orgID := openHandRaisePG(t)
+	ctx := context.Background()
+	inbox := repository.NewIntelWatchInboxRepository(pool)
+	now := time.Now().UTC()
+
+	inserted, err := inbox.AppendOpportunityEvent(ctx, inboxTestEvent(orgID, "evt-pg-1", "company:acme", now))
+	if err != nil || !inserted {
+		t.Fatalf("append: inserted=%v err=%v", inserted, err)
+	}
+	// A repeat post of the same id is a replay, not a second row, and does not
+	// rewrite the stored envelope.
+	again, err := inbox.AppendOpportunityEvent(ctx, inboxTestEvent(orgID, "evt-pg-1", "company:other", now))
+	if err != nil || again {
+		t.Fatalf("repeat append: inserted=%v err=%v", again, err)
+	}
+	stored, err := inbox.GetOpportunityEvent(ctx, orgID, "evt-pg-1")
+	if err != nil || stored == nil {
+		t.Fatalf("read back: %v", err)
+	}
+	if stored.SubjectKey != "company:acme" {
+		t.Fatalf("stored envelope was rewritten: %+v", stored)
+	}
+
+	// A brand-new producer holds no state; the row is the state.
+	events, err := liveintel.NewPostgresEventProducer(inbox).BindOrganization(orgID).Subscribe(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got []liveintel.OpportunityEvent
+	for event := range events {
+		got = append(got, event)
+	}
+	if len(got) != 1 || got[0].EventID != "evt-pg-1" || got[0].OrgID != orgID {
+		t.Fatalf("replay = %+v", got)
+	}
+	if ok, reason := got[0].Validate(); !ok {
+		t.Fatalf("replayed event is invalid: %s", reason)
+	}
+}
+
+// The emit lease bounds duplicate work between two producer instances, and an
+// expired lease makes the row claimable again. Correctness never depended on
+// the lease: nothing was consumed either way.
+func TestPGInboxEmitLeaseBoundsDuplicateWorkAndExpires(t *testing.T) {
+	pool, orgID := openHandRaisePG(t)
+	ctx := context.Background()
+	inbox := repository.NewIntelWatchInboxRepository(pool)
+	now := time.Now().UTC()
+	if _, err := inbox.AppendOpportunityEvent(ctx, inboxTestEvent(orgID, "evt-pg-lease", "company:acme", now)); err != nil {
+		t.Fatal(err)
+	}
+	first, err := inbox.ClaimReplayableEvents(ctx, orgID, now, time.Hour, 2*time.Minute, 10)
+	if err != nil || len(first) != 1 {
+		t.Fatalf("first claim = %d rows, err=%v", len(first), err)
+	}
+	second, err := inbox.ClaimReplayableEvents(ctx, orgID, now, time.Hour, 2*time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("a second producer instance claimed %d rows inside the lease", len(second))
+	}
+	// Past the lease the row is offered again, which is what makes an
+	// undelivered PENDING recoverable without a human.
+	afterLease, err := inbox.ClaimReplayableEvents(ctx, orgID, now.Add(5*time.Minute), time.Hour, 2*time.Minute, 10)
+	if err != nil || len(afterLease) != 1 {
+		t.Fatalf("claim after lease expiry = %d rows, err=%v", len(afterLease), err)
+	}
+	// Outside the replay window the row stops being offered.
+	outside, err := inbox.ClaimReplayableEvents(ctx, orgID, now.Add(48*time.Hour), time.Hour, 2*time.Minute, 10)
+	if err != nil || len(outside) != 0 {
+		t.Fatalf("claim outside the window = %d rows, err=%v", len(outside), err)
+	}
+}
+
+// The organization is part of the row identity, so one org's producer never
+// sees another org's events.
+func TestPGInboxReplayIsOrganizationScoped(t *testing.T) {
+	pool, orgID := openHandRaisePG(t)
+	ctx := context.Background()
+	inbox := repository.NewIntelWatchInboxRepository(pool)
+	now := time.Now().UTC()
+	if _, err := inbox.AppendOpportunityEvent(ctx, inboxTestEvent(orgID, "evt-pg-scope", "company:acme", now)); err != nil {
+		t.Fatal(err)
+	}
+	other := uuid.New()
+	rows, err := inbox.ClaimReplayableEvents(ctx, other, now, time.Hour, time.Minute, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("another organization's producer saw %d rows", len(rows))
+	}
+}
+
+// The INTEL_SEED ledger is the lane's own counter, and it is idempotent on the
+// message key so a crash-retry cannot double-count the cap.
+func TestPGIntelSeedLedgerCountsItsOwnLaneOnly(t *testing.T) {
+	pool, orgID := openHandRaisePG(t)
+	ctx := context.Background()
+	ledger := repository.NewIntelSeedRepository(pool)
+	now := time.Now().UTC()
+	dayStart := now.Truncate(24 * time.Hour)
+
+	send := models.IntelSeedSend{
+		OrganizationID: orgID, MessageKey: "email:intel_seed:contact:pg:subject:company:acme",
+		Recipient: "ana@example.com", SubjectKey: "company:acme", SentAt: now,
+	}
+	inserted, err := ledger.RecordSend(ctx, send)
+	if err != nil || !inserted {
+		t.Fatalf("record: inserted=%v err=%v", inserted, err)
+	}
+	again, err := ledger.RecordSend(ctx, send)
+	if err != nil || again {
+		t.Fatalf("repeat record: inserted=%v err=%v, want a no-op", again, err)
+	}
+	n, err := ledger.CountSendsSince(ctx, orgID, dayStart)
+	if err != nil || n != 1 {
+		t.Fatalf("count = %d err=%v, want 1", n, err)
+	}
+	sent, err := ledger.AlreadySent(ctx, orgID, send.MessageKey)
+	if err != nil || !sent {
+		t.Fatalf("already sent = %v err=%v", sent, err)
+	}
+	// Another organization's ledger is untouched.
+	if n, err := ledger.CountSendsSince(ctx, uuid.New(), dayStart); err != nil || n != 0 {
+		t.Fatalf("cross-org count = %d err=%v", n, err)
+	}
+}

--- a/internal/app/confenge/liveintel/events_envelope.go
+++ b/internal/app/confenge/liveintel/events_envelope.go
@@ -1,0 +1,46 @@
+package liveintel
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// Inbound recognition for opportunity events, parallel to the other envelope
+// recognizers the CONFENGE inbound webhook branches on.
+//
+// It must be checked before the inbound-lead fallthrough: an opportunity-event
+// body carries neither the search-observation nor the commercial-event schema,
+// so without this it would be misrouted into lead ingestion.
+
+// IsOpportunityEventEnvelope reports a CONFENGE_OPPORTUNITY_EVENT/1.0 body.
+func IsOpportunityEventEnvelope(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var peek struct {
+		Schema  string `json:"schema"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return false
+	}
+	return strings.TrimSpace(peek.Schema) == EventSchemaV1 ||
+		strings.TrimSpace(peek.Version) == EventSchemaV1
+}
+
+// ParseOpportunityEvent decodes the body. It does not validate: the caller
+// binds the organization first, because Validate requires one and the payload's
+// own org id is never trusted.
+func ParseOpportunityEvent(raw []byte) (OpportunityEvent, error) {
+	if !IsOpportunityEventEnvelope(raw) {
+		return OpportunityEvent{}, fmt.Errorf("not %s", EventSchemaV1)
+	}
+	var event OpportunityEvent
+	if err := json.Unmarshal(raw, &event); err != nil {
+		return OpportunityEvent{}, fmt.Errorf("%s: %w", EventSchemaV1, err)
+	}
+	event.Schema = EventSchemaV1
+	event.EventType = EventType(strings.ToUpper(strings.TrimSpace(string(event.EventType))))
+	return event, nil
+}

--- a/internal/app/confenge/liveintel/events_postgres.go
+++ b/internal/app/confenge/liveintel/events_postgres.go
@@ -1,0 +1,173 @@
+package liveintel
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// The durable-inbox opportunity-event producer.
+//
+// This is the production EventProducer. It resolves the replayability boundary
+// the fixture producer documented: the real upstream (extra-cli) posts once
+// over HTTP and cannot be asked to post again, so Warmbly persists the envelope
+// at ingestion and replays from its own table. Restart survival and
+// replay-after-transient-failure are then structural, not a property of the
+// caller.
+//
+// It deliberately reproduces the fixture's semantics rather than inventing new
+// ones, because the reclaim worker was built against them: Subscribe emits a
+// bounded batch and CLOSES the channel. The worker ranges to close, so a
+// producer that opened a live tail would hold one reclaim pass open forever.
+//
+// Rows are never consumed by being emitted. Marking a row consumed at hand-off
+// would lose the event whenever the consumer failed straight afterwards, which
+// is exactly the failure the inbox exists to prevent. Re-emission inside the
+// replay window is free: the delivery ledger refuses a duplicate by primary
+// key. The emit lease bounds duplicate WORK between two producer instances; it
+// is not what makes delivery safe.
+
+// EventInbox is the durable envelope store the production producer reads. The
+// repository satisfies it; a test fake satisfies it just as well.
+type EventInbox interface {
+	AppendOpportunityEvent(ctx context.Context, event models.IntelWatchInboxEvent) (bool, error)
+	ClaimReplayableEvents(ctx context.Context, orgID uuid.UUID, now time.Time, window, lease time.Duration, limit int) ([]models.IntelWatchInboxEvent, error)
+}
+
+const (
+	// DefaultInboxReplayWindow bounds how far back a pass replays. Past it an
+	// event is either delivered or terminally settled in the ledger, so
+	// re-offering it only costs work.
+	DefaultInboxReplayWindow = 24 * time.Hour
+	// defaultInboxEmitLease keeps two producer instances off the same rows for
+	// one pass. It matches the consumer's own delivery lease.
+	defaultInboxEmitLease = 2 * time.Minute
+	// defaultInboxBatchLimit bounds one pass. The events it does not reach stay
+	// in the window and are offered again on the next tick.
+	defaultInboxBatchLimit = 500
+)
+
+// PostgresEventProducer replays the durable inbox.
+type PostgresEventProducer struct {
+	mu     sync.RWMutex
+	inbox  EventInbox
+	window time.Duration
+	lease  time.Duration
+	limit  int
+	// orgFilter restricts a pass to one organization. uuid.Nil means every
+	// organization, which is the normal production shape: the org is
+	// authoritative on the row, having come from Warmbly's own webhook auth.
+	orgFilter uuid.UUID
+	now       func() time.Time
+}
+
+// NewPostgresEventProducer builds the production producer. It returns nil when
+// no inbox is available, so a caller's dormant-lane check stays one nil test.
+func NewPostgresEventProducer(inbox EventInbox) *PostgresEventProducer {
+	if inbox == nil {
+		return nil
+	}
+	return &PostgresEventProducer{
+		inbox: inbox, window: DefaultInboxReplayWindow,
+		lease: defaultInboxEmitLease, limit: defaultInboxBatchLimit,
+		now: func() time.Time { return time.Now().UTC() },
+	}
+}
+
+// BindOrganization restricts replay to one organization.
+func (p *PostgresEventProducer) BindOrganization(orgID uuid.UUID) *PostgresEventProducer {
+	if p == nil {
+		return nil
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.orgFilter = orgID
+	return p
+}
+
+// WithReplayWindow overrides how far back a pass replays.
+func (p *PostgresEventProducer) WithReplayWindow(window time.Duration) *PostgresEventProducer {
+	if p == nil || window <= 0 {
+		return p
+	}
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.window = window
+	return p
+}
+
+// Subscribe emits the events currently replayable and closes.
+//
+// Closing is the contract, not a shortcut: the reclaim worker ranges to close,
+// so one Subscribe is one pass. Anything this pass does not deliver is still in
+// the inbox for the next one.
+func (p *PostgresEventProducer) Subscribe(ctx context.Context) (<-chan OpportunityEvent, error) {
+	if p == nil || p.inbox == nil {
+		return nil, fmt.Errorf("intel watch event inbox is not configured")
+	}
+	p.mu.RLock()
+	inbox, window, lease, limit, orgFilter, now := p.inbox, p.window, p.lease, p.limit, p.orgFilter, p.now()
+	p.mu.RUnlock()
+
+	rows, err := inbox.ClaimReplayableEvents(ctx, orgFilter, now, window, lease, limit)
+	if err != nil {
+		return nil, fmt.Errorf("intel watch event inbox replay: %w", err)
+	}
+	out := make(chan OpportunityEvent)
+	go func() {
+		defer close(out)
+		for _, row := range rows {
+			select {
+			case <-ctx.Done():
+				return
+			case out <- OpportunityEventFromInbox(row):
+			}
+		}
+	}()
+	return out, nil
+}
+
+// OpportunityEventFromInbox rebuilds the event from its stored row. The
+// organization comes from the row's own column, never from the payload: the
+// column is what Warmbly's webhook auth resolved, and the payload is whatever
+// an external caller chose to write.
+func OpportunityEventFromInbox(row models.IntelWatchInboxEvent) OpportunityEvent {
+	return OpportunityEvent{
+		Schema:     EventSchemaV1,
+		EventID:    strings.TrimSpace(row.EventID),
+		EventType:  EventType(strings.TrimSpace(row.EventType)),
+		SubjectKey: strings.TrimSpace(row.SubjectKey),
+		OrgID:      row.OrganizationID,
+		OccurredAt: row.OccurredAt.UTC(),
+		Payload:    row.Payload,
+	}
+}
+
+// InboxRowFromEvent turns a validated event into the row to persist. orgID is
+// the caller-resolved organization and always wins over anything the event
+// carries.
+func InboxRowFromEvent(orgID uuid.UUID, event OpportunityEvent, receivedAt time.Time) models.IntelWatchInboxEvent {
+	if receivedAt.IsZero() {
+		receivedAt = time.Now().UTC()
+	}
+	occurred := event.OccurredAt.UTC()
+	if occurred.IsZero() {
+		occurred = receivedAt.UTC()
+	}
+	return models.IntelWatchInboxEvent{
+		OrganizationID: orgID,
+		EventID:        strings.TrimSpace(event.EventID),
+		Schema:         EventSchemaV1,
+		EventType:      string(event.EventType),
+		SubjectKey:     strings.TrimSpace(event.SubjectKey),
+		OccurredAt:     occurred,
+		Payload:        event.Payload,
+		ReceivedAt:     receivedAt.UTC(),
+	}
+}

--- a/internal/app/confenge/liveintel/events_postgres_pipeline_test.go
+++ b/internal/app/confenge/liveintel/events_postgres_pipeline_test.go
@@ -1,0 +1,179 @@
+package liveintel
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// The new producer slotted into the EXISTING proven pipeline.
+//
+// These do not re-prove compose, dispatch, dedup or parking; those already have
+// their own suites against the fixture producer. What they prove is that
+// swapping the source changes none of it.
+//
+// C: a real-shaped event through the inbox reaches the consumer and is
+//    delivered exactly once.
+// D: a transient dispatch failure before the fence stays deliverable and the
+//    next pass over the SAME inbox delivers it.
+// E: an ambiguous outcome parks and is never auto-retried.
+// F: replaying the same inbox row twice delivers once.
+
+// seedInbox stores one real-shaped envelope the way the webhook would.
+func seedInbox(t *testing.T, inbox *fakeInbox, orgID uuid.UUID, eventID, subject string) {
+	t.Helper()
+	row := InboxRowFromEvent(orgID, OpportunityEvent{
+		Schema: EventSchemaV1, EventID: eventID, EventType: EventDeadlineChanged,
+		SubjectKey: subject, OccurredAt: time.Now().UTC(),
+		Payload: map[string]string{"headline": "prazo alterado", "public_url": "https://example.gov/edital"},
+	}, time.Now().UTC())
+	if _, err := inbox.AppendOpportunityEvent(context.Background(), row); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// Proof C. Webhook envelope to durable row to Subscribe to the consumer's
+// ledger, delivered once.
+func TestInboxProducerDrivesTheExistingConsumerToDelivery(t *testing.T) {
+	orgID := uuid.New()
+	subject := "opportunity:pregao-2026-0042"
+	store := newFakeWatchStore(watchSubscription(orgID, "ana@example.com", subject))
+	dispatcher := &recordingDispatcher{}
+	inbox := newFakeInbox()
+	seedInbox(t, inbox, orgID, "evt-real-1", subject)
+
+	worker := NewWatchReclaimWorker(NewConsumer(store, dispatcher), NewPostgresEventProducer(inbox), time.Minute)
+	report, err := worker.ReclaimOnce(context.Background())
+	if err != nil {
+		t.Fatalf("reclaim pass: %v", err)
+	}
+	if report.EventsSeen != 1 || report.Dispatched != 1 {
+		t.Fatalf("report = %+v, want one event seen and one dispatched", report)
+	}
+	if got := dispatcher.delivered(); len(got) != 1 || got[0] != "ana@example.com|evt-real-1" {
+		t.Fatalf("delivered = %v", got)
+	}
+}
+
+// Proof F. A second pass over the same inbox row delivers nothing new: the
+// ledger's dedup key refuses it, exactly as it does for the fixture producer.
+func TestInboxProducerReplayIsDedupedNotResent(t *testing.T) {
+	orgID := uuid.New()
+	subject := "company:acme-holdings"
+	store := newFakeWatchStore(watchSubscription(orgID, "ana@example.com", subject))
+	dispatcher := &recordingDispatcher{}
+	inbox := newFakeInbox()
+	seedInbox(t, inbox, orgID, "evt-real-1", subject)
+
+	worker := NewWatchReclaimWorker(NewConsumer(store, dispatcher), NewPostgresEventProducer(inbox), time.Minute)
+	if _, err := worker.ReclaimOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// The emit lease is what stops a pass inside the lease from re-offering the
+	// row; clearing it forces the harder case, where the event IS re-offered.
+	inbox.lease = map[string]time.Time{}
+	report, err := worker.ReclaimOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Dispatched != 0 || report.Deduped != 1 {
+		t.Fatalf("second pass = %+v, want zero dispatched and one deduped", report)
+	}
+	if len(dispatcher.delivered()) != 1 {
+		t.Fatalf("watcher was written to %d times", len(dispatcher.delivered()))
+	}
+}
+
+// Proof D. A transient failure before the fence leaves the delivery claimable,
+// and the next pass over the SAME durable inbox delivers it. This is the
+// property the inbox exists for: against the old file source it held because
+// the file could be re-read, and it now holds because the row is still there.
+func TestInboxProducerRecoversATransientFailureOnTheNextPass(t *testing.T) {
+	orgID := uuid.New()
+	subject := "company:acme-holdings"
+	store := newFakeWatchStore(watchSubscription(orgID, "ana@example.com", subject))
+	dispatcher := &recordingDispatcher{outcomes: []dispatchStep{
+		{outcome: WatchTransient, err: errors.New("451 try again"), fence: false},
+	}}
+	inbox := newFakeInbox()
+	seedInbox(t, inbox, orgID, "evt-real-1", subject)
+
+	worker := NewWatchReclaimWorker(NewConsumer(store, dispatcher), NewPostgresEventProducer(inbox), time.Minute)
+	report, _ := worker.ReclaimOnce(context.Background())
+	if report.Retryable != 1 || report.Dispatched != 0 {
+		t.Fatalf("first pass = %+v, want one retryable", report)
+	}
+	if len(dispatcher.delivered()) != 0 {
+		t.Fatalf("a transient failure was recorded as delivered")
+	}
+	inbox.lease = map[string]time.Time{}
+	report, err := worker.ReclaimOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if report.Dispatched != 1 {
+		t.Fatalf("second pass = %+v, want the recovered delivery", report)
+	}
+	if len(dispatcher.delivered()) != 1 {
+		t.Fatalf("delivered = %v", dispatcher.delivered())
+	}
+}
+
+// Proof E. An ambiguous outcome parks and is never auto-retried, even though
+// the inbox keeps re-offering the event. A duplicate watch mail is worse than
+// a late one.
+func TestInboxProducerAmbiguousOutcomeStaysParkedAcrossReplays(t *testing.T) {
+	orgID := uuid.New()
+	subject := "company:acme-holdings"
+	store := newFakeWatchStore(watchSubscription(orgID, "ana@example.com", subject))
+	dispatcher := &recordingDispatcher{outcomes: []dispatchStep{
+		{outcome: WatchAmbiguous, err: errors.New("connection reset after DATA"), fence: true},
+	}}
+	inbox := newFakeInbox()
+	seedInbox(t, inbox, orgID, "evt-real-1", subject)
+
+	worker := NewWatchReclaimWorker(NewConsumer(store, dispatcher), NewPostgresEventProducer(inbox), time.Minute)
+	if report, _ := worker.ReclaimOnce(context.Background()); report.Parked != 1 {
+		t.Fatalf("first pass = %+v, want one parked", report)
+	}
+	for i := 0; i < 3; i++ {
+		inbox.lease = map[string]time.Time{}
+		report, err := worker.ReclaimOnce(context.Background())
+		if err != nil {
+			t.Fatal(err)
+		}
+		if report.Dispatched != 0 {
+			t.Fatalf("a parked delivery was retried on replay %d: %+v", i, report)
+		}
+	}
+	if len(dispatcher.delivered()) != 0 {
+		t.Fatalf("a parked delivery was sent: %v", dispatcher.delivered())
+	}
+}
+
+// Proof H (producer half). A dormant lane with no inbox produces a nil
+// producer, and the reclaim worker built on it runs and does nothing rather
+// than failing a boot.
+func TestDormantInboxProducerRunsAndDoesNothing(t *testing.T) {
+	store := newFakeWatchStore()
+	worker := NewWatchReclaimWorker(NewConsumer(store, &recordingDispatcher{}), nil, time.Minute)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	worker.Run(ctx)
+	if store.rows() != 0 {
+		t.Fatalf("a dormant lane touched %d ledger rows", store.rows())
+	}
+}
+
+// A store failure surfaces as a subscribe error, not as an empty pass that
+// looks like "nothing was owed".
+func TestInboxProducerSurfacesAStoreFailure(t *testing.T) {
+	inbox := newFakeInbox()
+	inbox.failNext = errors.New("connection refused")
+	if _, err := NewPostgresEventProducer(inbox).Subscribe(context.Background()); err == nil {
+		t.Fatal("an unreadable inbox subscribed cleanly")
+	}
+}

--- a/internal/app/confenge/liveintel/events_postgres_test.go
+++ b/internal/app/confenge/liveintel/events_postgres_test.go
@@ -1,0 +1,243 @@
+package liveintel
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Durable-inbox producer proofs.
+//
+// C (producer half): a stored envelope comes back out of Subscribe with the
+//    organization the row carries, not the one the payload claimed.
+// Restart survival: a fresh producer over the same store replays unconsumed
+//    rows, because emission never consumed them.
+
+// fakeInbox is an in-memory EventInbox. It reproduces the two properties the
+// production table has that matter here: insertion is idempotent on
+// (org, event id), and emission does not consume a row.
+type fakeInbox struct {
+	rows  []models.IntelWatchInboxEvent
+	lease map[string]time.Time
+	// failNext makes the next replay fail, so a caller can prove a producer
+	// error is surfaced rather than silently emitting nothing.
+	failNext error
+}
+
+func newFakeInbox() *fakeInbox {
+	return &fakeInbox{lease: map[string]time.Time{}}
+}
+
+func (f *fakeInbox) key(row models.IntelWatchInboxEvent) string {
+	return row.OrganizationID.String() + "/" + row.EventID
+}
+
+func (f *fakeInbox) AppendOpportunityEvent(_ context.Context, event models.IntelWatchInboxEvent) (bool, error) {
+	for _, existing := range f.rows {
+		if f.key(existing) == f.key(event) {
+			return false, nil
+		}
+	}
+	if event.ReceivedAt.IsZero() {
+		event.ReceivedAt = time.Now().UTC()
+	}
+	f.rows = append(f.rows, event)
+	return true, nil
+}
+
+func (f *fakeInbox) ClaimReplayableEvents(_ context.Context, orgID uuid.UUID, now time.Time, window, lease time.Duration, limit int) ([]models.IntelWatchInboxEvent, error) {
+	if f.failNext != nil {
+		err := f.failNext
+		f.failNext = nil
+		return nil, err
+	}
+	var out []models.IntelWatchInboxEvent
+	for _, row := range f.rows {
+		if orgID != uuid.Nil && row.OrganizationID != orgID {
+			continue
+		}
+		if !row.ReceivedAt.After(now.Add(-window)) {
+			continue
+		}
+		if held, ok := f.lease[f.key(row)]; ok && held.After(now) {
+			continue
+		}
+		f.lease[f.key(row)] = now.Add(lease)
+		out = append(out, row)
+		if limit > 0 && len(out) >= limit {
+			break
+		}
+	}
+	return out, nil
+}
+
+func storedEvent(orgID uuid.UUID, id, subject string, at time.Time) models.IntelWatchInboxEvent {
+	return models.IntelWatchInboxEvent{
+		OrganizationID: orgID, EventID: id, Schema: EventSchemaV1,
+		EventType: string(EventNewOpportunity), SubjectKey: subject,
+		OccurredAt: at, ReceivedAt: at, Payload: map[string]string{"headline": "edital publicado"},
+	}
+}
+
+func drain(t *testing.T, producer EventProducer) []OpportunityEvent {
+	t.Helper()
+	ch, err := producer.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	var out []OpportunityEvent
+	for event := range ch {
+		out = append(out, event)
+	}
+	return out
+}
+
+// The channel closes when the batch is drained. The reclaim worker ranges to
+// close, so a producer that kept it open would hold one pass open forever.
+func TestPostgresEventProducerEmitsABatchAndCloses(t *testing.T) {
+	orgID := uuid.New()
+	inbox := newFakeInbox()
+	now := time.Now().UTC()
+	for _, id := range []string{"evt-1", "evt-2"} {
+		if _, err := inbox.AppendOpportunityEvent(context.Background(), storedEvent(orgID, id, "company:acme", now)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	events := drain(t, NewPostgresEventProducer(inbox))
+	if len(events) != 2 {
+		t.Fatalf("emitted %d events, want 2", len(events))
+	}
+	for _, event := range events {
+		if ok, reason := event.Validate(); !ok {
+			t.Fatalf("emitted event is invalid: %s", reason)
+		}
+		if event.OrgID != orgID {
+			t.Fatalf("event org = %s, want %s", event.OrgID, orgID)
+		}
+	}
+}
+
+// Ingestion binds the organization the caller resolved. A payload naming a
+// different organization cannot reach it.
+func TestInboxRowFromEventBindsTheCallerResolvedOrganization(t *testing.T) {
+	trusted, attacker := uuid.New(), uuid.New()
+	row := InboxRowFromEvent(trusted, OpportunityEvent{
+		Schema: EventSchemaV1, EventID: "evt-x", EventType: EventNewOpportunity,
+		SubjectKey: "company:acme", OrgID: attacker,
+		Payload: map[string]string{"headline": "x"},
+	}, time.Now().UTC())
+	if row.OrganizationID != trusted {
+		t.Fatalf("stored org = %s, want the caller-resolved %s", row.OrganizationID, trusted)
+	}
+	if got := OpportunityEventFromInbox(row); got.OrgID != trusted {
+		t.Fatalf("replayed org = %s, want %s", got.OrgID, trusted)
+	}
+}
+
+// Restart survival. A brand-new producer over the same store replays the same
+// events: nothing was consumed by having been emitted once.
+func TestPostgresEventProducerSurvivesARestart(t *testing.T) {
+	orgID := uuid.New()
+	inbox := newFakeInbox()
+	now := time.Now().UTC()
+	if _, err := inbox.AppendOpportunityEvent(context.Background(), storedEvent(orgID, "evt-1", "company:acme", now)); err != nil {
+		t.Fatal(err)
+	}
+	first := drain(t, NewPostgresEventProducer(inbox))
+	if len(first) != 1 {
+		t.Fatalf("first pass emitted %d", len(first))
+	}
+	// A fresh producer holds no state of its own; only the store does.
+	restarted := NewPostgresEventProducer(inbox)
+	// The emit lease from the first pass is still live, so an immediate second
+	// pass yields nothing. That bounds duplicate work, not correctness.
+	if immediate := drain(t, restarted); len(immediate) != 0 {
+		t.Fatalf("a second pass inside the emit lease emitted %d events", len(immediate))
+	}
+	// Past the lease the same rows are offered again, which is what makes an
+	// undelivered PENDING recoverable without a human.
+	inbox.lease = map[string]time.Time{}
+	after := drain(t, restarted)
+	if len(after) != 1 || after[0].EventID != "evt-1" {
+		t.Fatalf("replay after lease expiry = %+v", after)
+	}
+}
+
+// A cancelled pass leaves the rows in the store. Nothing was consumed, so the
+// next pass still owes them.
+func TestPostgresEventProducerCancelledPassLosesNothing(t *testing.T) {
+	orgID := uuid.New()
+	inbox := newFakeInbox()
+	now := time.Now().UTC()
+	for _, id := range []string{"evt-1", "evt-2", "evt-3"} {
+		if _, err := inbox.AppendOpportunityEvent(context.Background(), storedEvent(orgID, id, "company:acme", now)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	producer := NewPostgresEventProducer(inbox)
+	ctx, cancel := context.WithCancel(context.Background())
+	ch, err := producer.Subscribe(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	<-ch
+	cancel()
+	for range ch { //nolint:revive // draining the cancelled channel
+	}
+	inbox.lease = map[string]time.Time{}
+	if replayed := drain(t, producer); len(replayed) != 3 {
+		t.Fatalf("after a cancelled pass the store replayed %d of 3 events", len(replayed))
+	}
+}
+
+// The same event id posted twice is one row, and the first envelope is kept.
+func TestInboxAppendIsIdempotentOnEventID(t *testing.T) {
+	orgID := uuid.New()
+	inbox := newFakeInbox()
+	now := time.Now().UTC()
+	first, err := inbox.AppendOpportunityEvent(context.Background(), storedEvent(orgID, "evt-1", "company:acme", now))
+	if err != nil || !first {
+		t.Fatalf("first append: inserted=%v err=%v", first, err)
+	}
+	second, err := inbox.AppendOpportunityEvent(context.Background(), storedEvent(orgID, "evt-1", "company:other", now))
+	if err != nil || second {
+		t.Fatalf("repeat append: inserted=%v err=%v, want a replay", second, err)
+	}
+	events := drain(t, NewPostgresEventProducer(inbox))
+	if len(events) != 1 || events[0].SubjectKey != "company:acme" {
+		t.Fatalf("stored envelope was rewritten: %+v", events)
+	}
+}
+
+// An unconfigured producer is nil, so the caller's dormant-lane check stays one
+// nil test and the lane never becomes a boot failure.
+func TestPostgresEventProducerNilWithoutAnInbox(t *testing.T) {
+	if producer := NewPostgresEventProducer(nil); producer != nil {
+		t.Fatal("a producer was built with no inbox")
+	}
+	var producer *PostgresEventProducer
+	if _, err := producer.Subscribe(context.Background()); err == nil {
+		t.Fatal("a nil producer subscribed without error")
+	}
+}
+
+// The recognizer claims its own body and refuses the sibling schemas.
+func TestOpportunityEventEnvelopeRecognizer(t *testing.T) {
+	if !IsOpportunityEventEnvelope([]byte(`{"schema":"` + EventSchemaV1 + `"}`)) {
+		t.Fatal("recognizer did not claim its own body")
+	}
+	if IsOpportunityEventEnvelope([]byte(`{"schema":"confenge.commercial_event.v1"}`)) {
+		t.Fatal("recognizer claimed a commercial event body")
+	}
+	event, err := ParseOpportunityEvent([]byte(`{"schema":"` + EventSchemaV1 + `","event_id":"e1","event_type":"new_opportunity","subject_key":"company:acme","payload":{"a":"b"}}`))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if event.EventType != EventNewOpportunity {
+		t.Fatalf("event type = %q, want the normalized closed-set value", event.EventType)
+	}
+}

--- a/internal/app/confenge/reply_handoff.go
+++ b/internal/app/confenge/reply_handoff.go
@@ -22,6 +22,11 @@ type InboundHandoff struct {
 	OccurredAt                                             time.Time
 	WarmblyContactID                                       *uuid.UUID
 	ActorID, AccountID, TouchpointID, MailboxID            uuid.UUID
+	// EngineLane is the acquisition engine whose message was replied to, when
+	// the caller knows it. Empty is honest: the lane is then derived only from
+	// a correlated touchpoint, and otherwise left unattributed rather than
+	// guessed onto whichever engine happens to be running.
+	EngineLane string
 }
 
 type HandoffResult struct {
@@ -173,6 +178,7 @@ func (s *service) ProcessInboundHandoff(ctx context.Context, orgID uuid.UUID, in
 		return nil, xerr
 	}
 	s.applyReplyCRM(ctx, orgID, in.ActorID, contactEmail, intentToCRMClass(intent.Intent), in.WarmblyContactID, cand, acc)
+	s.convergeReplyHandRaise(ctx, orgID, in, intent, cand, acc)
 	if stopsCadence {
 		s.markAccountDraftsReplied(ctx, orgID, acc.ID)
 	}

--- a/internal/app/confenge/reply_handraise.go
+++ b/internal/app/confenge/reply_handraise.go
@@ -1,0 +1,91 @@
+package confenge
+
+import (
+	"context"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Reply-side hand-raise convergence.
+//
+// A prospect answering a cold touch positively is the commercial fact the whole
+// outbound surface exists to produce. It has always updated the account; what
+// it did not do was land on the one next-action surface a founder looks at,
+// carrying which engine produced it. This is that writer.
+//
+// Attribution is never guessed. The lane comes from what the caller declared,
+// or from a correlated first-touch touchpoint, and otherwise stays empty. An
+// unattributed hand-raiser is still surfaced; it is simply honest about not
+// knowing which engine earned it.
+
+// ReplyEngineLane resolves the engine of origin for one inbound reply.
+func ReplyEngineLane(in InboundHandoff) string {
+	if lane := NormalizeEngineLane(in.EngineLane); lane != EngineLaneUnattributed {
+		return lane
+	}
+	// A correlated touchpoint is first-touch cadence state. No other engine
+	// writes one, so this is a read of an existing fact, not an inference.
+	if in.TouchpointID != uuid.Nil {
+		return EngineLaneFirstTouch
+	}
+	return EngineLaneUnattributed
+}
+
+// ReplyHandRaiseSignal maps one reply onto a hand-raise signal, given the
+// engine that produced the message being answered.
+//
+// Only the positive-interest intent converges. Every other intent already has
+// its own handling on the reply path, and duplicating it here as a hand-raiser
+// would put the same fact in two queues.
+//
+// INTEL_WATCH has no member of the closed signal set: the vocabulary has a
+// first-touch reply and an INTEL_SEED response and nothing for subscription
+// mail. A watch reply therefore converges under its own lane with the generic
+// positive-reply signal rather than a fabricated one, and adding a dedicated
+// signal is a policy decision, not something this mapping may invent.
+func ReplyHandRaiseSignal(intent, engineLane string) (HandRaiseSignal, bool) {
+	if strings.ToUpper(strings.TrimSpace(intent)) != IntentPositiveInterest {
+		return "", false
+	}
+	if NormalizeEngineLane(engineLane) == EngineLaneIntelSeed {
+		return SignalIntelSeedResponse, true
+	}
+	return SignalPositiveReplyFirstTouch, true
+}
+
+// convergeReplyHandRaise files a positive reply on the commercial-action
+// surface. It is best-effort by design: a reply is already recorded as an
+// outcome and an account state change by the time this runs, so failing to
+// converge must not fail the reply.
+func (s *service) convergeReplyHandRaise(ctx context.Context, orgID uuid.UUID, in InboundHandoff,
+	intent CommercialIntent, cand *models.OutreachContactCandidate, acc *models.OutreachAccount) {
+	if s == nil || acc == nil {
+		return
+	}
+	lane := ReplyEngineLane(in)
+	signal, ok := ReplyHandRaiseSignal(intent.Intent, lane)
+	if !ok {
+		return
+	}
+	raise := HandRaise{
+		OrganizationID: orgID, AccountID: acc.ID,
+		Signal: signal, EngineLane: lane, OccurredAt: in.OccurredAt,
+		Evidence: SanitizeText(in.Subject, 300),
+	}
+	if cand != nil {
+		id := cand.ID
+		raise.CandidateID = &id
+		if name := strings.TrimSpace(cand.Name); name != "" {
+			raise.PersonName = name
+		}
+	}
+	if _, xerr := s.PersistHandRaise(ctx, raise); xerr != nil {
+		log.Warn().Str("org_id", orgID.String()).Str("account_id", acc.ID.String()).
+			Str("engine_lane", lane).Str("reason", xerr.Message).
+			Msg("confenge: positive reply did not converge onto the hand-raiser surface")
+	}
+}

--- a/internal/app/confenge/sales_context.go
+++ b/internal/app/confenge/sales_context.go
@@ -1,0 +1,222 @@
+package confenge
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// CONFENGE_SALES_CONTEXT/1.0.
+//
+// A flat, versioned artifact describing the hand-raisers the acquisition
+// engines produced, so a downstream sales tool can pick a conversation up
+// without a second data model and without calling back into Warmbly per row.
+//
+// It is a projection, not a store. Every field is copied from an
+// OutreachCommercialAction that already exists; nothing here scores, ranks,
+// infers intent or invents a fact. Where the underlying row has no answer the
+// field is absent, because an empty field is honest and a filled one would not
+// be.
+
+// SalesContextSchemaV1 tags the artifact.
+const SalesContextSchemaV1 = "CONFENGE_SALES_CONTEXT/1.0"
+
+// salesContextScanLimit bounds how many open actions the export reads. It
+// matches the interrupt budget's scan: both project the same working queue.
+const salesContextScanLimit = 500
+
+// SalesContextFacts is one hand-raiser's evidence and its limits, kept together
+// so a reader cannot pick up the claim without the caveat attached to it.
+type SalesContextFacts struct {
+	// WhyNow and FactualHook are the assertions a human already wrote or a
+	// classifier already made. They are quoted, never re-derived.
+	WhyNow      string `json:"why_now,omitempty"`
+	FactualHook string `json:"factual_hook,omitempty"`
+	// EvidenceIDs is the provenance: what these assertions point at.
+	EvidenceIDs []string `json:"evidence_ids,omitempty"`
+	// Confidence and StatedLimits are the limits travelling with the facts.
+	// StatedLimits is the row's own warnings; it is never summarised away.
+	Confidence   string   `json:"confidence,omitempty"`
+	StatedLimits []string `json:"stated_limits,omitempty"`
+}
+
+// SalesContextTouchpoint is one outbound attempt or its answer.
+type SalesContextTouchpoint struct {
+	Ordinal    int        `json:"ordinal"`
+	Channel    string     `json:"channel"`
+	State      string     `json:"state"`
+	Subject    string     `json:"subject,omitempty"`
+	SentAt     *time.Time `json:"sent_at,omitempty"`
+	StopReason string     `json:"stop_reason,omitempty"`
+}
+
+// SalesContextItem is one hand-raiser, fully described.
+type SalesContextItem struct {
+	ActionID  uuid.UUID `json:"action_id"`
+	AccountID uuid.UUID `json:"account_id"`
+	// AcquisitionChannel is the engine of origin. Empty means the signal
+	// predates engine attribution; it is never guessed.
+	AcquisitionChannel string     `json:"acquisition_channel"`
+	CompanyRef         string     `json:"company_ref,omitempty"`
+	CompanyName        string     `json:"company_name,omitempty"`
+	PersonName         string     `json:"person_name,omitempty"`
+	CandidateID        *uuid.UUID `json:"candidate_id,omitempty"`
+	// OpportunityID is the watched asset when one is known. Only the engines
+	// that carry a subject key can fill it.
+	OpportunityID string `json:"opportunity_id,omitempty"`
+	// IntentReason is why this person is in the artifact at all: the converged
+	// signal, read back off the row's own idempotency key.
+	IntentReason string `json:"intent_reason,omitempty"`
+	// ReplyReason is the recorded outcome, when the row carries one.
+	ReplyReason         string `json:"reply_reason,omitempty"`
+	ConversationStarted bool   `json:"conversation_started"`
+	// Facts and its limits travel together; Touchpoints is what has already
+	// been said to this person and what came back.
+	Facts          SalesContextFacts        `json:"facts"`
+	Touchpoints    []SalesContextTouchpoint `json:"touchpoints"`
+	NextActionType string                   `json:"next_action_type,omitempty"`
+	NextActionAt   *time.Time               `json:"next_action_at,omitempty"`
+	State          string                   `json:"state"`
+	CreatedAt      time.Time                `json:"created_at"`
+}
+
+// SalesContextExport is the whole artifact.
+type SalesContextExport struct {
+	Schema         string    `json:"schema"`
+	OrganizationID uuid.UUID `json:"organization_id"`
+	GeneratedAt    time.Time `json:"generated_at"`
+	Total          int       `json:"total"`
+	// ByEngine counts the artifact's own items per engine, so a reader can see
+	// which engine produced the context they are holding.
+	ByEngine     map[string]int     `json:"by_engine"`
+	Unattributed int                `json:"unattributed"`
+	Items        []SalesContextItem `json:"items"`
+}
+
+// ExportSalesContext projects the artifact from the hand-raisers the engines
+// already produced. Read-only: it reserves nothing, sends nothing, mutates no
+// row.
+func (s *service) ExportSalesContext(ctx context.Context, orgID uuid.UUID, limit int) (*SalesContextExport, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if limit <= 0 || limit > 200 {
+		limit = 50
+	}
+	store := s.actionStore()
+	if store == nil {
+		return nil, errx.New(errx.Internal, "commercial action store is not wired")
+	}
+	actions, err := store.ListCommercialActions(ctx, orgID, uuid.Nil, true, salesContextScanLimit)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "failed to export sales context: "+err.Error())
+	}
+	out := &SalesContextExport{
+		Schema: SalesContextSchemaV1, OrganizationID: orgID,
+		GeneratedAt: s.now(), ByEngine: map[string]int{},
+	}
+	for _, engine := range EngineLanes {
+		out.ByEngine[engine] = 0
+	}
+	var items []SalesContextItem
+	for i := range actions {
+		action := &actions[i]
+		// Only hand-raisers. The artifact describes people who asked for
+		// something, not every open row in the cockpit.
+		if !HandRaiseAwaitsHuman(action) {
+			continue
+		}
+		item := salesContextItem(action)
+		if action.AccountID != uuid.Nil && s.repo != nil {
+			if tps, tpErr := s.repo.ListTouchpoints(ctx, orgID, action.AccountID, "", 50, 0); tpErr == nil {
+				item.Touchpoints = salesContextTouchpoints(tps)
+			}
+		}
+		if item.AcquisitionChannel == EngineLaneUnattributed {
+			out.Unattributed++
+		} else {
+			out.ByEngine[item.AcquisitionChannel]++
+		}
+		items = append(items, item)
+	}
+	out.Total = len(items)
+	// Newest first: a sales tool reads the top of this list.
+	sort.SliceStable(items, func(i, j int) bool { return items[i].CreatedAt.After(items[j].CreatedAt) })
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	out.Items = items
+	return out, nil
+}
+
+func salesContextItem(action *models.OutreachCommercialAction) SalesContextItem {
+	company, opportunity := SubjectKeyRefs(HandRaiseSubjectKeyOf(action))
+	if company == "" {
+		company = strings.TrimSpace(action.SourceLeadID)
+	}
+	return SalesContextItem{
+		ActionID: action.ID, AccountID: action.AccountID, CandidateID: action.CandidateID,
+		AcquisitionChannel:  NormalizeEngineLane(action.EngineLane),
+		CompanyRef:          company,
+		CompanyName:         strings.TrimSpace(action.CompanyName),
+		PersonName:          strings.TrimSpace(action.PersonName),
+		OpportunityID:       opportunity,
+		IntentReason:        HandRaiseSignalOf(action),
+		ReplyReason:         strings.TrimSpace(action.OutcomeCode),
+		ConversationStarted: action.ConversationStarted,
+		Facts: SalesContextFacts{
+			WhyNow: strings.TrimSpace(action.WhyNow), FactualHook: strings.TrimSpace(action.FactualHook),
+			EvidenceIDs: action.EvidenceIDs, Confidence: strings.TrimSpace(action.Confidence),
+			StatedLimits: action.Warnings,
+		},
+		NextActionType: strings.TrimSpace(action.NextActionType),
+		NextActionAt:   action.NextActionAt,
+		State:          action.State,
+		CreatedAt:      action.CreatedAt,
+	}
+}
+
+// SubjectKeyRefs splits a canonical subject key back into the reference it
+// names. It understands only the two shapes WebIntentSubjectKey produces.
+func SubjectKeyRefs(subjectKey string) (companyRef, opportunityID string) {
+	subjectKey = strings.TrimSpace(subjectKey)
+	switch {
+	case strings.HasPrefix(subjectKey, WebIntentSubjectCompanyPrefix):
+		return strings.TrimPrefix(subjectKey, WebIntentSubjectCompanyPrefix), ""
+	case strings.HasPrefix(subjectKey, WebIntentSubjectOpportunityPrefix):
+		return "", strings.TrimPrefix(subjectKey, WebIntentSubjectOpportunityPrefix)
+	default:
+		return "", ""
+	}
+}
+
+func salesContextTouchpoints(tps []models.OutreachTouchpoint) []SalesContextTouchpoint {
+	out := make([]SalesContextTouchpoint, 0, len(tps))
+	for _, tp := range tps {
+		out = append(out, SalesContextTouchpoint{
+			Ordinal: tp.Ordinal, Channel: tp.Channel, State: tp.State,
+			Subject: tp.Subject, SentAt: tp.SentAt, StopReason: tp.StopReason,
+		})
+	}
+	return out
+}
+
+// HandRaiseSignalOf reads the converged signal back off an action's own
+// idempotency key. The key is "handraise:<engine>:<signal>:...", so the signal
+// is recorded rather than re-derived from the row's shape.
+func HandRaiseSignalOf(action *models.OutreachCommercialAction) string {
+	if !HandRaiseAwaitsHuman(action) {
+		return ""
+	}
+	parts := strings.Split(strings.TrimSpace(action.IdempotencyKey), ":")
+	if len(parts) < 3 {
+		return ""
+	}
+	return parts[2]
+}

--- a/internal/app/confenge/schema.go
+++ b/internal/app/confenge/schema.go
@@ -701,6 +701,25 @@ func NormalizeCNPJ14(s string) string {
 	return d
 }
 
+// RejectsAsCNPJ reports a value that normalizes to a CNPJ. A tax register
+// number identifies a legal entity, never one company record or one
+// opportunity, so it must never be accepted as a correlation key.
+func RejectsAsCNPJ(s string) bool {
+	return NormalizeCNPJ14(s) != ""
+}
+
+// ShareTokenPrefix marks a web-cfg share-link token. Case sensitive: the
+// prefix is minted lowercase and a case-insensitive match would reject real
+// company references that merely start with the same two letters.
+const ShareTokenPrefix = "li_"
+
+// IsShareToken reports a share-link token. A token identifies a link and the
+// grant behind it, not the subject the link points at, so it is not a
+// correlation key either.
+func IsShareToken(s string) bool {
+	return strings.HasPrefix(strings.TrimSpace(s), ShareTokenPrefix)
+}
+
 // SanitizeText strips control chars and truncates; never invents content.
 func SanitizeText(s string, maxRunes int) string {
 	s = strings.TrimSpace(s)

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -134,9 +134,37 @@ type Service interface {
 	// first-touch admission predicates by composition and takes no dispatch
 	// reservation, so it cannot consume first-touch send budget.
 	GateIntelSeed(ctx context.Context, orgID, candidateID uuid.UUID) IntelSeedDecision
+	// WireIntelSeed installs INTEL_SEED's own send ledger, which is the lane's
+	// dedicated daily-cap counter and its no-resend record.
+	WireIntelSeed(ledger IntelSeedLedger)
+	// IntelSeedHeadroom reports how many seed touches remain today under the
+	// lane's OWN cap. Zero while dormant, uncapped, or exhausted.
+	IntelSeedHeadroom(ctx context.Context, orgID uuid.UUID, now time.Time) int
+	// ProcessIntelSeedOnce sends at most one INTEL_SEED touch. It claims no
+	// queue row and takes no dispatch reservation.
+	ProcessIntelSeedOnce(ctx context.Context) (bool, error)
 	// WireIntelWatch gives the INTEL_WATCH side lane its own database handle.
 	// It installs no transport authority over first touch.
 	WireIntelWatch(pool *pgxpool.Pool)
+	// WireIntelWatchSubscriptions installs the subscription store CONFENGE_WEB
+	// intake writes through, independently of the delivery lane.
+	WireIntelWatchSubscriptions(store IntelWatchSubscriptionStore)
+	// WireIntelWatchInbox installs the durable opportunity-event inbox that the
+	// production EventProducer replays from.
+	WireIntelWatchInbox(inbox liveintel.EventInbox)
+	// IntelWatchInbox returns the wired inbox, or nil when the lane is dormant.
+	IntelWatchInbox() liveintel.EventInbox
+	// IngestWebIntent validates and routes one CONFENGE_WEB_INTENT/1.0 envelope.
+	IngestWebIntent(ctx context.Context, orgID uuid.UUID, env intel.WebIntentEnvelope, now time.Time) (*WebIntentResult, *errx.Error)
+	// IngestOpportunityEvent durably stores one inbound opportunity event
+	// before anything else happens to it.
+	IngestOpportunityEvent(ctx context.Context, orgID uuid.UUID, event liveintel.OpportunityEvent, now time.Time) (*OpportunityEventReceipt, *errx.Error)
+	// PersistHandRaise converges one hand-raise signal onto the commercial
+	// action surface, stamped with its engine of origin.
+	PersistHandRaise(ctx context.Context, raise HandRaise) (*models.OutreachCommercialAction, *errx.Error)
+	// ExportSalesContext projects one CONFENGE_SALES_CONTEXT/1.0 artifact from
+	// the commercial actions the engines already produced.
+	ExportSalesContext(ctx context.Context, orgID uuid.UUID, limit int) (*SalesContextExport, *errx.Error)
 	// ResolveOutboundMailbox answers which mailbox CONFENGE mail leaves from,
 	// using the same rules the fast lane uses.
 	ResolveOutboundMailbox(ctx context.Context, orgID uuid.UUID) (uuid.UUID, error)
@@ -279,6 +307,16 @@ type service struct {
 	// INTEL_WATCH side-lane handle. Used only to resolve the sending mailbox
 	// when the fast lane is not wired; it never participates in first touch.
 	intelWatchDB *pgxpool.Pool
+	// INTEL_WATCH subscription store, written by CONFENGE_WEB intake. Wired
+	// independently of the delivery lane: recording consent must work even
+	// while delivery is dormant.
+	intelWatchSubs IntelWatchSubscriptionStore
+	// Durable opportunity-event inbox. Nil means inbound opportunity events are
+	// refused rather than accepted and dropped.
+	intelWatchInbox liveintel.EventInbox
+	// INTEL_SEED's own send ledger and daily-cap counter. Nil keeps the lane
+	// dormant: an uncountable cap is not a cap.
+	intelSeedLedger IntelSeedLedger
 }
 
 func (s *service) now() time.Time {

--- a/internal/app/confenge/web_intent.go
+++ b/internal/app/confenge/web_intent.go
@@ -1,0 +1,329 @@
+package confenge
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// CONFENGE_WEB intent intake.
+//
+// One envelope, four intents, two destinations. MONITOR_* records standing
+// consent as an INTEL_WATCH subscription. REQUEST_* converges through
+// ConvergeHandRaise onto the same next-action surface the other engines land
+// on, stamped with the confenge_web engine lane.
+//
+// Validation is fail-closed and whole-envelope: a rejected body creates
+// nothing, not even the half of it that was well formed.
+
+// Machine-readable web-intent rejection reasons. They are returned as the
+// response `code` so a caller can branch without parsing prose.
+const (
+	WebIntentReasonSchema         = "confenge_web_intent_schema_mismatch"
+	WebIntentReasonKindUnknown    = "confenge_web_intent_kind_unknown"
+	WebIntentReasonLane           = "confenge_web_intent_lane_not_confenge_web"
+	WebIntentReasonEmailMissing   = "confenge_web_intent_contact_email_missing"
+	WebIntentReasonCompanyMissing = "confenge_web_intent_company_ref_missing"
+	WebIntentReasonOpportunity    = "confenge_web_intent_opportunity_id_missing"
+	WebIntentReasonKeyIsCNPJ      = "confenge_web_intent_correlation_key_is_cnpj"
+	WebIntentReasonKeyIsShare     = "confenge_web_intent_correlation_key_is_share_token"
+	WebIntentReasonConsent        = "confenge_web_intent_consent_provenance_missing"
+	WebIntentReasonCadence        = "confenge_web_intent_cadence_unknown"
+	WebIntentReasonNoStore        = "confenge_web_intent_store_unavailable"
+)
+
+// Subject-key prefixes. This intake produces these two shapes and no other:
+// a free-form subject key would let a caller aim watch mail at any string.
+const (
+	WebIntentSubjectCompanyPrefix     = "company:"
+	WebIntentSubjectOpportunityPrefix = "opportunity:"
+)
+
+// webIntentDefaultWatchIntent is the subscription trigger a "watch this"
+// request maps to. The web envelope names the subject, not the trigger event,
+// and FIT_BECAME_RELEVANT is the only member of the closed set that does not
+// assert which kind of change the watcher asked for.
+const webIntentDefaultWatchIntent = models.IntelWatchIntentFitBecameRelevant
+
+// IntelWatchSubscriptionStore is the narrow subscription surface web intake
+// needs. The repository satisfies it; a test fake satisfies it just as well.
+type IntelWatchSubscriptionStore interface {
+	CreateOrReactivateSubscription(ctx context.Context, sub *models.IntelWatchSubscription) (*models.IntelWatchSubscription, error)
+}
+
+// WebIntentResult is what one accepted envelope did.
+type WebIntentResult struct {
+	Schema     string `json:"schema"`
+	IntentKind string `json:"intent_kind"`
+	EngineLane string `json:"engine_lane"`
+	SubjectKey string `json:"subject_key,omitempty"`
+	// SubscriptionID is set for MONITOR_*; ActionID for REQUEST_*. Never both.
+	SubscriptionID *uuid.UUID `json:"subscription_id,omitempty"`
+	ActionID       *uuid.UUID `json:"action_id,omitempty"`
+	// Matched reports whether the contact email resolved to a known account.
+	// An unmatched REQUEST_* cannot converge, because a commercial action is
+	// filed against an account; saying so is better than inventing one.
+	Matched bool   `json:"matched"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// WebIntentSubjectKey canonicalizes the subject a web intent points at. It is
+// the only producer of subject keys on this path.
+func WebIntentSubjectKey(intentKind, companyRef, opportunityID string) (string, *errx.Error) {
+	company := strings.TrimSpace(companyRef)
+	opportunity := strings.TrimSpace(opportunityID)
+	switch strings.ToUpper(strings.TrimSpace(intentKind)) {
+	case intel.WebIntentMonitorOpportunity:
+		if xerr := assertCorrelationKey(opportunity, WebIntentReasonOpportunity); xerr != nil {
+			return "", xerr
+		}
+		return WebIntentSubjectOpportunityPrefix + opportunity, nil
+	case intel.WebIntentMonitorCompany, intel.WebIntentRequestDeepDive, intel.WebIntentRequestHumanReview:
+		if xerr := assertCorrelationKey(company, WebIntentReasonCompanyMissing); xerr != nil {
+			return "", xerr
+		}
+		return WebIntentSubjectCompanyPrefix + company, nil
+	default:
+		return "", errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonKindUnknown,
+			"unknown confenge web intent_kind")
+	}
+}
+
+// assertCorrelationKey applies the three rules a correlation key must pass.
+func assertCorrelationKey(value, missingReason string) *errx.Error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errx.NewWithIdentifier(errx.BadRequest, missingReason,
+			"this intent_kind requires a correlation key")
+	}
+	if RejectsAsCNPJ(value) {
+		return errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonKeyIsCNPJ,
+			"a CNPJ is never accepted as a correlation key")
+	}
+	if IsShareToken(value) {
+		return errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonKeyIsShare,
+			"a share token is never accepted as a correlation key")
+	}
+	return nil
+}
+
+// ValidateWebIntent applies every envelope rule. It returns the canonical
+// subject key so a caller cannot derive a second one.
+func ValidateWebIntent(env intel.WebIntentEnvelope) (string, *errx.Error) {
+	if strings.TrimSpace(env.Schema) != intel.WebIntentSchemaV1 {
+		return "", errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonSchema,
+			"expected schema "+intel.WebIntentSchemaV1)
+	}
+	kind := strings.ToUpper(strings.TrimSpace(env.IntentKind))
+	if !containsStr(intel.WebIntentKinds, kind) {
+		return "", errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonKindUnknown,
+			"unknown confenge web intent_kind")
+	}
+	// The lane is ours, not the caller's. It is verified rather than read.
+	if strings.TrimSpace(env.Lane) != EngineLaneConfengeWeb {
+		return "", errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonLane,
+			"lane must be "+EngineLaneConfengeWeb)
+	}
+	if normalizeWebIntentEmail(env.ContactEmail) == "" {
+		return "", errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonEmailMissing,
+			"contact_email is required")
+	}
+	// Both correlation fields are screened, not only the one this intent uses:
+	// a rejected value must not ride along on the envelope into storage.
+	for _, candidate := range []string{env.CompanyRef, env.OpportunityID} {
+		if strings.TrimSpace(candidate) == "" {
+			continue
+		}
+		if RejectsAsCNPJ(candidate) {
+			return "", errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonKeyIsCNPJ,
+				"a CNPJ is never accepted as a correlation key")
+		}
+		if IsShareToken(candidate) {
+			return "", errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonKeyIsShare,
+				"a share token is never accepted as a correlation key")
+		}
+	}
+	subject, xerr := WebIntentSubjectKey(kind, env.CompanyRef, env.OpportunityID)
+	if xerr != nil {
+		return "", xerr
+	}
+	if webIntentCreatesSubscription(kind) {
+		// Only the MONITOR_* intents put an address on a standing mail list, so
+		// only they need consent provenance. A REQUEST_* is answered by a human.
+		if strings.TrimSpace(env.ConsentSource) == "" || env.ConsentAt == nil || !env.ConsentProvenanceOK {
+			return "", errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonConsent,
+				"consent_source, consent_at and consent_provenance_ok are required to start a watch")
+		}
+		if cadence := strings.TrimSpace(env.Cadence); cadence != "" && !containsStr(models.IntelWatchCadences, cadence) {
+			return "", errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonCadence,
+				"unknown cadence")
+		}
+	}
+	return subject, nil
+}
+
+func webIntentCreatesSubscription(kind string) bool {
+	return kind == intel.WebIntentMonitorCompany || kind == intel.WebIntentMonitorOpportunity
+}
+
+func normalizeWebIntentEmail(email string) string {
+	email = strings.ToLower(strings.TrimSpace(email))
+	if email == "" || !strings.Contains(email, "@") || strings.ContainsAny(email, " \t\r\n") {
+		return ""
+	}
+	return email
+}
+
+// webIntentSignal maps a REQUEST_* intent onto its hand-raise signal. The
+// strings are identical on purpose, so this is a membership check, not a
+// translation.
+func webIntentSignal(kind string) (HandRaiseSignal, bool) {
+	switch kind {
+	case intel.WebIntentRequestDeepDive:
+		return SignalRequestDeepDive, true
+	case intel.WebIntentRequestHumanReview:
+		return SignalRequestHumanReview, true
+	default:
+		return "", false
+	}
+}
+
+// WireIntelWatchSubscriptions installs the subscription store CONFENGE_WEB
+// intake writes through. It is wired independently of the INTEL_WATCH delivery
+// lane: recording consent must work even while delivery is dormant.
+func (s *service) WireIntelWatchSubscriptions(store IntelWatchSubscriptionStore) {
+	if s == nil {
+		return
+	}
+	s.intelWatchSubs = store
+}
+
+// IngestWebIntent validates one CONFENGE_WEB envelope and routes it.
+//
+// orgID is the organization Warmbly's own webhook auth resolved. Nothing on
+// the envelope can change it: an external caller must not be able to reach
+// another organization's watch list by naming it in the body.
+func (s *service) IngestWebIntent(ctx context.Context, orgID uuid.UUID, env intel.WebIntentEnvelope, now time.Time) (*WebIntentResult, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if orgID == uuid.Nil {
+		return nil, errx.New(errx.ServiceUnavailable, "inbound org is not configured")
+	}
+	subject, xerr := ValidateWebIntent(env)
+	if xerr != nil {
+		return nil, xerr
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	kind := strings.ToUpper(strings.TrimSpace(env.IntentKind))
+	email := normalizeWebIntentEmail(env.ContactEmail)
+	result := &WebIntentResult{
+		Schema: intel.WebIntentSchemaV1, IntentKind: kind,
+		EngineLane: EngineLaneConfengeWeb, SubjectKey: subject,
+	}
+
+	// The account and contact are looked up, never created. A web intent is
+	// evidence about a person; it is not authority to add them to the book.
+	var cand *models.OutreachContactCandidate
+	var acc *models.OutreachAccount
+	if s.repo != nil {
+		found, account, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+		if err != nil {
+			return nil, errx.New(errx.Internal, "confenge web intent contact lookup: "+err.Error())
+		}
+		cand, acc = found, account
+	}
+	result.Matched = acc != nil
+
+	if webIntentCreatesSubscription(kind) {
+		return s.webIntentSubscribe(ctx, orgID, env, subject, email, cand, acc, result)
+	}
+	return s.webIntentHandRaise(ctx, orgID, kind, env, cand, acc, now, result)
+}
+
+func (s *service) webIntentSubscribe(ctx context.Context, orgID uuid.UUID, env intel.WebIntentEnvelope, subject, email string,
+	cand *models.OutreachContactCandidate, acc *models.OutreachAccount, result *WebIntentResult) (*WebIntentResult, *errx.Error) {
+	if s.intelWatchSubs == nil {
+		return nil, errx.NewWithIdentifier(errx.ServiceUnavailable, WebIntentReasonNoStore,
+			"intel watch subscription store is not wired")
+	}
+	cadence := strings.TrimSpace(env.Cadence)
+	if cadence == "" {
+		cadence = models.IntelWatchCadenceImmediate
+	}
+	sub := &models.IntelWatchSubscription{
+		OrganizationID: orgID, ContactEmail: email,
+		IntentKind: webIntentDefaultWatchIntent, SubjectKey: subject,
+		Topic: SanitizeText(env.Topic, 300), Cadence: cadence,
+		ConsentSource: SanitizeText(env.ConsentSource, 200),
+		ConsentAt:     env.ConsentAt, ConsentProvenanceOK: env.ConsentProvenanceOK,
+	}
+	if cand != nil {
+		id := cand.ID
+		sub.ContactID = &id
+	}
+	if acc != nil {
+		id := acc.ID
+		sub.AccountID = &id
+	}
+	saved, err := s.intelWatchSubs.CreateOrReactivateSubscription(ctx, sub)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "confenge web intent subscription: "+err.Error())
+	}
+	if saved != nil {
+		id := saved.ID
+		result.SubscriptionID = &id
+	}
+	return result, nil
+}
+
+func (s *service) webIntentHandRaise(ctx context.Context, orgID uuid.UUID, kind string, env intel.WebIntentEnvelope,
+	cand *models.OutreachContactCandidate, acc *models.OutreachAccount, now time.Time, result *WebIntentResult) (*WebIntentResult, *errx.Error) {
+	signal, ok := webIntentSignal(kind)
+	if !ok {
+		return nil, errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonKindUnknown,
+			"unknown confenge web intent_kind")
+	}
+	if acc == nil {
+		// A commercial action is filed against an account. Without one there is
+		// nothing to file, and inventing an account would be worse than saying so.
+		result.Reason = "contact_not_matched_to_account"
+		return result, nil
+	}
+	raise := HandRaise{
+		OrganizationID: orgID, AccountID: acc.ID,
+		Signal: signal, EngineLane: EngineLaneConfengeWeb, OccurredAt: now,
+		SubjectKey: result.SubjectKey,
+		Evidence:   SanitizeText(firstNonEmpty(env.Evidence, env.Topic), 500),
+		HumanNotes: SanitizeText(env.Notes, 1000),
+	}
+	if env.OccurredAt != nil && !env.OccurredAt.IsZero() {
+		raise.OccurredAt = env.OccurredAt.UTC()
+	}
+	if cand != nil {
+		id := cand.ID
+		raise.CandidateID = &id
+		raise.PersonName = strings.TrimSpace(cand.Name)
+	}
+	if name := strings.TrimSpace(env.ContactName); raise.PersonName == "" && name != "" {
+		raise.PersonName = SanitizeText(name, 120)
+	}
+	action, xerr := s.PersistHandRaise(ctx, raise)
+	if xerr != nil {
+		return nil, xerr
+	}
+	if action != nil {
+		id := action.ID
+		result.ActionID = &id
+	}
+	return result, nil
+}

--- a/internal/app/confenge/web_intent_test.go
+++ b/internal/app/confenge/web_intent_test.go
@@ -1,0 +1,227 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// CONFENGE_WEB intake proofs.
+//
+// A: company_ref intake yields a company:* subscription.
+// B: opportunity_id intake yields an opportunity:* subscription.
+// I: a CNPJ or an li_ share token as a correlation key is refused.
+
+func webIntentConsentAt() *time.Time {
+	at := time.Date(2026, 9, 1, 12, 0, 0, 0, time.UTC)
+	return &at
+}
+
+func validWebIntent(kind string) intel.WebIntentEnvelope {
+	return intel.WebIntentEnvelope{
+		Schema: intel.WebIntentSchemaV1, IntentKind: kind, Lane: EngineLaneConfengeWeb,
+		CompanyRef: "acme-holdings", ContactEmail: "ana@example.com",
+		ConsentSource: "web_form:confenge.com/monitor", ConsentAt: webIntentConsentAt(),
+		ConsentProvenanceOK: true,
+	}
+}
+
+// fakeWatchSubs records what CONFENGE_WEB intake wrote.
+type fakeWatchSubs struct {
+	saved []models.IntelWatchSubscription
+}
+
+func (f *fakeWatchSubs) CreateOrReactivateSubscription(_ context.Context, sub *models.IntelWatchSubscription) (*models.IntelWatchSubscription, error) {
+	out := *sub
+	out.ID = uuid.New()
+	f.saved = append(f.saved, out)
+	return &out, nil
+}
+
+func TestWebIntentSubjectKeyCompanyShape(t *testing.T) {
+	key, xerr := WebIntentSubjectKey(intel.WebIntentMonitorCompany, "acme-holdings", "")
+	if xerr != nil {
+		t.Fatalf("valid company ref rejected: %v", xerr)
+	}
+	if key != "company:acme-holdings" {
+		t.Fatalf("subject key = %q, want company:acme-holdings", key)
+	}
+}
+
+func TestWebIntentSubjectKeyOpportunityShape(t *testing.T) {
+	key, xerr := WebIntentSubjectKey(intel.WebIntentMonitorOpportunity, "", "pregao-2026-0042")
+	if xerr != nil {
+		t.Fatalf("valid opportunity id rejected: %v", xerr)
+	}
+	if key != "opportunity:pregao-2026-0042" {
+		t.Fatalf("subject key = %q, want opportunity:pregao-2026-0042", key)
+	}
+}
+
+// Proof I. A tax identity and a share token are both refused as correlation
+// keys, on either field, for every intent kind.
+func TestWebIntentRejectsCNPJAndShareTokenAsCorrelationKey(t *testing.T) {
+	cases := []struct {
+		name       string
+		mutate     func(*intel.WebIntentEnvelope)
+		wantReason string
+	}{
+		{"cnpj in company_ref", func(e *intel.WebIntentEnvelope) { e.CompanyRef = "11.222.333/0001-81" }, WebIntentReasonKeyIsCNPJ},
+		{"bare cnpj digits in company_ref", func(e *intel.WebIntentEnvelope) { e.CompanyRef = "11222333000181" }, WebIntentReasonKeyIsCNPJ},
+		{"share token in company_ref", func(e *intel.WebIntentEnvelope) { e.CompanyRef = "li_abc123" }, WebIntentReasonKeyIsShare},
+		{"cnpj riding along on opportunity_id", func(e *intel.WebIntentEnvelope) { e.OpportunityID = "11222333000181" }, WebIntentReasonKeyIsCNPJ},
+		{"share token riding along on opportunity_id", func(e *intel.WebIntentEnvelope) { e.OpportunityID = "li_zzz" }, WebIntentReasonKeyIsShare},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := validWebIntent(intel.WebIntentMonitorCompany)
+			tc.mutate(&env)
+			_, xerr := ValidateWebIntent(env)
+			if xerr == nil {
+				t.Fatalf("envelope accepted, want rejection %s", tc.wantReason)
+			}
+			if xerr.Identifier != tc.wantReason {
+				t.Fatalf("rejection = %q, want %q", xerr.Identifier, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestWebIntentRejectsMissingCorrelationKeyPerIntent(t *testing.T) {
+	cases := []struct {
+		kind       string
+		wantReason string
+	}{
+		{intel.WebIntentMonitorCompany, WebIntentReasonCompanyMissing},
+		{intel.WebIntentRequestDeepDive, WebIntentReasonCompanyMissing},
+		{intel.WebIntentRequestHumanReview, WebIntentReasonCompanyMissing},
+		{intel.WebIntentMonitorOpportunity, WebIntentReasonOpportunity},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			env := validWebIntent(tc.kind)
+			env.CompanyRef = ""
+			env.OpportunityID = ""
+			_, xerr := ValidateWebIntent(env)
+			if xerr == nil || xerr.Identifier != tc.wantReason {
+				t.Fatalf("rejection = %v, want %s", xerr, tc.wantReason)
+			}
+		})
+	}
+}
+
+func TestWebIntentRejectsUnknownKindAndForeignLane(t *testing.T) {
+	env := validWebIntent("MONITOR_EVERYTHING")
+	if _, xerr := ValidateWebIntent(env); xerr == nil || xerr.Identifier != WebIntentReasonKindUnknown {
+		t.Fatalf("unknown intent_kind accepted: %v", xerr)
+	}
+	env = validWebIntent(intel.WebIntentMonitorCompany)
+	env.Lane = EngineLaneFirstTouch
+	if _, xerr := ValidateWebIntent(env); xerr == nil || xerr.Identifier != WebIntentReasonLane {
+		t.Fatalf("caller-chosen lane accepted: %v", xerr)
+	}
+	env = validWebIntent(intel.WebIntentMonitorCompany)
+	env.ContactEmail = ""
+	if _, xerr := ValidateWebIntent(env); xerr == nil || xerr.Identifier != WebIntentReasonEmailMissing {
+		t.Fatalf("missing contact_email accepted: %v", xerr)
+	}
+}
+
+// Consent provenance gates only the intents that put an address on a standing
+// mail list. A REQUEST_* is answered by a human and needs none.
+func TestWebIntentConsentRequiredOnlyForMonitorIntents(t *testing.T) {
+	env := validWebIntent(intel.WebIntentMonitorCompany)
+	env.ConsentProvenanceOK = false
+	if _, xerr := ValidateWebIntent(env); xerr == nil || xerr.Identifier != WebIntentReasonConsent {
+		t.Fatalf("monitor without consent accepted: %v", xerr)
+	}
+	env = validWebIntent(intel.WebIntentRequestDeepDive)
+	env.ConsentSource, env.ConsentAt, env.ConsentProvenanceOK = "", nil, false
+	if _, xerr := ValidateWebIntent(env); xerr != nil {
+		t.Fatalf("deep dive without consent rejected: %v", xerr)
+	}
+}
+
+// Proof A. A valid MONITOR_COMPANY intake creates a company:* subscription.
+func TestWebIntentMonitorCompanyCreatesCompanySubscription(t *testing.T) {
+	svc, orgID := newWebIntentService(t)
+	subs := &fakeWatchSubs{}
+	svc.WireIntelWatchSubscriptions(subs)
+
+	res, xerr := svc.IngestWebIntent(context.Background(), orgID, validWebIntent(intel.WebIntentMonitorCompany), time.Now().UTC())
+	if xerr != nil {
+		t.Fatalf("intake rejected: %v", xerr)
+	}
+	if res.SubjectKey != "company:acme-holdings" {
+		t.Fatalf("subject key = %q", res.SubjectKey)
+	}
+	if res.SubscriptionID == nil || res.ActionID != nil {
+		t.Fatalf("monitor intake must create a subscription and no action: %+v", res)
+	}
+	if len(subs.saved) != 1 {
+		t.Fatalf("saved %d subscriptions, want 1", len(subs.saved))
+	}
+	saved := subs.saved[0]
+	if saved.SubjectKey != "company:acme-holdings" || saved.OrganizationID != orgID {
+		t.Fatalf("subscription = %+v", saved)
+	}
+	if saved.IntentKind != models.IntelWatchIntentFitBecameRelevant {
+		t.Fatalf("subscription intent kind = %q, want the closed-set default", saved.IntentKind)
+	}
+	if !saved.ConsentProvenanceOK || saved.ConsentAt == nil {
+		t.Fatalf("consent provenance was not carried onto the subscription: %+v", saved)
+	}
+}
+
+// Proof B. A valid MONITOR_OPPORTUNITY intake creates an opportunity:*
+// subscription.
+func TestWebIntentMonitorOpportunityCreatesOpportunitySubscription(t *testing.T) {
+	svc, orgID := newWebIntentService(t)
+	subs := &fakeWatchSubs{}
+	svc.WireIntelWatchSubscriptions(subs)
+
+	env := validWebIntent(intel.WebIntentMonitorOpportunity)
+	env.CompanyRef = ""
+	env.OpportunityID = "pregao-2026-0042"
+	res, xerr := svc.IngestWebIntent(context.Background(), orgID, env, time.Now().UTC())
+	if xerr != nil {
+		t.Fatalf("intake rejected: %v", xerr)
+	}
+	if res.SubjectKey != "opportunity:pregao-2026-0042" {
+		t.Fatalf("subject key = %q", res.SubjectKey)
+	}
+	if len(subs.saved) != 1 || subs.saved[0].SubjectKey != "opportunity:pregao-2026-0042" {
+		t.Fatalf("subscriptions = %+v", subs.saved)
+	}
+}
+
+// A rejected envelope creates nothing at all, not even the half of it that was
+// well formed.
+func TestWebIntentRejectionIsWholeEnvelope(t *testing.T) {
+	svc, orgID := newWebIntentService(t)
+	subs := &fakeWatchSubs{}
+	svc.WireIntelWatchSubscriptions(subs)
+
+	env := validWebIntent(intel.WebIntentMonitorCompany)
+	env.CompanyRef = "11222333000181"
+	if _, xerr := svc.IngestWebIntent(context.Background(), orgID, env, time.Now().UTC()); xerr == nil {
+		t.Fatal("CNPJ correlation key accepted")
+	}
+	if len(subs.saved) != 0 {
+		t.Fatalf("a rejected envelope wrote %d subscriptions", len(subs.saved))
+	}
+}
+
+func TestWebIntentEnvelopeRecognizerDoesNotClaimOtherBodies(t *testing.T) {
+	if intel.IsWebIntentEnvelope([]byte(`{"schema":"confenge.commercial_event.v1"}`)) {
+		t.Fatal("web intent recognizer claimed a commercial event body")
+	}
+	if !intel.IsWebIntentEnvelope([]byte(`{"schema":"` + intel.WebIntentSchemaV1 + `"}`)) {
+		t.Fatal("web intent recognizer did not claim its own body")
+	}
+}

--- a/internal/infrastructure/db/migrations/000143_confenge_intel_watch_inbox.down.sql
+++ b/internal/infrastructure/db/migrations/000143_confenge_intel_watch_inbox.down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS confenge_intel_seed_sends_recipient_idx;
+DROP INDEX IF EXISTS confenge_intel_seed_sends_daily_idx;
+DROP TABLE IF EXISTS confenge_intel_seed_sends;
+DROP INDEX IF EXISTS confenge_intel_watch_inbox_replay_idx;
+DROP TABLE IF EXISTS confenge_intel_watch_inbox;

--- a/internal/infrastructure/db/migrations/000143_confenge_intel_watch_inbox.up.sql
+++ b/internal/infrastructure/db/migrations/000143_confenge_intel_watch_inbox.up.sql
@@ -1,0 +1,74 @@
+-- The durable INTEL_WATCH opportunity-event inbox.
+--
+-- This closes the replayability boundary. Dedup (confenge_intel_watch_dedup)
+-- buys at-most-once and is source-independent. Automatic reprocessing of a
+-- PENDING delivery is a different property: it needs the event to still exist
+-- somewhere, and the ledger deliberately stores delivery identity, not content.
+-- The real upstream posts once and cannot be asked to post again, so Warmbly
+-- persists the envelope here at the moment of ingestion and replays from this
+-- table instead of from the caller.
+--
+-- This is an inbox, not a second ledger. It is append-only inside a bounded
+-- replay window: a row is never marked consumed by the act of being emitted,
+-- because a consumer that fails transiently right after emission would
+-- otherwise lose the only copy of the event. Re-emission is free: the dedup
+-- ledger refuses a duplicate by primary key. emit_lease_until bounds duplicate
+-- WORK between two producer instances; it is not a correctness boundary.
+
+CREATE TABLE IF NOT EXISTS confenge_intel_watch_inbox (
+    organization_id  uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    event_id         text NOT NULL,
+    event_schema     text NOT NULL,
+    event_type       text NOT NULL,
+    subject_key      text NOT NULL,
+    occurred_at      timestamptz NOT NULL,
+    payload          jsonb NOT NULL,
+    received_at      timestamptz NOT NULL DEFAULT now(),
+    emit_lease_until timestamptz,
+    emitted_count    integer NOT NULL DEFAULT 0,
+    last_emitted_at  timestamptz,
+    -- The organization comes from Warmbly's own webhook auth, never from the
+    -- payload, so it is part of the identity rather than a column beside it.
+    PRIMARY KEY (organization_id, event_id),
+    CHECK (event_id <> ''),
+    CHECK (subject_key <> ''),
+    CHECK (event_schema = 'CONFENGE_OPPORTUNITY_EVENT/1.0'),
+    CHECK (event_type IN ('NEW_OPPORTUNITY', 'OPPORTUNITY_CHANGED', 'DEADLINE_CHANGED', 'FIT_BECAME_RELEVANT')),
+    CHECK (jsonb_typeof(payload) = 'object')
+);
+
+-- The producer's only read path: rows still inside the replay window whose
+-- emit lease is free.
+CREATE INDEX IF NOT EXISTS confenge_intel_watch_inbox_replay_idx
+    ON confenge_intel_watch_inbox (received_at DESC, emit_lease_until);
+
+COMMENT ON TABLE confenge_intel_watch_inbox IS
+'Durable inbound opportunity-event envelopes. Append-only inside a bounded replay window; emission never consumes a row. Replaces the fixture file as the production EventProducer source.';
+
+-- The INTEL_SEED send ledger.
+--
+-- INTEL_SEED takes no dispatch reservation and no queue row, so before this
+-- table there was nothing that counted an INTEL_SEED send. Its daily cap needs
+-- its OWN counter: a cap carved out of the first-touch governor would be a
+-- reduction of first touch's budget dressed up as a new lane. This table is
+-- that counter, and it doubles as the idempotency record for one seed touch.
+CREATE TABLE IF NOT EXISTS confenge_intel_seed_sends (
+    organization_id uuid NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+    message_key     text NOT NULL,
+    candidate_id    uuid REFERENCES outreach_contact_candidates(id) ON DELETE SET NULL,
+    account_id      uuid REFERENCES outreach_accounts(id) ON DELETE SET NULL,
+    recipient       text NOT NULL,
+    subject_key     text NOT NULL DEFAULT '',
+    sent_at         timestamptz NOT NULL DEFAULT now(),
+    PRIMARY KEY (organization_id, message_key),
+    CHECK (message_key <> ''),
+    CHECK (recipient <> '')
+);
+
+-- The cap's only read path: this organization's sends since the day boundary.
+CREATE INDEX IF NOT EXISTS confenge_intel_seed_sends_daily_idx
+    ON confenge_intel_seed_sends (organization_id, sent_at DESC);
+
+-- Reply attribution reads this: which lane last wrote to this address.
+CREATE INDEX IF NOT EXISTS confenge_intel_seed_sends_recipient_idx
+    ON confenge_intel_seed_sends (organization_id, recipient, sent_at DESC);

--- a/internal/models/intel_seed.go
+++ b/internal/models/intel_seed.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// IntelSeedSend is one recorded INTEL_SEED touch, the row
+// confenge_intel_seed_sends holds.
+//
+// INTEL_SEED takes no dispatch reservation and no queue row, so this table is
+// the only place a seed send is counted. It is both the lane's own daily-cap
+// counter and its no-resend record: the cap must never be a slice of the
+// first-touch budget, and a crash between recording and sending must not be
+// able to send the same recipient twice.
+type IntelSeedSend struct {
+	OrganizationID uuid.UUID `json:"organization_id"`
+	MessageKey     string    `json:"message_key"`
+	CandidateID    uuid.UUID `json:"candidate_id"`
+	AccountID      uuid.UUID `json:"account_id"`
+	Recipient      string    `json:"recipient"`
+	SubjectKey     string    `json:"subject_key"`
+	SentAt         time.Time `json:"sent_at"`
+}

--- a/internal/models/intel_watch_inbox.go
+++ b/internal/models/intel_watch_inbox.go
@@ -1,0 +1,31 @@
+package models
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// IntelWatchInboxEvent is one durably stored inbound opportunity-event
+// envelope, the row confenge_intel_watch_inbox holds.
+//
+// It exists because the real upstream posts once and cannot be asked to post
+// again. Persisting the envelope at ingestion is what lets a PENDING delivery
+// be reprocessed later: the delivery ledger stores identity, not content, so
+// without this row there would be nothing to rebuild the notification from.
+type IntelWatchInboxEvent struct {
+	// OrganizationID is resolved by Warmbly's webhook auth, never read from the
+	// posted payload. It is part of the row identity for that reason.
+	OrganizationID uuid.UUID         `json:"organization_id"`
+	EventID        string            `json:"event_id"`
+	Schema         string            `json:"schema"`
+	EventType      string            `json:"event_type"`
+	SubjectKey     string            `json:"subject_key"`
+	OccurredAt     time.Time         `json:"occurred_at"`
+	Payload        map[string]string `json:"payload"`
+	ReceivedAt     time.Time         `json:"received_at"`
+	// EmittedCount and LastEmittedAt are observability only. Emission never
+	// consumes a row, so neither field gates whether it is replayed again.
+	EmittedCount  int        `json:"emitted_count"`
+	LastEmittedAt *time.Time `json:"last_emitted_at,omitempty"`
+}

--- a/internal/repository/pg_intel_seed.go
+++ b/internal/repository/pg_intel_seed.go
@@ -1,0 +1,103 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// IntelSeedRepository owns the INTEL_SEED send ledger, the lane's own daily-cap
+// counter. Nothing here reads or writes first-touch dispatch state: the cap is
+// additional to the shared admission gates, never carved out of them.
+type IntelSeedRepository interface {
+	CountSendsSince(ctx context.Context, orgID uuid.UUID, since time.Time) (int, error)
+	// RecordSend inserts the no-resend record. It reports whether this call is
+	// what created it, so a racing worker learns the touch is not its to send.
+	RecordSend(ctx context.Context, send models.IntelSeedSend) (bool, error)
+	AlreadySent(ctx context.Context, orgID uuid.UUID, messageKey string) (bool, error)
+	// SeededCandidateIDs is the loop's skip set: contacts this lane already
+	// wrote to since the given time.
+	SeededCandidateIDs(ctx context.Context, orgID uuid.UUID, since time.Time) (map[uuid.UUID]bool, error)
+}
+
+type intelSeedRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewIntelSeedRepository(db *pgxpool.Pool) IntelSeedRepository {
+	return &intelSeedRepository{db: db}
+}
+
+func (r *intelSeedRepository) CountSendsSince(ctx context.Context, orgID uuid.UUID, since time.Time) (int, error) {
+	if orgID == uuid.Nil {
+		return 0, errors.New("intel seed send count requires an organization")
+	}
+	var n int
+	err := r.db.QueryRow(ctx, `
+		SELECT count(*)::int FROM confenge_intel_seed_sends
+		WHERE organization_id = $1 AND sent_at >= $2`, orgID, since.UTC()).Scan(&n)
+	return n, err
+}
+
+func (r *intelSeedRepository) RecordSend(ctx context.Context, send models.IntelSeedSend) (bool, error) {
+	key := strings.TrimSpace(send.MessageKey)
+	recipient := strings.ToLower(strings.TrimSpace(send.Recipient))
+	if send.OrganizationID == uuid.Nil || key == "" || recipient == "" {
+		return false, errors.New("intel seed send requires an organization, a message key and a recipient")
+	}
+	if send.SentAt.IsZero() {
+		send.SentAt = time.Now().UTC()
+	}
+	tag, err := r.db.Exec(ctx, `
+		INSERT INTO confenge_intel_seed_sends
+			(organization_id, message_key, candidate_id, account_id, recipient, subject_key, sent_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7)
+		ON CONFLICT (organization_id, message_key) DO NOTHING`,
+		send.OrganizationID, key, nullableUUID(send.CandidateID), nullableUUID(send.AccountID),
+		recipient, strings.TrimSpace(send.SubjectKey), send.SentAt.UTC())
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+func (r *intelSeedRepository) AlreadySent(ctx context.Context, orgID uuid.UUID, messageKey string) (bool, error) {
+	key := strings.TrimSpace(messageKey)
+	if orgID == uuid.Nil || key == "" {
+		return false, nil
+	}
+	var exists bool
+	err := r.db.QueryRow(ctx, `
+		SELECT EXISTS (SELECT 1 FROM confenge_intel_seed_sends
+			WHERE organization_id = $1 AND message_key = $2)`, orgID, key).Scan(&exists)
+	return exists, err
+}
+
+func (r *intelSeedRepository) SeededCandidateIDs(ctx context.Context, orgID uuid.UUID, since time.Time) (map[uuid.UUID]bool, error) {
+	out := map[uuid.UUID]bool{}
+	if orgID == uuid.Nil {
+		return out, nil
+	}
+	rows, err := r.db.Query(ctx, `
+		SELECT candidate_id FROM confenge_intel_seed_sends
+		WHERE organization_id = $1 AND sent_at >= $2 AND candidate_id IS NOT NULL`,
+		orgID, since.UTC())
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		out[id] = true
+	}
+	return out, rows.Err()
+}

--- a/internal/repository/pg_intel_watch_inbox.go
+++ b/internal/repository/pg_intel_watch_inbox.go
@@ -1,0 +1,181 @@
+package repository
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// IntelWatchInboxRepository owns the durable opportunity-event inbox.
+//
+// The inbox is append-only inside a bounded replay window. Nothing here marks a
+// row consumed: a consumer that fails right after an event is handed to it must
+// still find that event on the next pass, and the delivery ledger already
+// refuses the duplicate that re-emission would otherwise cause.
+type IntelWatchInboxRepository interface {
+	// AppendOpportunityEvent stores one envelope. It reports whether this call
+	// is what created the row; a repeat post of the same event id is a replay,
+	// not an error and not a second row.
+	AppendOpportunityEvent(ctx context.Context, event models.IntelWatchInboxEvent) (bool, error)
+	// ClaimReplayableEvents returns the events still inside the replay window
+	// whose emit lease is free, taking that lease. orgID uuid.Nil means every
+	// organization. The lease bounds duplicate work between producer instances;
+	// it is not what makes delivery safe.
+	ClaimReplayableEvents(ctx context.Context, orgID uuid.UUID, now time.Time, window, lease time.Duration, limit int) ([]models.IntelWatchInboxEvent, error)
+	// GetOpportunityEvent reads one stored envelope back.
+	GetOpportunityEvent(ctx context.Context, orgID uuid.UUID, eventID string) (*models.IntelWatchInboxEvent, error)
+}
+
+type intelWatchInboxRepository struct {
+	db *pgxpool.Pool
+}
+
+func NewIntelWatchInboxRepository(db *pgxpool.Pool) IntelWatchInboxRepository {
+	return &intelWatchInboxRepository{db: db}
+}
+
+func validateInboxEvent(event models.IntelWatchInboxEvent) error {
+	if event.OrganizationID == uuid.Nil {
+		return errors.New("intel watch inbox event requires an organization")
+	}
+	if strings.TrimSpace(event.EventID) == "" {
+		return errors.New("intel watch inbox event requires an event id")
+	}
+	if strings.TrimSpace(event.SubjectKey) == "" {
+		return errors.New("intel watch inbox event requires a subject key")
+	}
+	if len(event.Payload) == 0 {
+		return errors.New("intel watch inbox event requires a payload")
+	}
+	return nil
+}
+
+func (r *intelWatchInboxRepository) AppendOpportunityEvent(ctx context.Context, event models.IntelWatchInboxEvent) (bool, error) {
+	if err := validateInboxEvent(event); err != nil {
+		return false, err
+	}
+	payload, err := json.Marshal(event.Payload)
+	if err != nil {
+		return false, err
+	}
+	if event.ReceivedAt.IsZero() {
+		event.ReceivedAt = time.Now().UTC()
+	}
+	if event.OccurredAt.IsZero() {
+		event.OccurredAt = event.ReceivedAt
+	}
+	// DO NOTHING rather than DO UPDATE: the stored envelope is the evidence of
+	// what the upstream actually said, and a later post of the same id must not
+	// be able to rewrite it.
+	tag, err := r.db.Exec(ctx, `
+		INSERT INTO confenge_intel_watch_inbox
+			(organization_id, event_id, event_schema, event_type, subject_key, occurred_at, payload, received_at)
+		VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+		ON CONFLICT (organization_id, event_id) DO NOTHING`,
+		event.OrganizationID, strings.TrimSpace(event.EventID), strings.TrimSpace(event.Schema),
+		strings.TrimSpace(event.EventType), strings.TrimSpace(event.SubjectKey),
+		event.OccurredAt.UTC(), payload, event.ReceivedAt.UTC())
+	if err != nil {
+		return false, err
+	}
+	return tag.RowsAffected() == 1, nil
+}
+
+const intelWatchInboxColumns = `organization_id, event_id, event_schema, event_type, subject_key,
+	occurred_at, payload, received_at, emitted_count, last_emitted_at`
+
+func scanInboxEvent(scan func(dest ...any) error) (models.IntelWatchInboxEvent, error) {
+	var out models.IntelWatchInboxEvent
+	var payload []byte
+	if err := scan(&out.OrganizationID, &out.EventID, &out.Schema, &out.EventType, &out.SubjectKey,
+		&out.OccurredAt, &payload, &out.ReceivedAt, &out.EmittedCount, &out.LastEmittedAt); err != nil {
+		return out, err
+	}
+	if len(payload) > 0 {
+		if err := json.Unmarshal(payload, &out.Payload); err != nil {
+			return out, err
+		}
+	}
+	return out, nil
+}
+
+func (r *intelWatchInboxRepository) ClaimReplayableEvents(ctx context.Context, orgID uuid.UUID, now time.Time, window, lease time.Duration, limit int) ([]models.IntelWatchInboxEvent, error) {
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	if window <= 0 {
+		return nil, errors.New("intel watch inbox replay requires a positive window")
+	}
+	if lease <= 0 {
+		return nil, errors.New("intel watch inbox replay requires a positive lease")
+	}
+	if limit <= 0 {
+		limit = 500
+	}
+	// One statement so the lease is taken atomically with the read. FOR UPDATE
+	// SKIP LOCKED keeps two producer instances from queueing on each other.
+	rows, err := r.db.Query(ctx, `
+		UPDATE confenge_intel_watch_inbox AS inbox
+		SET emit_lease_until = $3,
+		    emitted_count = inbox.emitted_count + 1,
+		    last_emitted_at = $2
+		WHERE (inbox.organization_id, inbox.event_id) IN (
+			SELECT candidate.organization_id, candidate.event_id
+			FROM confenge_intel_watch_inbox AS candidate
+			WHERE ($1::uuid IS NULL OR candidate.organization_id = $1)
+			  AND candidate.received_at > $4
+			  AND (candidate.emit_lease_until IS NULL OR candidate.emit_lease_until <= $2)
+			ORDER BY candidate.received_at ASC
+			LIMIT $5
+			FOR UPDATE SKIP LOCKED
+		)
+		RETURNING `+intelWatchInboxColumns,
+		nullableOrgID(orgID), now, now.Add(lease), now.Add(-window), limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []models.IntelWatchInboxEvent
+	for rows.Next() {
+		event, err := scanInboxEvent(rows.Scan)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, event)
+	}
+	return out, rows.Err()
+}
+
+func (r *intelWatchInboxRepository) GetOpportunityEvent(ctx context.Context, orgID uuid.UUID, eventID string) (*models.IntelWatchInboxEvent, error) {
+	eventID = strings.TrimSpace(eventID)
+	if orgID == uuid.Nil || eventID == "" {
+		return nil, nil
+	}
+	row := r.db.QueryRow(ctx, `SELECT `+intelWatchInboxColumns+`
+		FROM confenge_intel_watch_inbox WHERE organization_id = $1 AND event_id = $2`, orgID, eventID)
+	event, err := scanInboxEvent(row.Scan)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &event, nil
+}
+
+// nullableOrgID turns the "every organization" sentinel into SQL NULL.
+func nullableOrgID(orgID uuid.UUID) *uuid.UUID {
+	if orgID == uuid.Nil {
+		return nil
+	}
+	return &orgID
+}


### PR DESCRIPTION
## Summary

- CONFENGE_WEB intake (`CONFENGE_WEB_INTENT/1.0`) fail-closed: rejects CNPJ and `li_` share tokens as correlation keys, requires `company_ref`/`opportunity_id` per intent, canonicalizes `subject_key` to `company:<ref>`/`opportunity:<id>` only. `MONITOR_*` creates an INTEL_WATCH subscription; `REQUEST_DEEP_DIVE`/`REQUEST_HUMAN_REVIEW` converge through the existing `ConvergeHandRaise` onto the commercial-action surface.
- Replaces the fixture-only INTEL_WATCH `EventProducer` with a durable Postgres inbox (migration 000143) fed by the real inbound webhook, since the real upstream cannot itself replay a fire-and-forget POST. Fixture producer kept for rehearsal/tests only.
- Wires real `engine_lane` writers (first-touch positive reply, INTEL_SEED response, CONFENGE_WEB requests) into `ConvergeHandRaise`, so `GET /confenge/interrupt-budget`'s `by_engine` and the new `GET /confenge/sales-context` (`CONFENGE_SALES_CONTEXT/1.0`) reflect real attribution instead of always-zero.
- Gives INTEL_SEED a real production caller and its own dedicated daily-cap ledger (separate table/counter), gated by `CONFENGE_INTEL_SEED_ENABLED` (default off). First-touch regression pack run both with the flag unset and with it enabled and the cap exhausted; output is byte-identical in both.

## Verified independently before opening this PR

- `gofmt -l internal cmd` clean, `go vet ./...` clean, `make lint` clean.
- All new unit tests pass; all new Postgres-backed tests (`TestPGInbox*`, `TestPGIntelSeedLedgerCountsItsOwnLaneOnly`) pass against a real local Postgres.
- Full `TestFirstTouchRegression*` pack and `TestFirstTouchUnchangedByIntelSeedState` pass.
- Docs updated in the same change: `docs/confenge/acquisition-engines.md`, `api/endpoints.mdx`, `api/error-codes.mdx`.

## Known gaps (left honest rather than fabricated)

- INTEL_WATCH replies have no dedicated `HandRaiseSignal`; they converge under the generic positive-reply signal with the correct `engine_lane` stamped instead (adding a 7th signal is a policy call, not made here).
- INTEL_SEED reply attribution is wired but has no live caller yet, since the shared IMAP reply path doesn't currently carry a lane marker.
- A non-accepted INTEL_SEED send still consumes its cap slot (no automatic retry on transient SMTP failure) — deliberately conservative given this is pre-canary.

## Test plan

- [x] `gofmt -l internal cmd` / `go vet ./...` / `make lint`
- [x] New unit + Postgres-backed tests (see above)
- [x] First-touch regression pack (flag unset and flag-on-with-cap-exhausted)
- [ ] CI on this PR
- [ ] CONFENGE product acceptance pack

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gu5bJFpxYcEH7AXKKAcVv