### PR TITLE
Wire CONFENGE_INTEL_WATCH and CONFENGE_INTEL_SEED env vars through the VPS compose override

### DIFF
--- a/deploy/confenge-vps/docker-compose.override.yml
+++ b/deploy/confenge-vps/docker-compose.override.yml
@@ -80,6 +80,19 @@ x-confenge-env: &confenge-env
   CONFENGE_EXTRA_CLI_ALLOWED_HOSTS: ${CONFENGE_EXTRA_CLI_ALLOWED_HOSTS:-host.docker.internal,127.0.0.1,159.195.18.88}
   CONFENGE_OUTCOME_WEBHOOK_URL: ${CONFENGE_OUTCOME_WEBHOOK_URL:-https://host.docker.internal:8443/webhooks/warmbly/outcome}
   CONFENGE_OUTCOME_WEBHOOK_SECRET: ${CONFENGE_OUTCOME_WEBHOOK_SECRET:-}
+  # INTEL_WATCH side lane. Opt-in and dormant unless both are set. Leaving
+  # CONFENGE_INTEL_WATCH_EVENTS_FILE unset (the default) selects the durable
+  # Postgres inbox as the event source instead of the rehearsal fixture.
+  CONFENGE_INTEL_WATCH_ENABLED: ${CONFENGE_INTEL_WATCH_ENABLED:-false}
+  CONFENGE_INTEL_WATCH_SECRET: ${CONFENGE_INTEL_WATCH_SECRET:-}
+  CONFENGE_INTEL_WATCH_EVENTS_FILE: ${CONFENGE_INTEL_WATCH_EVENTS_FILE:-}
+  CONFENGE_INTEL_WATCH_ORG_ID: ${CONFENGE_INTEL_WATCH_ORG_ID:-}
+  # INTEL_SEED. Opt-in and shares first touch's transport/window checks but
+  # never its cap: CONFENGE_INTEL_SEED_DAILY_CAP is its own counter, and the
+  # lane stays dormant unless both this and CONFENGE_INTEL_SEED_ENABLED are set.
+  CONFENGE_INTEL_SEED_ENABLED: ${CONFENGE_INTEL_SEED_ENABLED:-false}
+  CONFENGE_INTEL_SEED_DAILY_CAP: ${CONFENGE_INTEL_SEED_DAILY_CAP:-0}
+  CONFENGE_INTEL_SEED_ORG_ID: ${CONFENGE_INTEL_SEED_ORG_ID:-}
   # Same-host feed uses private CA; allow only when feed is loopback/host-gateway.
   WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS: ${WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS:-true}
   SSL_CERT_FILE: ${SSL_CERT_FILE:-/etc/ssl/certs/ca-certificates.crt}

--- a/deploy/confenge-vps/env.example
+++ b/deploy/confenge-vps/env.example
@@ -116,6 +116,22 @@ CONFENGE_OUTCOME_WEBHOOK_SECRET=
 # Required only because same-host feed uses a private CA.
 WARMBLY_ALLOW_UNSAFE_WEBHOOK_URLS=true
 
+# ── INTEL_WATCH side lane (opt-in) ───────────────────────────────────────────
+# Dormant unless both are set. gen-secrets.sh fills the secret if empty.
+CONFENGE_INTEL_WATCH_ENABLED=false
+CONFENGE_INTEL_WATCH_SECRET=
+# Leave unset: the durable Postgres inbox is the production event source.
+# Setting this replays the rehearsal fixture instead, for a test only.
+CONFENGE_INTEL_WATCH_EVENTS_FILE=
+CONFENGE_INTEL_WATCH_ORG_ID=
+
+# ── INTEL_SEED lane (opt-in) ──────────────────────────────────────────────────
+# Dormant unless both are set. This cap is its own counter, never carved out
+# of the first-touch governor's budget.
+CONFENGE_INTEL_SEED_ENABLED=false
+CONFENGE_INTEL_SEED_DAILY_CAP=0
+CONFENGE_INTEL_SEED_ORG_ID=
+
 # ── Hostinger mailbox (connect script; not permanent env password) ──────────
 CONFENGE_MAILBOX_EMAIL=tiago.sasaki@confenge.com.br
 CONFENGE_MAILBOX_NAME="Tiago Sasaki"

--- a/deploy/confenge-vps/gen-secrets.sh
+++ b/deploy/confenge-vps/gen-secrets.sh
@@ -68,6 +68,12 @@ if need_fill INTERNAL_API_TOKEN; then
 else
   echo "keep INTERNAL_API_TOKEN"
 fi
+if need_fill CONFENGE_INTEL_WATCH_SECRET; then
+  set_key CONFENGE_INTEL_WATCH_SECRET "$(openssl rand -hex 32)"
+  echo "filled CONFENGE_INTEL_WATCH_SECRET"
+else
+  echo "keep CONFENGE_INTEL_WATCH_SECRET"
+fi
 
 # Outcome secret from confenge-plane if present and empty here
 if need_fill CONFENGE_OUTCOME_WEBHOOK_SECRET && [[ -r /opt/confenge-plane/outcome.secret ]]; then


### PR DESCRIPTION
## Summary

The VPS backend/consumer/worker containers get CONFENGE_* config exclusively through the `x-confenge-env` anchor in `deploy/confenge-vps/docker-compose.override.yml`, not from `.env` directly (compose only forwards vars explicitly listed there). The INTEL_WATCH and INTEL_SEED lanes added in #258 had no entry in that anchor, so setting them in `.env` alone would silently do nothing.

- Adds `CONFENGE_INTEL_WATCH_ENABLED`, `CONFENGE_INTEL_WATCH_SECRET`, `CONFENGE_INTEL_WATCH_EVENTS_FILE`, `CONFENGE_INTEL_WATCH_ORG_ID` and `CONFENGE_INTEL_SEED_ENABLED`, `CONFENGE_INTEL_SEED_DAILY_CAP`, `CONFENGE_INTEL_SEED_ORG_ID` to the anchor, all defaulting to dormant/off.
- `gen-secrets.sh` now mints `CONFENGE_INTEL_WATCH_SECRET` (openssl rand -hex 32) when absent, following the exact existing pattern for `AUTH_SECRET`/`INTERNAL_API_TOKEN`. Never prints the value.
- `env.example` documents both blocks.

Validated with `docker compose ... config` that the new keys resolve into the backend/consumer/worker environments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gu5bJFpxYcEH7AXKKAcVv