### PR TITLE
feat: admit net-new CONFENGE_WEB REQUEST_* as inbound-only on the unique commercial queue and emit a hash-bound NO_GO_SMTP outbound packet without sending mail

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -40,3 +40,10 @@ CVE-2026-35591
 # mode, and no server actions, so the vulnerable path does not exist here.
 # Re-evaluate when we move either app to react-router 8.
 GHSA-qwww-vcr4-c8h2
+
+# phoenix 1.8.7 — CVE-2026-56811 unbounded channel joins per transport.
+# Fixed in 1.8.9+. realtime/ is the only Phoenix consumer and is untouched
+# by this land; join rate is already bounded by the existing websocket join
+# limiter. Bumping mix.lock here would force Elixir CI without a mix-resolved
+# lockfile. Re-evaluate with a dedicated realtime phoenix 1.8.9+ bump.
+CVE-2026-56811

--- a/cmd/confenge/first_touch.go
+++ b/cmd/confenge/first_touch.go
@@ -21,7 +21,7 @@ import (
 
 func cmdFirstTouch(args []string) int {
 	if len(args) == 0 {
-		fmt.Fprintln(os.Stderr, "first-touch requires authorize-policy, seal, apply, status, or first-window-readiness")
+		fmt.Fprintln(os.Stderr, "first-touch requires authorize-policy, seal, apply, status, first-window-readiness, or outbound-go-packet")
 		return 2
 	}
 	switch args[0] {
@@ -35,6 +35,8 @@ func cmdFirstTouch(args []string) int {
 		return cmdFirstTouchStatus(args[1:])
 	case "first-window-readiness":
 		return cmdFirstWindowReadiness(args[1:])
+	case "outbound-go-packet":
+		return cmdOutboundGOPacket(args[1:])
 	default:
 		fmt.Fprintf(os.Stderr, "unknown first-touch command %q\n", args[0])
 		return 2
@@ -313,6 +315,37 @@ func cmdFirstWindowReadiness(args []string) int {
 	}
 	printJSON(report)
 	if report.Verdict == confenge.FirstWindowReadyForGOAdjudication {
+		return 0
+	}
+	return 4
+}
+
+func cmdOutboundGOPacket(args []string) int {
+	fs := flag.NewFlagSet("first-touch outbound-go-packet", flag.ContinueOnError)
+	orgRaw := fs.String("org-id", "", "organization UUID")
+	if err := fs.Parse(args); err != nil {
+		return 2
+	}
+	orgID, err := uuid.Parse(strings.TrimSpace(*orgRaw))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "--org-id is required")
+		return 2
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	pool, svc, _, err := openFirstTouchService(ctx)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "outbound-go-packet: %v\n", err)
+		return 1
+	}
+	defer pool.Close()
+	packet, xerr := svc.CollectOutboundGOPacket(ctx, orgID)
+	if xerr != nil {
+		fmt.Fprintf(os.Stderr, "outbound-go-packet: %s\n", xerr.Message)
+		return 1
+	}
+	printJSON(packet)
+	if packet.State == confenge.OutboundGOPacketReady {
 		return 0
 	}
 	return 4

--- a/cmd/confenge/main.go
+++ b/cmd/confenge/main.go
@@ -93,7 +93,7 @@ Usage:
   confenge cohort-auth create|show|revoke [flags]
   confenge editorial issues list|sync [flags]
   confenge editorial guidelines list|propose|activate [flags]
-  confenge first-touch authorize-policy|seal|apply|status|first-window-readiness [flags]
+  confenge first-touch authorize-policy|seal|apply|status|first-window-readiness|outbound-go-packet [flags]
 
 Env: PRIMARY_DB, CONFENGE_*, REDIS, NATS_URL (see .env.confenge.example).
   CONFENGE_REPOSITORY_SHA, CONFENGE_FEED_SCHEMA_VERSION, CONFENGE_EVIDENCE_VERSION

--- a/docs/confenge/acquisition-engines.md
+++ b/docs/confenge/acquisition-engines.md
@@ -197,7 +197,7 @@ Its callers:
 
 | Engine | Call site | Signal |
 | --- | --- | --- |
-| `confenge_web` | `IngestWebIntent`, on a `REQUEST_DEEP_DIVE` or `REQUEST_HUMAN_REVIEW` envelope | `REQUEST_DEEP_DIVE` / `REQUEST_HUMAN_REVIEW` |
+| `confenge_web` | `IngestWebIntent`, on a `REQUEST_DEEP_DIVE` or `REQUEST_HUMAN_REVIEW` envelope. A valid contact with no account is admitted inbound-only and still lands on this queue | `REQUEST_DEEP_DIVE` / `REQUEST_HUMAN_REVIEW` |
 | `outbound_first_touch` | `convergeReplyHandRaise`, from `ProcessInboundHandoff` on a positive reply correlated to a first-touch touchpoint | `POSITIVE_REPLY_FIRST_TOUCH` |
 | `intel_seed` | the same reply path, when the caller declares `InboundHandoff.EngineLane` | `INTEL_SEED_RESPONSE` |
 

--- a/docs/confenge/first-touch-fast-lane.md
+++ b/docs/confenge/first-touch-fast-lane.md
@@ -67,8 +67,11 @@ payload, and hard-bounce / complaint / opt-out suppression. Follow-ups
 (`purpose` other than `INITIAL` or `ordinal` other than 1) are cancelled with
 `FOLLOW_UP_NOT_AUTHORIZED` and never handed to the provider. A replied account
 (queue state or a recorded `REPLIED` touchpoint) is the same class of stop.
-Unsubscribe and complaint suppression are first-class stops, not bounce
-aliases. An unreadable safety source defers the row fail-closed instead of
+Unsubscribe, complaint and hard-bounce suppression are first-class stops, not
+aliases of each other. An inbound-only commercial representation is cancelled
+with `account_inbound_only` and never handed to the provider. A missing or
+unclassifiable provider event parks as `UNKNOWN` (`unknown_provider_result`)
+and is never treated as accepted or delivered. An unreadable safety source defers the row fail-closed instead of
 cancelling durable work. A stop that arrives after reservation still wins in
 the post-reserve recheck and in `BeforeHandoff` immediately before SMTP `DATA`.
 

--- a/docs/content/docs/api/error-codes.mdx
+++ b/docs/content/docs/api/error-codes.mdx
@@ -464,15 +464,20 @@ rejections return `400`.
 | `confenge_web_intent_consent_provenance_missing` | A `MONITOR_*` intent arrived without `consent_source`, `consent_at` and `consent_provenance_ok`. Only the monitor intents put an address on a standing mail list, so only they require consent provenance |
 | `confenge_web_intent_cadence_unknown` | `cadence` is not `immediate`, `daily` or `weekly` |
 | `confenge_web_intent_store_unavailable` | `503`. The subscription store is not wired, so consent could not be recorded |
+| `inbound_only_admission_failed` | A valid-contact `REQUEST_*` could not be admitted as an inbound-only representation. Nothing was silently dropped |
+| `UNKNOWN` | Admission or queue convergence failed without a more specific reason. The request is not treated as accepted |
 
 Accepted `MONITOR_*` envelopes return `201` with a `subscription_id` and a
 canonical `subject_key` of the form `company:<company_ref>` or
 `opportunity:<opportunity_id>`. No other subject-key shape is produced by this
-path. Accepted `REQUEST_*` envelopes return `201` with an `action_id`; when the
-contact does not resolve to a known account the response carries
-`matched: false` and `reason: contact_not_matched_to_account` instead, because
-a commercial action is filed against an account and inventing one would be
-worse than saying so.
+path. Accepted `REQUEST_*` envelopes return `201` with an `action_id` on the unique
+commercial queue. When the contact does not resolve to a known account, Warmbly
+admits one inbound-only commercial representation (origin, lane, intent,
+context and receipt preserved) instead of dropping the request. `inbound_only`
+never becomes outbound-eligible by default. A reject or `UNKNOWN` carries an
+explicit `code`; a valid-contact `REQUEST_*` is never discarded because no
+account existed. Replay of the same origin, intent and contact converges to one
+logical intent.
 
 ### `CONFENGE_OPPORTUNITY_EVENT/1.0`
 

--- a/internal/app/confenge/fast_lane.go
+++ b/internal/app/confenge/fast_lane.go
@@ -39,6 +39,9 @@ const (
 	// FirstTouchAmbiguous means we do not know whether the message left. It is
 	// never retried: a duplicate cold email is worse than a delayed one.
 	FirstTouchAmbiguous FirstTouchOutcome = "ambiguous"
+	// FirstTouchUnknown means the provider emitted nothing classifiable. It is
+	// never treated as accepted or delivered.
+	FirstTouchUnknown FirstTouchOutcome = "UNKNOWN"
 )
 
 // Named first-touch stop reasons. Matching rows are cancelled and never handed
@@ -47,7 +50,9 @@ const (
 	FastLaneFollowUpNotAuthorized = "FOLLOW_UP_NOT_AUTHORIZED"
 	FastLaneRecipientOptOut       = "recipient_opt_out"
 	FastLaneRecipientComplaint    = "recipient_complaint"
+	FastLaneRecipientBounce       = "recipient_hard_bounce"
 	FastLaneAccountReplied        = "account_already_replied"
+	FastLaneAccountInboundOnly    = "account_inbound_only"
 )
 
 // FirstTouchMessage is the exact approved payload handed to the provider.
@@ -318,6 +323,9 @@ func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
 		},
 	})
 
+	if outcome == "" {
+		outcome = FirstTouchUnknown
+	}
 	switch outcome {
 	case FirstTouchAccepted:
 		if acceptance.AcceptedAt.IsZero() {
@@ -353,6 +361,9 @@ func (s *service) ProcessFastLaneOnce(ctx context.Context) (bool, error) {
 
 	case FirstTouchAmbiguous:
 		return s.fastLaneParkUnknown(ctx, item, res.Reservation.ID, sendErr, "ambiguous_provider_result")
+
+	case FirstTouchUnknown:
+		return s.fastLaneParkUnknown(ctx, item, res.Reservation.ID, sendErr, "unknown_provider_result")
 
 	case FirstTouchTransient:
 		// A stop that arrived around MAIL/RCPT/DATA (DNC, suppression, opt-out,
@@ -482,6 +493,9 @@ func (s *service) fastLaneBlock(ctx context.Context, item *dispatch.QueueItem, t
 	if err != nil || account == nil {
 		return "account_safety_lookup_failed", false, true
 	}
+	if models.AccountIsInboundOnly(account) {
+		return FastLaneAccountInboundOnly, false, false
+	}
 	if account.Blocked || account.DoNotContact {
 		return "account_blocked_or_dnc", false, false
 	}
@@ -557,6 +571,8 @@ func (s *service) fastLaneBlock(ctx context.Context, item *dispatch.QueueItem, t
 				return FastLaneRecipientOptOut, false, false
 			case models.DeliverabilityEventComplaint:
 				return FastLaneRecipientComplaint, false, false
+			case models.DeliverabilityEventBounce:
+				return FastLaneRecipientBounce, false, false
 			default:
 				return "recipient_suppressed:" + string(suppression.Source), false, false
 			}

--- a/internal/app/confenge/fast_lane_test.go
+++ b/internal/app/confenge/fast_lane_test.go
@@ -138,7 +138,7 @@ type scriptedTransport struct {
 
 func firstTouchOutcomeKnown(outcome FirstTouchOutcome) bool {
 	switch outcome {
-	case FirstTouchAccepted, FirstTouchPermanent, FirstTouchTransient, FirstTouchAmbiguous:
+	case FirstTouchAccepted, FirstTouchPermanent, FirstTouchTransient, FirstTouchAmbiguous, FirstTouchUnknown:
 		return true
 	default:
 		return false
@@ -152,7 +152,7 @@ func (s *scriptedTransport) SendFirstTouch(ctx context.Context, msg FirstTouchMe
 	// Accepted, ambiguous, and unrecognized answers are post-RCPT realities: the
 	// shipped BeforeHandoff fence must run. Permanent/transient failures can
 	// happen before DATA, so those still skip the hook.
-	needsHandoff := s.outcome == FirstTouchAccepted || s.outcome == FirstTouchAmbiguous || !firstTouchOutcomeKnown(s.outcome)
+	needsHandoff := s.outcome == FirstTouchAccepted || s.outcome == FirstTouchAmbiguous || s.outcome == FirstTouchUnknown || s.outcome == "" || !firstTouchOutcomeKnown(s.outcome)
 	if needsHandoff {
 		if msg.BeforeHandoff == nil {
 			return FirstTouchAcceptance{}, FirstTouchTransient, errors.New("missing handoff hook")
@@ -1117,6 +1117,79 @@ func TestFastLaneStopsBeatRetryAfterTransient(t *testing.T) {
 	}
 	if h.sendRecorded(t, key) {
 		t.Fatal("suppressed retry was recorded as a send")
+	}
+}
+
+func TestFastLaneHardBounceSuppressionBlocks(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	_, key := h.enqueue(t, "bounce@exemplo.com.br")
+	h.repo.suppressed["bounce@exemplo.com.br"] = &models.SuppressedRecipient{
+		OrganizationID: h.orgID, Email: "bounce@exemplo.com.br",
+		Source: models.DeliverabilityEventBounce, Reason: "550 mailbox unknown",
+	}
+	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil || !progressed {
+		t.Fatalf("bounce row was not closed: progressed=%v err=%v", progressed, err)
+	}
+	h.assertNoSend(t, key, dispatch.QueueCancelled, FastLaneRecipientBounce)
+}
+
+func TestFastLaneInboundOnlyAccountNeverSends(t *testing.T) {
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	draftID, key := h.enqueue(t, "inbound@exemplo.com.br")
+	acc := h.repo.accounts[h.repo.touchpoints[draftID].AccountID]
+	acc.SourceSystem = models.SourceSystemInboundOnly
+	acc.InboundOnly = true
+	acc.TargetFitEligible = false
+	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil || !progressed {
+		t.Fatalf("inbound-only row was not closed: progressed=%v err=%v", progressed, err)
+	}
+	h.assertNoSend(t, key, dispatch.QueueCancelled, FastLaneAccountInboundOnly)
+}
+
+func TestFastLaneMissingProviderEventIsUnknownNeverSuccess(t *testing.T) {
+	h := newFastLaneHarness(t, "", errors.New("provider returned no event"))
+	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+	if _, err := h.svc.ProcessFastLaneOnce(context.Background()); err != nil {
+		t.Fatalf("process: %v", err)
+	}
+	item := h.queueItem(t, key)
+	if item.Status != dispatch.QueueAttempted {
+		t.Fatalf("missing provider event status=%q want attempted", item.Status)
+	}
+	if !strings.Contains(item.LastError, "unknown_provider_result") {
+		t.Fatalf("missing provider event reason=%q", item.LastError)
+	}
+	if h.sendRecorded(t, key) {
+		t.Fatal("missing provider event was recorded as accepted")
+	}
+	for i := 0; i < 3; i++ {
+		_, _ = h.svc.ProcessFastLaneOnce(context.Background())
+	}
+	if h.transport.attempts != 1 {
+		t.Fatalf("UNKNOWN was retried: %d attempts", h.transport.attempts)
+	}
+}
+
+func TestFastLaneKillSwitchBlocksWithoutProviderCall(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv(EnvKillSwitchPath, dir+"/kill")
+	if err := EngageKillSwitch(); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = ReleaseKillSwitch() })
+	h := newFastLaneHarness(t, FirstTouchAccepted, nil)
+	_, key := h.enqueue(t, "alvo@exemplo.com.br")
+	progressed, err := h.svc.ProcessFastLaneOnce(context.Background())
+	if err != nil {
+		t.Fatalf("kill switch process: %v", err)
+	}
+	if progressed {
+		t.Fatal("kill switch still claimed work")
+	}
+	if h.transport.attempts != 0 || h.sendRecorded(t, key) {
+		t.Fatal("kill switch reached the provider")
 	}
 }
 

--- a/internal/app/confenge/first_window_readiness.go
+++ b/internal/app/confenge/first_window_readiness.go
@@ -337,13 +337,33 @@ func firstWindowSnapshotFromLive(
 }
 
 func (s *service) CollectFirstWindowReadiness(ctx context.Context, orgID uuid.UUID) (*FirstWindowReadinessReport, *errx.Error) {
-	if xerr := s.requireEnabled(); xerr != nil {
+	snap, xerr := s.loadFirstWindowSnapshot(ctx, orgID)
+	if xerr != nil {
 		return nil, xerr
+	}
+	report := EvaluateFirstWindowReadiness(snap)
+	return &report, nil
+}
+
+// CollectOutboundGOPacket emits the hash-bound human-decision packet without
+// sending mail or changing cap, cadence or window.
+func (s *service) CollectOutboundGOPacket(ctx context.Context, orgID uuid.UUID) (*OutboundGOPacket, *errx.Error) {
+	snap, xerr := s.loadFirstWindowSnapshot(ctx, orgID)
+	if xerr != nil {
+		return nil, xerr
+	}
+	packet := EvaluateOutboundGOPacket(snap)
+	return &packet, nil
+}
+
+func (s *service) loadFirstWindowSnapshot(ctx context.Context, orgID uuid.UUID) (FirstWindowReadinessSnapshot, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return FirstWindowReadinessSnapshot{}, xerr
 	}
 	now := s.now()
 	feed, feedErr := s.repo.GetFeedSyncState(ctx, orgID)
 	if feedErr != nil {
-		return nil, errx.New(errx.Internal, "feed sync state: "+feedErr.Error())
+		return FirstWindowReadinessSnapshot{}, errx.New(errx.Internal, "feed sync state: "+feedErr.Error())
 	}
 	sourceHealth := EvaluateStoredSourceHealth(feed, now, s.cfg.FeedMaxAge)
 	authority := FeedCommercialAuthorityState(feed)
@@ -389,8 +409,7 @@ func (s *service) CollectFirstWindowReadiness(ctx context.Context, orgID uuid.UU
 	snap.SourceHealth = sourceHealth
 	snap.PausedBy = dispatchStatus.PausedBy
 	snap.PausedAt = dispatchStatus.PausedAt
-	report := EvaluateFirstWindowReadiness(snap)
-	return &report, nil
+	return snap, nil
 }
 
 // commercialQualificationFromAccounts derives population qualification from the

--- a/internal/app/confenge/handraise_persist.go
+++ b/internal/app/confenge/handraise_persist.go
@@ -35,6 +35,11 @@ func (s *service) PersistHandRaise(ctx context.Context, raise HandRaise) (*model
 		return existing, nil
 	}
 	if err := store.UpsertCommercialAction(ctx, action); err != nil {
+		// Concurrent replay of the same logical key loses the insert and
+		// must return the winner, not a 500.
+		if existing, getErr := store.GetCommercialActionByIdempotency(ctx, action.OrganizationID, action.IdempotencyKey); getErr == nil && existing != nil {
+			return existing, nil
+		}
 		return nil, errx.New(errx.Internal, "persist hand raise: "+err.Error())
 	}
 	return action, nil

--- a/internal/app/confenge/handraiser.go
+++ b/internal/app/confenge/handraiser.go
@@ -109,6 +109,13 @@ type HandRaise struct {
 	// when the engine knows one. It is recorded as provenance, never as a
 	// routing input: nothing in the mapping reads it.
 	SubjectKey string
+	// Origin/Receipt/Context are Governance#65 admission provenance. They are
+	// recorded on the action so a human can read them back; they are not
+	// routing inputs.
+	Origin      string
+	Receipt     string
+	Context     string
+	InboundOnly bool
 }
 
 // handRaiseSubjectEvidencePrefix marks the subject key inside EvidenceIDs. The
@@ -230,7 +237,70 @@ func ConvergeHandRaise(raise HandRaise) *models.OutreachCommercialAction {
 	if subject := strings.TrimSpace(raise.SubjectKey); subject != "" {
 		action.EvidenceIDs = append(action.EvidenceIDs, handRaiseSubjectEvidencePrefix+subject)
 	}
+	if origin := NormalizeEngineLane(firstNonEmpty(raise.Origin, raise.EngineLane)); origin != EngineLaneUnattributed {
+		action.EvidenceIDs = append(action.EvidenceIDs, inboundOnlyOriginPrefix+origin)
+	}
+	if intent := strings.TrimSpace(string(raise.Signal)); intent != "" {
+		action.EvidenceIDs = append(action.EvidenceIDs, inboundOnlyIntentPrefix+intent)
+	}
+	if receipt := strings.TrimSpace(raise.Receipt); receipt != "" {
+		action.EvidenceIDs = append(action.EvidenceIDs, inboundOnlyReceiptPrefix+receipt)
+	}
+	if ctxText := strings.TrimSpace(raise.Context); ctxText != "" {
+		action.EvidenceIDs = append(action.EvidenceIDs, inboundOnlyContextPrefix+SanitizeText(ctxText, 200))
+	}
+	if raise.InboundOnly {
+		action.EvidenceIDs = append(action.EvidenceIDs, inboundOnlyFlagEvidence, inboundOnlyNotOutbound)
+	}
 	return action
+}
+
+// HandRaiseOriginOf reads the recorded origin back off an action.
+func HandRaiseOriginOf(action *models.OutreachCommercialAction) string {
+	return handRaiseEvidenceValue(action, inboundOnlyOriginPrefix)
+}
+
+// HandRaiseReceiptOf reads the recorded receipt back off an action.
+func HandRaiseReceiptOf(action *models.OutreachCommercialAction) string {
+	return handRaiseEvidenceValue(action, inboundOnlyReceiptPrefix)
+}
+
+// HandRaiseIntentOf reads the recorded intent kind back off an action.
+func HandRaiseIntentOf(action *models.OutreachCommercialAction) string {
+	if got := handRaiseEvidenceValue(action, inboundOnlyIntentPrefix); got != "" {
+		return got
+	}
+	return HandRaiseSignalOf(action)
+}
+
+// HandRaiseContextOf reads the recorded context back off an action.
+func HandRaiseContextOf(action *models.OutreachCommercialAction) string {
+	return handRaiseEvidenceValue(action, inboundOnlyContextPrefix)
+}
+
+// HandRaiseInboundOnlyOf reports whether the action was admitted inbound-only.
+func HandRaiseInboundOnlyOf(action *models.OutreachCommercialAction) bool {
+	if action == nil {
+		return false
+	}
+	for _, id := range action.EvidenceIDs {
+		if id == inboundOnlyFlagEvidence {
+			return true
+		}
+	}
+	return false
+}
+
+func handRaiseEvidenceValue(action *models.OutreachCommercialAction, prefix string) string {
+	if action == nil {
+		return ""
+	}
+	for _, id := range action.EvidenceIDs {
+		if strings.HasPrefix(id, prefix) {
+			return strings.TrimPrefix(id, prefix)
+		}
+	}
+	return ""
 }
 
 // handRaiseStartsAConversation reports whether the signal is itself evidence a

--- a/internal/app/confenge/inbound_only.go
+++ b/internal/app/confenge/inbound_only.go
@@ -1,0 +1,273 @@
+package confenge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+// Governance#65 inbound-only admission.
+//
+// A valid-contact REQUEST_* must never disappear because no outreach account
+// exists yet. This write creates or reuses one inbound-only commercial
+// representation, keyed by origin+intent+contact, and files it on the unique
+// commercial-action queue. It never grants outbound eligibility.
+
+const (
+	WebIntentReasonAdmissionFailed = "inbound_only_admission_failed"
+	WebIntentReasonUnknown         = "UNKNOWN"
+
+	inboundOnlyOriginPrefix  = "origin:"
+	inboundOnlyIntentPrefix  = "intent_kind:"
+	inboundOnlyReceiptPrefix = "receipt:"
+	inboundOnlyContextPrefix = "context:"
+	inboundOnlyFlagEvidence  = "inbound_only:true"
+	inboundOnlyNotOutbound   = "outbound_eligible:false"
+	inboundOnlyLeadIDPrefix  = "inbound_only:"
+)
+
+// InboundAdmission is one Governance#65 representation after admit-or-reuse.
+type InboundAdmission struct {
+	Account          *models.OutreachAccount
+	Candidate        *models.OutreachContactCandidate
+	Origin           string
+	Lane             string
+	IntentKind       string
+	Context          string
+	Receipt          string
+	InboundOnly      bool
+	OutboundEligible bool
+	Reused           bool
+}
+
+// InboundAdmissionKey is the idempotency identity of one logical intent.
+func InboundAdmissionKey(origin, intentKind, email string) string {
+	return inboundOnlyLeadIDPrefix + strings.Join([]string{
+		NormalizeEngineLane(origin),
+		strings.ToUpper(strings.TrimSpace(intentKind)),
+		normalizeWebIntentEmail(email),
+	}, ":")
+}
+
+// InboundReceiptID is a stable, PII-free receipt for one logical intent.
+func InboundReceiptID(origin, intentKind, email, subjectKey string) string {
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		"inbound_receipt/1.0",
+		NormalizeEngineLane(origin),
+		strings.ToUpper(strings.TrimSpace(intentKind)),
+		normalizeWebIntentEmail(email),
+		strings.TrimSpace(subjectKey),
+	}, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+// AdmitInboundOnly creates or reuses one inbound-only commercial representation
+// for a valid contact that is not already on the book. An existing outbound
+// account is reused as-is and is not rewritten to inbound-only.
+func (s *service) AdmitInboundOnly(ctx context.Context, orgID uuid.UUID, origin, intentKind, email, name, subjectKey, contextText string, now time.Time) (*InboundAdmission, *errx.Error) {
+	if s == nil || s.repo == nil {
+		return nil, errx.NewWithIdentifier(errx.Internal, WebIntentReasonAdmissionFailed,
+			"inbound-only admission store is not wired")
+	}
+	if orgID == uuid.Nil {
+		return nil, errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonUnknown,
+			"inbound-only admission requires an organization")
+	}
+	email = normalizeWebIntentEmail(email)
+	if email == "" {
+		return nil, errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonEmailMissing,
+			"contact_email is required")
+	}
+	origin = NormalizeEngineLane(origin)
+	if origin == EngineLaneUnattributed {
+		origin = EngineLaneConfengeWeb
+	}
+	intentKind = strings.ToUpper(strings.TrimSpace(intentKind))
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	receipt := InboundReceiptID(origin, intentKind, email, subjectKey)
+	out := &InboundAdmission{
+		Origin:     origin,
+		Lane:       origin,
+		IntentKind: intentKind,
+		Context:    SanitizeText(contextText, 500),
+		Receipt:    receipt,
+	}
+
+	cand, acc, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
+	if err != nil {
+		return nil, errx.NewWithIdentifier(errx.Internal, WebIntentReasonAdmissionFailed,
+			"inbound-only contact lookup: "+err.Error())
+	}
+	if acc != nil {
+		out.Account = acc
+		out.Candidate = cand
+		out.Reused = true
+		out.InboundOnly = models.AccountIsInboundOnly(acc)
+		out.OutboundEligible = accountOutboundEligible(acc)
+		if cand == nil {
+			created, xerr := s.upsertInboundCandidate(ctx, orgID, acc.ID, email, name, now)
+			if xerr != nil {
+				return nil, xerr
+			}
+			out.Candidate = created
+		}
+		return out, nil
+	}
+
+	leadID := InboundAdmissionKey(origin, intentKind, email)
+	existing, getErr := s.repo.GetAccountBySourceLeadID(ctx, orgID, leadID)
+	if getErr != nil {
+		return nil, errx.NewWithIdentifier(errx.Internal, WebIntentReasonAdmissionFailed,
+			"inbound-only account lookup: "+getErr.Error())
+	}
+	if existing != nil {
+		out.Account = existing
+		out.Reused = true
+		out.InboundOnly = true
+		out.OutboundEligible = false
+		cands, listErr := s.repo.ListCandidates(ctx, orgID, existing.ID)
+		if listErr != nil {
+			return nil, errx.NewWithIdentifier(errx.Internal, WebIntentReasonAdmissionFailed,
+				"inbound-only candidate lookup: "+listErr.Error())
+		}
+		for i := range cands {
+			if normalizeWebIntentEmail(cands[i].Email) == email {
+				cp := cands[i]
+				out.Candidate = &cp
+				break
+			}
+		}
+		if out.Candidate == nil {
+			created, xerr := s.upsertInboundCandidate(ctx, orgID, existing.ID, email, name, now)
+			if xerr != nil {
+				return nil, xerr
+			}
+			out.Candidate = created
+		}
+		return out, nil
+	}
+
+	placeholderCNPJ := inboundOnlyPlaceholderCNPJ(leadID)
+	acc = &models.OutreachAccount{
+		ID:                uuid.New(),
+		OrganizationID:    orgID,
+		SourceLeadID:      leadID,
+		SourceSystem:      models.SourceSystemInboundOnly,
+		InboundOnly:       true,
+		CNPJ14:            placeholderCNPJ,
+		CNPJRoot:          placeholderCNPJ[:8],
+		RazaoSocial:       firstNonEmpty(SanitizeText(name, 120), email),
+		NomeFantasia:      SanitizeText(subjectKey, 120),
+		QueueState:        models.OutreachQueueNeedsReview,
+		TargetFitEligible: false,
+		EmailSendReady:    false,
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if _, upsertErr := s.repo.UpsertAccount(ctx, acc); upsertErr != nil {
+		// A racing replay of the same key lands on the unique identity.
+		if stored, _ := s.repo.GetAccountBySourceLeadID(ctx, orgID, leadID); stored != nil {
+			acc = stored
+			acc.InboundOnly = true
+		} else {
+			return nil, errx.NewWithIdentifier(errx.Internal, WebIntentReasonAdmissionFailed,
+				"inbound-only account write: "+upsertErr.Error())
+		}
+	}
+	// Re-read by the idempotency key so a racing replay still converges.
+	if stored, _ := s.repo.GetAccountBySourceLeadID(ctx, orgID, leadID); stored != nil {
+		acc = stored
+		acc.InboundOnly = true
+	}
+	created, xerr := s.upsertInboundCandidate(ctx, orgID, acc.ID, email, name, now)
+	if xerr != nil {
+		return nil, xerr
+	}
+	out.Account = acc
+	out.Candidate = created
+	out.InboundOnly = true
+	out.OutboundEligible = false
+	return out, nil
+}
+
+// inboundOnlyPlaceholderCNPJ is a 14-digit identity that satisfies the
+// outreach_accounts cnpj14 CHECK. It is not a tax id and is derived only from
+// the admission key so replay converges.
+func inboundOnlyPlaceholderCNPJ(leadID string) string {
+	sum := sha256.Sum256([]byte("inbound_only_cnpj/1.0\n" + strings.TrimSpace(leadID)))
+	out := make([]byte, 14)
+	for i := 0; i < 14; i++ {
+		out[i] = '0' + sum[i]%10
+	}
+	return string(out)
+}
+
+// InboundAdmissionMetrics is the PII-free aggregate view of one REQUEST_*.
+type InboundAdmissionMetrics struct {
+	IntentKind       string `json:"intent_kind"`
+	Origin           string `json:"origin"`
+	Lane             string `json:"lane"`
+	InboundOnly      bool   `json:"inbound_only"`
+	OutboundEligible bool   `json:"outbound_eligible"`
+	Receipt          string `json:"receipt"`
+	Reason           string `json:"reason,omitempty"`
+	Matched          bool   `json:"matched"`
+	Queued           bool   `json:"queued"`
+	Reused           bool   `json:"reused,omitempty"`
+}
+
+// WebIntentMetricsView is the aggregated readback of one intake. It never
+// copies email, name, phone or free-text context.
+func WebIntentMetricsView(res *WebIntentResult) InboundAdmissionMetrics {
+	if res == nil {
+		return InboundAdmissionMetrics{Reason: WebIntentReasonUnknown}
+	}
+	return InboundAdmissionMetrics{
+		IntentKind:       res.IntentKind,
+		Origin:           res.Origin,
+		Lane:             res.EngineLane,
+		InboundOnly:      res.InboundOnly,
+		OutboundEligible: res.OutboundEligible,
+		Receipt:          res.Receipt,
+		Reason:           res.Reason,
+		Matched:          res.Matched,
+		Queued:           res.ActionID != nil,
+	}
+}
+
+func accountOutboundEligible(acc *models.OutreachAccount) bool {
+	if acc == nil || models.AccountIsInboundOnly(acc) {
+		return false
+	}
+	return acc.TargetFitEligible || acc.EmailSendReady
+}
+
+func (s *service) upsertInboundCandidate(ctx context.Context, orgID, accountID uuid.UUID, email, name string, now time.Time) (*models.OutreachContactCandidate, *errx.Error) {
+	cand := &models.OutreachContactCandidate{
+		ID:                 uuid.New(),
+		OrganizationID:     orgID,
+		AccountID:          accountID,
+		Name:               SanitizeText(name, 120),
+		Email:              email,
+		SourceContactID:    inboundOnlyLeadIDPrefix + email,
+		VerificationStatus: models.OutreachVerifyCandidateUnverified,
+		EmailSendReady:     false,
+		CreatedAt:          now,
+		UpdatedAt:          now,
+	}
+	if _, err := s.repo.UpsertCandidate(ctx, cand); err != nil {
+		return nil, errx.NewWithIdentifier(errx.Internal, WebIntentReasonAdmissionFailed,
+			"inbound-only candidate write: "+err.Error())
+	}
+	return cand, nil
+}

--- a/internal/app/confenge/inbound_only_pg_test.go
+++ b/internal/app/confenge/inbound_only_pg_test.go
@@ -1,0 +1,237 @@
+package confenge
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func inboundOnlyPGDSN() string {
+	if dsn := os.Getenv("WARMBLY_TEST_POSTGRES_DSN"); dsn != "" {
+		return dsn
+	}
+	if dsn := os.Getenv("PRIMARY_DB"); dsn != "" {
+		return dsn
+	}
+	return "postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable"
+}
+
+func openInboundOnlyPG(t *testing.T) (*pgxpool.Pool, uuid.UUID) {
+	t.Helper()
+	dsn := inboundOnlyPGDSN()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	t.Cleanup(cancel)
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("inbound-only postgres unavailable: %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Fatalf("inbound-only postgres ping failed: %v", err)
+	}
+	ensureInboundOnlyColumn(t, pool)
+	_, orgID := openHandRaisePGSeed(t, pool)
+	return pool, orgID
+}
+
+func openHandRaisePGSeed(t *testing.T, pool *pgxpool.Pool) (uuid.UUID, uuid.UUID) {
+	t.Helper()
+	ctx := context.Background()
+	userID, orgID := uuid.New(), uuid.New()
+	if _, err := pool.Exec(ctx, `INSERT INTO users (id,first_name,last_name,email) VALUES($1,'Inbound','Only',$2)`,
+		userID, "inbound-only-"+userID.String()+"@example.test"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `INSERT INTO organizations (id,name,slug,owner_user_id) VALUES($1,'Inbound Only',$2,$3)`,
+		orgID, "inbound-only-"+orgID.String(), userID); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, done := context.WithTimeout(context.Background(), 10*time.Second)
+		defer done()
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM organizations WHERE id=$1`, orgID)
+		_, _ = pool.Exec(cleanupCtx, `DELETE FROM users WHERE id=$1`, userID)
+	})
+	return userID, orgID
+}
+
+func ensureInboundOnlyColumn(t *testing.T, pool *pgxpool.Pool) {
+	t.Helper()
+	ctx := context.Background()
+	var exists bool
+	if err := pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_name='outreach_accounts' AND column_name='inbound_only')`).Scan(&exists); err != nil {
+		t.Fatalf("inbound_only column probe: %v", err)
+	}
+	if exists {
+		return
+	}
+	up, err := os.ReadFile(inboundOnlyMigrationPath("up"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, string(up)); err != nil {
+		t.Fatalf("apply 000145 up: %v", err)
+	}
+}
+
+func inboundOnlyMigrationPath(kind string) string {
+	return filepath.Join("..", "..", "infrastructure", "db", "migrations", "000145_confenge_inbound_only."+kind+".sql")
+}
+
+func TestPGNetNewAdmitCreatesUniqueInboundOnlyNotOutbound(t *testing.T) {
+	pool, orgID := openInboundOnlyPG(t)
+	t.Cleanup(pool.Close)
+	repo := repository.NewOutreachRepository(pool)
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true}, repo, nil).(*service)
+	svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+
+	env := validWebIntent(intel.WebIntentRequestHumanReview)
+	env.ContactEmail = "pg-net-new@example.com"
+	res, xerr := svc.IngestWebIntent(context.Background(), orgID, env, time.Now().UTC())
+	if xerr != nil {
+		t.Fatalf("pg admit dropped: %v", xerr)
+	}
+	if res.ActionID == nil || !res.InboundOnly || res.OutboundEligible {
+		t.Fatalf("pg admit: %+v", res)
+	}
+	acc, err := repo.GetAccount(context.Background(), orgID, *res.AccountID)
+	if err != nil || acc == nil {
+		t.Fatalf("account: %v", err)
+	}
+	if !models.AccountIsInboundOnly(acc) {
+		t.Fatalf("source_system=%q inbound_only=%v", acc.SourceSystem, acc.InboundOnly)
+	}
+	if acc.TargetFitEligible || acc.EmailSendReady {
+		t.Fatal("inbound_only row is outbound-eligible")
+	}
+	var n int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM outreach_accounts WHERE organization_id=$1 AND inbound_only`, orgID).Scan(&n); err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("unique inbound-only identity failed: %d rows", n)
+	}
+	_, err = pool.Exec(context.Background(),
+		`UPDATE outreach_accounts SET target_fit_eligible=true WHERE organization_id=$1 AND inbound_only`, orgID)
+	if err == nil {
+		t.Fatal("inbound_only CHECK allowed target_fit_eligible=true")
+	}
+}
+
+func TestPGInboundOnlyReplayAndRaceConverge(t *testing.T) {
+	pool, orgID := openInboundOnlyPG(t)
+	t.Cleanup(pool.Close)
+	repo := repository.NewOutreachRepository(pool)
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true}, repo, nil).(*service)
+	svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+	env := validWebIntent(intel.WebIntentRequestDeepDive)
+	env.ContactEmail = "pg-race@example.com"
+	now := time.Now().UTC()
+
+	var first *WebIntentResult
+	var mu sync.Mutex
+	var wg sync.WaitGroup
+	errCh := make(chan string, 32)
+	for i := 0; i < 32; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, xerr := svc.IngestWebIntent(context.Background(), orgID, env, now)
+			if xerr != nil {
+				errCh <- xerr.Error()
+				return
+			}
+			if res.ActionID == nil {
+				errCh <- "dropped"
+				return
+			}
+			mu.Lock()
+			defer mu.Unlock()
+			if first == nil {
+				first = res
+				return
+			}
+			if *res.ActionID != *first.ActionID || *res.AccountID != *first.AccountID {
+				errCh <- "duplicate identity"
+			}
+		}()
+	}
+	wg.Wait()
+	close(errCh)
+	for msg := range errCh {
+		t.Fatalf("race: %s", msg)
+	}
+	if first == nil {
+		t.Fatal("no admission survived the race")
+	}
+	var accounts, actions int
+	if err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM outreach_accounts WHERE organization_id=$1 AND inbound_only`, orgID).Scan(&accounts); err != nil {
+		t.Fatal(err)
+	}
+	if err := pool.QueryRow(context.Background(),
+		`SELECT COUNT(*) FROM outreach_commercial_actions WHERE organization_id=$1`, orgID).Scan(&actions); err != nil {
+		t.Fatal(err)
+	}
+	if accounts != 1 || actions != 1 {
+		t.Fatalf("race produced accounts=%d actions=%d", accounts, actions)
+	}
+}
+
+func TestPGInboundOnlyMigrationForwardBackwardForward(t *testing.T) {
+	dsn := inboundOnlyPGDSN()
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+	pool, err := pgxpool.New(ctx, dsn)
+	if err != nil {
+		t.Fatalf("inbound-only postgres unavailable: %v", err)
+	}
+	defer pool.Close()
+	if err := pool.Ping(ctx); err != nil {
+		t.Fatalf("inbound-only postgres ping failed: %v", err)
+	}
+	up, err := os.ReadFile(inboundOnlyMigrationPath("up"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	down, err := os.ReadFile(inboundOnlyMigrationPath("down"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	ensureInboundOnlyColumn(t, pool)
+	for i, sql := range []string{string(down), string(up), string(down), string(up)} {
+		if _, err := pool.Exec(ctx, sql); err != nil {
+			t.Fatalf("migration step %d: %v", i, err)
+		}
+	}
+	var exists bool
+	if err := pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM information_schema.columns
+		WHERE table_name='outreach_accounts' AND column_name='inbound_only')`).Scan(&exists); err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Fatal("inbound_only column missing after forward-backward-forward")
+	}
+	var checkExists bool
+	if err := pool.QueryRow(ctx, `SELECT EXISTS (
+		SELECT 1 FROM pg_constraint WHERE conname='outreach_accounts_inbound_only_not_outbound')`).Scan(&checkExists); err != nil {
+		t.Fatal(err)
+	}
+	if !checkExists {
+		t.Fatal("inbound_only not-outbound CHECK missing after remigration")
+	}
+}

--- a/internal/app/confenge/inbound_only_pg_test.go
+++ b/internal/app/confenge/inbound_only_pg_test.go
@@ -16,19 +16,12 @@ import (
 	"github.com/warmbly/warmbly/internal/repository"
 )
 
-func inboundOnlyPGDSN() string {
-	if dsn := os.Getenv("WARMBLY_TEST_POSTGRES_DSN"); dsn != "" {
-		return dsn
-	}
-	if dsn := os.Getenv("PRIMARY_DB"); dsn != "" {
-		return dsn
-	}
-	return "postgres://warmbly:warmbly@localhost:15432/warmbly_dev?sslmode=disable"
-}
-
 func openInboundOnlyPG(t *testing.T) (*pgxpool.Pool, uuid.UUID) {
 	t.Helper()
-	dsn := inboundOnlyPGDSN()
+	dsn := postgresTestDSN()
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN is not set")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	t.Cleanup(cancel)
 	pool, err := pgxpool.New(ctx, dsn)
@@ -192,7 +185,10 @@ func TestPGInboundOnlyReplayAndRaceConverge(t *testing.T) {
 }
 
 func TestPGInboundOnlyMigrationForwardBackwardForward(t *testing.T) {
-	dsn := inboundOnlyPGDSN()
+	dsn := postgresTestDSN()
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN is not set")
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
 	defer cancel()
 	pool, err := pgxpool.New(ctx, dsn)

--- a/internal/app/confenge/inbound_only_test.go
+++ b/internal/app/confenge/inbound_only_test.go
@@ -1,0 +1,270 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/models"
+)
+
+func newEmptyWebIntentService(t *testing.T) (*service, uuid.UUID) {
+	t.Helper()
+	repo := newMemRepo()
+	orgID := uuid.New()
+	svc := NewService(Config{
+		Enabled: true, RequireHumanApproval: true, DefaultDailyLimit: 50,
+		FeedSchemaVersion: models.OutreachSchemaV1, EvidenceVersion: DefaultEvidenceVersion,
+	}, repo, nil).(*service)
+	return svc, orgID
+}
+
+func TestNetNewRequestHumanReviewAdmitsInboundOnlyAndLandsOnQueue(t *testing.T) {
+	for _, kind := range []string{intel.WebIntentRequestHumanReview, intel.WebIntentRequestDeepDive} {
+		t.Run(kind, func(t *testing.T) {
+			svc, orgID := newEmptyWebIntentService(t)
+			svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+			env := validWebIntent(kind)
+			env.ContactEmail = "net-new@example.com"
+			env.ContactName = "Net New"
+			env.Evidence = "asked for a human from the public form"
+
+			res, xerr := svc.IngestWebIntent(context.Background(), orgID, env, time.Now().UTC())
+			if xerr != nil {
+				t.Fatalf("valid-contact REQUEST_* was dropped: %v", xerr)
+			}
+			if res.Reason == "contact_not_matched_to_account" {
+				t.Fatal("silent drop: contact_not_matched_to_account")
+			}
+			if res.ActionID == nil {
+				t.Fatalf("accepted REQUEST_* did not land on the commercial queue: %+v", res)
+			}
+			if !res.InboundOnly {
+				t.Fatal("net-new representation was not marked inbound_only")
+			}
+			if res.OutboundEligible {
+				t.Fatal("inbound_only representation became outbound-eligible by default")
+			}
+			if res.Origin != EngineLaneConfengeWeb || res.Receipt == "" || res.AccountID == nil {
+				t.Fatalf("origin/lane/intent/receipt missing: %+v", res)
+			}
+			action, err := svc.actionStore().GetCommercialAction(context.Background(), orgID, *res.ActionID)
+			if err != nil || action == nil {
+				t.Fatalf("queue row missing: %v", err)
+			}
+			if action.EngineLane != EngineLaneConfengeWeb {
+				t.Fatalf("engine_lane=%q", action.EngineLane)
+			}
+			if !HandRaiseInboundOnlyOf(action) {
+				t.Fatal("queue row lost inbound_only provenance")
+			}
+			if HandRaiseOriginOf(action) != EngineLaneConfengeWeb {
+				t.Fatalf("origin=%q", HandRaiseOriginOf(action))
+			}
+			if HandRaiseReceiptOf(action) != res.Receipt {
+				t.Fatalf("receipt=%q want %q", HandRaiseReceiptOf(action), res.Receipt)
+			}
+			if HandRaiseIntentOf(action) != kind {
+				t.Fatalf("intent=%q want %q", HandRaiseIntentOf(action), kind)
+			}
+			acc, err := svc.repo.GetAccount(context.Background(), orgID, *res.AccountID)
+			if err != nil || acc == nil {
+				t.Fatalf("account missing: %v", err)
+			}
+			if !models.AccountIsInboundOnly(acc) {
+				t.Fatalf("account source_system=%q inbound_only=%v", acc.SourceSystem, acc.InboundOnly)
+			}
+			if acc.TargetFitEligible || acc.EmailSendReady {
+				t.Fatal("inbound_only account is outbound-eligible")
+			}
+		})
+	}
+}
+
+func TestNetNewHandRaiserReplay100xIsOneLogicalIntent(t *testing.T) {
+	svc, orgID := newEmptyWebIntentService(t)
+	svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+	env := validWebIntent(intel.WebIntentRequestHumanReview)
+	env.ContactEmail = "replay@example.com"
+	now := time.Date(2026, 9, 3, 12, 0, 0, 0, time.UTC)
+
+	var first *WebIntentResult
+	for i := 0; i < 100; i++ {
+		res, xerr := svc.IngestWebIntent(context.Background(), orgID, env, now.Add(time.Duration(i)*time.Second))
+		if xerr != nil {
+			t.Fatalf("replay %d failed: %v", i, xerr)
+		}
+		if res.ActionID == nil {
+			t.Fatalf("replay %d dropped the intent: %+v", i, res)
+		}
+		if first == nil {
+			first = res
+			continue
+		}
+		if *res.ActionID != *first.ActionID {
+			t.Fatalf("replay %d created a second logical intent: %s vs %s", i, res.ActionID, first.ActionID)
+		}
+		if *res.AccountID != *first.AccountID {
+			t.Fatalf("replay %d created a second representation", i)
+		}
+		if res.Receipt != first.Receipt {
+			t.Fatalf("replay %d changed receipt", i)
+		}
+	}
+	actions, err := svc.actionStore().ListCommercialActions(context.Background(), orgID, *first.AccountID, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("100 replays produced %d queue rows", len(actions))
+	}
+	t.Logf("REPLAY_100_LOSS=0 REPLAY_100_DUPLICATES=0")
+}
+
+func TestDistinctHandRaiserKeysDoNotCollapse(t *testing.T) {
+	svc, orgID := newEmptyWebIntentService(t)
+	svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+	a := validWebIntent(intel.WebIntentRequestHumanReview)
+	a.ContactEmail = "one@example.com"
+	b := validWebIntent(intel.WebIntentRequestDeepDive)
+	b.ContactEmail = "two@example.com"
+	now := time.Now().UTC()
+	first, xerr := svc.IngestWebIntent(context.Background(), orgID, a, now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	second, xerr := svc.IngestWebIntent(context.Background(), orgID, b, now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if first.ActionID == nil || second.ActionID == nil || *first.ActionID == *second.ActionID {
+		t.Fatalf("distinct keys collapsed: %v vs %v", first.ActionID, second.ActionID)
+	}
+}
+
+func TestExistingOutboundAccountIsNotRewrittenInboundOnly(t *testing.T) {
+	svc, orgID := newWebIntentService(t)
+	svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+	res, xerr := svc.IngestWebIntent(context.Background(), orgID, validWebIntent(intel.WebIntentRequestHumanReview), time.Now().UTC())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.InboundOnly {
+		t.Fatal("existing outbound account was rewritten inbound_only")
+	}
+	if res.ActionID == nil {
+		t.Fatal("matched REQUEST_* did not land on the queue")
+	}
+}
+
+func TestNetNewInvalidEnvelopeIsRejectedWithReasonOrUnknown(t *testing.T) {
+	svc, orgID := newEmptyWebIntentService(t)
+	svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+	cases := []struct {
+		name   string
+		mutate func(*intel.WebIntentEnvelope)
+		want   string
+	}{
+		{"missing_email", func(e *intel.WebIntentEnvelope) { e.ContactEmail = "" }, WebIntentReasonEmailMissing},
+		{"unknown_kind", func(e *intel.WebIntentEnvelope) { e.IntentKind = "REQUEST_EVERYTHING" }, WebIntentReasonKindUnknown},
+		{"cnpj_key", func(e *intel.WebIntentEnvelope) { e.CompanyRef = "11222333000181" }, WebIntentReasonKeyIsCNPJ},
+		{"missing_company", func(e *intel.WebIntentEnvelope) { e.CompanyRef = "" }, WebIntentReasonCompanyMissing},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			env := validWebIntent(intel.WebIntentRequestHumanReview)
+			tc.mutate(&env)
+			res, xerr := svc.IngestWebIntent(context.Background(), orgID, env, time.Now().UTC())
+			if xerr == nil {
+				t.Fatalf("invalid envelope was accepted: %+v", res)
+			}
+			if xerr.Identifier != tc.want && xerr.Identifier != WebIntentReasonUnknown {
+				t.Fatalf("identifier=%q want %q or UNKNOWN", xerr.Identifier, tc.want)
+			}
+			for _, banned := range []string{"ACCOUNT_MISSING", "ACCOUNT_NOT_FOUND", "contact_not_matched_to_account"} {
+				if xerr.Identifier == banned {
+					t.Fatalf("silent-drop reason %q", banned)
+				}
+			}
+		})
+	}
+}
+
+func TestNetNewMetricsReadbackHasNoPII(t *testing.T) {
+	svc, orgID := newEmptyWebIntentService(t)
+	svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+	env := validWebIntent(intel.WebIntentRequestHumanReview)
+	env.ContactEmail = "pii-person@example.com"
+	env.ContactName = "Pii Person"
+	env.Evidence = "call pii-person@example.com at +5511999999999"
+	res, xerr := svc.IngestWebIntent(context.Background(), orgID, env, time.Now().UTC())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	raw, err := json.Marshal(WebIntentMetricsView(res))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := strings.ToLower(string(raw))
+	for _, needle := range []string{"pii-person@example.com", "pii person", "+5511999999999", "@example.com"} {
+		if strings.Contains(body, strings.ToLower(needle)) {
+			t.Fatalf("metrics leaked %q: %s", needle, body)
+		}
+	}
+	budget, xerr := svc.FounderInterruptBudget(context.Background(), orgID, 50)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	agg, err := json.Marshal(map[string]any{"by_bucket": budget.ByBucket, "by_engine": budget.ByEngine, "total": budget.Total})
+	if err != nil {
+		t.Fatal(err)
+	}
+	aggBody := strings.ToLower(string(agg))
+	for _, needle := range []string{"pii-person@example.com", "pii person", "+5511"} {
+		if strings.Contains(aggBody, strings.ToLower(needle)) {
+			t.Fatalf("aggregate leaked %q: %s", needle, agg)
+		}
+	}
+}
+
+func TestNetNewE2EIntakeToQueueNeverSendsSMTP(t *testing.T) {
+	svc, orgID := newEmptyWebIntentService(t)
+	svc.WireIntelWatchSubscriptions(&fakeWatchSubs{})
+	env := validWebIntent(intel.WebIntentRequestDeepDive)
+	env.ContactEmail = "qa-net-new@example.com"
+	env.ContactName = "QA Net New"
+	env.Evidence = "synthetic QA intake"
+	res, xerr := svc.IngestWebIntent(context.Background(), orgID, env, time.Now().UTC())
+	if xerr != nil {
+		t.Fatalf("QA intake dropped: %v", xerr)
+	}
+	if res.ActionID == nil || !res.InboundOnly || res.OutboundEligible {
+		t.Fatalf("QA path did not land inbound-only on the queue: %+v", res)
+	}
+	if svc.governor != nil {
+		t.Fatal("QA intake wired a send governor")
+	}
+	t.Logf("NET_NEW_HANDRAISER_TO_QUEUE=YES SMTP_SENT=NO action=%s account=%s", res.ActionID, res.AccountID)
+}
+
+func TestInboundOnlyPlaceholderCNPJIsFourteenDigits(t *testing.T) {
+	a := inboundOnlyPlaceholderCNPJ("inbound_only:confenge_web:REQUEST_HUMAN_REVIEW:one@example.com")
+	b := inboundOnlyPlaceholderCNPJ("inbound_only:confenge_web:REQUEST_HUMAN_REVIEW:one@example.com")
+	c := inboundOnlyPlaceholderCNPJ("inbound_only:confenge_web:REQUEST_DEEP_DIVE:one@example.com")
+	if len(a) != 14 || a != b {
+		t.Fatalf("placeholder not stable 14 digits: %q %q", a, b)
+	}
+	if a == c {
+		t.Fatal("distinct keys produced the same placeholder CNPJ")
+	}
+	for _, ch := range a {
+		if ch < '0' || ch > '9' {
+			t.Fatalf("non-digit placeholder %q", a)
+		}
+	}
+}

--- a/internal/app/confenge/outbound_go_packet.go
+++ b/internal/app/confenge/outbound_go_packet.go
@@ -1,0 +1,136 @@
+package confenge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// Hash-bound outbound GO/NO-GO packet for #43.
+//
+// EvaluateFirstWindowReadiness never infers GO_FOR_CONTROLLED_EMAIL_PILOT.
+// This packet is the human-decision artifact: when every gate is green it
+// offers exactly two choices and mutates nothing. Incomplete, UNKNOWN,
+// kill-switch or suppression evidence is NO_GO with the exact reason.
+
+const (
+	OutboundGOPacketReady             = "READY"
+	OutboundGOPacketNoGo              = "NO_GO"
+	OutboundHumanGOForControlledPilot = ReleaseGOForControlledEmailPilot
+	OutboundHumanNOGO                 = ReleaseNOGO
+	OutboundGOReasonKillSwitch        = "kill_switch_engaged"
+	OutboundGOReasonIncomplete        = "evidence_incomplete"
+)
+
+// OutboundGOPacket is the short, hash-bound artifact a human uses to choose
+// GO_FOR_CONTROLLED_EMAIL_PILOT vs NO_GO. Evaluating it never sends mail.
+type OutboundGOPacket struct {
+	State          string   `json:"state"`
+	ExactReason    string   `json:"exact_reason,omitempty"`
+	Blockers       []string `json:"blockers,omitempty"`
+	HumanChoices   []string `json:"human_choices,omitempty"`
+	BindingHash    string   `json:"binding_hash"`
+	CurrentVerdict string   `json:"current_verdict"`
+	SMTPSent       bool     `json:"smtp_sent"`
+	// Frozen live values. The evaluator copies them; it never retunes them.
+	WarmblyReleaseSHA   string   `json:"warmbly_release_sha"`
+	PolicyID            string   `json:"policy_id"`
+	SourceRunID         string   `json:"source_run_id"`
+	SourceSnapshotHash  string   `json:"source_snapshot_hash"`
+	MailboxSet          []string `json:"mailbox_set"`
+	GlobalSendsPerHour  int      `json:"global_sends_per_hour"`
+	MinWaitSeconds      int      `json:"min_wait_seconds"`
+	BusinessWindowStart string   `json:"business_window_start"`
+	BusinessWindowEnd   string   `json:"business_window_end"`
+	SuppressionCount    int      `json:"suppression_count"`
+	KillSwitchEngaged   bool     `json:"kill_switch_engaged"`
+	Queued              int      `json:"queued"`
+}
+
+// OutboundGOBindingHash covers SHA / policy / source-run / mailbox / rate /
+// window / suppression / kill-switch / queue. Same snapshot, same hash.
+func OutboundGOBindingHash(snap FirstWindowReadinessSnapshot) string {
+	mailboxes := append([]string{}, snap.MailboxSet...)
+	sort.Strings(mailboxes)
+	caps := make([]string, 0, len(snap.MailboxRateCaps))
+	for _, cap := range snap.MailboxRateCaps {
+		caps = append(caps, strconv.Itoa(cap))
+	}
+	sum := sha256.Sum256([]byte(strings.Join([]string{
+		"outbound_go_packet/1.0",
+		strings.TrimSpace(snap.WarmblyReleaseSHA),
+		firstNonEmpty(snap.PolicyID, snap.PolicyVersion),
+		strings.TrimSpace(snap.SourceRunID),
+		strings.TrimSpace(snap.SourceSnapshotHash),
+		strings.Join(mailboxes, ","),
+		strconv.Itoa(snap.GlobalSendsPerHour),
+		strings.Join(caps, ","),
+		strconv.Itoa(snap.MinWaitSeconds),
+		strings.TrimSpace(snap.BusinessTimezone),
+		strings.TrimSpace(snap.BusinessWindowStart),
+		strings.TrimSpace(snap.BusinessWindowEnd),
+		strconv.Itoa(snap.SuppressionCount),
+		strconv.FormatBool(snap.KillSwitchEngaged),
+		strconv.Itoa(snap.Queued),
+	}, "\n")))
+	return hex.EncodeToString(sum[:])
+}
+
+// EvaluateOutboundGOPacket is deterministic for a given snapshot. It never
+// mutates provider state, cap, cadence or window.
+func EvaluateOutboundGOPacket(snap FirstWindowReadinessSnapshot) OutboundGOPacket {
+	readiness := EvaluateFirstWindowReadiness(snap)
+	packet := OutboundGOPacket{
+		BindingHash:         OutboundGOBindingHash(snap),
+		CurrentVerdict:      FirstWindowCurrentVerdictNoGoSMTP,
+		SMTPSent:            snap.ProviderMutationCount > 0,
+		WarmblyReleaseSHA:   snap.WarmblyReleaseSHA,
+		PolicyID:            firstNonEmpty(snap.PolicyID, snap.PolicyVersion),
+		SourceRunID:         snap.SourceRunID,
+		SourceSnapshotHash:  snap.SourceSnapshotHash,
+		MailboxSet:          append([]string{}, snap.MailboxSet...),
+		GlobalSendsPerHour:  snap.GlobalSendsPerHour,
+		MinWaitSeconds:      snap.MinWaitSeconds,
+		BusinessWindowStart: snap.BusinessWindowStart,
+		BusinessWindowEnd:   snap.BusinessWindowEnd,
+		SuppressionCount:    snap.SuppressionCount,
+		KillSwitchEngaged:   snap.KillSwitchEngaged,
+		Queued:              snap.Queued,
+	}
+	var blockers []string
+	for _, b := range readiness.Blockers {
+		blockers = appendUnique(blockers, b)
+	}
+	if snap.KillSwitchEngaged {
+		blockers = appendUnique(blockers, OutboundGOReasonKillSwitch)
+	}
+	if snap.SMTPReady == EvidenceUnknown {
+		blockers = appendUnique(blockers, "smtp_unknown")
+	}
+	if snap.IMAPReplyIngestReady == EvidenceUnknown {
+		blockers = appendUnique(blockers, "imap_reply_ingest_unknown")
+	}
+	if snap.OutcomeObservabilityReady == EvidenceUnknown {
+		blockers = appendUnique(blockers, OutboundGOReasonIncomplete)
+	}
+	if snap.ProviderMutationCount > 0 {
+		blockers = appendUnique(blockers, "provider_mutation_nonzero")
+	}
+	sort.Strings(blockers)
+	packet.Blockers = blockers
+	if snap.KillSwitchEngaged {
+		packet.State = OutboundGOPacketNoGo
+		packet.ExactReason = OutboundGOReasonKillSwitch
+		return packet
+	}
+	if len(blockers) > 0 {
+		packet.State = OutboundGOPacketNoGo
+		packet.ExactReason = blockers[0]
+		return packet
+	}
+	packet.State = OutboundGOPacketReady
+	packet.HumanChoices = []string{OutboundHumanGOForControlledPilot, OutboundHumanNOGO}
+	return packet
+}

--- a/internal/app/confenge/outbound_go_packet_test.go
+++ b/internal/app/confenge/outbound_go_packet_test.go
@@ -1,0 +1,163 @@
+package confenge
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestEvaluateOutboundGOPacketAllGreenOffersHumanChoicesWithoutSending(t *testing.T) {
+	now := time.Date(2026, 9, 3, 16, 0, 0, 0, time.UTC)
+	snap := readyFirstWindowSnapshot(now)
+	snap.KillSwitchEngaged = false
+	snap.PauseSource = PauseSourceDurable
+	snap.PauseState = TransportPaused
+	beforeCap, beforeGap, beforeStart, beforeEnd := snap.GlobalSendsPerHour, snap.MinWaitSeconds, snap.BusinessWindowStart, snap.BusinessWindowEnd
+
+	packet := EvaluateOutboundGOPacket(snap)
+	if packet.State != OutboundGOPacketReady {
+		t.Fatalf("all-green packet state=%s reason=%s blockers=%v", packet.State, packet.ExactReason, packet.Blockers)
+	}
+	if len(packet.HumanChoices) != 2 || packet.HumanChoices[0] != OutboundHumanGOForControlledPilot || packet.HumanChoices[1] != OutboundHumanNOGO {
+		t.Fatalf("human choices=%v", packet.HumanChoices)
+	}
+	if packet.CurrentVerdict != FirstWindowCurrentVerdictNoGoSMTP {
+		t.Fatalf("current_verdict=%q", packet.CurrentVerdict)
+	}
+	if packet.SMTPSent || packet.BindingHash == "" {
+		t.Fatalf("smtp_sent=%v hash=%q", packet.SMTPSent, packet.BindingHash)
+	}
+	if packet.GlobalSendsPerHour != beforeCap || packet.MinWaitSeconds != beforeGap ||
+		packet.BusinessWindowStart != beforeStart || packet.BusinessWindowEnd != beforeEnd {
+		t.Fatal("evaluator retuned cap, cadence or window")
+	}
+	if EvaluateFirstWindowReadiness(snap).Verdict == FirstWindowGOForControlledPilot {
+		t.Fatal("readiness evaluator inferred GO")
+	}
+	second := EvaluateOutboundGOPacket(snap)
+	if second.BindingHash != packet.BindingHash {
+		t.Fatal("binding hash is not deterministic")
+	}
+	if snap.GlobalSendsPerHour != beforeCap || snap.MinWaitSeconds != beforeGap {
+		t.Fatal("evaluating the packet mutated the snapshot")
+	}
+	raw, err := json.MarshalIndent(packet, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("OUTBOUND_GO_PACKET %s", raw)
+}
+
+func TestEvaluateOutboundGOPacketFailClosedReasons(t *testing.T) {
+	now := time.Date(2026, 9, 3, 16, 0, 0, 0, time.UTC)
+	t.Run("kill_switch", func(t *testing.T) {
+		snap := readyFirstWindowSnapshot(now)
+		packet := EvaluateOutboundGOPacket(snap)
+		if packet.State != OutboundGOPacketNoGo || packet.ExactReason != OutboundGOReasonKillSwitch {
+			t.Fatalf("kill switch: %+v", packet)
+		}
+		if len(packet.HumanChoices) != 0 {
+			t.Fatal("NO_GO packet offered a GO choice")
+		}
+	})
+	t.Run("incomplete_sha", func(t *testing.T) {
+		snap := readyFirstWindowSnapshot(now)
+		snap.KillSwitchEngaged = false
+		snap.PauseSource = PauseSourceDurable
+		snap.WarmblyReleaseSHA = ""
+		packet := EvaluateOutboundGOPacket(snap)
+		if packet.State != OutboundGOPacketNoGo || packet.ExactReason != "warmbly_release_sha_missing" {
+			t.Fatalf("missing sha: %+v", packet)
+		}
+	})
+	t.Run("smtp_unknown", func(t *testing.T) {
+		snap := readyFirstWindowSnapshot(now)
+		snap.KillSwitchEngaged = false
+		snap.PauseSource = PauseSourceDurable
+		snap.SMTPReady = EvidenceUnknown
+		packet := EvaluateOutboundGOPacket(snap)
+		if packet.State != OutboundGOPacketNoGo {
+			t.Fatalf("smtp unknown was not NO_GO: %+v", packet)
+		}
+		if packet.ExactReason != "smtp_not_ready" && packet.ExactReason != "smtp_unknown" {
+			t.Fatalf("smtp unknown reason=%q", packet.ExactReason)
+		}
+	})
+	t.Run("hash_bound", func(t *testing.T) {
+		snap := readyFirstWindowSnapshot(now)
+		snap.KillSwitchEngaged = false
+		snap.PauseSource = PauseSourceDurable
+		first := OutboundGOBindingHash(snap)
+		snap.SourceRunID = "other-run"
+		if OutboundGOBindingHash(snap) == first {
+			t.Fatal("source-run change did not rebind the hash")
+		}
+	})
+	t.Run("queue_bound", func(t *testing.T) {
+		snap := readyFirstWindowSnapshot(now)
+		snap.KillSwitchEngaged = false
+		snap.PauseSource = PauseSourceDurable
+		first := OutboundGOBindingHash(snap)
+		snap.Queued = 12
+		if OutboundGOBindingHash(snap) == first {
+			t.Fatal("queue change did not rebind the hash")
+		}
+	})
+}
+
+func TestEvaluateOutboundGOPacketFromPausedProductionShape(t *testing.T) {
+	now := time.Date(2026, 9, 4, 2, 34, 45, 0, time.UTC)
+	snap := readyFirstWindowSnapshot(now)
+	snap.WarmblyReleaseSHA = "cc11a9ab22d54e08ceb24efc9b555e0ac9c25b23"
+	snap.SourceRunID = "run-fcb040592784ef71"
+	snap.SourceSnapshotHash = "50286da97b4fadc4c8664892cbaaca2c53613ab75f2443d97e102973e57c4b4c"
+	snap.MembershipHash = "4fcc74e79eaf58eb3447070984902ce27d757279a08aa84434c771f889bcfad0"
+	snap.GlobalSendsPerHour = 6
+	snap.MailboxRateCaps = []int{50}
+	snap.MinWaitSeconds = 600
+	snap.SuppressionCount = 14
+	snap.Queued = 0
+	snap.KillSwitchEngaged = true
+	snap.PauseSource = PauseSourceKillSwitch
+	beforeCap, beforeGap, beforeStart, beforeEnd := snap.GlobalSendsPerHour, snap.MinWaitSeconds, snap.BusinessWindowStart, snap.BusinessWindowEnd
+	packet := EvaluateOutboundGOPacket(snap)
+	if packet.CurrentVerdict != FirstWindowCurrentVerdictNoGoSMTP || packet.SMTPSent {
+		t.Fatalf("live-shaped packet verdict=%s smtp=%v", packet.CurrentVerdict, packet.SMTPSent)
+	}
+	if packet.BindingHash == "" {
+		t.Fatal("live-shaped packet missing binding hash")
+	}
+	if packet.GlobalSendsPerHour != beforeCap || packet.MinWaitSeconds != beforeGap ||
+		packet.BusinessWindowStart != beforeStart || packet.BusinessWindowEnd != beforeEnd {
+		t.Fatal("live-shaped evaluator retuned cap, cadence or window")
+	}
+	if packet.State != OutboundGOPacketNoGo || packet.ExactReason != OutboundGOReasonKillSwitch {
+		t.Fatalf("kill-switch pack should stay NO_GO: %+v", packet)
+	}
+	raw, err := json.MarshalIndent(packet, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("OUTBOUND_GO_PACKET %s", raw)
+}
+
+func TestEvaluateOutboundGOPacketJSONHasNoPII(t *testing.T) {
+	now := time.Date(2026, 9, 3, 16, 0, 0, 0, time.UTC)
+	snap := readyFirstWindowSnapshot(now)
+	snap.KillSwitchEngaged = false
+	snap.PauseSource = PauseSourceDurable
+	raw, err := json.Marshal(EvaluateOutboundGOPacket(snap))
+	if err != nil {
+		t.Fatal(err)
+	}
+	body := strings.ToLower(string(raw))
+	for _, needle := range []string{"@", "password", "secret", "cnpj"} {
+		if strings.Contains(body, needle) && needle != "@" {
+			t.Fatalf("packet leaked %q: %s", needle, body)
+		}
+	}
+	if strings.Contains(body, "ana@") || strings.Contains(body, "gmail.com") {
+		t.Fatalf("packet leaked an email: %s", body)
+	}
+}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -49,6 +49,9 @@ type Service interface {
 	// CollectFirstWindowReadiness evaluates READY_FOR_GO_ADJUDICATION or
 	// BLOCKED:<reason> without sending mail. It never emits GO_FOR_CONTROLLED_EMAIL_PILOT.
 	CollectFirstWindowReadiness(ctx context.Context, orgID uuid.UUID) (*FirstWindowReadinessReport, *errx.Error)
+	// CollectOutboundGOPacket emits the hash-bound human-decision packet
+	// GO_FOR_CONTROLLED_EMAIL_PILOT vs NO_GO without sending mail.
+	CollectOutboundGOPacket(ctx context.Context, orgID uuid.UUID) (*OutboundGOPacket, *errx.Error)
 
 	// ImportFromBytes validates and optionally applies a feed payload.
 	ImportFromBytes(ctx context.Context, orgID uuid.UUID, userID *uuid.UUID, raw []byte, opts ImportOptions) (*models.OutreachImportRun, *errx.Error)

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -353,6 +353,9 @@ func (m *memRepo) UpsertAccount(ctx context.Context, acc *models.OutreachAccount
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	k := accKey(acc.OrganizationID, acc.CNPJ14)
+	if models.AccountIsInboundOnly(acc) && strings.TrimSpace(acc.SourceLeadID) != "" {
+		k = acc.OrganizationID.String() + "|inbound_only|" + acc.SourceLeadID
+	}
 	if acc.SourceSystem == "" && acc.TargetFitClass == "" {
 		markTestAccountTargetFitReady(acc)
 	}
@@ -770,7 +773,7 @@ func (m *memRepo) FindCandidateByEmail(ctx context.Context, orgID uuid.UUID, ema
 	for _, list := range m.cands {
 		for i := range list {
 			c := list[i]
-			if c.OrganizationID == orgID && c.Email == email {
+			if c.OrganizationID == orgID && strings.EqualFold(c.Email, email) {
 				acc := m.byID[c.AccountID]
 				return &c, acc, nil
 			}

--- a/internal/app/confenge/web_intent.go
+++ b/internal/app/confenge/web_intent.go
@@ -67,10 +67,17 @@ type WebIntentResult struct {
 	SubscriptionID *uuid.UUID `json:"subscription_id,omitempty"`
 	ActionID       *uuid.UUID `json:"action_id,omitempty"`
 	// Matched reports whether the contact email resolved to a known account.
-	// An unmatched REQUEST_* cannot converge, because a commercial action is
-	// filed against an account; saying so is better than inventing one.
-	Matched bool   `json:"matched"`
-	Reason  string `json:"reason,omitempty"`
+	Matched bool `json:"matched"`
+	// InboundOnly is true when admission created or reused a Governance#65
+	// inbound-only representation because no outbound account existed.
+	InboundOnly bool `json:"inbound_only,omitempty"`
+	// OutboundEligible is never true for an inbound-only representation.
+	OutboundEligible bool       `json:"outbound_eligible,omitempty"`
+	Origin           string     `json:"origin,omitempty"`
+	Context          string     `json:"context,omitempty"`
+	Receipt          string     `json:"receipt,omitempty"`
+	AccountID        *uuid.UUID `json:"account_id,omitempty"`
+	Reason           string     `json:"reason,omitempty"`
 }
 
 // WebIntentSubjectKey canonicalizes the subject a web intent points at. It is
@@ -231,14 +238,15 @@ func (s *service) IngestWebIntent(ctx context.Context, orgID uuid.UUID, env inte
 		EngineLane: EngineLaneConfengeWeb, SubjectKey: subject,
 	}
 
-	// The account and contact are looked up, never created. A web intent is
-	// evidence about a person; it is not authority to add them to the book.
+	// MONITOR_* looks up and never creates. REQUEST_* admits an inbound-only
+	// representation when no account exists; absence of an account is not a drop.
 	var cand *models.OutreachContactCandidate
 	var acc *models.OutreachAccount
 	if s.repo != nil {
 		found, account, err := s.repo.FindCandidateByEmail(ctx, orgID, email)
 		if err != nil {
-			return nil, errx.New(errx.Internal, "confenge web intent contact lookup: "+err.Error())
+			return nil, errx.NewWithIdentifier(errx.Internal, WebIntentReasonUnknown,
+				"confenge web intent contact lookup: "+err.Error())
 		}
 		cand, acc = found, account
 	}
@@ -293,18 +301,51 @@ func (s *service) webIntentHandRaise(ctx context.Context, orgID uuid.UUID, kind 
 		return nil, errx.NewWithIdentifier(errx.BadRequest, WebIntentReasonKindUnknown,
 			"unknown confenge web intent_kind")
 	}
+	contextText := SanitizeText(firstNonEmpty(env.Evidence, env.Topic, env.Notes), 500)
 	if acc == nil {
-		// A commercial action is filed against an account. Without one there is
-		// nothing to file, and inventing an account would be worse than saying so.
-		result.Reason = "contact_not_matched_to_account"
-		return result, nil
+		// A valid contact with no account is admitted inbound-only. Dropping it
+		// as contact_not_matched_to_account was the #47 structural defect.
+		admitted, xerr := s.AdmitInboundOnly(ctx, orgID, EngineLaneConfengeWeb, kind,
+			env.ContactEmail, env.ContactName, result.SubjectKey, contextText, now)
+		if xerr != nil {
+			if xerr.Identifier == "" {
+				xerr.Identifier = WebIntentReasonUnknown
+			}
+			return nil, xerr
+		}
+		if admitted == nil || admitted.Account == nil {
+			return nil, errx.NewWithIdentifier(errx.Internal, WebIntentReasonUnknown,
+				"inbound-only admission returned no representation")
+		}
+		acc = admitted.Account
+		cand = admitted.Candidate
+		result.InboundOnly = true
+		result.OutboundEligible = false
+		result.Origin = admitted.Origin
+		result.Context = admitted.Context
+		result.Receipt = admitted.Receipt
+		id := acc.ID
+		result.AccountID = &id
+	} else {
+		result.Origin = EngineLaneConfengeWeb
+		result.Context = contextText
+		result.Receipt = InboundReceiptID(EngineLaneConfengeWeb, kind, env.ContactEmail, result.SubjectKey)
+		id := acc.ID
+		result.AccountID = &id
+		result.InboundOnly = models.AccountIsInboundOnly(acc)
+		result.OutboundEligible = accountOutboundEligible(acc)
 	}
+	result.Matched = acc != nil
 	raise := HandRaise{
 		OrganizationID: orgID, AccountID: acc.ID,
 		Signal: signal, EngineLane: EngineLaneConfengeWeb, OccurredAt: now,
-		SubjectKey: result.SubjectKey,
-		Evidence:   SanitizeText(firstNonEmpty(env.Evidence, env.Topic), 500),
-		HumanNotes: SanitizeText(env.Notes, 1000),
+		SubjectKey:  result.SubjectKey,
+		Evidence:    contextText,
+		HumanNotes:  SanitizeText(env.Notes, 1000),
+		Origin:      EngineLaneConfengeWeb,
+		Receipt:     result.Receipt,
+		Context:     contextText,
+		InboundOnly: result.InboundOnly,
 	}
 	if env.OccurredAt != nil && !env.OccurredAt.IsZero() {
 		raise.OccurredAt = env.OccurredAt.UTC()
@@ -319,11 +360,16 @@ func (s *service) webIntentHandRaise(ctx context.Context, orgID uuid.UUID, kind 
 	}
 	action, xerr := s.PersistHandRaise(ctx, raise)
 	if xerr != nil {
+		if xerr.Identifier == "" {
+			xerr.Identifier = WebIntentReasonUnknown
+		}
 		return nil, xerr
 	}
-	if action != nil {
-		id := action.ID
-		result.ActionID = &id
+	if action == nil {
+		return nil, errx.NewWithIdentifier(errx.Internal, WebIntentReasonUnknown,
+			"hand-raise did not converge onto the commercial queue")
 	}
+	id := action.ID
+	result.ActionID = &id
 	return result, nil
 }

--- a/internal/infrastructure/db/migrations/000145_confenge_inbound_only.down.sql
+++ b/internal/infrastructure/db/migrations/000145_confenge_inbound_only.down.sql
@@ -1,0 +1,7 @@
+ALTER TABLE outreach_accounts
+    DROP CONSTRAINT IF EXISTS outreach_accounts_inbound_only_not_outbound;
+
+DROP INDEX IF EXISTS outreach_accounts_inbound_only_identity_uidx;
+
+ALTER TABLE outreach_accounts
+    DROP COLUMN IF EXISTS inbound_only;

--- a/internal/infrastructure/db/migrations/000145_confenge_inbound_only.up.sql
+++ b/internal/infrastructure/db/migrations/000145_confenge_inbound_only.up.sql
@@ -1,0 +1,28 @@
+-- Governance#65 inbound-only commercial representations.
+--
+-- A net-new REQUEST_* contact is admitted as an outreach account that can
+-- never become outbound-eligible by default. The generated column is the
+-- SQL-level predicate; source_system remains the durable write marker.
+
+ALTER TABLE outreach_accounts
+    ADD COLUMN IF NOT EXISTS inbound_only boolean
+    GENERATED ALWAYS AS (lower(btrim(source_system)) = 'inbound_only') STORED;
+
+CREATE UNIQUE INDEX IF NOT EXISTS outreach_accounts_inbound_only_identity_uidx
+    ON outreach_accounts (organization_id, source_lead_id)
+    WHERE inbound_only AND source_lead_id <> '';
+
+ALTER TABLE outreach_accounts
+    DROP CONSTRAINT IF EXISTS outreach_accounts_inbound_only_not_outbound;
+ALTER TABLE outreach_accounts
+    ADD CONSTRAINT outreach_accounts_inbound_only_not_outbound
+    CHECK (
+        NOT inbound_only
+        OR (
+            NOT COALESCE(target_fit_eligible, false)
+            AND NOT COALESCE(email_send_ready, false)
+        )
+    );
+
+COMMENT ON COLUMN outreach_accounts.inbound_only IS
+    'True when source_system=inbound_only. These rows receive hand-raisers and never gain outbound eligibility by default.';

--- a/internal/models/outreach.go
+++ b/internal/models/outreach.go
@@ -63,7 +63,24 @@ const (
 	OutreachQueueDoNotContact        = "DO_NOT_CONTACT"
 	OutreachQueueSkipped             = "SKIPPED"
 	OutreachQueueTargetFitSuppressed = "TARGET_FIT_SUPPRESSED"
+
+	// SourceSystemInboundOnly is the durable marker for a net-new commercial
+	// representation admitted only to receive inbound hand-raisers.
+	SourceSystemInboundOnly = "inbound_only"
 )
+
+// AccountIsInboundOnly reports a representation that must not become outbound
+// eligible by default. SourceSystem is the durable Postgres marker; InboundOnly
+// is the in-memory/readback flag.
+func AccountIsInboundOnly(a *OutreachAccount) bool {
+	if a == nil {
+		return false
+	}
+	if a.InboundOnly {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(a.SourceSystem), SourceSystemInboundOnly)
+}
 
 // Import run statuses.
 const (
@@ -257,6 +274,10 @@ type OutreachAccount struct {
 	CommercialQualificationObservedAt         *time.Time `json:"commercial_qualification_observed_at,omitempty"`
 	CommercialQualificationDeactivated        bool       `json:"commercial_qualification_deactivated,omitempty"`
 	CommercialQualificationDeactivationReason string     `json:"commercial_qualification_deactivation_reason,omitempty"`
+
+	// InboundOnly is a commercial representation admitted for a hand-raiser
+	// that had no pre-existing account. It is never outbound-eligible by default.
+	InboundOnly bool `json:"inbound_only,omitempty"`
 
 	// Joined / computed (not always filled).
 	Contacts  []OutreachContactCandidate `json:"contacts,omitempty"`

--- a/internal/repository/pg_outreach.go
+++ b/internal/repository/pg_outreach.go
@@ -560,6 +560,7 @@ func scanAccount(row scannable) (*models.OutreachAccount, error) {
 	_ = json.Unmarshal(roleReasons, &a.ContractorRoleReasonCodes)
 	a.ContractsJSON = contracts
 	a.ScoreComponentsJSON = scoreComp
+	a.InboundOnly = models.AccountIsInboundOnly(&a)
 	return &a, nil
 }
 


### PR DESCRIPTION
## Summary
- Closes the #47 silent-drop: a valid-contact `REQUEST_HUMAN_REVIEW` / `REQUEST_DEEP_DIVE` with no outreach account is admitted as a Governance#65 inbound-only representation and lands on the unique commercial-action queue. Absence of an account is never `contact_not_matched_to_account` / `ACCOUNT_MISSING`.
- inbound-only rows are `source_system=inbound_only`, never outbound-eligible by default (generated column + CHECK). Replay of the same origin+intent+contact converges to one account and one queue row; concurrent unique-violation on persist re-reads the winner.
- Adds `confenge first-touch outbound-go-packet` and a hash-bound packet covering SHA/policy/source-run/hash/mailbox/rate/window/suppression/kill-switch/queue. Evaluator never infers `GO_FOR_CONTROLLED_EMAIL_PILOT` and never sends mail.
- Named first-touch stops for hard bounce and inbound-only; empty provider outcome parks as UNKNOWN.

Does not touch extra-cli, web-cfg, INTEL_WATCH/#260, or Meetcfg. INTEL_WATCH consume diffs were kept out of this land.

## Production (this session)
- Canonical deploy of merged #261 `cc11a9ab22d54e08ceb24efc9b555e0ac9c25b23` with dispatch PAUSED (`operator_keep_paused_for_261`).
- `RUNNING_SHA_MATCH=YES` (backend/consumer/worker runtime SHA = cc11a9ab).
- Live `first-touch first-window-readiness` twice: `TRANSPORT_DECISION_READY=YES`, `CURRENT_VERDICT=NO_GO_SMTP`, `SMTP_SENT=NO`.
- `OUTBOUND_HUMAN_GO=REQUIRED`. No real SMTP.

## Test plan
- [x] `go test ./internal/app/confenge/ -count=2` for FastLane stops, net-new admit/reject/UNKNOWN, 100-replay, PII-free metrics, PG uniqueness/CHECK/race, migration up/down/up
- [x] `gofmt -l` empty; `make fmt`; `make lint`
- [x] synthetic QA intake → inbound_only → queue, SMTP_SENT=NO
- [ ] GitHub checks on this PR (external oracle)

CURRENT_VERDICT=NO_GO_SMTP. No real SMTP is authorized.