### PR TITLE
feat: consume NET_NEW_INBOUND_HANDRAISER inbound-only on the existing commercial owner without SMTP

### DIFF
--- a/docs/confenge/net-new-inbound-handraiser.md
+++ b/docs/confenge/net-new-inbound-handraiser.md
@@ -1,0 +1,46 @@
+# NET_NEW_INBOUND_HANDRAISER consumer (campaign 07)
+
+Warmbly consumes `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904` on the
+existing inbound HMAC route. This is not a second CRM. Receipts land on
+`outreach_inbound_leads`, net-new people/companies reuse
+`AdmitInboundOnly`, and accepted events converge onto one commercial
+action through `ConvergeHandRaise`.
+
+Draft contract IDs are a fail-closed pin. A missing or divergent
+`schema_hash` / `policy_hash` is never `ACCEPTED`. Goal 97 ratifies the
+pin. HTTP 2xx is not acceptance; `outcome` plus readback of the same
+`logical_id` is.
+
+## Pin
+
+- Policy / envelope: `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904`
+- Intake: `CONFENGE_WEB_INTAKE/2.0.0-draft.20260904`
+- State: `CONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904`
+- Meetcfg projection: `MEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904`
+- Taxonomy: `CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904`
+- Catalog: `CONFENGE_OFFER_CATALOG/2.0.0-draft.20260904`
+- Hash: `92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b`
+- Source / lane: `CONFENGE_WEB`
+- Invariants: `outbound_eligible=false`, `auto_send=false`
+
+Fixture for campaigns 08 and 14:
+`internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json`
+
+## Outcomes
+
+Closed set: `ACCEPTED | REJECTED_WITH_REASON | UNKNOWN`.
+
+- Persist the receipt before admit or queue writes.
+- `ACCEPTED` creates or updates one inbound-only hand-raiser. Meetcfg
+  handoff is allowed only then.
+- Canonical entity ID reuses the existing account. The same display name
+  without that ID does not merge.
+- Conflict storage is a protected `conflict_ref` only.
+- INTEL_WATCH / Live Intelligence factual envelopes stay on their own
+  schema and never create a CONFENGE_WEB hand-raiser here.
+
+## Readback
+
+`GET /confenge/inbound/handraisers/:logicalId` returns `acknowledged_by`,
+`acknowledged_at`, policy version, receipt, reason, and outcome for the
+same logical ID.

--- a/docs/contracts/inbound-learning/net-new-inbound-handraiser.md
+++ b/docs/contracts/inbound-learning/net-new-inbound-handraiser.md
@@ -1,0 +1,11 @@
+# NET_NEW_INBOUND_HANDRAISER / CONFENGE_WEB intake (draft pin)
+
+Test-only coordination contract for campaign 07. Not a production
+fallback. Runtime without this version and hash fails closed.
+
+See `docs/confenge/net-new-inbound-handraiser.md` and the published
+fixture `internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json`.
+
+Producers (web-cfg campaign 08) send this envelope on
+`POST /api/v1/webhooks/confenge/inbound`. Downstream Meetcfg (campaign 14)
+may consume sales-context items only after `outcome=ACCEPTED`.

--- a/docs/integration/campaign-20260904/07/README.md
+++ b/docs/integration/campaign-20260904/07/README.md
@@ -1,0 +1,10 @@
+# Campaign 07 integration fragments
+
+Owner: Warmbly inbound consumer, inbound commercial state, readback.
+
+Shared files not edited here. Goal 97 consolidates.
+
+| fragment | target_path | operation | stable_key |
+| --- | --- | --- | --- |
+| error-codes.fragment.md | docs/content/docs/api/error-codes.mdx | insert section after CONFENGE_WEB_INTENT | NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904 |
+| endpoints.fragment.md | docs/content/docs/api/endpoints.mdx | document GET handraisers readback | GET /confenge/inbound/handraisers/:logicalId |

--- a/docs/integration/campaign-20260904/07/endpoints.fragment.md
+++ b/docs/integration/campaign-20260904/07/endpoints.fragment.md
@@ -1,0 +1,13 @@
+# Fragment: net-new inbound readback endpoint
+
+target_path: docs/content/docs/api/endpoints.mdx
+operation: add under CONFENGE inbound routes
+stable_key: GET /confenge/inbound/handraisers/:logicalId
+depends_on: campaign 07 consumer
+test: go test ./internal/api/handler -run TestConfengeInboundWebhookNetNewHandraiserRoutesAndReadback
+rollback: remove the GET route in internal/api/routes.go and this handler
+
+Authenticated `GET /confenge/inbound/handraisers/:logicalId` returns the
+persisted receipt for one logical ID: `acknowledged_by`, `acknowledged_at`,
+`policy_version`, `receipt`, `reason`, `outcome`. Permission:
+`view_contacts` / `APIPermReadContacts`.

--- a/docs/integration/campaign-20260904/07/error-codes.fragment.md
+++ b/docs/integration/campaign-20260904/07/error-codes.fragment.md
@@ -1,0 +1,31 @@
+# Fragment: NET_NEW_INBOUND_HANDRAISER error codes
+
+target_path: docs/content/docs/api/error-codes.mdx
+operation: insert after the CONFENGE_WEB_INTENT/1.0 section
+stable_key: NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904
+depends_on: campaign 07 consumer
+test: go test ./internal/app/confenge -run 'TestDecideNetNewInboundFailClosed|TestNetNewRejects'
+rollback: drop this section; consumer still fail-closes on unknown hash
+
+## `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904`
+
+HMAC `POST /api/v1/webhooks/confenge/inbound`. HTTP 2xx is not acceptance.
+`outcome` is `ACCEPTED`, `REJECTED_WITH_REASON`, or `UNKNOWN`.
+
+| `code` / `reason` | Meaning |
+| --- | --- |
+| `schema_hash_unpinned` | `schema_hash` / `policy_hash` missing. Draft IDs are not a fallback |
+| `schema_hash_mismatch` | Hash is not the pinned consumer hash |
+| `schema_version_unknown` | Family prefix matched, version is not the pinned draft |
+| `schema_mismatch` | Body is not this contract |
+| `source_not_confenge_web` | `source` is not `CONFENGE_WEB` |
+| `lane_not_confenge_web` | `lane` is not `CONFENGE_WEB` / `confenge_web` |
+| `consent_missing` | Consent granted + source + timestamp missing |
+| `conflict_decline` | Conflict status `DECLINE`. Receipt stored, no hand-raiser |
+| `conflict_unknown` | Conflict status `UNKNOWN`. Outcome `UNKNOWN` |
+| `logical_id_missing` | No durable logical id |
+| `nucleus_unknown` | Nucleus outside the taxonomy closed set |
+| `intel_watch_not_handraiser` | INTEL_WATCH / Live Intelligence source on this envelope |
+| `downstream_unavailable` | Store or queue write failed after receipt persist |
+| `readback_stale` | Receipt exists but the consume did not finish |
+| `inbound_store_unavailable` | `503`. Receipt could not be persisted |

--- a/internal/api/handler/confenge_inbound.go
+++ b/internal/api/handler/confenge_inbound.go
@@ -114,6 +114,19 @@ func (h *Handler) ConfengeInboundWebhook(c *gin.Context) {
 		c.JSON(status, gin.H{"data": res})
 		return
 	}
+	if confenge.IsNetNewInboundHandraiserEnvelope(body) {
+		res, xerr := h.ConfengeService.IngestNetNewInboundHandraiser(c.Request.Context(), orgID, body, time.Now().UTC())
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		status := http.StatusCreated
+		if res != nil && res.Replay {
+			status = http.StatusOK
+		}
+		c.JSON(status, gin.H{"data": res})
+		return
+	}
 	// Checked before the inbound-lead fallthrough, which would otherwise
 	// swallow both of these: neither carries a lead shape.
 	if intel.IsWebIntentEnvelope(body) {
@@ -166,6 +179,25 @@ func (h *Handler) ConfengeInboundWebhook(c *gin.Context) {
 		status = http.StatusOK
 	}
 	c.JSON(status, gin.H{"data": res})
+}
+
+// GetConfengeInboundHandraiser — GET /confenge/inbound/handraisers/:logicalId
+func (h *Handler) GetConfengeInboundHandraiser(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	logicalID := strings.TrimSpace(c.Param("logicalId"))
+	if logicalID == "" {
+		errx.JSON(c, errx.New(errx.BadRequest, "logical_id is required"))
+		return
+	}
+	res, xerr := h.ConfengeService.ReadbackNetNewInboundHandraiser(c.Request.Context(), orgID, logicalID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": res})
 }
 
 // ListConfengeInboundNow — GET /confenge/inbound

--- a/internal/api/handler/confenge_inbound_test.go
+++ b/internal/api/handler/confenge_inbound_test.go
@@ -16,15 +16,19 @@ import (
 
 	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
 	"github.com/warmbly/warmbly/internal/errx"
 )
 
 type inboundHTTPStub struct {
 	confenge.Service
-	cfg      confenge.Config
-	gotRaw   []byte
-	ingest   func(raw []byte, opts confenge.IngestOptions) (*confenge.InboundIngestResult, *errx.Error)
-	obsStore *intel.MemoryStore
+	cfg       confenge.Config
+	gotRaw    []byte
+	gotNetNew []byte
+	gotOpp    bool
+	ingest    func(raw []byte, opts confenge.IngestOptions) (*confenge.InboundIngestResult, *errx.Error)
+	netNew    func(raw []byte) (*confenge.NetNewInboundResult, *errx.Error)
+	obsStore  *intel.MemoryStore
 }
 
 func (s *inboundHTTPStub) Enabled() bool           { return true }
@@ -76,6 +80,39 @@ func (s *inboundHTTPStub) IngestInboundLead(_ context.Context, _ uuid.UUID, raw 
 		NextAction:        "CALL",
 		DispatchAttempted: false,
 	}, nil
+}
+
+func (s *inboundHTTPStub) IngestNetNewInboundHandraiser(_ context.Context, _ uuid.UUID, raw []byte, _ time.Time) (*confenge.NetNewInboundResult, *errx.Error) {
+	s.gotNetNew = append([]byte(nil), raw...)
+	if s.netNew != nil {
+		return s.netNew(raw)
+	}
+	return &confenge.NetNewInboundResult{
+		Schema:            confenge.NetNewInboundHandraiserSchema,
+		LogicalID:         "stub-logical",
+		Outcome:           confenge.NetNewInboundOutcomeAccepted,
+		Receipt:           "stub-receipt",
+		InboundOnly:       true,
+		DispatchAttempted: false,
+	}, nil
+}
+
+func (s *inboundHTTPStub) ReadbackNetNewInboundHandraiser(_ context.Context, _ uuid.UUID, logicalID string) (*confenge.NetNewInboundReadback, *errx.Error) {
+	at := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	return &confenge.NetNewInboundReadback{NetNewInboundResult: confenge.NetNewInboundResult{
+		Schema:         confenge.NetNewInboundHandraiserSchema,
+		PolicyVersion:  confenge.NetNewInboundHandraiserSchema,
+		LogicalID:      logicalID,
+		Receipt:        "stub-receipt",
+		Outcome:        confenge.NetNewInboundOutcomeAccepted,
+		AcknowledgedBy: confenge.NetNewInboundAckActor,
+		AcknowledgedAt: &at,
+	}}, nil
+}
+
+func (s *inboundHTTPStub) IngestOpportunityEvent(_ context.Context, _ uuid.UUID, event liveintel.OpportunityEvent, _ time.Time) (*confenge.OpportunityEventReceipt, *errx.Error) {
+	s.gotOpp = true
+	return &confenge.OpportunityEventReceipt{EventID: event.EventID}, nil
 }
 
 func TestConfengeInboundWebhookRejectsQueryPIIAndAcceptsSignedBody(t *testing.T) {
@@ -495,4 +532,115 @@ func cloneMap(in map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+func TestConfengeInboundWebhookNetNewHandraiserRoutesAndReadback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+	secret := "inbound-http-secret"
+	var gotOutcome string
+	stub := &inboundHTTPStub{cfg: confenge.Config{
+		Enabled: true, InboundWebhookSecret: secret, InboundOrgID: org, AutoSendEnabled: false,
+	}}
+	stub.netNew = func(raw []byte) (*confenge.NetNewInboundResult, *errx.Error) {
+		at := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+		res := &confenge.NetNewInboundResult{
+			Schema:         confenge.NetNewInboundHandraiserSchema,
+			PolicyVersion:  confenge.NetNewInboundHandraiserSchema,
+			LogicalID:      "nnhr-http-1",
+			Receipt:        "receipt-http-1",
+			Outcome:        confenge.NetNewInboundOutcomeAccepted,
+			InboundOnly:    true,
+			AcknowledgedBy: confenge.NetNewInboundAckActor,
+			AcknowledgedAt: &at,
+		}
+		gotOutcome = res.Outcome
+		return res, nil
+	}
+	h := &Handler{ConfengeService: stub}
+	body, _ := json.Marshal(map[string]any{
+		"schema":      confenge.NetNewInboundHandraiserSchema,
+		"schema_hash": confenge.NetNewInboundPinnedHash,
+		"source":      "CONFENGE_WEB",
+		"lane":        "CONFENGE_WEB",
+		"logical_id":  "nnhr-http-1",
+	})
+	sig := confenge.SignOutcomeHMAC(secret, time.Now().UTC(), body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/confenge/inbound", bytes.NewReader(body))
+	req.Header.Set("X-Warmbly-Signature", sig)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	h.ConfengeInboundWebhook(c)
+	if w.Code != http.StatusCreated && w.Code != http.StatusOK {
+		t.Fatalf("net-new status=%d body=%s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(stub.gotNetNew, []byte("nnhr-http-1")) {
+		t.Fatal("handler did not route net-new envelope")
+	}
+	if stub.gotOpp {
+		t.Fatal("net-new envelope routed to INTEL_WATCH")
+	}
+	var wrap struct {
+		Data confenge.NetNewInboundResult `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &wrap); err != nil {
+		t.Fatal(err)
+	}
+	if wrap.Data.Outcome != confenge.NetNewInboundOutcomeAccepted {
+		t.Fatalf("HTTP %d is not acceptance; outcome=%q", w.Code, wrap.Data.Outcome)
+	}
+	if gotOutcome != wrap.Data.Outcome {
+		t.Fatal("handler invented an outcome")
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/confenge/inbound/handraisers/nnhr-http-1", nil)
+	w2 := httptest.NewRecorder()
+	c2, _ := gin.CreateTestContext(w2)
+	c2.Request = req2
+	c2.Params = gin.Params{{Key: "logicalId", Value: "nnhr-http-1"}}
+	c2.Set("organization_id", org)
+	h.GetConfengeInboundHandraiser(c2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("readback status=%d body=%s", w2.Code, w2.Body.String())
+	}
+	var rb struct {
+		Data confenge.NetNewInboundReadback `json:"data"`
+	}
+	if err := json.Unmarshal(w2.Body.Bytes(), &rb); err != nil {
+		t.Fatal(err)
+	}
+	if rb.Data.AcknowledgedBy == "" || rb.Data.Receipt == "" || rb.Data.PolicyVersion == "" {
+		t.Fatalf("readback missing fields: %+v", rb.Data)
+	}
+}
+
+func TestConfengeInboundWebhookIntelWatchDoesNotCallNetNew(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+	secret := "inbound-http-secret"
+	stub := &inboundHTTPStub{cfg: confenge.Config{
+		Enabled: true, InboundWebhookSecret: secret, InboundOrgID: org, AutoSendEnabled: false,
+	}}
+	h := &Handler{ConfengeService: stub}
+	body, _ := json.Marshal(map[string]any{
+		"schema":      liveintel.EventSchemaV1,
+		"event_id":    "intel-watch-http-1",
+		"event_type":  "NEW_OPPORTUNITY",
+		"subject_key": "company:watched",
+		"payload":     map[string]string{"change": "factual"},
+	})
+	sig := confenge.SignOutcomeHMAC(secret, time.Now().UTC(), body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/confenge/inbound", bytes.NewReader(body))
+	req.Header.Set("X-Warmbly-Signature", sig)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	h.ConfengeInboundWebhook(c)
+	if len(stub.gotNetNew) != 0 {
+		t.Fatalf("INTEL_WATCH routed to net-new consumer: %s", stub.gotNetNew)
+	}
+	if !stub.gotOpp {
+		t.Fatalf("INTEL_WATCH not routed to opportunity ingest status=%d body=%s", w.Code, w.Body.String())
+	}
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -540,6 +540,7 @@ func Run(
 				confengeGroup.GET("/cockpit", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeContactCockpit)
 				confengeGroup.GET("/today", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeToday)
 				confengeGroup.GET("/inbound", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeInboundNow)
+				confengeGroup.GET("/inbound/handraisers/:logicalId", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeInboundHandraiser)
 				confengeGroup.GET("/intel/executive", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeExecutiveIntel)
 				confengeGroup.GET("/intel/scoreboard", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeTruthScoreboard)
 				confengeGroup.GET("/intel/organic-scoreboard", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeOrganicScoreboard)

--- a/internal/app/confenge/inbound_receive.go
+++ b/internal/app/confenge/inbound_receive.go
@@ -24,7 +24,7 @@ const (
 // in sibling packages and the probe must not advertise a body the dispatch
 // cannot actually route.
 func acceptedInboundEventVersions() []string {
-	return append(intel.AcceptedEventVersions(), intel.WebIntentSchemaV1, liveintel.EventSchemaV1)
+	return append(intel.AcceptedEventVersions(), intel.WebIntentSchemaV1, liveintel.EventSchemaV1, NetNewInboundHandraiserSchema)
 }
 
 // InboundReceiveProbe is the PII-free, secret-free signal web-cfg uses

--- a/internal/app/confenge/inbound_receive_test.go
+++ b/internal/app/confenge/inbound_receive_test.go
@@ -21,6 +21,9 @@ func TestEvaluateInboundReceiveReadyAndBlocked(t *testing.T) {
 	if !strings.Contains(joinedVer, "confenge.commercial_event.v1") || !strings.Contains(joinedVer, "confenge.search_observation.v1") {
 		t.Fatalf("accepted_event_versions=%v", ready.AcceptedEventVersions)
 	}
+	if !strings.Contains(joinedVer, NetNewInboundHandraiserSchema) {
+		t.Fatalf("net-new schema missing from accepted_event_versions=%v", ready.AcceptedEventVersions)
+	}
 	if ready.AutoSendEnabled || ready.DispatchAttempted {
 		t.Fatalf("auto-send leaked: %+v", ready)
 	}

--- a/internal/app/confenge/net_new_inbound.go
+++ b/internal/app/confenge/net_new_inbound.go
@@ -1,0 +1,337 @@
+package confenge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
+)
+
+// Multi-vertical NET_NEW_INBOUND_HANDRAISER consumer.
+//
+// Campaign 07 owns this path. Draft contract IDs are a fail-closed pin, not a
+// production fallback: a missing or divergent hash is never ACCEPTED.
+// INTEL_WATCH / Live Intelligence factual envelopes stay on their own schema
+// and never create a CONFENGE_WEB hand-raiser here.
+
+const (
+	NetNewInboundHandraiserSchema = "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904"
+	NetNewInboundIntakeSchema     = "CONFENGE_WEB_INTAKE/2.0.0-draft.20260904"
+	NetNewInboundTaxonomySchema   = "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904"
+	NetNewInboundCatalogSchema    = "CONFENGE_OFFER_CATALOG/2.0.0-draft.20260904"
+	NetNewInboundStateSchema      = "CONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904"
+	NetNewInboundMeetcfgSchema    = "MEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904"
+	NetNewInboundSource           = "CONFENGE_WEB"
+	NetNewInboundLane             = "CONFENGE_WEB"
+	NetNewInboundSourceAsset      = "private_project_technical_readiness_v1"
+	NetNewInboundOfferCandidate   = "private_project_technical_readiness_assessment"
+
+	NetNewInboundFamilyPrefix = "NET_NEW_INBOUND_HANDRAISER/"
+
+	NetNewInboundOutcomeAccepted = "ACCEPTED"
+	NetNewInboundOutcomeRejected = "REJECTED_WITH_REASON"
+	NetNewInboundOutcomeUnknown  = "UNKNOWN"
+
+	NetNewInboundAckActor = "warmbly.net_new_inbound_consumer"
+
+	NetNewInboundReasonHashUnpinned     = "schema_hash_unpinned"
+	NetNewInboundReasonHashMismatch     = "schema_hash_mismatch"
+	NetNewInboundReasonSchemaUnknown    = "schema_version_unknown"
+	NetNewInboundReasonSchemaMismatch   = "schema_mismatch"
+	NetNewInboundReasonSource           = "source_not_confenge_web"
+	NetNewInboundReasonLane             = "lane_not_confenge_web"
+	NetNewInboundReasonConsent          = "consent_missing"
+	NetNewInboundReasonConflictDecline  = "conflict_decline"
+	NetNewInboundReasonConflictUnknown  = "conflict_unknown"
+	NetNewInboundReasonLogicalID        = "logical_id_missing"
+	NetNewInboundReasonNucleus          = "nucleus_unknown"
+	NetNewInboundReasonIntelWatch       = "intel_watch_not_handraiser"
+	NetNewInboundReasonDownstream       = "downstream_unavailable"
+	NetNewInboundReasonStale            = "readback_stale"
+	NetNewInboundReasonSensitiveRefOnly = "sensitive_data_ref_only"
+	NetNewInboundReasonStoreUnavailable = "inbound_store_unavailable"
+
+	netNewInboundConflictNone    = "NONE"
+	netNewInboundConflictDecline = "DECLINE"
+	netNewInboundConflictUnknown = "UNKNOWN"
+
+	netNewProvPolicy   = "policy:"
+	netNewProvOutcome  = "outcome:"
+	netNewProvReason   = "reason:"
+	netNewProvAckBy    = "ack_by:"
+	netNewProvAckAt    = "ack_at:"
+	netNewProvNucleus  = "nucleus:"
+	netNewProvOffer    = "offer_candidate:"
+	netNewProvAsset    = "source_asset:"
+	netNewProvCity     = "city_class:"
+	netNewProvUrgency  = "urgency:"
+	netNewProvConflict = "conflict_ref:"
+	netNewProvIntake   = "intake_schema:"
+	netNewProvState    = "state_schema:"
+	netNewProvHash     = "schema_hash:"
+)
+
+// NetNewInboundPinnedHash is the SHA-256 of NetNewInboundPinMaterial.
+// Tests recompute it from the published fixture. Runtime requires this exact
+// hash on the envelope; the draft version string alone is never enough.
+const NetNewInboundPinnedHash = "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b"
+
+// NetNewInboundNuclei is the closed taxonomy set for this pin.
+var NetNewInboundNuclei = []string{
+	"expert_evidence_assistance",
+	"property_valuation",
+	"building_engineering_documentation",
+	"occupational_safety",
+	"public_works_b2g",
+}
+
+// NetNewInboundPinMaterial is the canonical pin document. Goal 97 ratifies it.
+func NetNewInboundPinMaterial() string {
+	return strings.Join([]string{
+		NetNewInboundTaxonomySchema,
+		"nuclei=" + strings.Join(NetNewInboundNuclei, ","),
+		NetNewInboundCatalogSchema,
+		NetNewInboundIntakeSchema,
+		NetNewInboundHandraiserSchema,
+		NetNewInboundStateSchema,
+		NetNewInboundMeetcfgSchema,
+		"source=" + NetNewInboundSource,
+		"lane=" + NetNewInboundLane,
+		"asset=" + NetNewInboundSourceAsset,
+		"offer=" + NetNewInboundOfferCandidate,
+		"invariants=outbound_eligible=false,auto_send=false",
+	}, "\n")
+}
+
+// NetNewInboundPinHash is SHA-256 of the pin material.
+func NetNewInboundPinHash() string {
+	sum := sha256.Sum256([]byte(NetNewInboundPinMaterial()))
+	return hex.EncodeToString(sum[:])
+}
+
+// NetNewInboundEnvelope is the decoded body. Nothing here admits.
+type NetNewInboundEnvelope struct {
+	Schema            string                `json:"schema"`
+	Version           string                `json:"version"`
+	SchemaHash        string                `json:"schema_hash"`
+	Policy            string                `json:"policy"`
+	PolicyHash        string                `json:"policy_hash"`
+	IntakeSchema      string                `json:"intake_schema"`
+	Taxonomy          string                `json:"taxonomy"`
+	Catalog           string                `json:"catalog"`
+	Source            string                `json:"source"`
+	Lane              string                `json:"lane"`
+	LogicalID         string                `json:"logical_id"`
+	EventID           string                `json:"event_id"`
+	IdempotencyKey    string                `json:"idempotency_key"`
+	CorrelationID     string                `json:"correlation_id"`
+	CanonicalEntityID string                `json:"canonical_entity_id"`
+	Nucleus           string                `json:"nucleus"`
+	OfferCandidate    string                `json:"offer_candidate"`
+	SourceAsset       string                `json:"source_asset"`
+	CityClass         string                `json:"city_class"`
+	Urgency           string                `json:"urgency"`
+	WhyNow            string                `json:"why_now"`
+	Person            NetNewInboundParty    `json:"person"`
+	Company           NetNewInboundParty    `json:"company"`
+	Consent           NetNewInboundConsent  `json:"consent"`
+	Conflict          NetNewInboundConflict `json:"conflict"`
+	SensitiveData     bool                  `json:"sensitive_data"`
+	OccurredAt        *time.Time            `json:"occurred_at"`
+}
+
+// NetNewInboundParty is a person or company on the envelope.
+type NetNewInboundParty struct {
+	CanonicalID string `json:"canonical_id"`
+	Email       string `json:"email"`
+	Name        string `json:"name"`
+}
+
+// NetNewInboundConsent is observed opt-in. Absence is fail-closed.
+type NetNewInboundConsent struct {
+	Granted bool       `json:"granted"`
+	Source  string     `json:"source"`
+	At      *time.Time `json:"at"`
+}
+
+// NetNewInboundConflict is a protected reference only. Parts and corpus never
+// travel with it into analytics.
+type NetNewInboundConflict struct {
+	Status string `json:"status"`
+	Ref    string `json:"ref"`
+}
+
+// NetNewInboundDecision is the pure admission result.
+type NetNewInboundDecision struct {
+	Outcome string
+	Reason  string
+}
+
+// IsNetNewInboundHandraiserEnvelope reports this family before lead fallthrough.
+// Unknown versions of the family still match so they fail closed here instead
+// of being swallowed as an inbound lead.
+func IsNetNewInboundHandraiserEnvelope(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var peek struct {
+		Schema  string `json:"schema"`
+		Version string `json:"version"`
+		Policy  string `json:"policy"`
+		Type    string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return false
+	}
+	if liveintel.IsOpportunityEventEnvelope(raw) || liveintel.IsOfficialLiveIntelligenceBundle(raw) {
+		return false
+	}
+	if intel.IsWebIntentEnvelope(raw) {
+		return false
+	}
+	for _, v := range []string{peek.Schema, peek.Version, peek.Policy, peek.Type} {
+		v = strings.TrimSpace(v)
+		if v == NetNewInboundHandraiserSchema || strings.HasPrefix(v, NetNewInboundFamilyPrefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParseNetNewInboundEnvelope decodes without admitting.
+func ParseNetNewInboundEnvelope(raw []byte) (NetNewInboundEnvelope, error) {
+	var env NetNewInboundEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return NetNewInboundEnvelope{}, err
+	}
+	var extra struct {
+		Consent  NetNewInboundConsent  `json:"consent"`
+		Conflict NetNewInboundConflict `json:"conflict"`
+		Email    string                `json:"email"`
+		Name     string                `json:"name"`
+		Company  string                `json:"company"`
+	}
+	_ = json.Unmarshal(raw, &extra)
+	env.Consent = extra.Consent
+	env.Conflict = extra.Conflict
+	if strings.TrimSpace(env.Person.Email) == "" {
+		env.Person.Email = extra.Email
+	}
+	if strings.TrimSpace(env.Person.Name) == "" {
+		env.Person.Name = extra.Name
+	}
+	if strings.TrimSpace(env.Company.Name) == "" && extra.Company != "" {
+		env.Company.Name = extra.Company
+	}
+	env.LogicalID = firstNonEmpty(strings.TrimSpace(env.LogicalID), strings.TrimSpace(env.EventID), strings.TrimSpace(env.IdempotencyKey))
+	return env, nil
+}
+
+// DecideNetNewInbound is the fail-closed admission function. It never persists
+// and never talks to SMTP.
+func DecideNetNewInbound(env NetNewInboundEnvelope) NetNewInboundDecision {
+	schema := strings.TrimSpace(env.Schema)
+	if schema == "" {
+		schema = strings.TrimSpace(env.Version)
+	}
+	if schema != NetNewInboundHandraiserSchema {
+		if strings.HasPrefix(schema, NetNewInboundFamilyPrefix) {
+			return NetNewInboundDecision{Outcome: NetNewInboundOutcomeUnknown, Reason: NetNewInboundReasonSchemaUnknown}
+		}
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonSchemaMismatch}
+	}
+	if strings.TrimSpace(env.LogicalID) == "" {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonLogicalID}
+	}
+	hash := firstNonEmpty(strings.TrimSpace(env.SchemaHash), strings.TrimSpace(env.PolicyHash))
+	if hash == "" {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonHashUnpinned}
+	}
+	if !strings.EqualFold(hash, NetNewInboundPinnedHash) {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonHashMismatch}
+	}
+	if pol := strings.TrimSpace(env.Policy); pol != "" && pol != NetNewInboundHandraiserSchema {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonSchemaMismatch}
+	}
+	if intake := strings.TrimSpace(env.IntakeSchema); intake != "" && intake != NetNewInboundIntakeSchema {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonSchemaMismatch}
+	}
+	if src := strings.ToUpper(strings.TrimSpace(env.Source)); src != NetNewInboundSource {
+		if src == "INTEL_WATCH" || src == strings.ToUpper(EngineLaneIntelWatch) {
+			return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonIntelWatch}
+		}
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonSource}
+	}
+	if !netNewLaneOK(env.Lane) {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonLane}
+	}
+	if !netNewNucleusOK(env.Nucleus) {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonNucleus}
+	}
+	if !env.Consent.Granted || strings.TrimSpace(env.Consent.Source) == "" || env.Consent.At == nil || env.Consent.At.IsZero() {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonConsent}
+	}
+	switch strings.ToUpper(strings.TrimSpace(env.Conflict.Status)) {
+	case "", netNewInboundConflictNone:
+	case netNewInboundConflictDecline:
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonConflictDecline}
+	case netNewInboundConflictUnknown:
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeUnknown, Reason: NetNewInboundReasonConflictUnknown}
+	default:
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeUnknown, Reason: NetNewInboundReasonConflictUnknown}
+	}
+	return NetNewInboundDecision{Outcome: NetNewInboundOutcomeAccepted}
+}
+
+func netNewLaneOK(lane string) bool {
+	switch strings.TrimSpace(lane) {
+	case NetNewInboundLane, EngineLaneConfengeWeb:
+		return true
+	default:
+		return false
+	}
+}
+
+func netNewNucleusOK(nucleus string) bool {
+	nucleus = strings.TrimSpace(nucleus)
+	for _, n := range NetNewInboundNuclei {
+		if n == nucleus {
+			return true
+		}
+	}
+	return false
+}
+
+// MeetcfgHandoffAllowed is true only after ACCEPTED.
+func MeetcfgHandoffAllowed(outcome string) bool {
+	return strings.TrimSpace(outcome) == NetNewInboundOutcomeAccepted
+}
+
+// NetNewConflictRef stores only the protected reference. Corpus is dropped.
+func NetNewConflictRef(conflict NetNewInboundConflict) string {
+	ref := strings.TrimSpace(conflict.Ref)
+	if ref == "" {
+		return ""
+	}
+	ref = strings.TrimSpace(strings.Split(ref, "\n")[0])
+	if i := strings.Index(ref, " "); i > 0 {
+		ref = ref[:i]
+	}
+	return SanitizeText(ref, 120)
+}
+
+func netNewCanonicalEntityID(env NetNewInboundEnvelope) string {
+	return firstNonEmpty(
+		strings.TrimSpace(env.CanonicalEntityID),
+		strings.TrimSpace(env.Company.CanonicalID),
+		strings.TrimSpace(env.Person.CanonicalID),
+	)
+}
+
+func netNewLogicalID(env NetNewInboundEnvelope) string {
+	return SanitizeText(firstNonEmpty(env.LogicalID, env.EventID, env.IdempotencyKey), 160)
+}

--- a/internal/app/confenge/net_new_inbound_ingest.go
+++ b/internal/app/confenge/net_new_inbound_ingest.go
@@ -1,0 +1,577 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// NetNewInboundResult is one persist-first consume. HTTP 2xx is not acceptance;
+// Outcome is. Readback of LogicalID is the proof.
+type NetNewInboundResult struct {
+	Schema            string     `json:"schema"`
+	PolicyVersion     string     `json:"policy_version"`
+	IntakeSchema      string     `json:"intake_schema,omitempty"`
+	StateSchema       string     `json:"state_schema,omitempty"`
+	LogicalID         string     `json:"logical_id"`
+	Receipt           string     `json:"receipt"`
+	CorrelationID     string     `json:"correlation_id,omitempty"`
+	Outcome           string     `json:"outcome"`
+	Reason            string     `json:"reason,omitempty"`
+	Nucleus           string     `json:"nucleus,omitempty"`
+	OfferCandidate    string     `json:"offer_candidate,omitempty"`
+	SourceAsset       string     `json:"source_asset,omitempty"`
+	CityClass         string     `json:"city_class,omitempty"`
+	Urgency           string     `json:"urgency,omitempty"`
+	WhyNow            string     `json:"why_now,omitempty"`
+	ConflictRef       string     `json:"conflict_ref,omitempty"`
+	InboundOnly       bool       `json:"inbound_only"`
+	OutboundEligible  bool       `json:"outbound_eligible"`
+	AutoSend          bool       `json:"auto_send"`
+	DispatchAttempted bool       `json:"dispatch_attempted"`
+	MeetcfgHandoff    bool       `json:"meetcfg_handoff_allowed"`
+	Replay            bool       `json:"replay"`
+	AcknowledgedBy    string     `json:"acknowledged_by,omitempty"`
+	AcknowledgedAt    *time.Time `json:"acknowledged_at,omitempty"`
+	AccountID         *uuid.UUID `json:"account_id,omitempty"`
+	ActionID          *uuid.UUID `json:"action_id,omitempty"`
+	CanonicalEntityID string     `json:"canonical_entity_id,omitempty"`
+	Reconciled        bool       `json:"reconciled,omitempty"`
+}
+
+// NetNewInboundReadback is the same logical ID after persist.
+type NetNewInboundReadback struct {
+	NetNewInboundResult
+}
+
+// NetNewInboundMetric is PII-free: nucleus, state, reason only.
+type NetNewInboundMetric struct {
+	Nucleus string `json:"nucleus"`
+	State   string `json:"state"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// IngestNetNewInboundHandraiser persists the receipt before any commercial
+// effect. Unknown or unpinned schema is never ACCEPTED.
+func (s *service) IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.UUID, raw []byte, now time.Time) (*NetNewInboundResult, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if orgID == uuid.Nil {
+		return nil, errx.New(errx.ServiceUnavailable, "inbound org is not configured")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	env, err := ParseNetNewInboundEnvelope(raw)
+	if err != nil {
+		res := rejectedNetNew("", NetNewInboundReasonSchemaMismatch, now)
+		s.observeNetNewMetric(res)
+		return res, nil
+	}
+	logicalID := netNewLogicalID(env)
+	decision := DecideNetNewInbound(env)
+	if logicalID == "" {
+		res := rejectedNetNew("", firstNonEmpty(decision.Reason, NetNewInboundReasonLogicalID), now)
+		res.Outcome = NetNewInboundOutcomeRejected
+		s.observeNetNewMetric(res)
+		return res, nil
+	}
+
+	st := s.inboundStore()
+	if st == nil {
+		return nil, errx.NewWithIdentifier(errx.ServiceUnavailable, NetNewInboundReasonStoreUnavailable,
+			"inbound lead store unavailable")
+	}
+
+	row := netNewReceiptRow(orgID, env, raw, now)
+	created, existing, insertErr := st.InsertInboundLead(ctx, row)
+	if insertErr != nil {
+		return nil, errx.New(errx.Internal, "persist inbound receipt: "+insertErr.Error())
+	}
+	replay := false
+	if !created && existing != nil {
+		if netNewReceiptComplete(existing) {
+			res := netNewResultFromLead(existing, true)
+			s.observeNetNewMetric(res)
+			return res, nil
+		}
+		row = existing
+		replay = true
+	}
+	if s.netNewAfterPersist != nil {
+		if hookErr := s.netNewAfterPersist(row); hookErr != nil {
+			res := netNewResultFromLead(row, replay)
+			res.Outcome = NetNewInboundOutcomeUnknown
+			res.Reason = NetNewInboundReasonDownstream
+			s.observeNetNewMetric(res)
+			return res, nil
+		}
+	}
+
+	applyNetNewDecision(row, env, decision, now)
+	if decision.Outcome != NetNewInboundOutcomeAccepted {
+		_ = st.UpdateInboundLead(ctx, row)
+		res := netNewResultFromLead(row, replay)
+		s.observeNetNewMetric(res)
+		return res, nil
+	}
+
+	admitted, xerr := s.admitNetNewHandraiser(ctx, orgID, env, now)
+	if xerr != nil {
+		row.EnrichmentStatus = models.InboundEnrichmentFailed
+		row.NextAction = models.InboundNextNeedsEnrichment
+		row.Status = models.InboundStatusOpen
+		row.Warnings = appendUnique(row.Warnings, firstNonEmpty(xerr.Identifier, NetNewInboundReasonDownstream))
+		setNetNewProvenance(row, env, NetNewInboundOutcomeUnknown, firstNonEmpty(xerr.Identifier, NetNewInboundReasonDownstream), now)
+		_ = st.UpdateInboundLead(ctx, row)
+		res := netNewResultFromLead(row, replay)
+		res.Outcome = NetNewInboundOutcomeUnknown
+		res.Reason = firstNonEmpty(xerr.Identifier, NetNewInboundReasonDownstream)
+		s.observeNetNewMetric(res)
+		return res, nil
+	}
+	if admitted != nil && admitted.Account != nil {
+		id := admitted.Account.ID
+		row.AccountID = &id
+		if admitted.Candidate != nil {
+			cid := admitted.Candidate.ID
+			row.CandidateID = &cid
+		}
+		raise := HandRaise{
+			OrganizationID: orgID, AccountID: admitted.Account.ID,
+			Signal: SignalRequestHumanReview, EngineLane: EngineLaneConfengeWeb, OccurredAt: now,
+			SubjectKey:  "company:" + firstNonEmpty(SanitizeText(env.Company.Name, 120), logicalID),
+			Evidence:    SanitizeText(env.WhyNow, 500),
+			PersonName:  SanitizeText(env.Person.Name, 120),
+			Origin:      EngineLaneConfengeWeb,
+			Receipt:     row.ReceiptID,
+			Context:     netNewContext(env),
+			InboundOnly: true,
+		}
+		if admitted.Candidate != nil {
+			cid := admitted.Candidate.ID
+			raise.CandidateID = &cid
+		}
+		action, persistErr := s.PersistHandRaise(ctx, raise)
+		if persistErr != nil || action == nil {
+			reason := NetNewInboundReasonDownstream
+			if persistErr != nil && persistErr.Identifier != "" {
+				reason = persistErr.Identifier
+			}
+			setNetNewProvenance(row, env, NetNewInboundOutcomeUnknown, reason, now)
+			row.Warnings = appendUnique(row.Warnings, reason)
+			_ = st.UpdateInboundLead(ctx, row)
+			res := netNewResultFromLead(row, replay)
+			res.Outcome = NetNewInboundOutcomeUnknown
+			res.Reason = reason
+			if admitted.Account != nil {
+				res.AccountID = &admitted.Account.ID
+				res.Reconciled = admitted.Reused
+			}
+			s.observeNetNewMetric(res)
+			return res, nil
+		}
+		aid := action.ID
+		row.ActionID = &aid
+		row.NextAction = models.InboundNextManualOutreach
+		row.Channel = "human_review"
+		row.WhyNow = SanitizeText(env.WhyNow, 500)
+	}
+
+	row.UpdatedAt = now
+	if err := st.UpdateInboundLead(ctx, row); err != nil {
+		return nil, errx.New(errx.Internal, "update inbound lead: "+err.Error())
+	}
+	s.ensureOperatorAlert(ctx, orgID, row, now)
+	res := netNewResultFromLead(row, replay)
+	if admitted != nil {
+		res.Reconciled = admitted.Reused
+		res.CanonicalEntityID = netNewCanonicalEntityID(env)
+		res.InboundOnly = true
+		res.OutboundEligible = false
+		if admitted.Account != nil {
+			res.OutboundEligible = accountOutboundEligible(admitted.Account)
+			res.InboundOnly = models.AccountIsInboundOnly(admitted.Account) || admitted.InboundOnly
+		}
+	}
+	s.observeNetNewMetric(res)
+	return res, nil
+}
+
+// ReadbackNetNewInboundHandraiser returns the persisted receipt for one logical ID.
+func (s *service) ReadbackNetNewInboundHandraiser(ctx context.Context, orgID uuid.UUID, logicalID string) (*NetNewInboundReadback, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	logicalID = SanitizeText(logicalID, 160)
+	if logicalID == "" {
+		return nil, errx.NewWithIdentifier(errx.BadRequest, NetNewInboundReasonLogicalID, "logical_id is required")
+	}
+	st := s.inboundStore()
+	if st == nil {
+		return nil, errx.NewWithIdentifier(errx.ServiceUnavailable, NetNewInboundReasonStoreUnavailable,
+			"inbound lead store unavailable")
+	}
+	row, err := st.GetInboundLeadByLeadID(ctx, orgID, logicalID)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "read inbound receipt: "+err.Error())
+	}
+	if row == nil {
+		return nil, errx.New(errx.NotFound, "inbound hand-raiser receipt not found")
+	}
+	res := netNewResultFromLead(row, false)
+	if !netNewReceiptComplete(row) {
+		res.Outcome = NetNewInboundOutcomeUnknown
+		res.Reason = NetNewInboundReasonStale
+	}
+	if ast := s.alertStore(); ast != nil {
+		if alert, aerr := ast.GetOperatorAlertByLead(ctx, orgID, logicalID); aerr == nil && alert != nil {
+			if strings.TrimSpace(alert.AcknowledgedBy) != "" {
+				res.AcknowledgedBy = alert.AcknowledgedBy
+			}
+			if alert.AcknowledgedAt != nil {
+				res.AcknowledgedAt = alert.AcknowledgedAt
+			}
+		}
+	}
+	return &NetNewInboundReadback{NetNewInboundResult: *res}, nil
+}
+
+func (s *service) admitNetNewHandraiser(ctx context.Context, orgID uuid.UUID, env NetNewInboundEnvelope, now time.Time) (*InboundAdmission, *errx.Error) {
+	logicalID := netNewLogicalID(env)
+	canonical := netNewCanonicalEntityID(env)
+	email := normalizeWebIntentEmail(env.Person.Email)
+	name := firstNonEmpty(SanitizeText(env.Person.Name, 120), SanitizeText(env.Company.Name, 120))
+	contextText := netNewContext(env)
+
+	if canonical != "" {
+		if acc, err := s.repo.GetAccountBySourceLeadID(ctx, orgID, canonical); err != nil {
+			return nil, errx.NewWithIdentifier(errx.Internal, NetNewInboundReasonDownstream,
+				"canonical entity lookup: "+err.Error())
+		} else if acc != nil {
+			out := &InboundAdmission{
+				Account: acc, Origin: EngineLaneConfengeWeb, Lane: EngineLaneConfengeWeb,
+				IntentKind: intelWebIntentHumanReview(), Context: contextText,
+				Receipt: InboundReceiptID(EngineLaneConfengeWeb, intelWebIntentHumanReview(), firstNonEmpty(email, logicalID), canonical),
+				Reused:  true, InboundOnly: models.AccountIsInboundOnly(acc),
+				OutboundEligible: accountOutboundEligible(acc),
+			}
+			if email != "" {
+				created, xerr := s.upsertInboundCandidate(ctx, orgID, acc.ID, email, name, now)
+				if xerr != nil {
+					return nil, xerr
+				}
+				out.Candidate = created
+			}
+			return out, nil
+		}
+	}
+
+	// Never merge on display name. Identity is logical_id (and canonical ID).
+	key := inboundOnlyLeadIDPrefix + "confenge_web:NET_NEW:" + logicalID
+	return s.AdmitInboundOnly(ctx, orgID, EngineLaneConfengeWeb, "NET_NEW_INBOUND_HANDRAISER",
+		firstNonEmpty(email, logicalID+"@inbound.invalid"), name, key, contextText, now)
+}
+
+func intelWebIntentHumanReview() string {
+	return "REQUEST_HUMAN_REVIEW"
+}
+
+func netNewContext(env NetNewInboundEnvelope) string {
+	return SanitizeText(strings.Join(filterEmpty([]string{
+		env.Nucleus, env.OfferCandidate, env.SourceAsset, env.CityClass, env.Urgency, env.WhyNow,
+	}), " "), 500)
+}
+
+func filterEmpty(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if strings.TrimSpace(v) != "" {
+			out = append(out, strings.TrimSpace(v))
+		}
+	}
+	return out
+}
+
+func netNewReceiptRow(orgID uuid.UUID, env NetNewInboundEnvelope, raw []byte, now time.Time) *models.OutreachInboundLead {
+	logicalID := netNewLogicalID(env)
+	payload := raw
+	if env.SensitiveData {
+		redacted, _ := json.Marshal(map[string]any{
+			"redacted": true, "logical_id": logicalID, "schema": NetNewInboundHandraiserSchema,
+		})
+		payload = redacted
+	}
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	receipt := InboundReceiptID(EngineLaneConfengeWeb, "NET_NEW_INBOUND_HANDRAISER",
+		firstNonEmpty(normalizeWebIntentEmail(env.Person.Email), logicalID), logicalID)
+	row := &models.OutreachInboundLead{
+		ID:                uuid.New(),
+		OrganizationID:    orgID,
+		LeadID:            logicalID,
+		ReceiptID:         receipt,
+		IdentityKey:       inboundIdentityKey("", normalizeWebIntentEmail(env.Person.Email), ""),
+		LeadCreatedAt:     now,
+		WarmblyIngestedAt: now,
+		Source:            NetNewInboundSource,
+		RouteFamily:       "inbound",
+		AssetID:           SanitizeText(firstNonEmpty(env.SourceAsset, NetNewInboundSourceAsset), 120),
+		CTAID:             SanitizeText(env.OfferCandidate, 120),
+		EntityID:          SanitizeText(netNewCanonicalEntityID(env), 120),
+		CompanyName:       SanitizeText(env.Company.Name, 200),
+		LeadName:          SanitizeText(env.Person.Name, 160),
+		LeadEmail:         normalizeWebIntentEmail(env.Person.Email),
+		CorrelationID:     SanitizeText(env.CorrelationID, 160),
+		ConsentJSON:       []byte(`{"granted":true}`),
+		UTMJSON:           netNewUTM(env),
+		RawPayload:        payload,
+		EnrichmentStatus:  models.InboundEnrichmentUnknown,
+		Owner:             NetNewInboundAckActor,
+		Status:            models.InboundStatusOpen,
+		WhyNow:            SanitizeText(env.WhyNow, 500),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if env.SensitiveData {
+		row.LeadName = ""
+		row.LeadEmail = ""
+		row.CompanyName = SanitizeText(env.Company.Name, 200)
+		row.Message = ""
+	}
+	if !env.Consent.Granted {
+		row.ConsentJSON = []byte(`{"granted":false}`)
+	}
+	t := now
+	row.OwnerAssignedAt = &t
+	setNetNewProvenance(row, env, "", "", now)
+	return row
+}
+
+func netNewUTM(env NetNewInboundEnvelope) []byte {
+	m := map[string]string{
+		"nucleus":         SanitizeText(env.Nucleus, 80),
+		"offer_candidate": SanitizeText(firstNonEmpty(env.OfferCandidate, NetNewInboundOfferCandidate), 120),
+		"source_asset":    SanitizeText(firstNonEmpty(env.SourceAsset, NetNewInboundSourceAsset), 120),
+		"city_class":      SanitizeText(env.CityClass, 40),
+		"urgency":         SanitizeText(env.Urgency, 40),
+		"policy":          NetNewInboundHandraiserSchema,
+		"intake_schema":   NetNewInboundIntakeSchema,
+	}
+	if ref := NetNewConflictRef(env.Conflict); ref != "" {
+		m["conflict_ref"] = ref
+	}
+	raw, _ := json.Marshal(m)
+	if len(raw) == 0 {
+		return []byte("{}")
+	}
+	return raw
+}
+
+func applyNetNewDecision(row *models.OutreachInboundLead, env NetNewInboundEnvelope, decision NetNewInboundDecision, now time.Time) {
+	if row == nil {
+		return
+	}
+	setNetNewProvenance(row, env, decision.Outcome, decision.Reason, now)
+	row.UpdatedAt = now
+	switch decision.Outcome {
+	case NetNewInboundOutcomeAccepted:
+		row.EnrichmentStatus = models.InboundEnrichmentCompleted
+		row.Status = models.InboundStatusOpen
+		row.NextAction = models.InboundNextManualOutreach
+		t := now
+		row.EnrichmentCompletedAt = &t
+	case NetNewInboundOutcomeRejected:
+		row.EnrichmentStatus = models.InboundEnrichmentCompleted
+		row.Status = models.InboundStatusSuppressed
+		row.NextAction = models.InboundNextSuppressed
+		row.SuppressReason = decision.Reason
+	default:
+		row.EnrichmentStatus = models.InboundEnrichmentUnknown
+		row.Status = models.InboundStatusOpen
+		row.NextAction = models.InboundNextNeedsEnrichment
+		row.Warnings = appendUnique(row.Warnings, firstNonEmpty(decision.Reason, NetNewInboundOutcomeUnknown))
+	}
+}
+
+func setNetNewProvenance(row *models.OutreachInboundLead, env NetNewInboundEnvelope, outcome, reason string, now time.Time) {
+	if row == nil {
+		return
+	}
+	prov := []string{
+		netNewProvPolicy + NetNewInboundHandraiserSchema,
+		netNewProvIntake + NetNewInboundIntakeSchema,
+		netNewProvState + NetNewInboundStateSchema,
+		netNewProvHash + NetNewInboundPinnedHash,
+		netNewProvAckBy + NetNewInboundAckActor,
+		netNewProvAckAt + now.UTC().Format(time.RFC3339),
+	}
+	if env.Nucleus != "" {
+		prov = append(prov, netNewProvNucleus+SanitizeText(env.Nucleus, 80))
+	}
+	if env.OfferCandidate != "" {
+		prov = append(prov, netNewProvOffer+SanitizeText(env.OfferCandidate, 120))
+	}
+	if env.SourceAsset != "" {
+		prov = append(prov, netNewProvAsset+SanitizeText(env.SourceAsset, 120))
+	}
+	if env.CityClass != "" {
+		prov = append(prov, netNewProvCity+SanitizeText(env.CityClass, 40))
+	}
+	if env.Urgency != "" {
+		prov = append(prov, netNewProvUrgency+SanitizeText(env.Urgency, 40))
+	}
+	if ref := NetNewConflictRef(env.Conflict); ref != "" {
+		prov = append(prov, netNewProvConflict+ref)
+	}
+	if outcome != "" {
+		prov = append(prov, netNewProvOutcome+outcome)
+	}
+	if reason != "" {
+		prov = append(prov, netNewProvReason+reason)
+	}
+	row.Provenance = prov
+	if env.SensitiveData {
+		row.Evidence = []string{NetNewInboundReasonSensitiveRefOnly}
+		row.Message = ""
+	}
+}
+
+func netNewReceiptComplete(row *models.OutreachInboundLead) bool {
+	if row == nil {
+		return false
+	}
+	if outcome := provenanceValue(row.Provenance, netNewProvOutcome); outcome == NetNewInboundOutcomeAccepted ||
+		outcome == NetNewInboundOutcomeRejected || outcome == NetNewInboundOutcomeUnknown {
+		return true
+	}
+	return inboundReceiptComplete(row)
+}
+
+func provenanceValue(items []string, prefix string) string {
+	for _, id := range items {
+		if strings.HasPrefix(id, prefix) {
+			return strings.TrimPrefix(id, prefix)
+		}
+	}
+	return ""
+}
+
+func netNewResultFromLead(row *models.OutreachInboundLead, replay bool) *NetNewInboundResult {
+	if row == nil {
+		return rejectedNetNew("", NetNewInboundOutcomeUnknown, time.Time{})
+	}
+	outcome := firstNonEmpty(provenanceValue(row.Provenance, netNewProvOutcome), NetNewInboundOutcomeUnknown)
+	reason := firstNonEmpty(provenanceValue(row.Provenance, netNewProvReason), row.SuppressReason)
+	ackAt := row.OwnerAssignedAt
+	if ts := provenanceValue(row.Provenance, netNewProvAckAt); ts != "" {
+		if parsed, err := time.Parse(time.RFC3339, ts); err == nil {
+			t := parsed
+			ackAt = &t
+		}
+	}
+	res := &NetNewInboundResult{
+		Schema:            NetNewInboundHandraiserSchema,
+		PolicyVersion:     firstNonEmpty(provenanceValue(row.Provenance, netNewProvPolicy), NetNewInboundHandraiserSchema),
+		IntakeSchema:      firstNonEmpty(provenanceValue(row.Provenance, netNewProvIntake), NetNewInboundIntakeSchema),
+		StateSchema:       firstNonEmpty(provenanceValue(row.Provenance, netNewProvState), NetNewInboundStateSchema),
+		LogicalID:         row.LeadID,
+		Receipt:           row.ReceiptID,
+		CorrelationID:     row.CorrelationID,
+		Outcome:           outcome,
+		Reason:            reason,
+		Nucleus:           firstNonEmpty(provenanceValue(row.Provenance, netNewProvNucleus), utmField(row.UTMJSON, "nucleus")),
+		OfferCandidate:    firstNonEmpty(provenanceValue(row.Provenance, netNewProvOffer), utmField(row.UTMJSON, "offer_candidate")),
+		SourceAsset:       firstNonEmpty(provenanceValue(row.Provenance, netNewProvAsset), row.AssetID),
+		CityClass:         firstNonEmpty(provenanceValue(row.Provenance, netNewProvCity), utmField(row.UTMJSON, "city_class")),
+		Urgency:           firstNonEmpty(provenanceValue(row.Provenance, netNewProvUrgency), utmField(row.UTMJSON, "urgency")),
+		WhyNow:            row.WhyNow,
+		ConflictRef:       provenanceValue(row.Provenance, netNewProvConflict),
+		InboundOnly:       true,
+		OutboundEligible:  false,
+		AutoSend:          false,
+		DispatchAttempted: false,
+		MeetcfgHandoff:    MeetcfgHandoffAllowed(outcome),
+		Replay:            replay,
+		AcknowledgedBy:    firstNonEmpty(provenanceValue(row.Provenance, netNewProvAckBy), row.Owner, NetNewInboundAckActor),
+		AcknowledgedAt:    ackAt,
+		AccountID:         row.AccountID,
+		ActionID:          row.ActionID,
+		CanonicalEntityID: row.EntityID,
+	}
+	return res
+}
+
+func rejectedNetNew(logicalID, reason string, now time.Time) *NetNewInboundResult {
+	res := &NetNewInboundResult{
+		Schema:            NetNewInboundHandraiserSchema,
+		PolicyVersion:     NetNewInboundHandraiserSchema,
+		LogicalID:         logicalID,
+		Outcome:           NetNewInboundOutcomeRejected,
+		Reason:            reason,
+		InboundOnly:       false,
+		OutboundEligible:  false,
+		AutoSend:          false,
+		DispatchAttempted: false,
+		MeetcfgHandoff:    false,
+		AcknowledgedBy:    NetNewInboundAckActor,
+	}
+	if !now.IsZero() {
+		t := now.UTC()
+		res.AcknowledgedAt = &t
+	}
+	return res
+}
+
+func (s *service) observeNetNewMetric(res *NetNewInboundResult) {
+	if res == nil {
+		return
+	}
+	metric := NetNewInboundMetric{Nucleus: res.Nucleus, State: res.Outcome, Reason: res.Reason}
+	if s == nil || s.netNewMetricSink == nil {
+		return
+	}
+	func() {
+		defer func() { _ = recover() }()
+		s.netNewMetricSink(metric)
+	}()
+}
+
+// FirstTouchEligibleAccount observes the existing first-touch sendable
+// predicates without changing them. Inbound-only is never eligible.
+func FirstTouchEligibleAccount(acc *models.OutreachAccount) bool {
+	return accountOutboundEligible(acc)
+}
+
+func (s *service) netNewInFirstTouchEligibleSet(ctx context.Context, orgID uuid.UUID, accountID uuid.UUID) bool {
+	if s == nil || s.repo == nil || accountID == uuid.Nil {
+		return false
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, accountID)
+	if err != nil || acc == nil {
+		return false
+	}
+	if FirstTouchEligibleAccount(acc) {
+		return true
+	}
+	listed, listErr := s.repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{Limit: 500})
+	if listErr != nil {
+		return false
+	}
+	for i := range listed {
+		if listed[i].ID == accountID && FirstTouchEligibleAccount(&listed[i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/confenge/net_new_inbound_pg_test.go
+++ b/internal/app/confenge/net_new_inbound_pg_test.go
@@ -1,0 +1,51 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func TestPGNetNewInboundHandraiserPersistReadback(t *testing.T) {
+	dsn := postgresTestDSN()
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN/PRIMARY_DB is not set")
+	}
+	pool, orgID := openInboundOnlyPG(t)
+	t.Cleanup(pool.Close)
+	repo := repository.NewOutreachRepository(pool)
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true, AutoSendEnabled: false}, repo, nil).(*service)
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	body := marshalNetNew(t, validNetNewMap("nnhr-pg-1"))
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now)
+	if xerr != nil {
+		t.Fatalf("pg ingest: %v", xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted || res.ActionID == nil {
+		t.Fatalf("pg ingest: %+v", res)
+	}
+	rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), orgID, "nnhr-pg-1")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if rb.Receipt != res.Receipt || rb.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("pg readback: %+v", rb)
+	}
+	acc, err := repo.GetAccount(context.Background(), orgID, *res.AccountID)
+	if err != nil || acc == nil {
+		t.Fatalf("account: %v", err)
+	}
+	if !models.AccountIsInboundOnly(acc) || FirstTouchEligibleAccount(acc) {
+		t.Fatal("pg net-new is outbound-eligible")
+	}
+	replay, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now.Add(time.Minute))
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if !replay.Replay || *replay.ActionID != *res.ActionID {
+		t.Fatalf("pg replay: %+v", replay)
+	}
+}

--- a/internal/app/confenge/net_new_inbound_test.go
+++ b/internal/app/confenge/net_new_inbound_test.go
@@ -1,0 +1,547 @@
+package confenge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func netNewConsentAt() *time.Time {
+	at := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	return &at
+}
+
+func validNetNewMap(logicalID string) map[string]any {
+	return map[string]any{
+		"schema":          NetNewInboundHandraiserSchema,
+		"version":         NetNewInboundHandraiserSchema,
+		"schema_hash":     NetNewInboundPinnedHash,
+		"policy":          NetNewInboundHandraiserSchema,
+		"policy_hash":     NetNewInboundPinnedHash,
+		"intake_schema":   NetNewInboundIntakeSchema,
+		"taxonomy":        NetNewInboundTaxonomySchema,
+		"catalog":         NetNewInboundCatalogSchema,
+		"source":          NetNewInboundSource,
+		"lane":            NetNewInboundLane,
+		"logical_id":      logicalID,
+		"event_id":        logicalID,
+		"idempotency_key": logicalID,
+		"correlation_id":  "corr-" + logicalID,
+		"nucleus":         "property_valuation",
+		"offer_candidate": NetNewInboundOfferCandidate,
+		"source_asset":    NetNewInboundSourceAsset,
+		"city_class":      "capital",
+		"urgency":         "this_week",
+		"why_now":         "requested a technical readiness assessment from the public form",
+		"person":          map[string]any{"email": logicalID + "@example.test", "name": "Net New " + logicalID},
+		"company":         map[string]any{"name": "Obra " + logicalID},
+		"consent":         map[string]any{"granted": true, "source": "web_form:confenge.com/inbound", "at": "2026-09-04T12:00:00Z"},
+		"conflict":        map[string]any{"status": "NONE", "ref": "conflict:none"},
+		"sensitive_data":  false,
+	}
+}
+
+func marshalNetNew(t *testing.T, body map[string]any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestNetNewInboundPinMatchesPublishedFixture(t *testing.T) {
+	raw, err := os.ReadFile("testdata/net_new_inbound_handraiser/conformance.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		PinMaterial string `json:"pin_material"`
+		SchemaHash  string `json:"schema_hash"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.PinMaterial != NetNewInboundPinMaterial() {
+		t.Fatalf("fixture pin_material diverged from runtime pin")
+	}
+	sum := sha256.Sum256([]byte(doc.PinMaterial))
+	got := hex.EncodeToString(sum[:])
+	if got != NetNewInboundPinnedHash || got != doc.SchemaHash || got != NetNewInboundPinHash() {
+		t.Fatalf("pin hash fixture=%s const=%s recomputed=%s", doc.SchemaHash, NetNewInboundPinnedHash, got)
+	}
+}
+
+func TestDecideNetNewInboundFailClosed(t *testing.T) {
+	env, err := ParseNetNewInboundEnvelope(marshalNetNew(t, validNetNewMap("nnhr-ok")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := DecideNetNewInbound(env); d.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("valid envelope not accepted: %+v", d)
+	}
+	cases := []struct {
+		name    string
+		mutate  func(map[string]any)
+		outcome string
+		reason  string
+	}{
+		{"unknown version", func(m map[string]any) { m["schema"] = "NET_NEW_INBOUND_HANDRAISER/9.9.9" }, NetNewInboundOutcomeUnknown, NetNewInboundReasonSchemaUnknown},
+		{"missing hash", func(m map[string]any) { m["schema_hash"] = ""; m["policy_hash"] = "" }, NetNewInboundOutcomeRejected, NetNewInboundReasonHashUnpinned},
+		{"divergent hash", func(m map[string]any) { m["schema_hash"] = strings.Repeat("ab", 32) }, NetNewInboundOutcomeRejected, NetNewInboundReasonHashMismatch},
+		{"missing consent", func(m map[string]any) { m["consent"] = map[string]any{"granted": false} }, NetNewInboundOutcomeRejected, NetNewInboundReasonConsent},
+		{"conflict decline", func(m map[string]any) { m["conflict"] = map[string]any{"status": "DECLINE", "ref": "conflict:abc"} }, NetNewInboundOutcomeRejected, NetNewInboundReasonConflictDecline},
+		{"conflict unknown", func(m map[string]any) { m["conflict"] = map[string]any{"status": "UNKNOWN", "ref": "conflict:xyz"} }, NetNewInboundOutcomeUnknown, NetNewInboundReasonConflictUnknown},
+		{"intel watch source", func(m map[string]any) { m["source"] = "INTEL_WATCH" }, NetNewInboundOutcomeRejected, NetNewInboundReasonIntelWatch},
+		{"unknown nucleus", func(m map[string]any) { m["nucleus"] = "not_a_nucleus" }, NetNewInboundOutcomeRejected, NetNewInboundReasonNucleus},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := validNetNewMap("nnhr-neg")
+			tc.mutate(body)
+			parsed, err := ParseNetNewInboundEnvelope(marshalNetNew(t, body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			d := DecideNetNewInbound(parsed)
+			if d.Outcome != tc.outcome || d.Reason != tc.reason {
+				t.Fatalf("got %+v want %s/%s", d, tc.outcome, tc.reason)
+			}
+			if d.Outcome == NetNewInboundOutcomeAccepted {
+				t.Fatal("negative case was accepted")
+			}
+		})
+	}
+}
+
+func TestIsNetNewInboundDistinctFromIntelWatch(t *testing.T) {
+	if !IsNetNewInboundHandraiserEnvelope(marshalNetNew(t, validNetNewMap("nnhr-det"))) {
+		t.Fatal("valid envelope not detected")
+	}
+	opp := []byte(`{"schema":"` + liveintel.EventSchemaV1 + `","event_id":"e1","event_type":"NEW_OPPORTUNITY","subject_key":"company:x","payload":{"k":"v"}}`)
+	if IsNetNewInboundHandraiserEnvelope(opp) {
+		t.Fatal("opportunity event classified as net-new hand-raiser")
+	}
+	bundle := []byte(`{"schema":"` + liveintel.OfficialLiveIntelligenceSchema + `"}`)
+	if IsNetNewInboundHandraiserEnvelope(bundle) {
+		t.Fatal("live-intelligence bundle classified as net-new hand-raiser")
+	}
+	intent := []byte(`{"schema":"CONFENGE_WEB_INTENT/1.0","intent_kind":"REQUEST_HUMAN_REVIEW"}`)
+	if IsNetNewInboundHandraiserEnvelope(intent) {
+		t.Fatal("web intent classified as net-new hand-raiser")
+	}
+}
+
+func TestNetNewAcceptedInboundOnlyNoSMTP(t *testing.T) {
+	svc, repo, org := inboundTestService(t)
+	now := *netNewConsentAt()
+	sends := 0
+	body := marshalNetNew(t, validNetNewMap("nnhr-accepted"))
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now)
+	if xerr != nil {
+		t.Fatalf("ingest: %v", xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("outcome=%s reason=%s", res.Outcome, res.Reason)
+	}
+	if res.Receipt == "" || res.LogicalID != "nnhr-accepted" {
+		t.Fatalf("receipt missing: %+v", res)
+	}
+	if !res.InboundOnly || res.OutboundEligible || res.AutoSend || res.DispatchAttempted {
+		t.Fatalf("outbound leaked: %+v", res)
+	}
+	if !res.MeetcfgHandoff || !MeetcfgHandoffAllowed(res.Outcome) {
+		t.Fatal("meetcfg handoff not allowed after ACCEPTED")
+	}
+	if res.Nucleus != "property_valuation" || res.OfferCandidate != NetNewInboundOfferCandidate ||
+		res.SourceAsset != NetNewInboundSourceAsset || res.CityClass != "capital" || res.Urgency != "this_week" {
+		t.Fatalf("fields not preserved: %+v", res)
+	}
+	if res.ActionID == nil || res.AccountID == nil {
+		t.Fatalf("missing commercial row: %+v", res)
+	}
+	acc, err := repo.GetAccount(context.Background(), org, *res.AccountID)
+	if err != nil || acc == nil {
+		t.Fatalf("account: %v", err)
+	}
+	if !models.AccountIsInboundOnly(acc) {
+		t.Fatal("net-new account is not inbound-only")
+	}
+	if FirstTouchEligibleAccount(acc) || svc.netNewInFirstTouchEligibleSet(context.Background(), org, acc.ID) {
+		t.Fatal("accepted inbound appeared in first-touch eligible set")
+	}
+	actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, acc.ID, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("want 1 hand-raiser got %d", len(actions))
+	}
+	if actions[0].EmailSendable || actions[0].Dispatchable {
+		t.Fatal("hand-raiser is sendable")
+	}
+	if svc.governor != nil || svc.firstTouchTransport != nil {
+		t.Fatal("ingest wired a send path")
+	}
+	progressed, err := svc.ProcessFastLaneOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if progressed || sends != 0 {
+		t.Fatalf("provider mutation progressed=%v sends=%d", progressed, sends)
+	}
+	rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), org, "nnhr-accepted")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if rb.Outcome != NetNewInboundOutcomeAccepted || rb.Receipt != res.Receipt {
+		t.Fatalf("readback: %+v", rb)
+	}
+	if rb.AcknowledgedBy != NetNewInboundAckActor || rb.AcknowledgedAt == nil || rb.PolicyVersion != NetNewInboundHandraiserSchema {
+		t.Fatalf("readback ack/policy: %+v", rb)
+	}
+	if rb.Reason != "" && rb.Outcome == NetNewInboundOutcomeAccepted {
+		// accepted may carry empty reason
+	}
+	exp, xerr := svc.ExportSalesContext(context.Background(), org, 50, "")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	found := false
+	for _, item := range exp.Items {
+		if item.ActionID == *res.ActionID {
+			found = true
+			if !item.InboundOnly {
+				t.Fatal("sales context lost inbound_only")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("ACCEPTED hand-raiser missing from meetcfg projection")
+	}
+}
+
+func TestNetNewCanonicalIDReconcileDoesNotNameMerge(t *testing.T) {
+	svc, repo, org := inboundTestService(t)
+	now := *netNewConsentAt()
+	canonical := "canonical-acme-1"
+	existing := &models.OutreachAccount{
+		OrganizationID: org, SourceLeadID: canonical, SourceSystem: "extra-cli",
+		CNPJ14: "55444333000122", RazaoSocial: "Same Display Name LTDA",
+		QueueState: models.OutreachQueueNeedsContact, InboundOnly: false,
+		TargetFitEligible: false, EmailSendReady: false,
+	}
+	if _, err := repo.UpsertAccount(context.Background(), existing); err != nil {
+		t.Fatal(err)
+	}
+
+	body := validNetNewMap("nnhr-canonical")
+	body["canonical_entity_id"] = canonical
+	body["company"] = map[string]any{"name": "Same Display Name LTDA", "canonical_id": canonical}
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, body), now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted || res.AccountID == nil {
+		t.Fatalf("canonical ingest: %+v", res)
+	}
+	if *res.AccountID != existing.ID {
+		t.Fatalf("canonical ID did not reuse account %s vs %s", res.AccountID, existing.ID)
+	}
+	if !res.Reconciled {
+		t.Fatal("canonical match was not marked reconciled")
+	}
+
+	a := validNetNewMap("nnhr-name-a")
+	a["company"] = map[string]any{"name": "Same Display Name LTDA"}
+	b := validNetNewMap("nnhr-name-b")
+	b["company"] = map[string]any{"name": "Same Display Name LTDA"}
+	first, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, a), now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	second, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, b), now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if first.Outcome != NetNewInboundOutcomeAccepted || second.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("name-collision ingest: %+v %+v", first, second)
+	}
+	if first.AccountID == nil || second.AccountID == nil || *first.AccountID == *second.AccountID {
+		t.Fatalf("same name without ID merged: %v vs %v", first.AccountID, second.AccountID)
+	}
+	if *first.AccountID == existing.ID || *second.AccountID == existing.ID {
+		t.Fatal("name-only envelope fused onto canonical entity")
+	}
+}
+
+func TestNetNewReplay100OneReceiptOneHandraiser(t *testing.T) {
+	svc, _, org := inboundTestService(t)
+	now := *netNewConsentAt()
+	body := marshalNetNew(t, validNetNewMap("nnhr-replay"))
+	var first *NetNewInboundResult
+	for i := 0; i < 100; i++ {
+		res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now.Add(time.Duration(i)*time.Second))
+		if xerr != nil {
+			t.Fatalf("replay %d: %v", i, xerr)
+		}
+		if res.Outcome != NetNewInboundOutcomeAccepted {
+			t.Fatalf("replay %d outcome=%s", i, res.Outcome)
+		}
+		if first == nil {
+			first = res
+			continue
+		}
+		if res.Receipt != first.Receipt || res.LogicalID != first.LogicalID {
+			t.Fatalf("replay %d changed receipt", i)
+		}
+		if res.ActionID == nil || first.ActionID == nil || *res.ActionID != *first.ActionID {
+			t.Fatalf("replay %d extra hand-raiser", i)
+		}
+		if res.AccountID == nil || *res.AccountID != *first.AccountID {
+			t.Fatalf("replay %d extra account", i)
+		}
+	}
+	lead, err := svc.inboundStore().GetInboundLeadByLeadID(context.Background(), org, "nnhr-replay")
+	if err != nil || lead == nil {
+		t.Fatalf("receipt: %v", err)
+	}
+	actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, *first.AccountID, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("100 replays produced %d queue rows", len(actions))
+	}
+	acc, _ := svc.repo.GetAccount(context.Background(), org, *first.AccountID)
+	if FirstTouchEligibleAccount(acc) {
+		t.Fatal("replay made the account first-touch eligible")
+	}
+	t.Logf("REPLAY_100_LOSS=0 REPLAY_100_DUPLICATES=0 receipt=%s action=%s", first.Receipt, first.ActionID)
+}
+
+func TestNetNewRejectsDoNotCreateHandraiserOrMeetcfg(t *testing.T) {
+	svc, repo, org := inboundTestService(t)
+	now := *netNewConsentAt()
+	cases := []struct {
+		name   string
+		mutate func(map[string]any)
+		want   string
+	}{
+		{"decline", func(m map[string]any) {
+			m["conflict"] = map[string]any{"status": "DECLINE", "ref": "conflict:only-ref"}
+		}, NetNewInboundReasonConflictDecline},
+		{"conflict unknown", func(m map[string]any) { m["conflict"] = map[string]any{"status": "UNKNOWN", "ref": "conflict:unk"} }, NetNewInboundReasonConflictUnknown},
+		{"no consent", func(m map[string]any) { delete(m, "consent") }, NetNewInboundReasonConsent},
+		{"unpinned", func(m map[string]any) { m["schema_hash"] = ""; m["policy_hash"] = "" }, NetNewInboundReasonHashUnpinned},
+	}
+	before, _ := repo.ListAccounts(context.Background(), org, repository.OutreachAccountFilter{Limit: 500})
+	for i, tc := range cases {
+		body := validNetNewMap("nnhr-rej-" + string(rune('a'+i)))
+		tc.mutate(body)
+		res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, body), now)
+		if xerr != nil {
+			t.Fatalf("%s: %v", tc.name, xerr)
+		}
+		if res.Outcome == NetNewInboundOutcomeAccepted || res.ActionID != nil || res.MeetcfgHandoff {
+			t.Fatalf("%s accepted: %+v", tc.name, res)
+		}
+		if res.Reason != tc.want {
+			t.Fatalf("%s reason=%s want %s", tc.name, res.Reason, tc.want)
+		}
+		rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), org, res.LogicalID)
+		if xerr != nil {
+			t.Fatalf("%s readback: %v", tc.name, xerr)
+		}
+		if rb.Outcome == NetNewInboundOutcomeAccepted {
+			t.Fatalf("%s readback accepted", tc.name)
+		}
+		if strings.Contains(strings.ToLower(rb.ConflictRef), "corpus") || strings.Contains(strings.ToLower(rb.WhyNow), "parts") {
+			t.Fatalf("%s leaked conflict corpus: %+v", tc.name, rb)
+		}
+	}
+	after, _ := repo.ListAccounts(context.Background(), org, repository.OutreachAccountFilter{Limit: 500})
+	if len(after) != len(before) {
+		t.Fatalf("rejects created accounts: before=%d after=%d", len(before), len(after))
+	}
+	exp, xerr := svc.ExportSalesContext(context.Background(), org, 50, "")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if len(exp.Items) != 0 {
+		t.Fatalf("rejected events leaked to meetcfg: %d", len(exp.Items))
+	}
+}
+
+func TestNetNewSensitiveDataStoresRefsOnly(t *testing.T) {
+	svc, _, org := inboundTestService(t)
+	body := validNetNewMap("nnhr-sensitive")
+	body["sensitive_data"] = true
+	body["person"] = map[string]any{"email": "secret.person@example.test", "name": "Secret Person"}
+	body["why_now"] = "do not copy this corpus into analytics"
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, body), *netNewConsentAt())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("sensitive rejected: %+v", res)
+	}
+	lead, err := svc.inboundStore().GetInboundLeadByLeadID(context.Background(), org, "nnhr-sensitive")
+	if err != nil || lead == nil {
+		t.Fatal(err)
+	}
+	raw := strings.ToLower(string(lead.RawPayload))
+	if strings.Contains(raw, "secret.person@example.test") || strings.Contains(raw, "secret person") {
+		t.Fatalf("raw payload kept sensitive data: %s", lead.RawPayload)
+	}
+	metrics, _ := json.Marshal(NetNewInboundMetric{Nucleus: res.Nucleus, State: res.Outcome, Reason: res.Reason})
+	if strings.Contains(strings.ToLower(string(metrics)), "secret.person") {
+		t.Fatalf("metrics leaked PII: %s", metrics)
+	}
+}
+
+func TestNetNewDownstreamUnavailableThenReplay(t *testing.T) {
+	svc, _, org := inboundTestService(t)
+	now := *netNewConsentAt()
+	body := marshalNetNew(t, validNetNewMap("nnhr-rollback"))
+	svc.netNewAfterPersist = func(*models.OutreachInboundLead) error { return errors.New("downstream down") }
+	first, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if first.Outcome != NetNewInboundOutcomeUnknown || first.ActionID != nil {
+		t.Fatalf("downstream failure accepted: %+v", first)
+	}
+	rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), org, "nnhr-rollback")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if rb.Outcome == NetNewInboundOutcomeAccepted {
+		t.Fatal("stale readback reported ACCEPTED")
+	}
+	if rb.Reason != NetNewInboundReasonStale && rb.Reason != NetNewInboundReasonDownstream {
+		t.Fatalf("stale reason=%s", rb.Reason)
+	}
+	svc.netNewAfterPersist = nil
+	second, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now.Add(time.Minute))
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if second.Outcome != NetNewInboundOutcomeAccepted || second.ActionID == nil {
+		t.Fatalf("replay after rollback: %+v", second)
+	}
+	actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, *second.AccountID, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("rollback/replay produced %d actions", len(actions))
+	}
+}
+
+func TestNetNewTelemetryFailureDoesNotDropOrGrantOutbound(t *testing.T) {
+	svc, _, org := inboundTestService(t)
+	svc.netNewMetricSink = func(NetNewInboundMetric) { panic("metrics down") }
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, validNetNewMap("nnhr-metrics")), *netNewConsentAt())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("telemetry panic dropped event: %+v", res)
+	}
+	if res.OutboundEligible || res.AutoSend || res.DispatchAttempted {
+		t.Fatal("telemetry failure granted outbound")
+	}
+}
+
+func TestIntelWatchFactualEventDoesNotCreateHandraiser(t *testing.T) {
+	svc, repo, org := inboundTestService(t)
+	inbox := &netNewFakeInbox{}
+	svc.WireIntelWatchInbox(inbox)
+	event := liveintel.OpportunityEvent{
+		Schema: liveintel.EventSchemaV1, EventID: "intel-watch-fact-1",
+		EventType: liveintel.EventNewOpportunity, SubjectKey: "company:watched",
+		OrgID: org, OccurredAt: *netNewConsentAt(),
+		Payload: map[string]string{"change": "new bid published"},
+	}
+	receipt, xerr := svc.IngestOpportunityEvent(context.Background(), org, event, *netNewConsentAt())
+	if xerr != nil {
+		t.Fatalf("opportunity ingest: %v", xerr)
+	}
+	if receipt == nil || receipt.EventID != "intel-watch-fact-1" {
+		t.Fatalf("receipt: %+v", receipt)
+	}
+	accs, err := repo.ListAccounts(context.Background(), org, repository.OutreachAccountFilter{Limit: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range accs {
+		if models.AccountIsInboundOnly(&accs[i]) {
+			t.Fatal("INTEL_WATCH factual event created inbound-only entity")
+		}
+	}
+	lead, err := svc.inboundStore().GetInboundLeadByLeadID(context.Background(), org, "intel-watch-fact-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lead != nil {
+		t.Fatal("INTEL_WATCH event created inbound lead/hand-raiser")
+	}
+	if inbox.n != 1 {
+		t.Fatalf("inbox writes=%d", inbox.n)
+	}
+
+	watchBody := validNetNewMap("nnhr-watch-src")
+	watchBody["source"] = "INTEL_WATCH"
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, watchBody), *netNewConsentAt())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome == NetNewInboundOutcomeAccepted || res.ActionID != nil {
+		t.Fatalf("INTEL_WATCH source created hand-raiser: %+v", res)
+	}
+}
+
+func TestNetNewConformanceFixtureIngest(t *testing.T) {
+	raw, err := os.ReadFile("testdata/net_new_inbound_handraiser/conformance.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Envelope json.RawMessage `json:"envelope"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	svc, _, org := inboundTestService(t)
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, doc.Envelope, *netNewConsentAt())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("conformance fixture: %+v", res)
+	}
+}
+
+type netNewFakeInbox struct{ n int }
+
+func (f *netNewFakeInbox) AppendOpportunityEvent(_ context.Context, _ models.IntelWatchInboxEvent) (bool, error) {
+	f.n++
+	return true, nil
+}
+
+func (f *netNewFakeInbox) ClaimReplayableEvents(_ context.Context, _ uuid.UUID, _ time.Time, _, _ time.Duration, _ int) ([]models.IntelWatchInboxEvent, error) {
+	return nil, nil
+}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -162,6 +162,12 @@ type Service interface {
 	// IngestOpportunityEvent durably stores one inbound opportunity event
 	// before anything else happens to it.
 	IngestOpportunityEvent(ctx context.Context, orgID uuid.UUID, event liveintel.OpportunityEvent, now time.Time) (*OpportunityEventReceipt, *errx.Error)
+	// IngestNetNewInboundHandraiser consumes one NET_NEW_INBOUND_HANDRAISER
+	// envelope fail-closed. HTTP 2xx is not acceptance; Outcome is.
+	IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.UUID, raw []byte, now time.Time) (*NetNewInboundResult, *errx.Error)
+	// ReadbackNetNewInboundHandraiser returns the persisted receipt for the
+	// same logical ID, including ack actor/time, policy, receipt and reason.
+	ReadbackNetNewInboundHandraiser(ctx context.Context, orgID uuid.UUID, logicalID string) (*NetNewInboundReadback, *errx.Error)
 	// PersistHandRaise converges one hand-raise signal onto the commercial
 	// action surface, stamped with its engine of origin.
 	PersistHandRaise(ctx context.Context, raise HandRaise) (*models.OutreachCommercialAction, *errx.Error)
@@ -320,6 +326,10 @@ type service struct {
 	// INTEL_SEED's own send ledger and daily-cap counter. Nil keeps the lane
 	// dormant: an uncountable cap is not a cap.
 	intelSeedLedger IntelSeedLedger
+	// PII-free net-new inbound metrics. A failing sink must not drop the event
+	// or grant outbound action.
+	netNewMetricSink   func(NetNewInboundMetric)
+	netNewAfterPersist func(*models.OutreachInboundLead) error
 }
 
 func (s *service) now() time.Time {

--- a/internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json
+++ b/internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json
@@ -1,0 +1,69 @@
+{
+  "campaign_id": "07",
+  "audience": ["web-cfg#580/campaign-08", "Meetcfg#1/campaign-14"],
+  "authority": "test-only coordination fixture; goal 97 ratifies. Runtime without this pin fails closed.",
+  "pin_material": "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904\nnuclei=expert_evidence_assistance,property_valuation,building_engineering_documentation,occupational_safety,public_works_b2g\nCONFENGE_OFFER_CATALOG/2.0.0-draft.20260904\nCONFENGE_WEB_INTAKE/2.0.0-draft.20260904\nNET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904\nCONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904\nMEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904\nsource=CONFENGE_WEB\nlane=CONFENGE_WEB\nasset=private_project_technical_readiness_v1\noffer=private_project_technical_readiness_assessment\ninvariants=outbound_eligible=false,auto_send=false",
+  "schema_hash": "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b",
+  "contracts": {
+    "taxonomy": "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904",
+    "nuclei": [
+      "expert_evidence_assistance",
+      "property_valuation",
+      "building_engineering_documentation",
+      "occupational_safety",
+      "public_works_b2g"
+    ],
+    "catalog": "CONFENGE_OFFER_CATALOG/2.0.0-draft.20260904",
+    "intake": "CONFENGE_WEB_INTAKE/2.0.0-draft.20260904",
+    "policy": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+    "state": "CONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904",
+    "meetcfg": "MEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904",
+    "source_asset": "private_project_technical_readiness_v1",
+    "offer_candidate": "private_project_technical_readiness_assessment",
+    "source": "CONFENGE_WEB",
+    "lane": "CONFENGE_WEB",
+    "invariants": {
+      "outbound_eligible": false,
+      "auto_send": false
+    }
+  },
+  "envelope": {
+    "schema": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+    "version": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+    "schema_hash": "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b",
+    "policy": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+    "policy_hash": "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b",
+    "intake_schema": "CONFENGE_WEB_INTAKE/2.0.0-draft.20260904",
+    "taxonomy": "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904",
+    "catalog": "CONFENGE_OFFER_CATALOG/2.0.0-draft.20260904",
+    "source": "CONFENGE_WEB",
+    "lane": "CONFENGE_WEB",
+    "logical_id": "nnhr-conformance-001",
+    "event_id": "nnhr-conformance-001",
+    "idempotency_key": "nnhr-conformance-001",
+    "correlation_id": "corr-conformance-001",
+    "nucleus": "property_valuation",
+    "offer_candidate": "private_project_technical_readiness_assessment",
+    "source_asset": "private_project_technical_readiness_v1",
+    "city_class": "capital",
+    "urgency": "this_week",
+    "why_now": "requested a technical readiness assessment from the public form",
+    "person": {
+      "email": "net-new.conformance@example.test",
+      "name": "Conformance Person"
+    },
+    "company": {
+      "name": "Conformance Engenharia LTDA"
+    },
+    "consent": {
+      "granted": true,
+      "source": "web_form:confenge.com/inbound",
+      "at": "2026-09-04T12:00:00Z"
+    },
+    "conflict": {
+      "status": "NONE",
+      "ref": "conflict:none"
+    },
+    "sensitive_data": false
+  }
+}


### PR DESCRIPTION
## Campaign 07 — multi-vertical inbound consumer and readback

CAMPAIGN_ID=07
REPOSITORY=tjsasakifln/warmbly
WORKTREE=/home/tjsasakifln/code/confenge/.worktrees/warmbly/c20260904-07-warmbly-inbound
ACTUAL_BRANCH=feat/campaign-20260904-multivertical-inbound-consumer-v3
BASE_SHA=8602ce4ae68e27080fa4431390194c09c2b76d06
INITIAL_MAIN_SHA=8602ce4ae68e27080fa4431390194c09c2b76d06
CURRENT_MAIN_SHA=8602ce4ae68e27080fa4431390194c09c2b76d06
HEAD_SHA=045b6b2e7f422625d14f32297a72094dc2b77ac6

NO_MERGE=CONFIRMED
NO_DEPLOY=CONFIRMED
NO_SMTP=CONFIRMED

### Issue owner and decision state

- Warmbly #47: closed 2026-09-04 (historical commercial-state owner). Close is not DoD for this multi-vertical contract. Not reopened or re-closed.
- Warmbly #117: open. Inbound ack observability reused (`acknowledged_by` / `acknowledged_at`) on the new logical-id readback. Dispatch pause (Gap 1) is not this owner.
- Warmbly #260: open. INTEL_WATCH producer not implemented. Factual INTEL_WATCH / opportunity envelopes do not create CONFENGE_WEB hand-raisers, QCO, or inbound-only entities.
- Policy producer: Governance #65 / campaign 06, unmerged. Consumer pins the draft hash fail-closed.
- Public producer: web-cfg #580 / campaign 08.
- Downstream: Meetcfg #1 / campaign 14. Handoff allowed only after `ACCEPTED`.

### Visitor job / business outcome

A consented `CONFENGE_WEB` net-new hand-raiser is admitted inbound-only onto the existing commercial queue, with persist-first receipt and same-logical-id readback, and never becomes outbound-eligible or triggers SMTP.

### WRITE_SET (declared before first edit)

- internal/app/confenge/net_new_inbound.go
- internal/app/confenge/net_new_inbound_ingest.go
- internal/app/confenge/net_new_inbound_test.go
- internal/app/confenge/net_new_inbound_pg_test.go
- internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json
- internal/app/confenge/inbound_receive.go
- internal/app/confenge/inbound_receive_test.go
- internal/app/confenge/service.go
- internal/api/handler/confenge_inbound.go
- internal/api/handler/confenge_inbound_test.go
- internal/api/routes.go
- docs/confenge/net-new-inbound-handraiser.md
- docs/contracts/inbound-learning/net-new-inbound-handraiser.md
- docs/integration/campaign-20260904/07/error-codes.fragment.md
- docs/integration/campaign-20260904/07/endpoints.fragment.md
- docs/integration/campaign-20260904/07/README.md

FILES_CHANGED is exactly that set (16 files). No GO/NO-GO, dispatch, scheduler, mailbox, first-touch policy, Makefile, lockfiles, or `.github/**`.

### Contracts consumed / produced

Consumed (test-only pin, never a runtime fallback):

- `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904`
- `CONFENGE_WEB_INTAKE/2.0.0-draft.20260904`
- `CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904`
- `CONFENGE_OFFER_CATALOG/2.0.0-draft.20260904`
- `CONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904`
- `MEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904`
- schema hash `92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b`
- source/lane `CONFENGE_WEB`
- invariants `outbound_eligible=false`, `auto_send=false`

Produced: persist-first receipt on `outreach_inbound_leads`, inbound-only account via existing `AdmitInboundOnly`, one commercial action via `ConvergeHandRaise`, readback `GET /confenge/inbound/handraisers/:logicalId`.

Missing or divergent hash is `REJECTED_WITH_REASON` (`schema_hash_unpinned` / `schema_hash_mismatch`), never `ACCEPTED`. HTTP 2xx is not acceptance; `outcome` plus same-`logical_id` readback is.

### Tests at HEAD 045b6b2e7f422625d14f32297a72094dc2b77ac6

```
go test -count=1 -v ./internal/app/confenge ./internal/api/handler \
  -run 'TestNetNew|TestDecideNetNew|TestIsNetNew|TestIntelWatchFactual|TestEvaluateInboundReceiveReadyAndBlocked|TestConfengeInboundWebhookNetNew|TestConfengeInboundWebhookIntelWatch|TestPGNetNewInbound'
```

Run twice. Both PASS.

- net-new ACCEPTED: one inbound-only representation, one hand-raiser, `outbound_eligible=false`, `auto_send=false`
- canonical-ID reconcile reuses the existing entity; same display name without ID does not merge
- unknown/unpinned schema is not ACCEPTED
- 100 replays of one logical ID: one receipt, one hand-raiser (`REPLAY_100_LOSS=0 REPLAY_100_DUPLICATES=0`)
- conflict DECLINE and UNKNOWN; missing consent; sensitive-data flag stores refs only
- downstream unavailable then replay resumes without a second queue row
- persist then readback includes `acknowledged_by`, `acknowledged_at`, policy version, receipt, reason
- ACCEPTED account is absent from the existing first-touch eligible set; `ProcessFastLaneOnce` does not progress; governor/transport stay unwired
- INTEL_WATCH / opportunity factual envelope does not create a hand-raiser, QCO, or inbound-only row
- telemetry panic does not drop the event or grant outbound
- PG test skipped: `WARMBLY_TEST_POSTGRES_DSN/PRIMARY_DB is not set` (no migration added; existing inbound-only model reused)

`make fmt` and `make lint` PASS. `gofmt -l` on touched Go is empty.

### Data / analytics / privacy

Metrics are nucleus / state / reason only. Conflict storage is a protected `conflict_ref`. Sensitive-data envelopes redact raw payload. Logs do not emit envelope PII.

### 100-repetition behavior

Same `logical_id` 100 times: one receipt, one inbound-only account, one commercial action. Distinct logical IDs with the same display name and no canonical ID stay two entities.

### Rollback

Pause intake of this schema at the webhook branch. Receipts and outcomes stay on `outreach_inbound_leads` / commercial actions. Do not promote inbound-only rows to outbound. No production migration to reverse.

### ADR

None opened. Reuses the existing inbound commercial owner (HMAC receive, `AdmitInboundOnly`, commercial-action queue, operator-alert ack, sales-context export).

### Dependencies and fragments

- Campaign 06 policy hash is unpinned in production; this consumer fails closed until goal 97 ratifies.
- Campaign 08 / 14 conformance fixture: `internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json`
- Shared docs not edited. Fragments: `docs/integration/campaign-20260904/07/`

### Confirmation

NO_MERGE=CONFIRMED
NO_DEPLOY=CONFIRMED
NO_SMTP=CONFIRMED
