### PR TITLE
feat: consume multi-vertical NET_NEW_INBOUND_HANDRAISER inbound-only on the existing commercial owner without SMTP

### DIFF
--- a/docs/confenge/net-new-inbound-handraiser.md
+++ b/docs/confenge/net-new-inbound-handraiser.md
@@ -1,0 +1,50 @@
+# NET_NEW_INBOUND_HANDRAISER consumer (REV-03)
+
+Warmbly consumes a multi-vertical `NET_NEW_INBOUND_HANDRAISER` hand-raiser
+on the existing inbound HMAC route. This is not a second CRM. Receipts
+land on `outreach_inbound_leads`, net-new people/companies reuse
+`AdmitInboundOnly`, and accepted events converge onto one commercial
+action through `ConvergeHandRaise` / `PersistHandRaise`.
+
+Admission is fail-closed on REV-02 `contract_id + version + content hash`.
+Until a final REV-02 SHA is recorded in `RuntimeRev02Pin`, the matching
+adapter is test-only. Fixture schemas are never production authority.
+HTTP 2xx is not acceptance; `outcome` plus readback of the same
+`logical_id` is.
+
+## Pin
+
+- Contract ID: `NET_NEW_INBOUND_HANDRAISER`
+- Version: `1.0.0-draft.20260904`
+- Canonical: `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904`
+- Content hash (test-only adapter): `92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b`
+- Observed REV-02 HEAD (not a final pin): `230d73a22a321112abe09b34a0d5fe743790b857` (`tjsasakifln/Governance`)
+- Runtime pin: unpinned (`WAITING_GOVERNANCE_PIN`)
+- Source / lane: `CONFENGE_WEB`
+- Invariants: `outbound_eligible=false`, `auto_send=false`
+
+Test-only fixture: `internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json`
+
+## Outcomes
+
+Closed set: `ACCEPTED | REJECTED_WITH_REASON | UNKNOWN`.
+
+- Persist the receipt before admit or queue writes.
+- `ACCEPTED` creates or updates one inbound-only hand-raiser. Meetcfg
+  handoff is allowed only then.
+- Canonical entity ID reuses the existing account. The same display name
+  without that ID does not merge.
+- Conflict storage is a protected `conflict_ref` only.
+- INTEL_WATCH / Live Intelligence factual envelopes stay on their own
+  schema and never create a CONFENGE_WEB hand-raiser here.
+
+## Readback
+
+`GET /confenge/inbound/handraisers/:logicalId` returns `acknowledged_by`,
+`acknowledged_at`, policy version, hash, receipt, reason, and outcome for
+the same logical ID.
+
+## Metrics
+
+Nucleus, state, and reason only. No protected payload, email, name, or
+conflict corpus.

--- a/docs/contracts/inbound-learning/net-new-inbound-handraiser.md
+++ b/docs/contracts/inbound-learning/net-new-inbound-handraiser.md
@@ -1,0 +1,13 @@
+# NET_NEW_INBOUND_HANDRAISER / CONFENGE_WEB intake (REV-03)
+
+Test-only coordination contract for REV-03. Not a production fallback.
+Runtime without a matching REV-02 `contract_id + version + content hash`
+fails closed. `RuntimeRev02Pin` stays empty until a final REV-02 SHA is
+recorded.
+
+See `docs/confenge/net-new-inbound-handraiser.md` and the published
+fixture `internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json`.
+
+Producers send this envelope on `POST /api/v1/webhooks/confenge/inbound`.
+Downstream Meetcfg may consume sales-context items only after
+`outcome=ACCEPTED`.

--- a/docs/integration/revenue-20260905/rev-03/README.md
+++ b/docs/integration/revenue-20260905/rev-03/README.md
@@ -1,0 +1,10 @@
+# REV-03 integration fragments
+
+Owner: Warmbly inbound consumer, inbound commercial state, readback.
+
+Shared files not edited here. REV-02 final SHA is not yet the runtime pin.
+
+| fragment | target_path | operation | stable_key |
+| --- | --- | --- | --- |
+| error-codes.fragment.md | docs/content/docs/api/error-codes.mdx | insert section after CONFENGE_WEB_INTENT | NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904 |
+| endpoints.fragment.md | docs/content/docs/api/endpoints.mdx | document GET handraisers readback | GET /confenge/inbound/handraisers/:logicalId |

--- a/docs/integration/revenue-20260905/rev-03/endpoints.fragment.md
+++ b/docs/integration/revenue-20260905/rev-03/endpoints.fragment.md
@@ -1,0 +1,13 @@
+# Fragment: net-new inbound readback endpoint
+
+target_path: docs/content/docs/api/endpoints.mdx
+operation: add under CONFENGE inbound routes
+stable_key: GET /confenge/inbound/handraisers/:logicalId
+depends_on: REV-03 consumer
+test: go test ./internal/api/handler -run TestConfengeInboundWebhookNetNewHandraiserRoutesAndReadback
+rollback: remove the GET route in internal/api/routes.go and this handler
+
+Authenticated `GET /confenge/inbound/handraisers/:logicalId` returns the
+persisted receipt for one logical ID: `acknowledged_by`, `acknowledged_at`,
+`policy_version`, `hash`, `receipt`, `reason`, `outcome`. Permission:
+`view_contacts` / `APIPermReadContacts`.

--- a/docs/integration/revenue-20260905/rev-03/error-codes.fragment.md
+++ b/docs/integration/revenue-20260905/rev-03/error-codes.fragment.md
@@ -1,0 +1,32 @@
+# Fragment: NET_NEW_INBOUND_HANDRAISER error codes
+
+target_path: docs/content/docs/api/error-codes.mdx
+operation: insert after the CONFENGE_WEB_INTENT/1.0 section
+stable_key: NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904
+depends_on: REV-03 consumer
+test: go test ./internal/app/confenge -run 'TestDecideNetNewInboundFailClosed|TestNetNewRejects'
+rollback: drop this section; consumer still fail-closes on unknown hash
+
+## `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904`
+
+HMAC `POST /api/v1/webhooks/confenge/inbound`. HTTP 2xx is not acceptance.
+`outcome` is `ACCEPTED`, `REJECTED_WITH_REASON`, or `UNKNOWN`.
+
+| `code` / `reason` | Meaning |
+| --- | --- |
+| `schema_hash_unpinned` | `content_hash` / `schema_hash` / `policy_hash` missing, or runtime pin empty |
+| `schema_hash_mismatch` | Hash is not the pinned content hash |
+| `schema_version_unknown` | Family prefix matched, version is not the pinned draft |
+| `schema_mismatch` | Body is not this contract |
+| `contract_id_mismatch` | `contract_id` / `policy_id` is not `NET_NEW_INBOUND_HANDRAISER` |
+| `source_not_confenge_web` | `source` is not `CONFENGE_WEB` |
+| `lane_not_confenge_web` | `lane` is not `CONFENGE_WEB` / `confenge_web` |
+| `consent_missing` | Consent granted + source + timestamp missing |
+| `conflict_decline` | Conflict status `DECLINE`. Receipt stored, no hand-raiser |
+| `conflict_unknown` | Conflict status `UNKNOWN`. Outcome `UNKNOWN` |
+| `logical_id_missing` | No durable logical id |
+| `nucleus_unknown` | Nucleus outside the taxonomy closed set |
+| `intel_watch_not_handraiser` | INTEL_WATCH / Live Intelligence source on this envelope |
+| `downstream_unavailable` | Store or queue write failed after receipt persist |
+| `readback_stale` | Receipt exists but the consume did not finish |
+| `inbound_store_unavailable` | `503`. Receipt could not be persisted |

--- a/internal/api/handler/confenge_inbound.go
+++ b/internal/api/handler/confenge_inbound.go
@@ -114,6 +114,19 @@ func (h *Handler) ConfengeInboundWebhook(c *gin.Context) {
 		c.JSON(status, gin.H{"data": res})
 		return
 	}
+	if confenge.IsNetNewInboundHandraiserEnvelope(body) {
+		res, xerr := h.ConfengeService.IngestNetNewInboundHandraiser(c.Request.Context(), orgID, body, time.Now().UTC())
+		if xerr != nil {
+			errx.JSON(c, xerr)
+			return
+		}
+		status := http.StatusCreated
+		if res != nil && res.Replay {
+			status = http.StatusOK
+		}
+		c.JSON(status, gin.H{"data": res})
+		return
+	}
 	// Checked before the inbound-lead fallthrough, which would otherwise
 	// swallow both of these: neither carries a lead shape.
 	if intel.IsWebIntentEnvelope(body) {
@@ -166,6 +179,25 @@ func (h *Handler) ConfengeInboundWebhook(c *gin.Context) {
 		status = http.StatusOK
 	}
 	c.JSON(status, gin.H{"data": res})
+}
+
+// GetConfengeInboundHandraiser — GET /confenge/inbound/handraisers/:logicalId
+func (h *Handler) GetConfengeInboundHandraiser(c *gin.Context) {
+	orgID, ok := h.confengeOrg(c)
+	if !ok {
+		return
+	}
+	logicalID := strings.TrimSpace(c.Param("logicalId"))
+	if logicalID == "" {
+		errx.JSON(c, errx.New(errx.BadRequest, "logical_id is required"))
+		return
+	}
+	res, xerr := h.ConfengeService.ReadbackNetNewInboundHandraiser(c.Request.Context(), orgID, logicalID)
+	if xerr != nil {
+		errx.JSON(c, xerr)
+		return
+	}
+	c.JSON(http.StatusOK, gin.H{"data": res})
 }
 
 // ListConfengeInboundNow — GET /confenge/inbound

--- a/internal/api/handler/confenge_inbound_test.go
+++ b/internal/api/handler/confenge_inbound_test.go
@@ -16,15 +16,19 @@ import (
 
 	"github.com/warmbly/warmbly/internal/app/confenge"
 	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
 	"github.com/warmbly/warmbly/internal/errx"
 )
 
 type inboundHTTPStub struct {
 	confenge.Service
-	cfg      confenge.Config
-	gotRaw   []byte
-	ingest   func(raw []byte, opts confenge.IngestOptions) (*confenge.InboundIngestResult, *errx.Error)
-	obsStore *intel.MemoryStore
+	cfg       confenge.Config
+	gotRaw    []byte
+	gotNetNew []byte
+	gotOpp    bool
+	ingest    func(raw []byte, opts confenge.IngestOptions) (*confenge.InboundIngestResult, *errx.Error)
+	netNew    func(raw []byte) (*confenge.NetNewInboundResult, *errx.Error)
+	obsStore  *intel.MemoryStore
 }
 
 func (s *inboundHTTPStub) Enabled() bool           { return true }
@@ -76,6 +80,40 @@ func (s *inboundHTTPStub) IngestInboundLead(_ context.Context, _ uuid.UUID, raw 
 		NextAction:        "CALL",
 		DispatchAttempted: false,
 	}, nil
+}
+
+func (s *inboundHTTPStub) IngestNetNewInboundHandraiser(_ context.Context, _ uuid.UUID, raw []byte, _ time.Time) (*confenge.NetNewInboundResult, *errx.Error) {
+	s.gotNetNew = append([]byte(nil), raw...)
+	if s.netNew != nil {
+		return s.netNew(raw)
+	}
+	return &confenge.NetNewInboundResult{
+		Schema:            confenge.NetNewInboundHandraiserSchema,
+		LogicalID:         "stub-logical",
+		Outcome:           confenge.NetNewInboundOutcomeAccepted,
+		Receipt:           "stub-receipt",
+		InboundOnly:       true,
+		DispatchAttempted: false,
+	}, nil
+}
+
+func (s *inboundHTTPStub) ReadbackNetNewInboundHandraiser(_ context.Context, _ uuid.UUID, logicalID string) (*confenge.NetNewInboundReadback, *errx.Error) {
+	at := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	return &confenge.NetNewInboundReadback{NetNewInboundResult: confenge.NetNewInboundResult{
+		Schema:         confenge.NetNewInboundHandraiserSchema,
+		PolicyVersion:  confenge.NetNewInboundHandraiserSchema,
+		Hash:           confenge.NetNewInboundPinnedHash,
+		LogicalID:      logicalID,
+		Receipt:        "stub-receipt",
+		Outcome:        confenge.NetNewInboundOutcomeAccepted,
+		AcknowledgedBy: confenge.NetNewInboundAckActor,
+		AcknowledgedAt: &at,
+	}}, nil
+}
+
+func (s *inboundHTTPStub) IngestOpportunityEvent(_ context.Context, _ uuid.UUID, event liveintel.OpportunityEvent, _ time.Time) (*confenge.OpportunityEventReceipt, *errx.Error) {
+	s.gotOpp = true
+	return &confenge.OpportunityEventReceipt{EventID: event.EventID}, nil
 }
 
 func TestConfengeInboundWebhookRejectsQueryPIIAndAcceptsSignedBody(t *testing.T) {
@@ -495,4 +533,165 @@ func cloneMap(in map[string]any) map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+func TestConfengeInboundWebhookNetNewHandraiserRoutesAndReadback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+	secret := "inbound-http-secret"
+	var gotOutcome string
+	stub := &inboundHTTPStub{cfg: confenge.Config{
+		Enabled: true, InboundWebhookSecret: secret, InboundOrgID: org, AutoSendEnabled: false,
+	}}
+	stub.netNew = func(raw []byte) (*confenge.NetNewInboundResult, *errx.Error) {
+		at := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+		res := &confenge.NetNewInboundResult{
+			Schema:         confenge.NetNewInboundHandraiserSchema,
+			PolicyVersion:  confenge.NetNewInboundHandraiserSchema,
+			Hash:           confenge.NetNewInboundPinnedHash,
+			LogicalID:      "nnhr-http-1",
+			Receipt:        "receipt-http-1",
+			Outcome:        confenge.NetNewInboundOutcomeAccepted,
+			InboundOnly:    true,
+			AcknowledgedBy: confenge.NetNewInboundAckActor,
+			AcknowledgedAt: &at,
+		}
+		gotOutcome = res.Outcome
+		return res, nil
+	}
+	h := &Handler{ConfengeService: stub}
+	body, _ := json.Marshal(map[string]any{
+		"schema":       confenge.NetNewInboundHandraiserSchema,
+		"contract_id":  confenge.NetNewInboundContractID,
+		"version":      confenge.NetNewInboundPinVersion,
+		"content_hash": confenge.NetNewInboundPinnedHash,
+		"schema_hash":  confenge.NetNewInboundPinnedHash,
+		"source":       "CONFENGE_WEB",
+		"lane":         "CONFENGE_WEB",
+		"logical_id":   "nnhr-http-1",
+	})
+	sig := confenge.SignOutcomeHMAC(secret, time.Now().UTC(), body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/confenge/inbound", bytes.NewReader(body))
+	req.Header.Set("X-Warmbly-Signature", sig)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	h.ConfengeInboundWebhook(c)
+	if w.Code != http.StatusCreated && w.Code != http.StatusOK {
+		t.Fatalf("net-new status=%d body=%s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(stub.gotNetNew, []byte("nnhr-http-1")) {
+		t.Fatal("handler did not route net-new envelope")
+	}
+	if stub.gotOpp {
+		t.Fatal("net-new envelope routed to INTEL_WATCH")
+	}
+	var wrap struct {
+		Data confenge.NetNewInboundResult `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &wrap); err != nil {
+		t.Fatal(err)
+	}
+	if wrap.Data.Outcome != confenge.NetNewInboundOutcomeAccepted {
+		t.Fatalf("HTTP %d is not acceptance; outcome=%q", w.Code, wrap.Data.Outcome)
+	}
+	if gotOutcome != wrap.Data.Outcome {
+		t.Fatal("handler invented an outcome")
+	}
+
+	req2 := httptest.NewRequest(http.MethodGet, "/confenge/inbound/handraisers/nnhr-http-1", nil)
+	w2 := httptest.NewRecorder()
+	c2, _ := gin.CreateTestContext(w2)
+	c2.Request = req2
+	c2.Params = gin.Params{{Key: "logicalId", Value: "nnhr-http-1"}}
+	c2.Set("organization_id", org)
+	h.GetConfengeInboundHandraiser(c2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("readback status=%d body=%s", w2.Code, w2.Body.String())
+	}
+	var rb struct {
+		Data confenge.NetNewInboundReadback `json:"data"`
+	}
+	if err := json.Unmarshal(w2.Body.Bytes(), &rb); err != nil {
+		t.Fatal(err)
+	}
+	if rb.Data.AcknowledgedBy == "" || rb.Data.Receipt == "" || rb.Data.PolicyVersion == "" || rb.Data.Hash == "" {
+		t.Fatalf("readback missing fields: %+v", rb.Data)
+	}
+}
+
+func TestConfengeInboundWebhookIntelWatchDoesNotCallNetNew(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+	secret := "inbound-http-secret"
+	stub := &inboundHTTPStub{cfg: confenge.Config{
+		Enabled: true, InboundWebhookSecret: secret, InboundOrgID: org, AutoSendEnabled: false,
+	}}
+	h := &Handler{ConfengeService: stub}
+	body, _ := json.Marshal(map[string]any{
+		"schema":      liveintel.EventSchemaV1,
+		"event_id":    "intel-watch-http-1",
+		"event_type":  "NEW_OPPORTUNITY",
+		"subject_key": "company:watched",
+		"payload":     map[string]string{"change": "factual"},
+	})
+	sig := confenge.SignOutcomeHMAC(secret, time.Now().UTC(), body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/confenge/inbound", bytes.NewReader(body))
+	req.Header.Set("X-Warmbly-Signature", sig)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	h.ConfengeInboundWebhook(c)
+	if len(stub.gotNetNew) != 0 {
+		t.Fatalf("INTEL_WATCH routed to net-new consumer: %s", stub.gotNetNew)
+	}
+	if !stub.gotOpp {
+		t.Fatalf("INTEL_WATCH not routed to opportunity ingest status=%d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestConfengeInboundWebhookHTTP2xxIsNotAcceptance(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	org := uuid.MustParse("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+	secret := "inbound-http-secret"
+	stub := &inboundHTTPStub{cfg: confenge.Config{
+		Enabled: true, InboundWebhookSecret: secret, InboundOrgID: org, AutoSendEnabled: false,
+	}}
+	stub.netNew = func(raw []byte) (*confenge.NetNewInboundResult, *errx.Error) {
+		return &confenge.NetNewInboundResult{
+			Schema:    confenge.NetNewInboundHandraiserSchema,
+			LogicalID: "nnhr-http-reject",
+			Outcome:   confenge.NetNewInboundOutcomeRejected,
+			Reason:    confenge.NetNewInboundReasonHashUnpinned,
+			Receipt:   "receipt-reject",
+		}, nil
+	}
+	h := &Handler{ConfengeService: stub}
+	body, _ := json.Marshal(map[string]any{
+		"schema":     confenge.NetNewInboundHandraiserSchema,
+		"logical_id": "nnhr-http-reject",
+		"source":     "CONFENGE_WEB",
+	})
+	sig := confenge.SignOutcomeHMAC(secret, time.Now().UTC(), body)
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/confenge/inbound", bytes.NewReader(body))
+	req.Header.Set("X-Warmbly-Signature", sig)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = req
+	h.ConfengeInboundWebhook(c)
+	if w.Code != http.StatusCreated && w.Code != http.StatusOK {
+		t.Fatalf("rejected envelope HTTP status=%d body=%s", w.Code, w.Body.String())
+	}
+	var wrap struct {
+		Data confenge.NetNewInboundResult `json:"data"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &wrap); err != nil {
+		t.Fatal(err)
+	}
+	if wrap.Data.Outcome == confenge.NetNewInboundOutcomeAccepted {
+		t.Fatal("HTTP 2xx was treated as acceptance")
+	}
+	if wrap.Data.Outcome != confenge.NetNewInboundOutcomeRejected {
+		t.Fatalf("outcome=%q", wrap.Data.Outcome)
+	}
 }

--- a/internal/api/routes.go
+++ b/internal/api/routes.go
@@ -540,6 +540,7 @@ func Run(
 				confengeGroup.GET("/cockpit", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeContactCockpit)
 				confengeGroup.GET("/today", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeToday)
 				confengeGroup.GET("/inbound", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.ListConfengeInboundNow)
+				confengeGroup.GET("/inbound/handraisers/:logicalId", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeInboundHandraiser)
 				confengeGroup.GET("/intel/executive", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeExecutiveIntel)
 				confengeGroup.GET("/intel/scoreboard", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeTruthScoreboard)
 				confengeGroup.GET("/intel/organic-scoreboard", m.RequireAccess(models.PermViewContacts, models.APIPermReadContacts), h.GetConfengeOrganicScoreboard)

--- a/internal/app/confenge/inbound_receive.go
+++ b/internal/app/confenge/inbound_receive.go
@@ -24,7 +24,7 @@ const (
 // in sibling packages and the probe must not advertise a body the dispatch
 // cannot actually route.
 func acceptedInboundEventVersions() []string {
-	return append(intel.AcceptedEventVersions(), intel.WebIntentSchemaV1, liveintel.EventSchemaV1)
+	return append(intel.AcceptedEventVersions(), intel.WebIntentSchemaV1, liveintel.EventSchemaV1, NetNewInboundHandraiserSchema)
 }
 
 // InboundReceiveProbe is the PII-free, secret-free signal web-cfg uses

--- a/internal/app/confenge/inbound_receive_test.go
+++ b/internal/app/confenge/inbound_receive_test.go
@@ -21,6 +21,9 @@ func TestEvaluateInboundReceiveReadyAndBlocked(t *testing.T) {
 	if !strings.Contains(joinedVer, "confenge.commercial_event.v1") || !strings.Contains(joinedVer, "confenge.search_observation.v1") {
 		t.Fatalf("accepted_event_versions=%v", ready.AcceptedEventVersions)
 	}
+	if !strings.Contains(joinedVer, NetNewInboundHandraiserSchema) {
+		t.Fatalf("net-new schema missing from accepted_event_versions=%v", ready.AcceptedEventVersions)
+	}
 	if ready.AutoSendEnabled || ready.DispatchAttempted {
 		t.Fatalf("auto-send leaked: %+v", ready)
 	}

--- a/internal/app/confenge/net_new_inbound.go
+++ b/internal/app/confenge/net_new_inbound.go
@@ -1,0 +1,358 @@
+package confenge
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/intel"
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
+)
+
+// Multi-vertical NET_NEW_INBOUND_HANDRAISER consumer (REV-03).
+//
+// Admission is fail-closed on REV-02 contract_id + version + content hash.
+// RuntimeRev02Pin is empty until a final REV-02 SHA is recorded; fixture
+// schemas are never a production fallback. INTEL_WATCH / Live Intelligence
+// factual envelopes stay on their own schema and never create a CONFENGE_WEB
+// hand-raiser here.
+
+const (
+	NetNewInboundHandraiserSchema = "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904"
+	NetNewInboundIntakeSchema     = "CONFENGE_WEB_INTAKE/2.0.0-draft.20260904"
+	NetNewInboundTaxonomySchema   = "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904"
+	NetNewInboundCatalogSchema    = "CONFENGE_OFFER_CATALOG/2.0.0-draft.20260904"
+	NetNewInboundStateSchema      = "CONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904"
+	NetNewInboundMeetcfgSchema    = "MEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904"
+	NetNewInboundSource           = "CONFENGE_WEB"
+	NetNewInboundLane             = "CONFENGE_WEB"
+	NetNewInboundSourceAsset      = "private_project_technical_readiness_v1"
+	NetNewInboundOfferCandidate   = "private_project_technical_readiness_assessment"
+
+	NetNewInboundFamilyPrefix = "NET_NEW_INBOUND_HANDRAISER/"
+	NetNewInboundContractID   = "NET_NEW_INBOUND_HANDRAISER"
+	NetNewInboundPinVersion   = "1.0.0-draft.20260904"
+
+	NetNewInboundOutcomeAccepted = "ACCEPTED"
+	NetNewInboundOutcomeRejected = "REJECTED_WITH_REASON"
+	NetNewInboundOutcomeUnknown  = "UNKNOWN"
+
+	NetNewInboundAckActor = "warmbly.net_new_inbound_consumer"
+
+	NetNewInboundReasonHashUnpinned     = "schema_hash_unpinned"
+	NetNewInboundReasonHashMismatch     = "schema_hash_mismatch"
+	NetNewInboundReasonSchemaUnknown    = "schema_version_unknown"
+	NetNewInboundReasonSchemaMismatch   = "schema_mismatch"
+	NetNewInboundReasonContractMismatch = "contract_id_mismatch"
+	NetNewInboundReasonSource           = "source_not_confenge_web"
+	NetNewInboundReasonLane             = "lane_not_confenge_web"
+	NetNewInboundReasonConsent          = "consent_missing"
+	NetNewInboundReasonConflictDecline  = "conflict_decline"
+	NetNewInboundReasonConflictUnknown  = "conflict_unknown"
+	NetNewInboundReasonLogicalID        = "logical_id_missing"
+	NetNewInboundReasonNucleus          = "nucleus_unknown"
+	NetNewInboundReasonIntelWatch       = "intel_watch_not_handraiser"
+	NetNewInboundReasonDownstream       = "downstream_unavailable"
+	NetNewInboundReasonStale            = "readback_stale"
+	NetNewInboundReasonSensitiveRefOnly = "sensitive_data_ref_only"
+	NetNewInboundReasonStoreUnavailable = "inbound_store_unavailable"
+
+	netNewInboundConflictNone    = "NONE"
+	netNewInboundConflictDecline = "DECLINE"
+	netNewInboundConflictUnknown = "UNKNOWN"
+
+	netNewProvPolicy   = "policy:"
+	netNewProvOutcome  = "outcome:"
+	netNewProvReason   = "reason:"
+	netNewProvAckBy    = "ack_by:"
+	netNewProvAckAt    = "ack_at:"
+	netNewProvNucleus  = "nucleus:"
+	netNewProvOffer    = "offer_candidate:"
+	netNewProvAsset    = "source_asset:"
+	netNewProvCity     = "city_class:"
+	netNewProvUrgency  = "urgency:"
+	netNewProvConflict = "conflict_ref:"
+	netNewProvIntake   = "intake_schema:"
+	netNewProvState    = "state_schema:"
+	netNewProvHash     = "schema_hash:"
+)
+
+// NetNewInboundPinnedHash is the SHA-256 of NetNewInboundPinMaterial.
+// Tests recompute it from the test-only fixture. RuntimeRev02Pin does not
+// use this constant; a missing production pin is never ACCEPTED.
+const NetNewInboundPinnedHash = "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b"
+
+// NetNewInboundNuclei is the closed taxonomy set for this pin.
+var NetNewInboundNuclei = []string{
+	"expert_evidence_assistance",
+	"property_valuation",
+	"building_engineering_documentation",
+	"occupational_safety",
+	"public_works_b2g",
+}
+
+// NetNewInboundEnvelope is the decoded body. Nothing here admits.
+type NetNewInboundEnvelope struct {
+	Schema            string                `json:"schema"`
+	ContractID        string                `json:"contract_id"`
+	PolicyID          string                `json:"policy_id"`
+	Version           string                `json:"version"`
+	PolicyVersion     string                `json:"policy_version"`
+	ContentHash       string                `json:"content_hash"`
+	SchemaHash        string                `json:"schema_hash"`
+	Policy            string                `json:"policy"`
+	PolicyHash        string                `json:"policy_hash"`
+	IntakeSchema      string                `json:"intake_schema"`
+	Taxonomy          string                `json:"taxonomy"`
+	Catalog           string                `json:"catalog"`
+	Source            string                `json:"source"`
+	Lane              string                `json:"lane"`
+	LogicalID         string                `json:"logical_id"`
+	EventID           string                `json:"event_id"`
+	IdempotencyKey    string                `json:"idempotency_key"`
+	CorrelationID     string                `json:"correlation_id"`
+	CanonicalEntityID string                `json:"canonical_entity_id"`
+	Nucleus           string                `json:"nucleus"`
+	OfferCandidate    string                `json:"offer_candidate"`
+	SourceAsset       string                `json:"source_asset"`
+	CityClass         string                `json:"city_class"`
+	Urgency           string                `json:"urgency"`
+	WhyNow            string                `json:"why_now"`
+	Person            NetNewInboundParty    `json:"person"`
+	Company           NetNewInboundParty    `json:"company"`
+	Consent           NetNewInboundConsent  `json:"consent"`
+	Conflict          NetNewInboundConflict `json:"conflict"`
+	SensitiveData     bool                  `json:"sensitive_data"`
+	OccurredAt        *time.Time            `json:"occurred_at"`
+}
+
+// NetNewInboundParty is a person or company on the envelope.
+type NetNewInboundParty struct {
+	CanonicalID string `json:"canonical_id"`
+	Email       string `json:"email"`
+	Name        string `json:"name"`
+}
+
+// NetNewInboundConsent is observed opt-in. Absence is fail-closed.
+type NetNewInboundConsent struct {
+	Granted bool       `json:"granted"`
+	Source  string     `json:"source"`
+	At      *time.Time `json:"at"`
+}
+
+// NetNewInboundConflict is a protected reference only. Parts and corpus never
+// travel with it into analytics.
+type NetNewInboundConflict struct {
+	Status string `json:"status"`
+	Ref    string `json:"ref"`
+}
+
+// NetNewInboundDecision is the pure admission result.
+type NetNewInboundDecision struct {
+	Outcome string
+	Reason  string
+}
+
+// IsNetNewInboundHandraiserEnvelope reports this family before lead fallthrough.
+// Unknown versions of the family still match so they fail closed here instead
+// of being swallowed as an inbound lead.
+func IsNetNewInboundHandraiserEnvelope(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	var peek struct {
+		Schema  string `json:"schema"`
+		Version string `json:"version"`
+		Policy  string `json:"policy"`
+		Type    string `json:"type"`
+	}
+	if err := json.Unmarshal(raw, &peek); err != nil {
+		return false
+	}
+	if liveintel.IsOpportunityEventEnvelope(raw) || liveintel.IsOfficialLiveIntelligenceBundle(raw) {
+		return false
+	}
+	if intel.IsWebIntentEnvelope(raw) {
+		return false
+	}
+	for _, v := range []string{peek.Schema, peek.Version, peek.Policy, peek.Type} {
+		v = strings.TrimSpace(v)
+		if v == NetNewInboundHandraiserSchema || strings.HasPrefix(v, NetNewInboundFamilyPrefix) || v == NetNewInboundContractID {
+			return true
+		}
+	}
+	var ids struct {
+		ContractID string `json:"contract_id"`
+		PolicyID   string `json:"policy_id"`
+	}
+	if err := json.Unmarshal(raw, &ids); err == nil {
+		for _, v := range []string{ids.ContractID, ids.PolicyID} {
+			v = strings.TrimSpace(v)
+			if v == NetNewInboundContractID || strings.HasPrefix(v, NetNewInboundFamilyPrefix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ParseNetNewInboundEnvelope decodes without admitting.
+func ParseNetNewInboundEnvelope(raw []byte) (NetNewInboundEnvelope, error) {
+	var env NetNewInboundEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return NetNewInboundEnvelope{}, err
+	}
+	var extra struct {
+		Consent  NetNewInboundConsent  `json:"consent"`
+		Conflict NetNewInboundConflict `json:"conflict"`
+		Email    string                `json:"email"`
+		Name     string                `json:"name"`
+		Company  string                `json:"company"`
+	}
+	_ = json.Unmarshal(raw, &extra)
+	env.Consent = extra.Consent
+	env.Conflict = extra.Conflict
+	if strings.TrimSpace(env.Person.Email) == "" {
+		env.Person.Email = extra.Email
+	}
+	if strings.TrimSpace(env.Person.Name) == "" {
+		env.Person.Name = extra.Name
+	}
+	if strings.TrimSpace(env.Company.Name) == "" && extra.Company != "" {
+		env.Company.Name = extra.Company
+	}
+	env.LogicalID = firstNonEmpty(strings.TrimSpace(env.LogicalID), strings.TrimSpace(env.EventID), strings.TrimSpace(env.IdempotencyKey))
+	env.ContractID = firstNonEmpty(strings.TrimSpace(env.ContractID), strings.TrimSpace(env.PolicyID))
+	env.Version = firstNonEmpty(strings.TrimSpace(env.Version), strings.TrimSpace(env.PolicyVersion))
+	env.ContentHash = firstNonEmpty(strings.TrimSpace(env.ContentHash), strings.TrimSpace(env.SchemaHash), strings.TrimSpace(env.PolicyHash))
+	return env, nil
+}
+
+func netNewEnvelopeContractID(env NetNewInboundEnvelope) string {
+	return firstNonEmpty(strings.TrimSpace(env.ContractID), strings.TrimSpace(env.PolicyID), strings.TrimSpace(env.Schema), strings.TrimSpace(env.Policy))
+}
+
+func netNewEnvelopeVersion(env NetNewInboundEnvelope) string {
+	schema := strings.TrimSpace(env.Schema)
+	if strings.HasPrefix(schema, NetNewInboundFamilyPrefix) {
+		return schema
+	}
+	return firstNonEmpty(strings.TrimSpace(env.Version), strings.TrimSpace(env.PolicyVersion), schema)
+}
+
+func netNewEnvelopeContentHash(env NetNewInboundEnvelope) string {
+	return normalizeContentHash(firstNonEmpty(env.ContentHash, env.SchemaHash, env.PolicyHash))
+}
+
+// DecideNetNewInbound is the fail-closed admission function. It never persists
+// and never talks to SMTP. pin must be contract_id + version + content hash;
+// an unpinned runtime pin is never ACCEPTED.
+func DecideNetNewInbound(env NetNewInboundEnvelope, pin Rev02ContractPin) NetNewInboundDecision {
+	if !pin.Pinned() {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonHashUnpinned}
+	}
+	contractID := netNewEnvelopeContractID(env)
+	version := netNewEnvelopeVersion(env)
+	if !pin.acceptsContractID(contractID) {
+		if strings.HasPrefix(contractID, NetNewInboundFamilyPrefix) || contractID == NetNewInboundContractID {
+			return NetNewInboundDecision{Outcome: NetNewInboundOutcomeUnknown, Reason: NetNewInboundReasonSchemaUnknown}
+		}
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonContractMismatch}
+	}
+	if !pin.acceptsVersion(version) {
+		if strings.HasPrefix(version, NetNewInboundFamilyPrefix) || strings.HasPrefix(contractID, NetNewInboundFamilyPrefix) || contractID == NetNewInboundContractID {
+			return NetNewInboundDecision{Outcome: NetNewInboundOutcomeUnknown, Reason: NetNewInboundReasonSchemaUnknown}
+		}
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonSchemaMismatch}
+	}
+	if strings.TrimSpace(env.LogicalID) == "" {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonLogicalID}
+	}
+	hash := netNewEnvelopeContentHash(env)
+	if hash == "" {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonHashUnpinned}
+	}
+	if hash != normalizeContentHash(pin.ContentHash) {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonHashMismatch}
+	}
+	if pol := strings.TrimSpace(env.Policy); pol != "" && !pin.acceptsVersion(pol) && pol != NetNewInboundHandraiserSchema {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonSchemaMismatch}
+	}
+	if intake := strings.TrimSpace(env.IntakeSchema); intake != "" && intake != NetNewInboundIntakeSchema {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonSchemaMismatch}
+	}
+	if src := strings.ToUpper(strings.TrimSpace(env.Source)); src != NetNewInboundSource {
+		if src == "INTEL_WATCH" || src == strings.ToUpper(EngineLaneIntelWatch) {
+			return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonIntelWatch}
+		}
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonSource}
+	}
+	if !netNewLaneOK(env.Lane) {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonLane}
+	}
+	if !netNewNucleusOK(env.Nucleus) {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonNucleus}
+	}
+	if !env.Consent.Granted || strings.TrimSpace(env.Consent.Source) == "" || env.Consent.At == nil || env.Consent.At.IsZero() {
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonConsent}
+	}
+	switch strings.ToUpper(strings.TrimSpace(env.Conflict.Status)) {
+	case "", netNewInboundConflictNone:
+	case netNewInboundConflictDecline:
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonConflictDecline}
+	case netNewInboundConflictUnknown:
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeUnknown, Reason: NetNewInboundReasonConflictUnknown}
+	default:
+		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeUnknown, Reason: NetNewInboundReasonConflictUnknown}
+	}
+	return NetNewInboundDecision{Outcome: NetNewInboundOutcomeAccepted}
+}
+
+func netNewLaneOK(lane string) bool {
+	switch strings.TrimSpace(lane) {
+	case NetNewInboundLane, EngineLaneConfengeWeb:
+		return true
+	default:
+		return false
+	}
+}
+
+func netNewNucleusOK(nucleus string) bool {
+	nucleus = strings.TrimSpace(nucleus)
+	for _, n := range NetNewInboundNuclei {
+		if n == nucleus {
+			return true
+		}
+	}
+	return false
+}
+
+// MeetcfgHandoffAllowed is true only after ACCEPTED.
+func MeetcfgHandoffAllowed(outcome string) bool {
+	return strings.TrimSpace(outcome) == NetNewInboundOutcomeAccepted
+}
+
+// NetNewConflictRef stores only the protected reference. Corpus is dropped.
+func NetNewConflictRef(conflict NetNewInboundConflict) string {
+	ref := strings.TrimSpace(conflict.Ref)
+	if ref == "" {
+		return ""
+	}
+	ref = strings.TrimSpace(strings.Split(ref, "\n")[0])
+	if i := strings.Index(ref, " "); i > 0 {
+		ref = ref[:i]
+	}
+	return SanitizeText(ref, 120)
+}
+
+func netNewCanonicalEntityID(env NetNewInboundEnvelope) string {
+	return firstNonEmpty(
+		strings.TrimSpace(env.CanonicalEntityID),
+		strings.TrimSpace(env.Company.CanonicalID),
+		strings.TrimSpace(env.Person.CanonicalID),
+	)
+}
+
+func netNewLogicalID(env NetNewInboundEnvelope) string {
+	return SanitizeText(firstNonEmpty(env.LogicalID, env.EventID, env.IdempotencyKey), 160)
+}

--- a/internal/app/confenge/net_new_inbound.go
+++ b/internal/app/confenge/net_new_inbound.go
@@ -1,7 +1,10 @@
 package confenge
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 
@@ -9,11 +12,11 @@ import (
 	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
 )
 
-// Multi-vertical NET_NEW_INBOUND_HANDRAISER consumer (REV-03).
+// Multi-vertical NET_NEW_INBOUND_HANDRAISER consumer.
 //
-// Admission is fail-closed on REV-02 contract_id + version + content hash.
-// RuntimeRev02Pin is empty until a final REV-02 SHA is recorded; fixture
-// schemas are never a production fallback. INTEL_WATCH / Live Intelligence
+// Admission is fail-closed on the published Governance authority:
+// contract_id + version + policy_hash. RuntimeInboundAuthorityPin carries that
+// authority; fixture schemas are never a production fallback. INTEL_WATCH / Live Intelligence
 // factual envelopes stay on their own schema and never create a CONFENGE_WEB
 // hand-raiser here.
 
@@ -56,6 +59,10 @@ const (
 	NetNewInboundReasonStale            = "readback_stale"
 	NetNewInboundReasonSensitiveRefOnly = "sensitive_data_ref_only"
 	NetNewInboundReasonStoreUnavailable = "inbound_store_unavailable"
+	// NetNewInboundReasonKeyConflict is returned when a logical_id is reused
+	// with material that would decide differently. Fail-closed: the stored
+	// decision is never handed to a payload that did not earn it.
+	NetNewInboundReasonKeyConflict = "idempotency_key_conflict"
 
 	netNewInboundConflictNone    = "NONE"
 	netNewInboundConflictDecline = "DECLINE"
@@ -75,11 +82,13 @@ const (
 	netNewProvIntake   = "intake_schema:"
 	netNewProvState    = "state_schema:"
 	netNewProvHash     = "schema_hash:"
+	netNewProvDigest   = "admission_digest:"
 )
 
-// NetNewInboundPinnedHash is the SHA-256 of NetNewInboundPinMaterial.
-// Tests recompute it from the test-only fixture. RuntimeRev02Pin does not
-// use this constant; a missing production pin is never ACCEPTED.
+// NetNewInboundPinnedHash is the SHA-256 of NetNewInboundPinMaterial: this
+// repository's LOCAL drift digest over its own restatement of the nuclei and
+// schemas. It is NOT the Governance policy_hash and is never an admission key.
+// RuntimeInboundAuthorityPin does not use this constant.
 const NetNewInboundPinnedHash = "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b"
 
 // NetNewInboundNuclei is the closed taxonomy set for this pin.
@@ -247,7 +256,7 @@ func netNewEnvelopeContentHash(env NetNewInboundEnvelope) string {
 // DecideNetNewInbound is the fail-closed admission function. It never persists
 // and never talks to SMTP. pin must be contract_id + version + content hash;
 // an unpinned runtime pin is never ACCEPTED.
-func DecideNetNewInbound(env NetNewInboundEnvelope, pin Rev02ContractPin) NetNewInboundDecision {
+func DecideNetNewInbound(env NetNewInboundEnvelope, pin InboundAuthorityPin) NetNewInboundDecision {
 	if !pin.Pinned() {
 		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeRejected, Reason: NetNewInboundReasonHashUnpinned}
 	}
@@ -306,6 +315,35 @@ func DecideNetNewInbound(env NetNewInboundEnvelope, pin Rev02ContractPin) NetNew
 		return NetNewInboundDecision{Outcome: NetNewInboundOutcomeUnknown, Reason: NetNewInboundReasonConflictUnknown}
 	}
 	return NetNewInboundDecision{Outcome: NetNewInboundOutcomeAccepted}
+}
+
+// NetNewAdmissionDigest is a canonical digest over exactly the fields
+// DecideNetNewInbound reads. It is stable across JSON key ordering and
+// cosmetic re-serialization, and changes if and only if the admission-relevant
+// material changes. It is the idempotency-key binding: a reused logical_id
+// carrying different admission material is a conflict, not a replay.
+func NetNewAdmissionDigest(env NetNewInboundEnvelope) string {
+	consentAt := ""
+	if env.Consent.At != nil {
+		consentAt = env.Consent.At.UTC().Format(time.RFC3339)
+	}
+	parts := []string{
+		"contract_id=" + netNewEnvelopeContractID(env),
+		"version=" + netNewEnvelopeVersion(env),
+		"content_hash=" + netNewEnvelopeContentHash(env),
+		"policy=" + strings.TrimSpace(env.Policy),
+		"intake_schema=" + strings.TrimSpace(env.IntakeSchema),
+		"logical_id=" + netNewLogicalID(env),
+		"source=" + strings.ToUpper(strings.TrimSpace(env.Source)),
+		"lane=" + strings.TrimSpace(env.Lane),
+		"nucleus=" + strings.TrimSpace(env.Nucleus),
+		"consent_granted=" + strconv.FormatBool(env.Consent.Granted),
+		"consent_source=" + strings.TrimSpace(env.Consent.Source),
+		"consent_at=" + consentAt,
+		"conflict_status=" + strings.ToUpper(strings.TrimSpace(env.Conflict.Status)),
+	}
+	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
+	return hex.EncodeToString(sum[:])
 }
 
 func netNewLaneOK(lane string) bool {

--- a/internal/app/confenge/net_new_inbound_authority_pg_test.go
+++ b/internal/app/confenge/net_new_inbound_authority_pg_test.go
@@ -1,0 +1,423 @@
+package confenge
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// netNewAuthorityPGService builds a service WITHOUT any test-only pin override,
+// so admission runs against RuntimeInboundAuthorityPin (the published
+// Governance authority). Anything accepted here was accepted by production
+// authority, not by a fixture.
+func netNewAuthorityPGService(t *testing.T, pool *pgxpool.Pool) *service {
+	t.Helper()
+	repo := repository.NewOutreachRepository(pool)
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true, AutoSendEnabled: false}, repo, nil).(*service)
+	if svc.authorityPin.Pinned() {
+		t.Fatal("service must not carry a pin override; production authority is under test")
+	}
+	if got := svc.activeAuthorityPin(); got.ContentHash != GovernanceInboundPolicyHash || got.TestOnly {
+		t.Fatalf("active pin is not the published authority: %+v", got)
+	}
+	return svc
+}
+
+func netNewOrgRowCounts(t *testing.T, pool *pgxpool.Pool, orgID uuid.UUID) (leads, accounts, actions, alerts int) {
+	t.Helper()
+	ctx := context.Background()
+	q := func(sql string) int {
+		var n int
+		if err := pool.QueryRow(ctx, sql, orgID).Scan(&n); err != nil {
+			t.Fatalf("count (%s): %v", sql, err)
+		}
+		return n
+	}
+	return q(`SELECT count(*) FROM outreach_inbound_leads WHERE organization_id=$1`),
+		q(`SELECT count(*) FROM outreach_accounts WHERE organization_id=$1`),
+		q(`SELECT count(*) FROM outreach_commercial_actions WHERE organization_id=$1`),
+		q(`SELECT count(*) FROM outreach_operator_alerts WHERE organization_id=$1`)
+}
+
+func netNewPGCleanup(t *testing.T, pool *pgxpool.Pool, orgID uuid.UUID) {
+	t.Helper()
+	t.Cleanup(func() {
+		ctx, done := context.WithTimeout(context.Background(), 20*time.Second)
+		defer done()
+		for _, tbl := range []string{
+			"outreach_operator_alerts", "outreach_inbound_leads",
+			"outreach_commercial_actions", "outreach_contact_candidates", "outreach_accounts",
+		} {
+			_, _ = pool.Exec(ctx, `DELETE FROM `+tbl+` WHERE organization_id=$1`, orgID)
+		}
+	})
+}
+
+// TestPGGovernanceAuthorityAdmits100ReplaysAsOneIntent is the Phase B proof.
+//
+// It replays the identical NET_NEW_INBOUND_HANDRAISER request 100 times
+// against a REAL PostgreSQL instance, with admission decided by the published
+// Governance authority (no test-only pin), and asserts on persisted ROW COUNTS
+// rather than on Go return values: HTTP 2xx is not acceptance and a Go struct
+// is not a row.
+func TestPGGovernanceAuthorityAdmits100ReplaysAsOneIntent(t *testing.T) {
+	if postgresTestDSN() == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN/PRIMARY_DB is not set")
+	}
+	pool, orgID := openInboundOnlyPG(t)
+	t.Cleanup(pool.Close)
+	netNewPGCleanup(t, pool, orgID)
+
+	svc := netNewAuthorityPGService(t, pool)
+	logicalID := "nnhr-authority-100x-" + uuid.NewString()[:8]
+	body := marshalNetNew(t, governanceNetNewMap(logicalID))
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	if l, a, c, _ := netNewOrgRowCounts(t, pool, orgID); l+a+c != 0 {
+		t.Fatalf("org not clean before replay: leads=%d accounts=%d actions=%d", l, a, c)
+	}
+
+	var first *NetNewInboundResult
+	for i := 0; i < 100; i++ {
+		res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now.Add(time.Duration(i)*time.Second))
+		if xerr != nil {
+			t.Fatalf("replay %d failed: %v", i, xerr)
+		}
+		if res.Outcome != NetNewInboundOutcomeAccepted {
+			t.Fatalf("replay %d not ACCEPTED by published authority: outcome=%s reason=%s", i, res.Outcome, res.Reason)
+		}
+		if res.ActionID == nil || res.AccountID == nil {
+			t.Fatalf("replay %d dropped the intent: %+v", i, res)
+		}
+		if first == nil {
+			first = res
+			if res.Replay {
+				t.Fatal("first ingest reported as a replay")
+			}
+			continue
+		}
+		if !res.Replay {
+			t.Fatalf("replay %d was not marked as a replay", i)
+		}
+		if *res.ActionID != *first.ActionID {
+			t.Fatalf("replay %d created a second commercial action: %s vs %s", i, res.ActionID, first.ActionID)
+		}
+		if *res.AccountID != *first.AccountID {
+			t.Fatalf("replay %d created a second account", i)
+		}
+		if res.Receipt != first.Receipt {
+			t.Fatalf("replay %d changed the receipt", i)
+		}
+	}
+
+	// The proof: persisted row counts, org-scoped (openHandRaisePGSeed mints a
+	// fresh org per test, so a stray row cannot hide behind a filter).
+	leads, accounts, actions, alerts := netNewOrgRowCounts(t, pool, orgID)
+	if leads != 1 {
+		t.Fatalf("100 replays persisted %d receipts, want 1", leads)
+	}
+	if accounts != 1 {
+		t.Fatalf("100 replays persisted %d accounts, want 1", accounts)
+	}
+	if actions != 1 {
+		t.Fatalf("100 replays persisted %d commercial actions, want 1", actions)
+	}
+	if alerts > 1 {
+		t.Fatalf("100 replays persisted %d operator alerts, want <=1", alerts)
+	}
+
+	// The persisted receipt must attest the authority it was admitted against.
+	var prov []string
+	if err := pool.QueryRow(context.Background(),
+		`SELECT ARRAY(SELECT jsonb_array_elements_text(provenance)) FROM outreach_inbound_leads WHERE organization_id=$1 AND lead_id=$2`,
+		orgID, logicalID).Scan(&prov); err != nil {
+		t.Fatalf("read provenance: %v", err)
+	}
+	gotHash := provenanceValue(prov, netNewProvHash)
+	if gotHash != GovernanceInboundPolicyHash {
+		t.Fatalf("receipt attests hash=%s, want the admitted Governance policy_hash %s", gotHash, GovernanceInboundPolicyHash)
+	}
+	if outcome := provenanceValue(prov, netNewProvOutcome); outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("persisted outcome=%s", outcome)
+	}
+	// The admission digest must be persisted, and must match the material that
+	// was admitted. Without it the idempotency-conflict guard silently
+	// degrades to "trust the stored decision", so assert it explicitly: the
+	// guard has to be tamper-evident, not best-effort.
+	env, perr := ParseNetNewInboundEnvelope(body)
+	if perr != nil {
+		t.Fatal(perr)
+	}
+	storedDigest := provenanceValue(prov, netNewProvDigest)
+	if storedDigest == "" {
+		t.Fatal("receipt has no admission_digest; the replay-conflict guard is inert")
+	}
+	if storedDigest != NetNewAdmissionDigest(env) {
+		t.Fatalf("admission_digest=%s want %s", storedDigest, NetNewAdmissionDigest(env))
+	}
+
+	// Inbound-only must hold at the DB level, not only in the returned struct.
+	acc, err := repository.NewOutreachRepository(pool).GetAccount(context.Background(), orgID, *first.AccountID)
+	if err != nil || acc == nil {
+		t.Fatalf("account: %v", err)
+	}
+	if !models.AccountIsInboundOnly(acc) || FirstTouchEligibleAccount(acc) {
+		t.Fatal("net-new inbound account is outbound-eligible")
+	}
+	var inboundOnly bool
+	if err := pool.QueryRow(context.Background(),
+		`SELECT inbound_only FROM outreach_accounts WHERE organization_id=$1 AND id=$2`, orgID, acc.ID).Scan(&inboundOnly); err != nil {
+		t.Fatalf("read inbound_only: %v", err)
+	}
+	if !inboundOnly {
+		t.Fatal("generated column inbound_only is false for a net-new inbound account")
+	}
+
+	// Outbound-eligibility must be impossible at the DB level, not merely
+	// unset by the application. Postgres must refuse the write outright.
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE outreach_accounts SET email_send_ready=true WHERE organization_id=$1 AND id=$2`, orgID, acc.ID); err == nil {
+		t.Fatal("DB allowed an inbound-only account to become outbound-eligible (email_send_ready)")
+	}
+	if _, err := pool.Exec(context.Background(),
+		`UPDATE outreach_accounts SET target_fit_eligible=true WHERE organization_id=$1 AND id=$2`, orgID, acc.ID); err == nil {
+		t.Fatal("DB allowed an inbound-only account to become outbound-eligible (target_fit_eligible)")
+	}
+
+	t.Logf("REPLAY_100_LOSS=0 REPLAY_100_DUPLICATES=0 receipts=%d accounts=%d actions=%d alerts=%d authority=%s source_sha=%s",
+		leads, accounts, actions, alerts, GovernanceInboundPolicyHash, GovernanceInboundSourceSHA)
+}
+
+// TestPGGovernanceAuthorityConcurrentReplayIsOneIntent hits the same logical
+// key from many goroutines at once. Sequential replay never exercises the DB
+// uniqueness constraints; PersistHandRaise is check-then-act, so only
+// outreach_commercial_actions_org_idempotency_uidx makes this safe.
+func TestPGGovernanceAuthorityConcurrentReplayIsOneIntent(t *testing.T) {
+	if postgresTestDSN() == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN/PRIMARY_DB is not set")
+	}
+	pool, orgID := openInboundOnlyPG(t)
+	t.Cleanup(pool.Close)
+	netNewPGCleanup(t, pool, orgID)
+
+	svc := netNewAuthorityPGService(t, pool)
+	logicalID := "nnhr-authority-conc-" + uuid.NewString()[:8]
+	body := marshalNetNew(t, governanceNetNewMap(logicalID))
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	const workers = 24
+	var wg sync.WaitGroup
+	errs := make(chan error, workers)
+	start := make(chan struct{})
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			<-start
+			res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now)
+			if xerr != nil {
+				errs <- fmt.Errorf("worker %d: %v", i, xerr)
+				return
+			}
+			if res.Outcome != NetNewInboundOutcomeAccepted && res.Outcome != NetNewInboundOutcomeUnknown {
+				errs <- fmt.Errorf("worker %d: outcome=%s reason=%s", i, res.Outcome, res.Reason)
+			}
+		}(i)
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Error(err)
+	}
+
+	// A racing loser may leave the receipt short of a commercial action; a
+	// later replay must finish it. This is the fail-closed direction: retry,
+	// never a duplicate.
+	final, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now.Add(time.Minute))
+	if xerr != nil {
+		t.Fatalf("settling replay: %v", xerr)
+	}
+	if final.Outcome != NetNewInboundOutcomeAccepted || final.ActionID == nil {
+		t.Fatalf("settling replay did not converge: %+v", final)
+	}
+
+	leads, accounts, actions, _ := netNewOrgRowCounts(t, pool, orgID)
+	if leads != 1 || accounts != 1 || actions != 1 {
+		t.Fatalf("%d concurrent replays produced leads=%d accounts=%d actions=%d, want 1/1/1",
+			workers, leads, accounts, actions)
+	}
+	t.Logf("CONCURRENT_REPLAY_%d receipts=%d accounts=%d actions=%d", workers, leads, accounts, actions)
+}
+
+// TestPGDifferentPayloadUnderSameLogicalIDDoesNotInheritAcceptance is the
+// adversarial idempotency probe. A SECOND, materially different payload sent
+// under the same logical_id must not be handed the first payload's ACCEPTED
+// decision. Material that production authority would reject must never receive
+// an acceptance receipt just because a prior request reused the key.
+func TestPGDifferentPayloadUnderSameLogicalIDDoesNotInheritAcceptance(t *testing.T) {
+	if postgresTestDSN() == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN/PRIMARY_DB is not set")
+	}
+	pool, orgID := openInboundOnlyPG(t)
+	t.Cleanup(pool.Close)
+	netNewPGCleanup(t, pool, orgID)
+
+	svc := netNewAuthorityPGService(t, pool)
+	logicalID := "nnhr-authority-conflict-" + uuid.NewString()[:8]
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	good, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID,
+		marshalNetNew(t, governanceNetNewMap(logicalID)), now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if good.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("baseline not accepted: %+v", good)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		mutate func(map[string]any)
+	}{
+		{"unpinned_content_hash", func(m map[string]any) {
+			m["content_hash"] = "sha256:" + NetNewInboundPinnedHash
+			m["schema_hash"] = "sha256:" + NetNewInboundPinnedHash
+			m["policy_hash"] = "sha256:" + NetNewInboundPinnedHash
+		}},
+		{"conflict_decline", func(m map[string]any) {
+			m["conflict"] = map[string]any{"status": "DECLINE", "ref": "conflict:declined"}
+		}},
+		{"consent_withdrawn", func(m map[string]any) {
+			m["consent"] = map[string]any{"granted": false}
+		}},
+		{"foreign_contract_id", func(m map[string]any) {
+			m["contract_id"] = "SOME_OTHER_AUTHORITY"
+			m["policy_id"] = "SOME_OTHER_AUTHORITY"
+			m["schema"] = "SOME_OTHER_AUTHORITY/9.9.9"
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := governanceNetNewMap(logicalID)
+			tc.mutate(m)
+			res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, marshalNetNew(t, m), now.Add(time.Minute))
+			if xerr != nil {
+				t.Fatalf("mutated ingest: %v", xerr)
+			}
+			if res.Outcome == NetNewInboundOutcomeAccepted {
+				t.Fatalf("ADMISSION BYPASS: rejectable payload (%s) inherited ACCEPTED under a reused logical_id: %+v",
+					tc.name, res)
+			}
+			if res.Reason != NetNewInboundReasonKeyConflict {
+				t.Fatalf("%s: reason=%s want %s", tc.name, res.Reason, NetNewInboundReasonKeyConflict)
+			}
+			if res.MeetcfgHandoff {
+				t.Fatalf("%s: conflicted payload was cleared for meetcfg handoff", tc.name)
+			}
+
+			// The stored receipt must be untouched: the original decision
+			// stands, and the colliding payload creates nothing.
+			rb, rerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), orgID, logicalID)
+			if rerr != nil {
+				t.Fatalf("%s: readback: %v", tc.name, rerr)
+			}
+			if rb.Outcome != NetNewInboundOutcomeAccepted || rb.Receipt != good.Receipt {
+				t.Fatalf("%s: stored receipt was mutated by a conflicting payload: %+v", tc.name, rb)
+			}
+			if leads, accounts, actions, _ := netNewOrgRowCounts(t, pool, orgID); leads != 1 || accounts != 1 || actions != 1 {
+				t.Fatalf("%s: conflicting payload wrote rows: leads=%d accounts=%d actions=%d",
+					tc.name, leads, accounts, actions)
+			}
+		})
+	}
+
+	// A byte-different but logically identical re-send (different JSON key
+	// order, cosmetic-only field change) must still replay, not conflict.
+	same := governanceNetNewMap(logicalID)
+	same["why_now"] = "requested a technical readiness assessment from the public form"
+	same["correlation_id"] = "corr-" + logicalID
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, marshalNetNew(t, same), now.Add(2*time.Minute))
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted || !res.Replay {
+		t.Fatalf("logically identical re-send did not replay: %+v", res)
+	}
+}
+
+// TestPGConflictGuardHoldsOnIncompleteReceipt closes the path this branch was
+// built for: a receipt persisted but left INCOMPLETE because the downstream
+// commercial write failed, which a later replay is meant to finish. A mutated
+// payload must not be the thing that finishes it -- otherwise an attacker's
+// material completes a receipt under the original request's identity.
+func TestPGConflictGuardHoldsOnIncompleteReceipt(t *testing.T) {
+	if postgresTestDSN() == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN/PRIMARY_DB is not set")
+	}
+	pool, orgID := openInboundOnlyPG(t)
+	t.Cleanup(pool.Close)
+	netNewPGCleanup(t, pool, orgID)
+
+	svc := netNewAuthorityPGService(t, pool)
+	logicalID := "nnhr-authority-incomplete-" + uuid.NewString()[:8]
+	body := marshalNetNew(t, governanceNetNewMap(logicalID))
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+
+	// Force the receipt to persist while the downstream effect fails.
+	svc.netNewAfterPersist = func(*models.OutreachInboundLead) error {
+		return errors.New("downstream unavailable")
+	}
+	first, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if first.Outcome == NetNewInboundOutcomeAccepted {
+		t.Fatalf("expected a non-accepted, retryable receipt: %+v", first)
+	}
+	if leads, _, actions, _ := netNewOrgRowCounts(t, pool, orgID); leads != 1 || actions != 0 {
+		t.Fatalf("incomplete state not as expected: leads=%d actions=%d", leads, actions)
+	}
+	svc.netNewAfterPersist = nil
+
+	// A mutated payload must NOT be allowed to complete the incomplete receipt.
+	mutated := governanceNetNewMap(logicalID)
+	mutated["conflict"] = map[string]any{"status": "DECLINE", "ref": "conflict:declined"}
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, marshalNetNew(t, mutated), now.Add(time.Minute))
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome == NetNewInboundOutcomeAccepted {
+		t.Fatalf("ADMISSION BYPASS: mutated payload completed an incomplete receipt: %+v", res)
+	}
+	if res.Reason != NetNewInboundReasonKeyConflict {
+		t.Fatalf("incomplete-row conflict reason=%s want %s", res.Reason, NetNewInboundReasonKeyConflict)
+	}
+	if _, _, actions, _ := netNewOrgRowCounts(t, pool, orgID); actions != 0 {
+		t.Fatalf("mutated payload filed %d commercial actions against an incomplete receipt", actions)
+	}
+
+	// The ORIGINAL material must still be able to finish the receipt: the
+	// guard blocks conflicting material, it does not break legitimate retry.
+	settled, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now.Add(2*time.Minute))
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if settled.Outcome != NetNewInboundOutcomeAccepted || settled.ActionID == nil {
+		t.Fatalf("legitimate retry could not finish the receipt: %+v", settled)
+	}
+	leads, accounts, actions, _ := netNewOrgRowCounts(t, pool, orgID)
+	if leads != 1 || accounts != 1 || actions != 1 {
+		t.Fatalf("after settle: leads=%d accounts=%d actions=%d, want 1/1/1", leads, accounts, actions)
+	}
+	t.Logf("INCOMPLETE_RECEIPT_GUARD conflict_blocked=1 legit_retry_completed=1 leads=%d accounts=%d actions=%d",
+		leads, accounts, actions)
+}

--- a/internal/app/confenge/net_new_inbound_ingest.go
+++ b/internal/app/confenge/net_new_inbound_ingest.go
@@ -128,15 +128,14 @@ func (s *service) IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.
 
 	admitted, xerr := s.admitNetNewHandraiser(ctx, orgID, env, now)
 	if xerr != nil {
-		row.EnrichmentStatus = models.InboundEnrichmentFailed
-		row.NextAction = models.InboundNextNeedsEnrichment
-		row.Status = models.InboundStatusOpen
-		row.Warnings = appendUnique(row.Warnings, firstNonEmpty(xerr.Identifier, NetNewInboundReasonDownstream))
-		setNetNewProvenance(row, env, NetNewInboundOutcomeUnknown, firstNonEmpty(xerr.Identifier, NetNewInboundReasonDownstream), now)
+		if id := strings.TrimSpace(xerr.Identifier); id != "" && id != NetNewInboundReasonDownstream {
+			row.Warnings = appendUnique(row.Warnings, id)
+		}
+		markNetNewDownstreamUnavailable(row, env, NetNewInboundReasonDownstream, now)
 		_ = st.UpdateInboundLead(ctx, row)
 		res := netNewResultFromLead(row, replay)
 		res.Outcome = NetNewInboundOutcomeUnknown
-		res.Reason = firstNonEmpty(xerr.Identifier, NetNewInboundReasonDownstream)
+		res.Reason = NetNewInboundReasonDownstream
 		s.observeNetNewMetric(res)
 		return res, nil
 	}
@@ -164,16 +163,16 @@ func (s *service) IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.
 		}
 		action, persistErr := s.PersistHandRaise(ctx, raise)
 		if persistErr != nil || action == nil {
-			reason := NetNewInboundReasonDownstream
-			if persistErr != nil && persistErr.Identifier != "" {
-				reason = persistErr.Identifier
+			if persistErr != nil {
+				if id := strings.TrimSpace(persistErr.Identifier); id != "" && id != NetNewInboundReasonDownstream {
+					row.Warnings = appendUnique(row.Warnings, id)
+				}
 			}
-			setNetNewProvenance(row, env, NetNewInboundOutcomeUnknown, reason, now)
-			row.Warnings = appendUnique(row.Warnings, reason)
+			markNetNewDownstreamUnavailable(row, env, NetNewInboundReasonDownstream, now)
 			_ = st.UpdateInboundLead(ctx, row)
 			res := netNewResultFromLead(row, replay)
 			res.Outcome = NetNewInboundOutcomeUnknown
-			res.Reason = reason
+			res.Reason = NetNewInboundReasonDownstream
 			if admitted.Account != nil {
 				res.AccountID = &admitted.Account.ID
 				res.Reconciled = admitted.Reused
@@ -232,7 +231,9 @@ func (s *service) ReadbackNetNewInboundHandraiser(ctx context.Context, orgID uui
 	res := netNewResultFromLead(row, false)
 	if !netNewReceiptComplete(row) {
 		res.Outcome = NetNewInboundOutcomeUnknown
-		res.Reason = NetNewInboundReasonStale
+		if !netNewDownstreamRetryable(row) {
+			res.Reason = NetNewInboundReasonStale
+		}
 	}
 	if ast := s.alertStore(); ast != nil {
 		if alert, aerr := ast.GetOperatorAlertByLead(ctx, orgID, logicalID); aerr == nil && alert != nil {
@@ -448,12 +449,49 @@ func setNetNewProvenance(row *models.OutreachInboundLead, env NetNewInboundEnvel
 	}
 }
 
+func markNetNewDownstreamUnavailable(row *models.OutreachInboundLead, env NetNewInboundEnvelope, reason string, now time.Time) {
+	if row == nil {
+		return
+	}
+	if strings.TrimSpace(reason) == "" {
+		reason = NetNewInboundReasonDownstream
+	}
+	// Leave enrichment and next-action unset so a later replay can finish.
+	row.EnrichmentStatus = models.InboundEnrichmentUnknown
+	row.NextAction = ""
+	row.Status = models.InboundStatusOpen
+	row.UpdatedAt = now
+	row.Warnings = appendUnique(row.Warnings, reason)
+	setNetNewProvenance(row, env, NetNewInboundOutcomeUnknown, reason, now)
+}
+
+func netNewDownstreamRetryable(row *models.OutreachInboundLead) bool {
+	if row == nil {
+		return false
+	}
+	reason := firstNonEmpty(provenanceValue(row.Provenance, netNewProvReason), row.SuppressReason)
+	switch reason {
+	case NetNewInboundReasonDownstream, NetNewInboundReasonStoreUnavailable, NetNewInboundReasonStale:
+		return true
+	}
+	if provenanceValue(row.Provenance, netNewProvOutcome) == NetNewInboundOutcomeAccepted && row.ActionID == nil {
+		return true
+	}
+	return false
+}
+
 func netNewReceiptComplete(row *models.OutreachInboundLead) bool {
 	if row == nil {
 		return false
 	}
-	if outcome := provenanceValue(row.Provenance, netNewProvOutcome); outcome == NetNewInboundOutcomeAccepted ||
-		outcome == NetNewInboundOutcomeRejected || outcome == NetNewInboundOutcomeUnknown {
+	if netNewDownstreamRetryable(row) {
+		return false
+	}
+	outcome := provenanceValue(row.Provenance, netNewProvOutcome)
+	switch outcome {
+	case NetNewInboundOutcomeAccepted:
+		return row.ActionID != nil
+	case NetNewInboundOutcomeRejected, NetNewInboundOutcomeUnknown:
 		return true
 	}
 	return inboundReceiptComplete(row)

--- a/internal/app/confenge/net_new_inbound_ingest.go
+++ b/internal/app/confenge/net_new_inbound_ingest.go
@@ -79,7 +79,9 @@ func (s *service) IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.
 		return res, nil
 	}
 	logicalID := netNewLogicalID(env)
-	decision := DecideNetNewInbound(env, s.activeRev02Pin())
+	pin := s.activeAuthorityPin()
+	pinHash := normalizeContentHash(pin.ContentHash)
+	decision := DecideNetNewInbound(env, pin)
 	if logicalID == "" {
 		res := rejectedNetNew("", firstNonEmpty(decision.Reason, NetNewInboundReasonLogicalID), now)
 		res.Outcome = NetNewInboundOutcomeRejected
@@ -93,13 +95,24 @@ func (s *service) IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.
 			"inbound lead store unavailable")
 	}
 
-	row := netNewReceiptRow(orgID, env, raw, now)
+	row := netNewReceiptRow(orgID, env, raw, pinHash, now)
 	created, existing, insertErr := st.InsertInboundLead(ctx, row)
 	if insertErr != nil {
 		return nil, errx.New(errx.Internal, "persist inbound receipt: "+insertErr.Error())
 	}
 	replay := false
 	if !created && existing != nil {
+		// A reused logical_id must carry the same admission material. If it
+		// does not, the stored decision was earned by a different payload and
+		// must never be handed to this one: fail closed, leave the stored
+		// receipt untouched, and make the caller resolve the collision.
+		if stored := provenanceValue(existing.Provenance, netNewProvDigest); stored != "" && stored != NetNewAdmissionDigest(env) {
+			res := rejectedNetNew(logicalID, NetNewInboundReasonKeyConflict, now)
+			res.Receipt = existing.ReceiptID
+			res.CorrelationID = existing.CorrelationID
+			s.observeNetNewMetric(res)
+			return res, nil
+		}
 		if netNewReceiptComplete(existing) {
 			res := netNewResultFromLead(existing, true)
 			s.observeNetNewMetric(res)
@@ -118,7 +131,7 @@ func (s *service) IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.
 		}
 	}
 
-	applyNetNewDecision(row, env, decision, now)
+	applyNetNewDecision(row, env, decision, pinHash, now)
 	if decision.Outcome != NetNewInboundOutcomeAccepted {
 		_ = st.UpdateInboundLead(ctx, row)
 		res := netNewResultFromLead(row, replay)
@@ -131,7 +144,7 @@ func (s *service) IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.
 		if id := strings.TrimSpace(xerr.Identifier); id != "" && id != NetNewInboundReasonDownstream {
 			row.Warnings = appendUnique(row.Warnings, id)
 		}
-		markNetNewDownstreamUnavailable(row, env, NetNewInboundReasonDownstream, now)
+		markNetNewDownstreamUnavailable(row, env, NetNewInboundReasonDownstream, pinHash, now)
 		_ = st.UpdateInboundLead(ctx, row)
 		res := netNewResultFromLead(row, replay)
 		res.Outcome = NetNewInboundOutcomeUnknown
@@ -168,7 +181,7 @@ func (s *service) IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.
 					row.Warnings = appendUnique(row.Warnings, id)
 				}
 			}
-			markNetNewDownstreamUnavailable(row, env, NetNewInboundReasonDownstream, now)
+			markNetNewDownstreamUnavailable(row, env, NetNewInboundReasonDownstream, pinHash, now)
 			_ = st.UpdateInboundLead(ctx, row)
 			res := netNewResultFromLead(row, replay)
 			res.Outcome = NetNewInboundOutcomeUnknown
@@ -304,7 +317,7 @@ func filterEmpty(in []string) []string {
 	return out
 }
 
-func netNewReceiptRow(orgID uuid.UUID, env NetNewInboundEnvelope, raw []byte, now time.Time) *models.OutreachInboundLead {
+func netNewReceiptRow(orgID uuid.UUID, env NetNewInboundEnvelope, raw []byte, pinHash string, now time.Time) *models.OutreachInboundLead {
 	logicalID := netNewLogicalID(env)
 	payload := raw
 	if env.SensitiveData {
@@ -356,7 +369,7 @@ func netNewReceiptRow(orgID uuid.UUID, env NetNewInboundEnvelope, raw []byte, no
 	}
 	t := now
 	row.OwnerAssignedAt = &t
-	setNetNewProvenance(row, env, "", "", now)
+	setNetNewProvenance(row, env, "", "", pinHash, now)
 	return row
 }
 
@@ -380,11 +393,11 @@ func netNewUTM(env NetNewInboundEnvelope) []byte {
 	return raw
 }
 
-func applyNetNewDecision(row *models.OutreachInboundLead, env NetNewInboundEnvelope, decision NetNewInboundDecision, now time.Time) {
+func applyNetNewDecision(row *models.OutreachInboundLead, env NetNewInboundEnvelope, decision NetNewInboundDecision, pinHash string, now time.Time) {
 	if row == nil {
 		return
 	}
-	setNetNewProvenance(row, env, decision.Outcome, decision.Reason, now)
+	setNetNewProvenance(row, env, decision.Outcome, decision.Reason, pinHash, now)
 	row.UpdatedAt = now
 	switch decision.Outcome {
 	case NetNewInboundOutcomeAccepted:
@@ -406,7 +419,10 @@ func applyNetNewDecision(row *models.OutreachInboundLead, env NetNewInboundEnvel
 	}
 }
 
-func setNetNewProvenance(row *models.OutreachInboundLead, env NetNewInboundEnvelope, outcome, reason string, now time.Time) {
+// setNetNewProvenance records the authority the decision was actually made
+// against. pinHash is the admitted pin's content hash (the Governance
+// policy_hash), never this repository's local drift digest.
+func setNetNewProvenance(row *models.OutreachInboundLead, env NetNewInboundEnvelope, outcome, reason, pinHash string, now time.Time) {
 	if row == nil {
 		return
 	}
@@ -414,7 +430,8 @@ func setNetNewProvenance(row *models.OutreachInboundLead, env NetNewInboundEnvel
 		netNewProvPolicy + NetNewInboundHandraiserSchema,
 		netNewProvIntake + NetNewInboundIntakeSchema,
 		netNewProvState + NetNewInboundStateSchema,
-		netNewProvHash + NetNewInboundPinnedHash,
+		netNewProvHash + normalizeContentHash(pinHash),
+		netNewProvDigest + NetNewAdmissionDigest(env),
 		netNewProvAckBy + NetNewInboundAckActor,
 		netNewProvAckAt + now.UTC().Format(time.RFC3339),
 	}
@@ -449,7 +466,7 @@ func setNetNewProvenance(row *models.OutreachInboundLead, env NetNewInboundEnvel
 	}
 }
 
-func markNetNewDownstreamUnavailable(row *models.OutreachInboundLead, env NetNewInboundEnvelope, reason string, now time.Time) {
+func markNetNewDownstreamUnavailable(row *models.OutreachInboundLead, env NetNewInboundEnvelope, reason, pinHash string, now time.Time) {
 	if row == nil {
 		return
 	}
@@ -462,7 +479,7 @@ func markNetNewDownstreamUnavailable(row *models.OutreachInboundLead, env NetNew
 	row.Status = models.InboundStatusOpen
 	row.UpdatedAt = now
 	row.Warnings = appendUnique(row.Warnings, reason)
-	setNetNewProvenance(row, env, NetNewInboundOutcomeUnknown, reason, now)
+	setNetNewProvenance(row, env, NetNewInboundOutcomeUnknown, reason, pinHash, now)
 }
 
 func netNewDownstreamRetryable(row *models.OutreachInboundLead) bool {
@@ -522,7 +539,7 @@ func netNewResultFromLead(row *models.OutreachInboundLead, replay bool) *NetNewI
 	res := &NetNewInboundResult{
 		Schema:            NetNewInboundHandraiserSchema,
 		PolicyVersion:     firstNonEmpty(provenanceValue(row.Provenance, netNewProvPolicy), NetNewInboundHandraiserSchema),
-		Hash:              firstNonEmpty(provenanceValue(row.Provenance, netNewProvHash), NetNewInboundPinnedHash),
+		Hash:              provenanceValue(row.Provenance, netNewProvHash),
 		IntakeSchema:      firstNonEmpty(provenanceValue(row.Provenance, netNewProvIntake), NetNewInboundIntakeSchema),
 		StateSchema:       firstNonEmpty(provenanceValue(row.Provenance, netNewProvState), NetNewInboundStateSchema),
 		LogicalID:         row.LeadID,

--- a/internal/app/confenge/net_new_inbound_ingest.go
+++ b/internal/app/confenge/net_new_inbound_ingest.go
@@ -1,0 +1,579 @@
+package confenge
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/errx"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+// NetNewInboundResult is one persist-first consume. HTTP 2xx is not acceptance;
+// Outcome is. Readback of LogicalID is the proof.
+type NetNewInboundResult struct {
+	Schema            string     `json:"schema"`
+	PolicyVersion     string     `json:"policy_version"`
+	Hash              string     `json:"hash,omitempty"`
+	IntakeSchema      string     `json:"intake_schema,omitempty"`
+	StateSchema       string     `json:"state_schema,omitempty"`
+	LogicalID         string     `json:"logical_id"`
+	Receipt           string     `json:"receipt"`
+	CorrelationID     string     `json:"correlation_id,omitempty"`
+	Outcome           string     `json:"outcome"`
+	Reason            string     `json:"reason,omitempty"`
+	Nucleus           string     `json:"nucleus,omitempty"`
+	OfferCandidate    string     `json:"offer_candidate,omitempty"`
+	SourceAsset       string     `json:"source_asset,omitempty"`
+	CityClass         string     `json:"city_class,omitempty"`
+	Urgency           string     `json:"urgency,omitempty"`
+	WhyNow            string     `json:"why_now,omitempty"`
+	ConflictRef       string     `json:"conflict_ref,omitempty"`
+	InboundOnly       bool       `json:"inbound_only"`
+	OutboundEligible  bool       `json:"outbound_eligible"`
+	AutoSend          bool       `json:"auto_send"`
+	DispatchAttempted bool       `json:"dispatch_attempted"`
+	MeetcfgHandoff    bool       `json:"meetcfg_handoff_allowed"`
+	Replay            bool       `json:"replay"`
+	AcknowledgedBy    string     `json:"acknowledged_by,omitempty"`
+	AcknowledgedAt    *time.Time `json:"acknowledged_at,omitempty"`
+	AccountID         *uuid.UUID `json:"account_id,omitempty"`
+	ActionID          *uuid.UUID `json:"action_id,omitempty"`
+	CanonicalEntityID string     `json:"canonical_entity_id,omitempty"`
+	Reconciled        bool       `json:"reconciled,omitempty"`
+}
+
+// NetNewInboundReadback is the same logical ID after persist.
+type NetNewInboundReadback struct {
+	NetNewInboundResult
+}
+
+// NetNewInboundMetric is PII-free: nucleus, state, reason only.
+type NetNewInboundMetric struct {
+	Nucleus string `json:"nucleus"`
+	State   string `json:"state"`
+	Reason  string `json:"reason,omitempty"`
+}
+
+// IngestNetNewInboundHandraiser persists the receipt before any commercial
+// effect. Unknown or unpinned schema is never ACCEPTED.
+func (s *service) IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.UUID, raw []byte, now time.Time) (*NetNewInboundResult, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	if orgID == uuid.Nil {
+		return nil, errx.New(errx.ServiceUnavailable, "inbound org is not configured")
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	now = now.UTC()
+	env, err := ParseNetNewInboundEnvelope(raw)
+	if err != nil {
+		res := rejectedNetNew("", NetNewInboundReasonSchemaMismatch, now)
+		s.observeNetNewMetric(res)
+		return res, nil
+	}
+	logicalID := netNewLogicalID(env)
+	decision := DecideNetNewInbound(env, s.activeRev02Pin())
+	if logicalID == "" {
+		res := rejectedNetNew("", firstNonEmpty(decision.Reason, NetNewInboundReasonLogicalID), now)
+		res.Outcome = NetNewInboundOutcomeRejected
+		s.observeNetNewMetric(res)
+		return res, nil
+	}
+
+	st := s.inboundStore()
+	if st == nil {
+		return nil, errx.NewWithIdentifier(errx.ServiceUnavailable, NetNewInboundReasonStoreUnavailable,
+			"inbound lead store unavailable")
+	}
+
+	row := netNewReceiptRow(orgID, env, raw, now)
+	created, existing, insertErr := st.InsertInboundLead(ctx, row)
+	if insertErr != nil {
+		return nil, errx.New(errx.Internal, "persist inbound receipt: "+insertErr.Error())
+	}
+	replay := false
+	if !created && existing != nil {
+		if netNewReceiptComplete(existing) {
+			res := netNewResultFromLead(existing, true)
+			s.observeNetNewMetric(res)
+			return res, nil
+		}
+		row = existing
+		replay = true
+	}
+	if s.netNewAfterPersist != nil {
+		if hookErr := s.netNewAfterPersist(row); hookErr != nil {
+			res := netNewResultFromLead(row, replay)
+			res.Outcome = NetNewInboundOutcomeUnknown
+			res.Reason = NetNewInboundReasonDownstream
+			s.observeNetNewMetric(res)
+			return res, nil
+		}
+	}
+
+	applyNetNewDecision(row, env, decision, now)
+	if decision.Outcome != NetNewInboundOutcomeAccepted {
+		_ = st.UpdateInboundLead(ctx, row)
+		res := netNewResultFromLead(row, replay)
+		s.observeNetNewMetric(res)
+		return res, nil
+	}
+
+	admitted, xerr := s.admitNetNewHandraiser(ctx, orgID, env, now)
+	if xerr != nil {
+		row.EnrichmentStatus = models.InboundEnrichmentFailed
+		row.NextAction = models.InboundNextNeedsEnrichment
+		row.Status = models.InboundStatusOpen
+		row.Warnings = appendUnique(row.Warnings, firstNonEmpty(xerr.Identifier, NetNewInboundReasonDownstream))
+		setNetNewProvenance(row, env, NetNewInboundOutcomeUnknown, firstNonEmpty(xerr.Identifier, NetNewInboundReasonDownstream), now)
+		_ = st.UpdateInboundLead(ctx, row)
+		res := netNewResultFromLead(row, replay)
+		res.Outcome = NetNewInboundOutcomeUnknown
+		res.Reason = firstNonEmpty(xerr.Identifier, NetNewInboundReasonDownstream)
+		s.observeNetNewMetric(res)
+		return res, nil
+	}
+	if admitted != nil && admitted.Account != nil {
+		id := admitted.Account.ID
+		row.AccountID = &id
+		if admitted.Candidate != nil {
+			cid := admitted.Candidate.ID
+			row.CandidateID = &cid
+		}
+		raise := HandRaise{
+			OrganizationID: orgID, AccountID: admitted.Account.ID,
+			Signal: SignalRequestHumanReview, EngineLane: EngineLaneConfengeWeb, OccurredAt: now,
+			SubjectKey:  "company:" + firstNonEmpty(SanitizeText(env.Company.Name, 120), logicalID),
+			Evidence:    SanitizeText(env.WhyNow, 500),
+			PersonName:  SanitizeText(env.Person.Name, 120),
+			Origin:      EngineLaneConfengeWeb,
+			Receipt:     row.ReceiptID,
+			Context:     netNewContext(env),
+			InboundOnly: true,
+		}
+		if admitted.Candidate != nil {
+			cid := admitted.Candidate.ID
+			raise.CandidateID = &cid
+		}
+		action, persistErr := s.PersistHandRaise(ctx, raise)
+		if persistErr != nil || action == nil {
+			reason := NetNewInboundReasonDownstream
+			if persistErr != nil && persistErr.Identifier != "" {
+				reason = persistErr.Identifier
+			}
+			setNetNewProvenance(row, env, NetNewInboundOutcomeUnknown, reason, now)
+			row.Warnings = appendUnique(row.Warnings, reason)
+			_ = st.UpdateInboundLead(ctx, row)
+			res := netNewResultFromLead(row, replay)
+			res.Outcome = NetNewInboundOutcomeUnknown
+			res.Reason = reason
+			if admitted.Account != nil {
+				res.AccountID = &admitted.Account.ID
+				res.Reconciled = admitted.Reused
+			}
+			s.observeNetNewMetric(res)
+			return res, nil
+		}
+		aid := action.ID
+		row.ActionID = &aid
+		row.NextAction = models.InboundNextManualOutreach
+		row.Channel = "human_review"
+		row.WhyNow = SanitizeText(env.WhyNow, 500)
+	}
+
+	row.UpdatedAt = now
+	if err := st.UpdateInboundLead(ctx, row); err != nil {
+		return nil, errx.New(errx.Internal, "update inbound lead: "+err.Error())
+	}
+	s.ensureOperatorAlert(ctx, orgID, row, now)
+	res := netNewResultFromLead(row, replay)
+	if admitted != nil {
+		res.Reconciled = admitted.Reused
+		res.CanonicalEntityID = netNewCanonicalEntityID(env)
+		res.InboundOnly = true
+		res.OutboundEligible = false
+		if admitted.Account != nil {
+			res.OutboundEligible = accountOutboundEligible(admitted.Account)
+			res.InboundOnly = models.AccountIsInboundOnly(admitted.Account) || admitted.InboundOnly
+		}
+	}
+	s.observeNetNewMetric(res)
+	return res, nil
+}
+
+// ReadbackNetNewInboundHandraiser returns the persisted receipt for one logical ID.
+func (s *service) ReadbackNetNewInboundHandraiser(ctx context.Context, orgID uuid.UUID, logicalID string) (*NetNewInboundReadback, *errx.Error) {
+	if xerr := s.requireEnabled(); xerr != nil {
+		return nil, xerr
+	}
+	logicalID = SanitizeText(logicalID, 160)
+	if logicalID == "" {
+		return nil, errx.NewWithIdentifier(errx.BadRequest, NetNewInboundReasonLogicalID, "logical_id is required")
+	}
+	st := s.inboundStore()
+	if st == nil {
+		return nil, errx.NewWithIdentifier(errx.ServiceUnavailable, NetNewInboundReasonStoreUnavailable,
+			"inbound lead store unavailable")
+	}
+	row, err := st.GetInboundLeadByLeadID(ctx, orgID, logicalID)
+	if err != nil {
+		return nil, errx.New(errx.Internal, "read inbound receipt: "+err.Error())
+	}
+	if row == nil {
+		return nil, errx.New(errx.NotFound, "inbound hand-raiser receipt not found")
+	}
+	res := netNewResultFromLead(row, false)
+	if !netNewReceiptComplete(row) {
+		res.Outcome = NetNewInboundOutcomeUnknown
+		res.Reason = NetNewInboundReasonStale
+	}
+	if ast := s.alertStore(); ast != nil {
+		if alert, aerr := ast.GetOperatorAlertByLead(ctx, orgID, logicalID); aerr == nil && alert != nil {
+			if strings.TrimSpace(alert.AcknowledgedBy) != "" {
+				res.AcknowledgedBy = alert.AcknowledgedBy
+			}
+			if alert.AcknowledgedAt != nil {
+				res.AcknowledgedAt = alert.AcknowledgedAt
+			}
+		}
+	}
+	return &NetNewInboundReadback{NetNewInboundResult: *res}, nil
+}
+
+func (s *service) admitNetNewHandraiser(ctx context.Context, orgID uuid.UUID, env NetNewInboundEnvelope, now time.Time) (*InboundAdmission, *errx.Error) {
+	logicalID := netNewLogicalID(env)
+	canonical := netNewCanonicalEntityID(env)
+	email := normalizeWebIntentEmail(env.Person.Email)
+	name := firstNonEmpty(SanitizeText(env.Person.Name, 120), SanitizeText(env.Company.Name, 120))
+	contextText := netNewContext(env)
+
+	if canonical != "" {
+		if acc, err := s.repo.GetAccountBySourceLeadID(ctx, orgID, canonical); err != nil {
+			return nil, errx.NewWithIdentifier(errx.Internal, NetNewInboundReasonDownstream,
+				"canonical entity lookup: "+err.Error())
+		} else if acc != nil {
+			out := &InboundAdmission{
+				Account: acc, Origin: EngineLaneConfengeWeb, Lane: EngineLaneConfengeWeb,
+				IntentKind: intelWebIntentHumanReview(), Context: contextText,
+				Receipt: InboundReceiptID(EngineLaneConfengeWeb, intelWebIntentHumanReview(), firstNonEmpty(email, logicalID), canonical),
+				Reused:  true, InboundOnly: models.AccountIsInboundOnly(acc),
+				OutboundEligible: accountOutboundEligible(acc),
+			}
+			if email != "" {
+				created, xerr := s.upsertInboundCandidate(ctx, orgID, acc.ID, email, name, now)
+				if xerr != nil {
+					return nil, xerr
+				}
+				out.Candidate = created
+			}
+			return out, nil
+		}
+	}
+
+	// Never merge on display name. Identity is logical_id (and canonical ID).
+	key := inboundOnlyLeadIDPrefix + "confenge_web:NET_NEW:" + logicalID
+	return s.AdmitInboundOnly(ctx, orgID, EngineLaneConfengeWeb, "NET_NEW_INBOUND_HANDRAISER",
+		firstNonEmpty(email, logicalID+"@inbound.invalid"), name, key, contextText, now)
+}
+
+func intelWebIntentHumanReview() string {
+	return "REQUEST_HUMAN_REVIEW"
+}
+
+func netNewContext(env NetNewInboundEnvelope) string {
+	return SanitizeText(strings.Join(filterEmpty([]string{
+		env.Nucleus, env.OfferCandidate, env.SourceAsset, env.CityClass, env.Urgency, env.WhyNow,
+	}), " "), 500)
+}
+
+func filterEmpty(in []string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if strings.TrimSpace(v) != "" {
+			out = append(out, strings.TrimSpace(v))
+		}
+	}
+	return out
+}
+
+func netNewReceiptRow(orgID uuid.UUID, env NetNewInboundEnvelope, raw []byte, now time.Time) *models.OutreachInboundLead {
+	logicalID := netNewLogicalID(env)
+	payload := raw
+	if env.SensitiveData {
+		redacted, _ := json.Marshal(map[string]any{
+			"redacted": true, "logical_id": logicalID, "schema": NetNewInboundHandraiserSchema,
+		})
+		payload = redacted
+	}
+	if len(payload) == 0 {
+		payload = []byte("{}")
+	}
+	receipt := InboundReceiptID(EngineLaneConfengeWeb, "NET_NEW_INBOUND_HANDRAISER",
+		firstNonEmpty(normalizeWebIntentEmail(env.Person.Email), logicalID), logicalID)
+	row := &models.OutreachInboundLead{
+		ID:                uuid.New(),
+		OrganizationID:    orgID,
+		LeadID:            logicalID,
+		ReceiptID:         receipt,
+		IdentityKey:       inboundIdentityKey("", normalizeWebIntentEmail(env.Person.Email), ""),
+		LeadCreatedAt:     now,
+		WarmblyIngestedAt: now,
+		Source:            NetNewInboundSource,
+		RouteFamily:       "inbound",
+		AssetID:           SanitizeText(firstNonEmpty(env.SourceAsset, NetNewInboundSourceAsset), 120),
+		CTAID:             SanitizeText(env.OfferCandidate, 120),
+		EntityID:          SanitizeText(netNewCanonicalEntityID(env), 120),
+		CompanyName:       SanitizeText(env.Company.Name, 200),
+		LeadName:          SanitizeText(env.Person.Name, 160),
+		LeadEmail:         normalizeWebIntentEmail(env.Person.Email),
+		CorrelationID:     SanitizeText(env.CorrelationID, 160),
+		ConsentJSON:       []byte(`{"granted":true}`),
+		UTMJSON:           netNewUTM(env),
+		RawPayload:        payload,
+		EnrichmentStatus:  models.InboundEnrichmentUnknown,
+		Owner:             NetNewInboundAckActor,
+		Status:            models.InboundStatusOpen,
+		WhyNow:            SanitizeText(env.WhyNow, 500),
+		CreatedAt:         now,
+		UpdatedAt:         now,
+	}
+	if env.SensitiveData {
+		row.LeadName = ""
+		row.LeadEmail = ""
+		row.CompanyName = SanitizeText(env.Company.Name, 200)
+		row.Message = ""
+	}
+	if !env.Consent.Granted {
+		row.ConsentJSON = []byte(`{"granted":false}`)
+	}
+	t := now
+	row.OwnerAssignedAt = &t
+	setNetNewProvenance(row, env, "", "", now)
+	return row
+}
+
+func netNewUTM(env NetNewInboundEnvelope) []byte {
+	m := map[string]string{
+		"nucleus":         SanitizeText(env.Nucleus, 80),
+		"offer_candidate": SanitizeText(firstNonEmpty(env.OfferCandidate, NetNewInboundOfferCandidate), 120),
+		"source_asset":    SanitizeText(firstNonEmpty(env.SourceAsset, NetNewInboundSourceAsset), 120),
+		"city_class":      SanitizeText(env.CityClass, 40),
+		"urgency":         SanitizeText(env.Urgency, 40),
+		"policy":          NetNewInboundHandraiserSchema,
+		"intake_schema":   NetNewInboundIntakeSchema,
+	}
+	if ref := NetNewConflictRef(env.Conflict); ref != "" {
+		m["conflict_ref"] = ref
+	}
+	raw, _ := json.Marshal(m)
+	if len(raw) == 0 {
+		return []byte("{}")
+	}
+	return raw
+}
+
+func applyNetNewDecision(row *models.OutreachInboundLead, env NetNewInboundEnvelope, decision NetNewInboundDecision, now time.Time) {
+	if row == nil {
+		return
+	}
+	setNetNewProvenance(row, env, decision.Outcome, decision.Reason, now)
+	row.UpdatedAt = now
+	switch decision.Outcome {
+	case NetNewInboundOutcomeAccepted:
+		row.EnrichmentStatus = models.InboundEnrichmentCompleted
+		row.Status = models.InboundStatusOpen
+		row.NextAction = models.InboundNextManualOutreach
+		t := now
+		row.EnrichmentCompletedAt = &t
+	case NetNewInboundOutcomeRejected:
+		row.EnrichmentStatus = models.InboundEnrichmentCompleted
+		row.Status = models.InboundStatusSuppressed
+		row.NextAction = models.InboundNextSuppressed
+		row.SuppressReason = decision.Reason
+	default:
+		row.EnrichmentStatus = models.InboundEnrichmentUnknown
+		row.Status = models.InboundStatusOpen
+		row.NextAction = models.InboundNextNeedsEnrichment
+		row.Warnings = appendUnique(row.Warnings, firstNonEmpty(decision.Reason, NetNewInboundOutcomeUnknown))
+	}
+}
+
+func setNetNewProvenance(row *models.OutreachInboundLead, env NetNewInboundEnvelope, outcome, reason string, now time.Time) {
+	if row == nil {
+		return
+	}
+	prov := []string{
+		netNewProvPolicy + NetNewInboundHandraiserSchema,
+		netNewProvIntake + NetNewInboundIntakeSchema,
+		netNewProvState + NetNewInboundStateSchema,
+		netNewProvHash + NetNewInboundPinnedHash,
+		netNewProvAckBy + NetNewInboundAckActor,
+		netNewProvAckAt + now.UTC().Format(time.RFC3339),
+	}
+	if env.Nucleus != "" {
+		prov = append(prov, netNewProvNucleus+SanitizeText(env.Nucleus, 80))
+	}
+	if env.OfferCandidate != "" {
+		prov = append(prov, netNewProvOffer+SanitizeText(env.OfferCandidate, 120))
+	}
+	if env.SourceAsset != "" {
+		prov = append(prov, netNewProvAsset+SanitizeText(env.SourceAsset, 120))
+	}
+	if env.CityClass != "" {
+		prov = append(prov, netNewProvCity+SanitizeText(env.CityClass, 40))
+	}
+	if env.Urgency != "" {
+		prov = append(prov, netNewProvUrgency+SanitizeText(env.Urgency, 40))
+	}
+	if ref := NetNewConflictRef(env.Conflict); ref != "" {
+		prov = append(prov, netNewProvConflict+ref)
+	}
+	if outcome != "" {
+		prov = append(prov, netNewProvOutcome+outcome)
+	}
+	if reason != "" {
+		prov = append(prov, netNewProvReason+reason)
+	}
+	row.Provenance = prov
+	if env.SensitiveData {
+		row.Evidence = []string{NetNewInboundReasonSensitiveRefOnly}
+		row.Message = ""
+	}
+}
+
+func netNewReceiptComplete(row *models.OutreachInboundLead) bool {
+	if row == nil {
+		return false
+	}
+	if outcome := provenanceValue(row.Provenance, netNewProvOutcome); outcome == NetNewInboundOutcomeAccepted ||
+		outcome == NetNewInboundOutcomeRejected || outcome == NetNewInboundOutcomeUnknown {
+		return true
+	}
+	return inboundReceiptComplete(row)
+}
+
+func provenanceValue(items []string, prefix string) string {
+	for _, id := range items {
+		if strings.HasPrefix(id, prefix) {
+			return strings.TrimPrefix(id, prefix)
+		}
+	}
+	return ""
+}
+
+func netNewResultFromLead(row *models.OutreachInboundLead, replay bool) *NetNewInboundResult {
+	if row == nil {
+		return rejectedNetNew("", NetNewInboundOutcomeUnknown, time.Time{})
+	}
+	outcome := firstNonEmpty(provenanceValue(row.Provenance, netNewProvOutcome), NetNewInboundOutcomeUnknown)
+	reason := firstNonEmpty(provenanceValue(row.Provenance, netNewProvReason), row.SuppressReason)
+	ackAt := row.OwnerAssignedAt
+	if ts := provenanceValue(row.Provenance, netNewProvAckAt); ts != "" {
+		if parsed, err := time.Parse(time.RFC3339, ts); err == nil {
+			t := parsed
+			ackAt = &t
+		}
+	}
+	res := &NetNewInboundResult{
+		Schema:            NetNewInboundHandraiserSchema,
+		PolicyVersion:     firstNonEmpty(provenanceValue(row.Provenance, netNewProvPolicy), NetNewInboundHandraiserSchema),
+		Hash:              firstNonEmpty(provenanceValue(row.Provenance, netNewProvHash), NetNewInboundPinnedHash),
+		IntakeSchema:      firstNonEmpty(provenanceValue(row.Provenance, netNewProvIntake), NetNewInboundIntakeSchema),
+		StateSchema:       firstNonEmpty(provenanceValue(row.Provenance, netNewProvState), NetNewInboundStateSchema),
+		LogicalID:         row.LeadID,
+		Receipt:           row.ReceiptID,
+		CorrelationID:     row.CorrelationID,
+		Outcome:           outcome,
+		Reason:            reason,
+		Nucleus:           firstNonEmpty(provenanceValue(row.Provenance, netNewProvNucleus), utmField(row.UTMJSON, "nucleus")),
+		OfferCandidate:    firstNonEmpty(provenanceValue(row.Provenance, netNewProvOffer), utmField(row.UTMJSON, "offer_candidate")),
+		SourceAsset:       firstNonEmpty(provenanceValue(row.Provenance, netNewProvAsset), row.AssetID),
+		CityClass:         firstNonEmpty(provenanceValue(row.Provenance, netNewProvCity), utmField(row.UTMJSON, "city_class")),
+		Urgency:           firstNonEmpty(provenanceValue(row.Provenance, netNewProvUrgency), utmField(row.UTMJSON, "urgency")),
+		WhyNow:            row.WhyNow,
+		ConflictRef:       provenanceValue(row.Provenance, netNewProvConflict),
+		InboundOnly:       true,
+		OutboundEligible:  false,
+		AutoSend:          false,
+		DispatchAttempted: false,
+		MeetcfgHandoff:    MeetcfgHandoffAllowed(outcome),
+		Replay:            replay,
+		AcknowledgedBy:    firstNonEmpty(provenanceValue(row.Provenance, netNewProvAckBy), row.Owner, NetNewInboundAckActor),
+		AcknowledgedAt:    ackAt,
+		AccountID:         row.AccountID,
+		ActionID:          row.ActionID,
+		CanonicalEntityID: row.EntityID,
+	}
+	return res
+}
+
+func rejectedNetNew(logicalID, reason string, now time.Time) *NetNewInboundResult {
+	res := &NetNewInboundResult{
+		Schema:            NetNewInboundHandraiserSchema,
+		PolicyVersion:     NetNewInboundHandraiserSchema,
+		LogicalID:         logicalID,
+		Outcome:           NetNewInboundOutcomeRejected,
+		Reason:            reason,
+		InboundOnly:       false,
+		OutboundEligible:  false,
+		AutoSend:          false,
+		DispatchAttempted: false,
+		MeetcfgHandoff:    false,
+		AcknowledgedBy:    NetNewInboundAckActor,
+	}
+	if !now.IsZero() {
+		t := now.UTC()
+		res.AcknowledgedAt = &t
+	}
+	return res
+}
+
+func (s *service) observeNetNewMetric(res *NetNewInboundResult) {
+	if res == nil {
+		return
+	}
+	metric := NetNewInboundMetric{Nucleus: res.Nucleus, State: res.Outcome, Reason: res.Reason}
+	if s == nil || s.netNewMetricSink == nil {
+		return
+	}
+	func() {
+		defer func() { _ = recover() }()
+		s.netNewMetricSink(metric)
+	}()
+}
+
+// FirstTouchEligibleAccount observes the existing first-touch sendable
+// predicates without changing them. Inbound-only is never eligible.
+func FirstTouchEligibleAccount(acc *models.OutreachAccount) bool {
+	return accountOutboundEligible(acc)
+}
+
+func (s *service) netNewInFirstTouchEligibleSet(ctx context.Context, orgID uuid.UUID, accountID uuid.UUID) bool {
+	if s == nil || s.repo == nil || accountID == uuid.Nil {
+		return false
+	}
+	acc, err := s.repo.GetAccount(ctx, orgID, accountID)
+	if err != nil || acc == nil {
+		return false
+	}
+	if FirstTouchEligibleAccount(acc) {
+		return true
+	}
+	listed, listErr := s.repo.ListAccounts(ctx, orgID, repository.OutreachAccountFilter{Limit: 500})
+	if listErr != nil {
+		return false
+	}
+	for i := range listed {
+		if listed[i].ID == accountID && FirstTouchEligibleAccount(&listed[i]) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/app/confenge/net_new_inbound_pg_test.go
+++ b/internal/app/confenge/net_new_inbound_pg_test.go
@@ -1,0 +1,52 @@
+package confenge
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func TestPGNetNewInboundHandraiserPersistReadback(t *testing.T) {
+	dsn := postgresTestDSN()
+	if dsn == "" {
+		t.Skip("WARMBLY_TEST_POSTGRES_DSN/PRIMARY_DB is not set")
+	}
+	pool, orgID := openInboundOnlyPG(t)
+	t.Cleanup(pool.Close)
+	repo := repository.NewOutreachRepository(pool)
+	svc := NewService(Config{Enabled: true, RequireHumanApproval: true, AutoSendEnabled: false}, repo, nil).(*service)
+	svc.rev02Pin = rev02TestOnlyPin()
+	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	body := marshalNetNew(t, validNetNewMap("nnhr-pg-1"))
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now)
+	if xerr != nil {
+		t.Fatalf("pg ingest: %v", xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted || res.ActionID == nil {
+		t.Fatalf("pg ingest: %+v", res)
+	}
+	rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), orgID, "nnhr-pg-1")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if rb.Receipt != res.Receipt || rb.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("pg readback: %+v", rb)
+	}
+	acc, err := repo.GetAccount(context.Background(), orgID, *res.AccountID)
+	if err != nil || acc == nil {
+		t.Fatalf("account: %v", err)
+	}
+	if !models.AccountIsInboundOnly(acc) || FirstTouchEligibleAccount(acc) {
+		t.Fatal("pg net-new is outbound-eligible")
+	}
+	replay, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now.Add(time.Minute))
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if !replay.Replay || *replay.ActionID != *res.ActionID {
+		t.Fatalf("pg replay: %+v", replay)
+	}
+}

--- a/internal/app/confenge/net_new_inbound_pg_test.go
+++ b/internal/app/confenge/net_new_inbound_pg_test.go
@@ -18,7 +18,7 @@ func TestPGNetNewInboundHandraiserPersistReadback(t *testing.T) {
 	t.Cleanup(pool.Close)
 	repo := repository.NewOutreachRepository(pool)
 	svc := NewService(Config{Enabled: true, RequireHumanApproval: true, AutoSendEnabled: false}, repo, nil).(*service)
-	svc.rev02Pin = rev02TestOnlyPin()
+	svc.authorityPin = testOnlyAuthorityPin()
 	now := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
 	body := marshalNetNew(t, validNetNewMap("nnhr-pg-1"))
 	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), orgID, body, now)

--- a/internal/app/confenge/net_new_inbound_pin.go
+++ b/internal/app/confenge/net_new_inbound_pin.go
@@ -1,0 +1,110 @@
+package confenge
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// Rev02ContractPin is the only admission key for this consume path:
+// contract_id + version + content hash. Fixture schemas are never a
+// runtime fallback. READY requires a final REV-02 SHA in RuntimeRev02Pin.
+type Rev02ContractPin struct {
+	ContractID       string
+	Version          string
+	ContentHash      string
+	SourceSHA        string
+	AcceptedVersions []string
+	TestOnly         bool
+}
+
+// Pinned is true only when contract_id, version, and content hash are all set.
+func (p Rev02ContractPin) Pinned() bool {
+	return strings.TrimSpace(p.ContractID) != "" &&
+		strings.TrimSpace(p.Version) != "" &&
+		strings.TrimSpace(p.ContentHash) != ""
+}
+
+// RuntimeRev02Pin is the production pin. It stays empty until REV-02
+// publishes a final SHA that is recorded here and the suite is re-run.
+// Testdata under testdata/net_new_inbound_handraiser is not consulted.
+func RuntimeRev02Pin() Rev02ContractPin {
+	return Rev02ContractPin{
+		SourceSHA: "",
+		TestOnly:  false,
+	}
+}
+
+func (s *service) activeRev02Pin() Rev02ContractPin {
+	if s != nil && s.rev02Pin.Pinned() {
+		return s.rev02Pin
+	}
+	return RuntimeRev02Pin()
+}
+
+func (p Rev02ContractPin) acceptsVersion(version string) bool {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		return false
+	}
+	if version == strings.TrimSpace(p.Version) {
+		return true
+	}
+	canonical := strings.TrimSpace(p.ContractID) + "/" + strings.TrimSpace(p.Version)
+	if version == canonical {
+		return true
+	}
+	for _, v := range p.AcceptedVersions {
+		if version == strings.TrimSpace(v) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p Rev02ContractPin) acceptsContractID(id string) bool {
+	id = strings.TrimSpace(id)
+	want := strings.TrimSpace(p.ContractID)
+	if id == "" || want == "" {
+		return false
+	}
+	if id == want {
+		return true
+	}
+	if strings.HasPrefix(id, want+"/") {
+		return true
+	}
+	return false
+}
+
+func normalizeContentHash(h string) string {
+	h = strings.TrimSpace(strings.ToLower(h))
+	h = strings.TrimPrefix(h, "sha256:")
+	return h
+}
+
+// NetNewInboundPinMaterial is the canonical multi-vertical pin document.
+// Tests recompute the content hash from this string. RuntimeRev02Pin does
+// not read it; it is not a production fallback.
+func NetNewInboundPinMaterial() string {
+	return strings.Join([]string{
+		NetNewInboundTaxonomySchema,
+		"nuclei=" + strings.Join(NetNewInboundNuclei, ","),
+		NetNewInboundCatalogSchema,
+		NetNewInboundIntakeSchema,
+		NetNewInboundHandraiserSchema,
+		NetNewInboundStateSchema,
+		NetNewInboundMeetcfgSchema,
+		"source=" + NetNewInboundSource,
+		"lane=" + NetNewInboundLane,
+		"asset=" + NetNewInboundSourceAsset,
+		"offer=" + NetNewInboundOfferCandidate,
+		"invariants=outbound_eligible=false,auto_send=false",
+	}, "\n")
+}
+
+// NetNewInboundPinHash is SHA-256 of the pin material (no sha256: prefix).
+func NetNewInboundPinHash() string {
+	sum := sha256.Sum256([]byte(NetNewInboundPinMaterial()))
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/app/confenge/net_new_inbound_pin.go
+++ b/internal/app/confenge/net_new_inbound_pin.go
@@ -6,10 +6,11 @@ import (
 	"strings"
 )
 
-// Rev02ContractPin is the only admission key for this consume path:
-// contract_id + version + content hash. Fixture schemas are never a
-// runtime fallback. READY requires a final REV-02 SHA in RuntimeRev02Pin.
-type Rev02ContractPin struct {
+// InboundAuthorityPin is the only admission key for this consume path:
+// contract_id + version + content hash, as published by the Governance
+// producer. Fixture schemas are never a runtime fallback; READY requires a
+// published authority SHA recorded in RuntimeInboundAuthorityPin.
+type InboundAuthorityPin struct {
 	ContractID       string
 	Version          string
 	ContentHash      string
@@ -19,30 +20,45 @@ type Rev02ContractPin struct {
 }
 
 // Pinned is true only when contract_id, version, and content hash are all set.
-func (p Rev02ContractPin) Pinned() bool {
+func (p InboundAuthorityPin) Pinned() bool {
 	return strings.TrimSpace(p.ContractID) != "" &&
 		strings.TrimSpace(p.Version) != "" &&
 		strings.TrimSpace(p.ContentHash) != ""
 }
 
-// RuntimeRev02Pin is the production pin. It stays empty until REV-02
-// publishes a final SHA that is recorded here and the suite is re-run.
-// Testdata under testdata/net_new_inbound_handraiser is not consulted.
-func RuntimeRev02Pin() Rev02ContractPin {
-	return Rev02ContractPin{
-		SourceSHA: "",
-		TestOnly:  false,
+// GovernanceInboundPolicyHash is the policy_hash published by the Governance
+// producer for NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904, taken from
+// commercial/inbound/CONSUMER-PIN.1.0.0-draft.20260904.md at the merge commit
+// named by GovernanceInboundSourceSHA. It is the authority Warmbly consumes;
+// it is NOT derived from anything in this repository.
+const GovernanceInboundPolicyHash = "984f442690f7c74f309173b31008518631170d63733b5cc04c32abaf88c67e28"
+
+// GovernanceInboundSourceSHA is the Governance merge commit that published the
+// authority above (PR #171 on origin/main).
+const GovernanceInboundSourceSHA = "22ad810a8c1d46d9a787efcfac825d6ba0336bff"
+
+// RuntimeInboundAuthorityPin is the production pin. It names the published
+// Governance authority: contract_id, version, and the producer's policy_hash.
+// Testdata under testdata/net_new_inbound_handraiser is not consulted, and
+// NetNewInboundPinHash (this repo's local drift digest) is never a fallback.
+func RuntimeInboundAuthorityPin() InboundAuthorityPin {
+	return InboundAuthorityPin{
+		ContractID:  NetNewInboundContractID,
+		Version:     NetNewInboundPinVersion,
+		ContentHash: GovernanceInboundPolicyHash,
+		SourceSHA:   GovernanceInboundSourceSHA,
+		TestOnly:    false,
 	}
 }
 
-func (s *service) activeRev02Pin() Rev02ContractPin {
-	if s != nil && s.rev02Pin.Pinned() {
-		return s.rev02Pin
+func (s *service) activeAuthorityPin() InboundAuthorityPin {
+	if s != nil && s.authorityPin.Pinned() {
+		return s.authorityPin
 	}
-	return RuntimeRev02Pin()
+	return RuntimeInboundAuthorityPin()
 }
 
-func (p Rev02ContractPin) acceptsVersion(version string) bool {
+func (p InboundAuthorityPin) acceptsVersion(version string) bool {
 	version = strings.TrimSpace(version)
 	if version == "" {
 		return false
@@ -62,7 +78,7 @@ func (p Rev02ContractPin) acceptsVersion(version string) bool {
 	return false
 }
 
-func (p Rev02ContractPin) acceptsContractID(id string) bool {
+func (p InboundAuthorityPin) acceptsContractID(id string) bool {
 	id = strings.TrimSpace(id)
 	want := strings.TrimSpace(p.ContractID)
 	if id == "" || want == "" {
@@ -84,8 +100,8 @@ func normalizeContentHash(h string) string {
 }
 
 // NetNewInboundPinMaterial is the canonical multi-vertical pin document.
-// Tests recompute the content hash from this string. RuntimeRev02Pin does
-// not read it; it is not a production fallback.
+// Tests recompute the content hash from this string. RuntimeInboundAuthorityPin does
+// not read it; it is not a production fallback and never admits.
 func NetNewInboundPinMaterial() string {
 	return strings.Join([]string{
 		NetNewInboundTaxonomySchema,

--- a/internal/app/confenge/net_new_inbound_pin_test.go
+++ b/internal/app/confenge/net_new_inbound_pin_test.go
@@ -8,11 +8,12 @@ import (
 	"github.com/google/uuid"
 )
 
-// rev02TestOnlyPin is the test-only adapter. It is never a runtime fallback.
-// Production consults RuntimeRev02Pin, which stays unpinned until a final
-// REV-02 SHA is recorded and this suite is re-run.
-func rev02TestOnlyPin() Rev02ContractPin {
-	return Rev02ContractPin{
+// testOnlyAuthorityPin is the test-only adapter, keyed on this repository's
+// LOCAL drift digest. It is never a runtime fallback: production consults
+// RuntimeInboundAuthorityPin, which carries the published Governance
+// policy_hash instead.
+func testOnlyAuthorityPin() InboundAuthorityPin {
+	return InboundAuthorityPin{
 		ContractID:  NetNewInboundContractID,
 		Version:     NetNewInboundPinVersion,
 		ContentHash: NetNewInboundPinnedHash,
@@ -28,27 +29,51 @@ func rev02TestOnlyPin() Rev02ContractPin {
 func netNewTestService(t *testing.T) (*service, *memRepo, uuid.UUID) {
 	t.Helper()
 	svc, repo, org := inboundTestService(t)
-	svc.rev02Pin = rev02TestOnlyPin()
+	svc.authorityPin = testOnlyAuthorityPin()
 	return svc, repo, org
 }
 
-func TestRuntimeRev02PinIsUnpinnedAndNeverAccepts(t *testing.T) {
-	if RuntimeRev02Pin().Pinned() {
-		t.Fatal("runtime pin must stay unpinned until REV-02 final SHA")
+// TestRuntimeAuthorityPinIsTheGovernanceAuthority asserts the production pin
+// names the published Governance authority verbatim, and that a local-fixture
+// envelope (carrying this repo's own drift digest) is still rejected by it.
+// A fixture must never be admissible against production authority.
+func TestRuntimeAuthorityPinIsTheGovernanceAuthority(t *testing.T) {
+	pin := RuntimeInboundAuthorityPin()
+	if !pin.Pinned() || pin.TestOnly {
+		t.Fatalf("production pin must be pinned and not test-only: %+v", pin)
 	}
-	if rev02TestOnlyPin().TestOnly == false || !rev02TestOnlyPin().Pinned() {
-		t.Fatal("test-only adapter must be pinned and marked test-only")
+	if pin.ContractID != NetNewInboundContractID || pin.Version != NetNewInboundPinVersion {
+		t.Fatalf("production pin identity drifted: %+v", pin)
 	}
-	env, err := ParseNetNewInboundEnvelope(marshalNetNew(t, validNetNewMap("nnhr-unpinned-runtime")))
+	if pin.ContentHash != GovernanceInboundPolicyHash {
+		t.Fatalf("production pin hash=%s want the published Governance policy_hash", pin.ContentHash)
+	}
+	if pin.SourceSHA != GovernanceInboundSourceSHA {
+		t.Fatalf("production pin source_sha=%s", pin.SourceSHA)
+	}
+	// The local fixture digest is not the authority, so the fixture envelope
+	// must be rejected on hash mismatch (not admitted, not "unpinned").
+	env, err := ParseNetNewInboundEnvelope(marshalNetNew(t, validNetNewMap("nnhr-fixture-vs-authority")))
 	if err != nil {
 		t.Fatal(err)
 	}
-	d := DecideNetNewInbound(env, RuntimeRev02Pin())
+	d := DecideNetNewInbound(env, pin)
 	if d.Outcome == NetNewInboundOutcomeAccepted {
-		t.Fatal("unpinned runtime pin accepted a fixture envelope")
+		t.Fatal("production authority accepted a local fixture envelope")
 	}
-	if d.Reason != NetNewInboundReasonHashUnpinned {
-		t.Fatalf("unpinned reason=%s", d.Reason)
+	if d.Reason != NetNewInboundReasonHashMismatch {
+		t.Fatalf("fixture-vs-authority reason=%s want %s", d.Reason, NetNewInboundReasonHashMismatch)
+	}
+	// The Governance envelope is the one that admits.
+	genv, err := ParseNetNewInboundEnvelope(marshalNetNew(t, governanceNetNewMap("nnhr-authority-admits")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gd := DecideNetNewInbound(genv, pin); gd.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("published authority envelope not accepted: %+v", gd)
+	}
+	if testOnlyAuthorityPin().TestOnly == false || !testOnlyAuthorityPin().Pinned() {
+		t.Fatal("test-only adapter must be pinned and marked test-only")
 	}
 }
 
@@ -66,7 +91,13 @@ func TestTestOnlyAdapterIsNotProductionAuthority(t *testing.T) {
 	if doc.Authority == "" {
 		t.Fatal("fixture missing authority disclaimer")
 	}
-	if RuntimeRev02Pin().ContentHash != "" {
-		t.Fatal("production pin copied fixture content hash")
+	// Stronger than "production pin is empty": the production pin must not be
+	// this repository's own material digest. Warmbly consumes an authority it
+	// does not compute.
+	if RuntimeInboundAuthorityPin().ContentHash == NetNewInboundPinnedHash {
+		t.Fatal("production pin copied this repo's local drift digest as authority")
+	}
+	if RuntimeInboundAuthorityPin().ContentHash == NetNewInboundPinHash() {
+		t.Fatal("production pin is self-computed, not consumed from Governance")
 	}
 }

--- a/internal/app/confenge/net_new_inbound_pin_test.go
+++ b/internal/app/confenge/net_new_inbound_pin_test.go
@@ -1,0 +1,72 @@
+package confenge
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+// rev02TestOnlyPin is the test-only adapter. It is never a runtime fallback.
+// Production consults RuntimeRev02Pin, which stays unpinned until a final
+// REV-02 SHA is recorded and this suite is re-run.
+func rev02TestOnlyPin() Rev02ContractPin {
+	return Rev02ContractPin{
+		ContractID:  NetNewInboundContractID,
+		Version:     NetNewInboundPinVersion,
+		ContentHash: NetNewInboundPinnedHash,
+		SourceSHA:   "",
+		AcceptedVersions: []string{
+			NetNewInboundPinVersion,
+			NetNewInboundHandraiserSchema,
+		},
+		TestOnly: true,
+	}
+}
+
+func netNewTestService(t *testing.T) (*service, *memRepo, uuid.UUID) {
+	t.Helper()
+	svc, repo, org := inboundTestService(t)
+	svc.rev02Pin = rev02TestOnlyPin()
+	return svc, repo, org
+}
+
+func TestRuntimeRev02PinIsUnpinnedAndNeverAccepts(t *testing.T) {
+	if RuntimeRev02Pin().Pinned() {
+		t.Fatal("runtime pin must stay unpinned until REV-02 final SHA")
+	}
+	if rev02TestOnlyPin().TestOnly == false || !rev02TestOnlyPin().Pinned() {
+		t.Fatal("test-only adapter must be pinned and marked test-only")
+	}
+	env, err := ParseNetNewInboundEnvelope(marshalNetNew(t, validNetNewMap("nnhr-unpinned-runtime")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	d := DecideNetNewInbound(env, RuntimeRev02Pin())
+	if d.Outcome == NetNewInboundOutcomeAccepted {
+		t.Fatal("unpinned runtime pin accepted a fixture envelope")
+	}
+	if d.Reason != NetNewInboundReasonHashUnpinned {
+		t.Fatalf("unpinned reason=%s", d.Reason)
+	}
+}
+
+func TestTestOnlyAdapterIsNotProductionAuthority(t *testing.T) {
+	raw, err := os.ReadFile("testdata/net_new_inbound_handraiser/conformance.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Authority string `json:"authority"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.Authority == "" {
+		t.Fatal("fixture missing authority disclaimer")
+	}
+	if RuntimeRev02Pin().ContentHash != "" {
+		t.Fatal("production pin copied fixture content hash")
+	}
+}

--- a/internal/app/confenge/net_new_inbound_test.go
+++ b/internal/app/confenge/net_new_inbound_test.go
@@ -426,42 +426,92 @@ func TestNetNewSensitiveDataStoresRefsOnly(t *testing.T) {
 }
 
 func TestNetNewDownstreamUnavailableThenReplay(t *testing.T) {
-	svc, _, org := netNewTestService(t)
-	now := *netNewConsentAt()
-	body := marshalNetNew(t, validNetNewMap("nnhr-rollback"))
-	svc.netNewAfterPersist = func(*models.OutreachInboundLead) error { return errors.New("downstream down") }
-	first, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now)
-	if xerr != nil {
-		t.Fatal(xerr)
-	}
-	if first.Outcome != NetNewInboundOutcomeUnknown || first.ActionID != nil {
-		t.Fatalf("downstream failure accepted: %+v", first)
-	}
-	rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), org, "nnhr-rollback")
-	if xerr != nil {
-		t.Fatal(xerr)
-	}
-	if rb.Outcome == NetNewInboundOutcomeAccepted {
-		t.Fatal("stale readback reported ACCEPTED")
-	}
-	if rb.Reason != NetNewInboundReasonStale && rb.Reason != NetNewInboundReasonDownstream {
-		t.Fatalf("stale reason=%s", rb.Reason)
-	}
-	svc.netNewAfterPersist = nil
-	second, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now.Add(time.Minute))
-	if xerr != nil {
-		t.Fatal(xerr)
-	}
-	if second.Outcome != NetNewInboundOutcomeAccepted || second.ActionID == nil {
-		t.Fatalf("replay after rollback: %+v", second)
-	}
-	actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, *second.AccountID, false, 50)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if len(actions) != 1 {
-		t.Fatalf("rollback/replay produced %d actions", len(actions))
-	}
+	t.Run("action store", func(t *testing.T) {
+		svc, repo, org := netNewTestService(t)
+		now := *netNewConsentAt()
+		body := marshalNetNew(t, validNetNewMap("nnhr-rollback-action"))
+		repo.actionUpsertErr = errors.New("commercial action store down")
+		first, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now)
+		if xerr != nil {
+			t.Fatal(xerr)
+		}
+		if first.Outcome != NetNewInboundOutcomeUnknown || first.ActionID != nil {
+			t.Fatalf("action-store failure accepted: %+v", first)
+		}
+		if first.Reason != NetNewInboundReasonDownstream {
+			t.Fatalf("action-store reason=%s", first.Reason)
+		}
+		lead, err := svc.inboundStore().GetInboundLeadByLeadID(context.Background(), org, "nnhr-rollback-action")
+		if err != nil || lead == nil {
+			t.Fatalf("receipt: %v", err)
+		}
+		if netNewReceiptComplete(lead) {
+			t.Fatal("downstream UNKNOWN marked complete; replay would skip PersistHandRaise")
+		}
+		rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), org, "nnhr-rollback-action")
+		if xerr != nil {
+			t.Fatal(xerr)
+		}
+		if rb.Outcome == NetNewInboundOutcomeAccepted {
+			t.Fatal("stale readback reported ACCEPTED")
+		}
+		if rb.Reason != NetNewInboundReasonStale && rb.Reason != NetNewInboundReasonDownstream {
+			t.Fatalf("stale reason=%s", rb.Reason)
+		}
+		repo.actionUpsertErr = nil
+		second, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now.Add(time.Minute))
+		if xerr != nil {
+			t.Fatal(xerr)
+		}
+		if second.Outcome != NetNewInboundOutcomeAccepted || second.ActionID == nil {
+			t.Fatalf("replay after action-store failure: %+v", second)
+		}
+		actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, *second.AccountID, false, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(actions) != 1 {
+			t.Fatalf("action-store rollback/replay produced %d actions", len(actions))
+		}
+	})
+	t.Run("account store", func(t *testing.T) {
+		svc, repo, org := netNewTestService(t)
+		now := *netNewConsentAt()
+		body := marshalNetNew(t, validNetNewMap("nnhr-rollback-account"))
+		repo.accountUpsertErr = errors.New("account store down")
+		first, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now)
+		if xerr != nil {
+			t.Fatal(xerr)
+		}
+		if first.Outcome != NetNewInboundOutcomeUnknown || first.ActionID != nil || first.AccountID != nil {
+			t.Fatalf("account-store failure accepted: %+v", first)
+		}
+		if first.Reason != NetNewInboundReasonDownstream {
+			t.Fatalf("account-store reason=%s", first.Reason)
+		}
+		lead, err := svc.inboundStore().GetInboundLeadByLeadID(context.Background(), org, "nnhr-rollback-account")
+		if err != nil || lead == nil {
+			t.Fatalf("receipt: %v", err)
+		}
+		if netNewReceiptComplete(lead) {
+			t.Fatal("admit failure marked complete; replay would skip AdmitInboundOnly")
+		}
+		repo.accountUpsertErr = nil
+		second, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now.Add(time.Minute))
+		if xerr != nil {
+			t.Fatal(xerr)
+		}
+		if second.Outcome != NetNewInboundOutcomeAccepted || second.ActionID == nil {
+			t.Fatalf("replay after account-store failure: %+v", second)
+		}
+		actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, *second.AccountID, false, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(actions) != 1 {
+			t.Fatalf("account-store rollback/replay produced %d actions", len(actions))
+		}
+	})
 }
 
 func TestNetNewTelemetryFailureDoesNotDropOrGrantOutbound(t *testing.T) {

--- a/internal/app/confenge/net_new_inbound_test.go
+++ b/internal/app/confenge/net_new_inbound_test.go
@@ -1,0 +1,604 @@
+package confenge
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/warmbly/warmbly/internal/app/confenge/liveintel"
+	"github.com/warmbly/warmbly/internal/models"
+	"github.com/warmbly/warmbly/internal/repository"
+)
+
+func netNewConsentAt() *time.Time {
+	at := time.Date(2026, 9, 4, 12, 0, 0, 0, time.UTC)
+	return &at
+}
+
+func validNetNewMap(logicalID string) map[string]any {
+	return map[string]any{
+		"schema":          NetNewInboundHandraiserSchema,
+		"contract_id":     NetNewInboundContractID,
+		"policy_id":       NetNewInboundContractID,
+		"version":         NetNewInboundPinVersion,
+		"policy_version":  NetNewInboundPinVersion,
+		"content_hash":    NetNewInboundPinnedHash,
+		"schema_hash":     NetNewInboundPinnedHash,
+		"policy":          NetNewInboundHandraiserSchema,
+		"policy_hash":     NetNewInboundPinnedHash,
+		"intake_schema":   NetNewInboundIntakeSchema,
+		"taxonomy":        NetNewInboundTaxonomySchema,
+		"catalog":         NetNewInboundCatalogSchema,
+		"source":          NetNewInboundSource,
+		"lane":            NetNewInboundLane,
+		"logical_id":      logicalID,
+		"event_id":        logicalID,
+		"idempotency_key": logicalID,
+		"correlation_id":  "corr-" + logicalID,
+		"nucleus":         "property_valuation",
+		"offer_candidate": NetNewInboundOfferCandidate,
+		"source_asset":    NetNewInboundSourceAsset,
+		"city_class":      "capital",
+		"urgency":         "this_week",
+		"why_now":         "requested a technical readiness assessment from the public form",
+		"person":          map[string]any{"email": logicalID + "@example.test", "name": "Net New " + logicalID},
+		"company":         map[string]any{"name": "Obra " + logicalID},
+		"consent":         map[string]any{"granted": true, "source": "web_form:confenge.com/inbound", "at": "2026-09-04T12:00:00Z"},
+		"conflict":        map[string]any{"status": "NONE", "ref": "conflict:none"},
+		"sensitive_data":  false,
+	}
+}
+
+func marshalNetNew(t *testing.T, body map[string]any) []byte {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return raw
+}
+
+func TestNetNewInboundPinMatchesPublishedFixture(t *testing.T) {
+	raw, err := os.ReadFile("testdata/net_new_inbound_handraiser/conformance.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		PinMaterial string `json:"pin_material"`
+		SchemaHash  string `json:"schema_hash"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	if doc.PinMaterial != NetNewInboundPinMaterial() {
+		t.Fatalf("fixture pin_material diverged from runtime pin")
+	}
+	sum := sha256.Sum256([]byte(doc.PinMaterial))
+	got := hex.EncodeToString(sum[:])
+	if got != NetNewInboundPinnedHash || got != doc.SchemaHash || got != NetNewInboundPinHash() {
+		t.Fatalf("pin hash fixture=%s const=%s recomputed=%s", doc.SchemaHash, NetNewInboundPinnedHash, got)
+	}
+}
+
+func TestDecideNetNewInboundFailClosed(t *testing.T) {
+	env, err := ParseNetNewInboundEnvelope(marshalNetNew(t, validNetNewMap("nnhr-ok")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if d := DecideNetNewInbound(env, rev02TestOnlyPin()); d.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("valid envelope not accepted: %+v", d)
+	}
+	cases := []struct {
+		name    string
+		mutate  func(map[string]any)
+		outcome string
+		reason  string
+	}{
+		{"unknown version", func(m map[string]any) {
+			m["schema"] = "NET_NEW_INBOUND_HANDRAISER/9.9.9"
+			m["version"] = "9.9.9"
+			m["policy_version"] = "9.9.9"
+		}, NetNewInboundOutcomeUnknown, NetNewInboundReasonSchemaUnknown},
+		{"missing hash", func(m map[string]any) { m["schema_hash"] = ""; m["policy_hash"] = ""; m["content_hash"] = "" }, NetNewInboundOutcomeRejected, NetNewInboundReasonHashUnpinned},
+		{"divergent hash", func(m map[string]any) {
+			bad := strings.Repeat("ab", 32)
+			m["schema_hash"] = bad
+			m["policy_hash"] = bad
+			m["content_hash"] = bad
+		}, NetNewInboundOutcomeRejected, NetNewInboundReasonHashMismatch},
+		{"missing consent", func(m map[string]any) { m["consent"] = map[string]any{"granted": false} }, NetNewInboundOutcomeRejected, NetNewInboundReasonConsent},
+		{"conflict decline", func(m map[string]any) { m["conflict"] = map[string]any{"status": "DECLINE", "ref": "conflict:abc"} }, NetNewInboundOutcomeRejected, NetNewInboundReasonConflictDecline},
+		{"conflict unknown", func(m map[string]any) { m["conflict"] = map[string]any{"status": "UNKNOWN", "ref": "conflict:xyz"} }, NetNewInboundOutcomeUnknown, NetNewInboundReasonConflictUnknown},
+		{"intel watch source", func(m map[string]any) { m["source"] = "INTEL_WATCH" }, NetNewInboundOutcomeRejected, NetNewInboundReasonIntelWatch},
+		{"unknown nucleus", func(m map[string]any) { m["nucleus"] = "not_a_nucleus" }, NetNewInboundOutcomeRejected, NetNewInboundReasonNucleus},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			body := validNetNewMap("nnhr-neg")
+			tc.mutate(body)
+			parsed, err := ParseNetNewInboundEnvelope(marshalNetNew(t, body))
+			if err != nil {
+				t.Fatal(err)
+			}
+			d := DecideNetNewInbound(parsed, rev02TestOnlyPin())
+			if d.Outcome != tc.outcome || d.Reason != tc.reason {
+				t.Fatalf("got %+v want %s/%s", d, tc.outcome, tc.reason)
+			}
+			if d.Outcome == NetNewInboundOutcomeAccepted {
+				t.Fatal("negative case was accepted")
+			}
+		})
+	}
+}
+
+func TestIsNetNewInboundDistinctFromIntelWatch(t *testing.T) {
+	if !IsNetNewInboundHandraiserEnvelope(marshalNetNew(t, validNetNewMap("nnhr-det"))) {
+		t.Fatal("valid envelope not detected")
+	}
+	opp := []byte(`{"schema":"` + liveintel.EventSchemaV1 + `","event_id":"e1","event_type":"NEW_OPPORTUNITY","subject_key":"company:x","payload":{"k":"v"}}`)
+	if IsNetNewInboundHandraiserEnvelope(opp) {
+		t.Fatal("opportunity event classified as net-new hand-raiser")
+	}
+	bundle := []byte(`{"schema":"` + liveintel.OfficialLiveIntelligenceSchema + `"}`)
+	if IsNetNewInboundHandraiserEnvelope(bundle) {
+		t.Fatal("live-intelligence bundle classified as net-new hand-raiser")
+	}
+	intent := []byte(`{"schema":"CONFENGE_WEB_INTENT/1.0","intent_kind":"REQUEST_HUMAN_REVIEW"}`)
+	if IsNetNewInboundHandraiserEnvelope(intent) {
+		t.Fatal("web intent classified as net-new hand-raiser")
+	}
+}
+
+func TestNetNewAcceptedInboundOnlyNoSMTP(t *testing.T) {
+	svc, repo, org := netNewTestService(t)
+	now := *netNewConsentAt()
+	sends := 0
+	body := marshalNetNew(t, validNetNewMap("nnhr-accepted"))
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now)
+	if xerr != nil {
+		t.Fatalf("ingest: %v", xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("outcome=%s reason=%s", res.Outcome, res.Reason)
+	}
+	if res.Receipt == "" || res.LogicalID != "nnhr-accepted" {
+		t.Fatalf("receipt missing: %+v", res)
+	}
+	if !res.InboundOnly || res.OutboundEligible || res.AutoSend || res.DispatchAttempted {
+		t.Fatalf("outbound leaked: %+v", res)
+	}
+	if !res.MeetcfgHandoff || !MeetcfgHandoffAllowed(res.Outcome) {
+		t.Fatal("meetcfg handoff not allowed after ACCEPTED")
+	}
+	if res.Nucleus != "property_valuation" || res.OfferCandidate != NetNewInboundOfferCandidate ||
+		res.SourceAsset != NetNewInboundSourceAsset || res.CityClass != "capital" || res.Urgency != "this_week" {
+		t.Fatalf("fields not preserved: %+v", res)
+	}
+	if res.ActionID == nil || res.AccountID == nil {
+		t.Fatalf("missing commercial row: %+v", res)
+	}
+	acc, err := repo.GetAccount(context.Background(), org, *res.AccountID)
+	if err != nil || acc == nil {
+		t.Fatalf("account: %v", err)
+	}
+	if !models.AccountIsInboundOnly(acc) {
+		t.Fatal("net-new account is not inbound-only")
+	}
+	if FirstTouchEligibleAccount(acc) || svc.netNewInFirstTouchEligibleSet(context.Background(), org, acc.ID) {
+		t.Fatal("accepted inbound appeared in first-touch eligible set")
+	}
+	actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, acc.ID, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("want 1 hand-raiser got %d", len(actions))
+	}
+	if actions[0].EmailSendable || actions[0].Dispatchable {
+		t.Fatal("hand-raiser is sendable")
+	}
+	if svc.governor != nil || svc.firstTouchTransport != nil {
+		t.Fatal("ingest wired a send path")
+	}
+	progressed, err := svc.ProcessFastLaneOnce(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if progressed || sends != 0 {
+		t.Fatalf("provider mutation progressed=%v sends=%d", progressed, sends)
+	}
+	rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), org, "nnhr-accepted")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if rb.Outcome != NetNewInboundOutcomeAccepted || rb.Receipt != res.Receipt {
+		t.Fatalf("readback: %+v", rb)
+	}
+	if rb.AcknowledgedBy != NetNewInboundAckActor || rb.AcknowledgedAt == nil || rb.PolicyVersion != NetNewInboundHandraiserSchema || rb.Hash == "" || rb.Receipt == "" {
+		t.Fatalf("readback ack/policy/hash/receipt: %+v", rb)
+	}
+	if rb.Reason != "" && rb.Outcome == NetNewInboundOutcomeAccepted {
+		// accepted may carry empty reason
+	}
+	exp, xerr := svc.ExportSalesContext(context.Background(), org, 50, "")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	found := false
+	for _, item := range exp.Items {
+		if item.ActionID == *res.ActionID {
+			found = true
+			if !item.InboundOnly {
+				t.Fatal("sales context lost inbound_only")
+			}
+		}
+	}
+	if !found {
+		t.Fatal("ACCEPTED hand-raiser missing from meetcfg projection")
+	}
+}
+
+func TestNetNewCanonicalIDReconcileDoesNotNameMerge(t *testing.T) {
+	svc, repo, org := netNewTestService(t)
+	now := *netNewConsentAt()
+	canonical := "canonical-acme-1"
+	existing := &models.OutreachAccount{
+		OrganizationID: org, SourceLeadID: canonical, SourceSystem: "extra-cli",
+		CNPJ14: "55444333000122", RazaoSocial: "Same Display Name LTDA",
+		QueueState: models.OutreachQueueNeedsContact, InboundOnly: false,
+		TargetFitEligible: false, EmailSendReady: false,
+	}
+	if _, err := repo.UpsertAccount(context.Background(), existing); err != nil {
+		t.Fatal(err)
+	}
+
+	body := validNetNewMap("nnhr-canonical")
+	body["canonical_entity_id"] = canonical
+	body["company"] = map[string]any{"name": "Same Display Name LTDA", "canonical_id": canonical}
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, body), now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted || res.AccountID == nil {
+		t.Fatalf("canonical ingest: %+v", res)
+	}
+	if *res.AccountID != existing.ID {
+		t.Fatalf("canonical ID did not reuse account %s vs %s", res.AccountID, existing.ID)
+	}
+	if !res.Reconciled {
+		t.Fatal("canonical match was not marked reconciled")
+	}
+
+	a := validNetNewMap("nnhr-name-a")
+	a["company"] = map[string]any{"name": "Same Display Name LTDA"}
+	b := validNetNewMap("nnhr-name-b")
+	b["company"] = map[string]any{"name": "Same Display Name LTDA"}
+	first, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, a), now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	second, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, b), now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if first.Outcome != NetNewInboundOutcomeAccepted || second.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("name-collision ingest: %+v %+v", first, second)
+	}
+	if first.AccountID == nil || second.AccountID == nil || *first.AccountID == *second.AccountID {
+		t.Fatalf("same name without ID merged: %v vs %v", first.AccountID, second.AccountID)
+	}
+	if *first.AccountID == existing.ID || *second.AccountID == existing.ID {
+		t.Fatal("name-only envelope fused onto canonical entity")
+	}
+}
+
+func TestNetNewReplay100OneReceiptOneHandraiser(t *testing.T) {
+	svc, _, org := netNewTestService(t)
+	now := *netNewConsentAt()
+	body := marshalNetNew(t, validNetNewMap("nnhr-replay"))
+	var first *NetNewInboundResult
+	for i := 0; i < 100; i++ {
+		res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now.Add(time.Duration(i)*time.Second))
+		if xerr != nil {
+			t.Fatalf("replay %d: %v", i, xerr)
+		}
+		if res.Outcome != NetNewInboundOutcomeAccepted {
+			t.Fatalf("replay %d outcome=%s", i, res.Outcome)
+		}
+		if first == nil {
+			first = res
+			continue
+		}
+		if res.Receipt != first.Receipt || res.LogicalID != first.LogicalID {
+			t.Fatalf("replay %d changed receipt", i)
+		}
+		if res.ActionID == nil || first.ActionID == nil || *res.ActionID != *first.ActionID {
+			t.Fatalf("replay %d extra hand-raiser", i)
+		}
+		if res.AccountID == nil || *res.AccountID != *first.AccountID {
+			t.Fatalf("replay %d extra account", i)
+		}
+	}
+	lead, err := svc.inboundStore().GetInboundLeadByLeadID(context.Background(), org, "nnhr-replay")
+	if err != nil || lead == nil {
+		t.Fatalf("receipt: %v", err)
+	}
+	actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, *first.AccountID, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("100 replays produced %d queue rows", len(actions))
+	}
+	acc, _ := svc.repo.GetAccount(context.Background(), org, *first.AccountID)
+	if FirstTouchEligibleAccount(acc) {
+		t.Fatal("replay made the account first-touch eligible")
+	}
+	t.Logf("REPLAY_100_LOSS=0 REPLAY_100_DUPLICATES=0 receipt=%s action=%s", first.Receipt, first.ActionID)
+}
+
+func TestNetNewRejectsDoNotCreateHandraiserOrMeetcfg(t *testing.T) {
+	svc, repo, org := netNewTestService(t)
+	now := *netNewConsentAt()
+	cases := []struct {
+		name   string
+		mutate func(map[string]any)
+		want   string
+	}{
+		{"decline", func(m map[string]any) {
+			m["conflict"] = map[string]any{"status": "DECLINE", "ref": "conflict:only-ref"}
+		}, NetNewInboundReasonConflictDecline},
+		{"conflict unknown", func(m map[string]any) { m["conflict"] = map[string]any{"status": "UNKNOWN", "ref": "conflict:unk"} }, NetNewInboundReasonConflictUnknown},
+		{"no consent", func(m map[string]any) { delete(m, "consent") }, NetNewInboundReasonConsent},
+		{"unpinned", func(m map[string]any) { m["schema_hash"] = ""; m["policy_hash"] = ""; m["content_hash"] = "" }, NetNewInboundReasonHashUnpinned},
+	}
+	before, _ := repo.ListAccounts(context.Background(), org, repository.OutreachAccountFilter{Limit: 500})
+	for i, tc := range cases {
+		body := validNetNewMap("nnhr-rej-" + string(rune('a'+i)))
+		tc.mutate(body)
+		res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, body), now)
+		if xerr != nil {
+			t.Fatalf("%s: %v", tc.name, xerr)
+		}
+		if res.Outcome == NetNewInboundOutcomeAccepted || res.ActionID != nil || res.MeetcfgHandoff {
+			t.Fatalf("%s accepted: %+v", tc.name, res)
+		}
+		if res.Reason != tc.want {
+			t.Fatalf("%s reason=%s want %s", tc.name, res.Reason, tc.want)
+		}
+		rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), org, res.LogicalID)
+		if xerr != nil {
+			t.Fatalf("%s readback: %v", tc.name, xerr)
+		}
+		if rb.Outcome == NetNewInboundOutcomeAccepted {
+			t.Fatalf("%s readback accepted", tc.name)
+		}
+		if strings.Contains(strings.ToLower(rb.ConflictRef), "corpus") || strings.Contains(strings.ToLower(rb.WhyNow), "parts") {
+			t.Fatalf("%s leaked conflict corpus: %+v", tc.name, rb)
+		}
+	}
+	after, _ := repo.ListAccounts(context.Background(), org, repository.OutreachAccountFilter{Limit: 500})
+	if len(after) != len(before) {
+		t.Fatalf("rejects created accounts: before=%d after=%d", len(before), len(after))
+	}
+	exp, xerr := svc.ExportSalesContext(context.Background(), org, 50, "")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if len(exp.Items) != 0 {
+		t.Fatalf("rejected events leaked to meetcfg: %d", len(exp.Items))
+	}
+}
+
+func TestNetNewSensitiveDataStoresRefsOnly(t *testing.T) {
+	svc, _, org := netNewTestService(t)
+	body := validNetNewMap("nnhr-sensitive")
+	body["sensitive_data"] = true
+	body["person"] = map[string]any{"email": "secret.person@example.test", "name": "Secret Person"}
+	body["why_now"] = "do not copy this corpus into analytics"
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, body), *netNewConsentAt())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("sensitive rejected: %+v", res)
+	}
+	lead, err := svc.inboundStore().GetInboundLeadByLeadID(context.Background(), org, "nnhr-sensitive")
+	if err != nil || lead == nil {
+		t.Fatal(err)
+	}
+	raw := strings.ToLower(string(lead.RawPayload))
+	if strings.Contains(raw, "secret.person@example.test") || strings.Contains(raw, "secret person") {
+		t.Fatalf("raw payload kept sensitive data: %s", lead.RawPayload)
+	}
+	metrics, _ := json.Marshal(NetNewInboundMetric{Nucleus: res.Nucleus, State: res.Outcome, Reason: res.Reason})
+	if strings.Contains(strings.ToLower(string(metrics)), "secret.person") {
+		t.Fatalf("metrics leaked PII: %s", metrics)
+	}
+}
+
+func TestNetNewDownstreamUnavailableThenReplay(t *testing.T) {
+	svc, _, org := netNewTestService(t)
+	now := *netNewConsentAt()
+	body := marshalNetNew(t, validNetNewMap("nnhr-rollback"))
+	svc.netNewAfterPersist = func(*models.OutreachInboundLead) error { return errors.New("downstream down") }
+	first, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now)
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if first.Outcome != NetNewInboundOutcomeUnknown || first.ActionID != nil {
+		t.Fatalf("downstream failure accepted: %+v", first)
+	}
+	rb, xerr := svc.ReadbackNetNewInboundHandraiser(context.Background(), org, "nnhr-rollback")
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if rb.Outcome == NetNewInboundOutcomeAccepted {
+		t.Fatal("stale readback reported ACCEPTED")
+	}
+	if rb.Reason != NetNewInboundReasonStale && rb.Reason != NetNewInboundReasonDownstream {
+		t.Fatalf("stale reason=%s", rb.Reason)
+	}
+	svc.netNewAfterPersist = nil
+	second, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, body, now.Add(time.Minute))
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if second.Outcome != NetNewInboundOutcomeAccepted || second.ActionID == nil {
+		t.Fatalf("replay after rollback: %+v", second)
+	}
+	actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, *second.AccountID, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(actions) != 1 {
+		t.Fatalf("rollback/replay produced %d actions", len(actions))
+	}
+}
+
+func TestNetNewTelemetryFailureDoesNotDropOrGrantOutbound(t *testing.T) {
+	svc, _, org := netNewTestService(t)
+	svc.netNewMetricSink = func(NetNewInboundMetric) { panic("metrics down") }
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, validNetNewMap("nnhr-metrics")), *netNewConsentAt())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("telemetry panic dropped event: %+v", res)
+	}
+	if res.OutboundEligible || res.AutoSend || res.DispatchAttempted {
+		t.Fatal("telemetry failure granted outbound")
+	}
+}
+
+func TestIntelWatchFactualEventDoesNotCreateHandraiser(t *testing.T) {
+	svc, repo, org := netNewTestService(t)
+	inbox := &netNewFakeInbox{}
+	svc.WireIntelWatchInbox(inbox)
+	event := liveintel.OpportunityEvent{
+		Schema: liveintel.EventSchemaV1, EventID: "intel-watch-fact-1",
+		EventType: liveintel.EventNewOpportunity, SubjectKey: "company:watched",
+		OrgID: org, OccurredAt: *netNewConsentAt(),
+		Payload: map[string]string{"change": "new bid published"},
+	}
+	receipt, xerr := svc.IngestOpportunityEvent(context.Background(), org, event, *netNewConsentAt())
+	if xerr != nil {
+		t.Fatalf("opportunity ingest: %v", xerr)
+	}
+	if receipt == nil || receipt.EventID != "intel-watch-fact-1" {
+		t.Fatalf("receipt: %+v", receipt)
+	}
+	accs, err := repo.ListAccounts(context.Background(), org, repository.OutreachAccountFilter{Limit: 500})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := range accs {
+		if models.AccountIsInboundOnly(&accs[i]) {
+			t.Fatal("INTEL_WATCH factual event created inbound-only entity")
+		}
+	}
+	lead, err := svc.inboundStore().GetInboundLeadByLeadID(context.Background(), org, "intel-watch-fact-1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if lead != nil {
+		t.Fatal("INTEL_WATCH event created inbound lead/hand-raiser")
+	}
+	if inbox.n != 1 {
+		t.Fatalf("inbox writes=%d", inbox.n)
+	}
+
+	watchBody := validNetNewMap("nnhr-watch-src")
+	watchBody["source"] = "INTEL_WATCH"
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, watchBody), *netNewConsentAt())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome == NetNewInboundOutcomeAccepted || res.ActionID != nil {
+		t.Fatalf("INTEL_WATCH source created hand-raiser: %+v", res)
+	}
+}
+
+func TestNetNewFiveNucleiAcceptedInboundOnly(t *testing.T) {
+	svc, repo, org := netNewTestService(t)
+	now := *netNewConsentAt()
+	if len(NetNewInboundNuclei) != 5 {
+		t.Fatalf("closed nuclei want 5 got %d", len(NetNewInboundNuclei))
+	}
+	ids := map[uuid.UUID]string{}
+	for _, nucleus := range NetNewInboundNuclei {
+		body := validNetNewMap("nnhr-nucleus-" + nucleus)
+		body["nucleus"] = nucleus
+		res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, marshalNetNew(t, body), now)
+		if xerr != nil {
+			t.Fatalf("%s: %v", nucleus, xerr)
+		}
+		if res.Outcome != NetNewInboundOutcomeAccepted {
+			t.Fatalf("%s outcome=%s reason=%s", nucleus, res.Outcome, res.Reason)
+		}
+		if !res.InboundOnly || res.OutboundEligible || res.AutoSend || res.DispatchAttempted {
+			t.Fatalf("%s outbound leaked: %+v", nucleus, res)
+		}
+		if res.AccountID == nil || res.ActionID == nil {
+			t.Fatalf("%s missing commercial row: %+v", nucleus, res)
+		}
+		if _, dup := ids[*res.AccountID]; dup {
+			t.Fatalf("%s reused another nucleus account", nucleus)
+		}
+		ids[*res.AccountID] = nucleus
+		acc, err := repo.GetAccount(context.Background(), org, *res.AccountID)
+		if err != nil || acc == nil {
+			t.Fatalf("%s account: %v", nucleus, err)
+		}
+		if !models.AccountIsInboundOnly(acc) || FirstTouchEligibleAccount(acc) {
+			t.Fatalf("%s first-touch eligible", nucleus)
+		}
+		actions, err := svc.actionStore().ListCommercialActions(context.Background(), org, acc.ID, false, 50)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(actions) != 1 {
+			t.Fatalf("%s want 1 action got %d", nucleus, len(actions))
+		}
+	}
+}
+
+func TestNetNewConformanceFixtureIngest(t *testing.T) {
+	raw, err := os.ReadFile("testdata/net_new_inbound_handraiser/conformance.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var doc struct {
+		Envelope json.RawMessage `json:"envelope"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatal(err)
+	}
+	svc, _, org := netNewTestService(t)
+	res, xerr := svc.IngestNetNewInboundHandraiser(context.Background(), org, doc.Envelope, *netNewConsentAt())
+	if xerr != nil {
+		t.Fatal(xerr)
+	}
+	if res.Outcome != NetNewInboundOutcomeAccepted {
+		t.Fatalf("conformance fixture: %+v", res)
+	}
+}
+
+type netNewFakeInbox struct{ n int }
+
+func (f *netNewFakeInbox) AppendOpportunityEvent(_ context.Context, _ models.IntelWatchInboxEvent) (bool, error) {
+	f.n++
+	return true, nil
+}
+
+func (f *netNewFakeInbox) ClaimReplayableEvents(_ context.Context, _ uuid.UUID, _ time.Time, _, _ time.Duration, _ int) ([]models.IntelWatchInboxEvent, error) {
+	return nil, nil
+}

--- a/internal/app/confenge/net_new_inbound_test.go
+++ b/internal/app/confenge/net_new_inbound_test.go
@@ -57,6 +57,18 @@ func validNetNewMap(logicalID string) map[string]any {
 	}
 }
 
+// governanceNetNewMap is the fixture as a REAL producer sends it: identical to
+// validNetNewMap except the hash fields carry the published Governance
+// policy_hash instead of this repository's local drift digest. It is the only
+// fixture admissible against RuntimeInboundAuthorityPin.
+func governanceNetNewMap(logicalID string) map[string]any {
+	m := validNetNewMap(logicalID)
+	m["content_hash"] = "sha256:" + GovernanceInboundPolicyHash
+	m["schema_hash"] = "sha256:" + GovernanceInboundPolicyHash
+	m["policy_hash"] = "sha256:" + GovernanceInboundPolicyHash
+	return m
+}
+
 func marshalNetNew(t *testing.T, body map[string]any) []byte {
 	t.Helper()
 	raw, err := json.Marshal(body)
@@ -93,7 +105,7 @@ func TestDecideNetNewInboundFailClosed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if d := DecideNetNewInbound(env, rev02TestOnlyPin()); d.Outcome != NetNewInboundOutcomeAccepted {
+	if d := DecideNetNewInbound(env, testOnlyAuthorityPin()); d.Outcome != NetNewInboundOutcomeAccepted {
 		t.Fatalf("valid envelope not accepted: %+v", d)
 	}
 	cases := []struct {
@@ -128,7 +140,7 @@ func TestDecideNetNewInboundFailClosed(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			d := DecideNetNewInbound(parsed, rev02TestOnlyPin())
+			d := DecideNetNewInbound(parsed, testOnlyAuthorityPin())
 			if d.Outcome != tc.outcome || d.Reason != tc.reason {
 				t.Fatalf("got %+v want %s/%s", d, tc.outcome, tc.reason)
 			}

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -330,9 +330,10 @@ type service struct {
 	// or grant outbound action.
 	netNewMetricSink   func(NetNewInboundMetric)
 	netNewAfterPersist func(*models.OutreachInboundLead) error
-	// Optional REV-02 pin override. Tests inject the test-only adapter.
-	// Production uses RuntimeRev02Pin, which is unpinned until a final SHA.
-	rev02Pin Rev02ContractPin
+	// Optional authority-pin override. Tests inject the test-only adapter.
+	// Production uses RuntimeInboundAuthorityPin (the published Governance
+	// authority); an unpinned override falls through to it.
+	authorityPin InboundAuthorityPin
 }
 
 func (s *service) now() time.Time {

--- a/internal/app/confenge/service.go
+++ b/internal/app/confenge/service.go
@@ -162,6 +162,12 @@ type Service interface {
 	// IngestOpportunityEvent durably stores one inbound opportunity event
 	// before anything else happens to it.
 	IngestOpportunityEvent(ctx context.Context, orgID uuid.UUID, event liveintel.OpportunityEvent, now time.Time) (*OpportunityEventReceipt, *errx.Error)
+	// IngestNetNewInboundHandraiser consumes one NET_NEW_INBOUND_HANDRAISER
+	// envelope fail-closed. HTTP 2xx is not acceptance; Outcome is.
+	IngestNetNewInboundHandraiser(ctx context.Context, orgID uuid.UUID, raw []byte, now time.Time) (*NetNewInboundResult, *errx.Error)
+	// ReadbackNetNewInboundHandraiser returns the persisted receipt for the
+	// same logical ID, including ack actor/time, policy, hash, receipt and reason.
+	ReadbackNetNewInboundHandraiser(ctx context.Context, orgID uuid.UUID, logicalID string) (*NetNewInboundReadback, *errx.Error)
 	// PersistHandRaise converges one hand-raise signal onto the commercial
 	// action surface, stamped with its engine of origin.
 	PersistHandRaise(ctx context.Context, raise HandRaise) (*models.OutreachCommercialAction, *errx.Error)
@@ -320,6 +326,13 @@ type service struct {
 	// INTEL_SEED's own send ledger and daily-cap counter. Nil keeps the lane
 	// dormant: an uncountable cap is not a cap.
 	intelSeedLedger IntelSeedLedger
+	// PII-free net-new inbound metrics. A failing sink must not drop the event
+	// or grant outbound action.
+	netNewMetricSink   func(NetNewInboundMetric)
+	netNewAfterPersist func(*models.OutreachInboundLead) error
+	// Optional REV-02 pin override. Tests inject the test-only adapter.
+	// Production uses RuntimeRev02Pin, which is unpinned until a final SHA.
+	rev02Pin Rev02ContractPin
 }
 
 func (s *service) now() time.Time {

--- a/internal/app/confenge/service_test.go
+++ b/internal/app/confenge/service_test.go
@@ -40,6 +40,8 @@ type memRepo struct {
 	inboundInsertErr   error
 	inboundUpdateErr   error
 	alertInsertErr     error
+	accountUpsertErr   error
+	actionUpsertErr    error
 	actions            map[uuid.UUID]*models.OutreachCommercialAction
 	actionByIdem       map[string]*models.OutreachCommercialAction
 	inbound            map[string]*models.OutreachInboundLead
@@ -352,6 +354,9 @@ func (m *memRepo) GetAccount(ctx context.Context, orgID, id uuid.UUID) (*models.
 func (m *memRepo) UpsertAccount(ctx context.Context, acc *models.OutreachAccount) (bool, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.accountUpsertErr != nil {
+		return false, m.accountUpsertErr
+	}
 	k := accKey(acc.OrganizationID, acc.CNPJ14)
 	if models.AccountIsInboundOnly(acc) && strings.TrimSpace(acc.SourceLeadID) != "" {
 		k = acc.OrganizationID.String() + "|inbound_only|" + acc.SourceLeadID
@@ -1622,6 +1627,9 @@ func (m *memRepo) ensureActions() {
 func (m *memRepo) UpsertCommercialAction(_ context.Context, a *models.OutreachCommercialAction) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if m.actionUpsertErr != nil {
+		return m.actionUpsertErr
+	}
 	m.ensureActions()
 	if a.ID == uuid.Nil {
 		a.ID = uuid.New()

--- a/internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json
+++ b/internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json
@@ -1,0 +1,80 @@
+{
+  "campaign_id": "REV-03",
+  "rev02_campaign_id": "REV-02",
+  "rev02_repository": "tjsasakifln/Governance",
+  "rev02_observed_head": "230d73a22a321112abe09b34a0d5fe743790b857",
+  "rev02_final_sha": false,
+  "audience": ["REV-02", "web-cfg", "Meetcfg"],
+  "authority": "test-only adapter/fixture; never production authority. RuntimeRev02Pin stays unpinned until a final REV-02 SHA is recorded and the suite is re-run. Fixture schemas are not a runtime fallback.",
+  "pin_material": "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904\nnuclei=expert_evidence_assistance,property_valuation,building_engineering_documentation,occupational_safety,public_works_b2g\nCONFENGE_OFFER_CATALOG/2.0.0-draft.20260904\nCONFENGE_WEB_INTAKE/2.0.0-draft.20260904\nNET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904\nCONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904\nMEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904\nsource=CONFENGE_WEB\nlane=CONFENGE_WEB\nasset=private_project_technical_readiness_v1\noffer=private_project_technical_readiness_assessment\ninvariants=outbound_eligible=false,auto_send=false",
+  "contract_id": "NET_NEW_INBOUND_HANDRAISER",
+  "version": "1.0.0-draft.20260904",
+  "content_hash": "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b",
+  "schema_hash": "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b",
+  "contracts": {
+    "taxonomy": "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904",
+    "nuclei": [
+      "expert_evidence_assistance",
+      "property_valuation",
+      "building_engineering_documentation",
+      "occupational_safety",
+      "public_works_b2g"
+    ],
+    "catalog": "CONFENGE_OFFER_CATALOG/2.0.0-draft.20260904",
+    "intake": "CONFENGE_WEB_INTAKE/2.0.0-draft.20260904",
+    "policy": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+    "state": "CONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904",
+    "meetcfg": "MEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904",
+    "source_asset": "private_project_technical_readiness_v1",
+    "offer_candidate": "private_project_technical_readiness_assessment",
+    "source": "CONFENGE_WEB",
+    "lane": "CONFENGE_WEB",
+    "invariants": {
+      "outbound_eligible": false,
+      "auto_send": false
+    }
+  },
+  "envelope": {
+    "schema": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+    "contract_id": "NET_NEW_INBOUND_HANDRAISER",
+    "policy_id": "NET_NEW_INBOUND_HANDRAISER",
+    "version": "1.0.0-draft.20260904",
+    "policy_version": "1.0.0-draft.20260904",
+    "content_hash": "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b",
+    "schema_hash": "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b",
+    "policy": "NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904",
+    "policy_hash": "92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b",
+    "intake_schema": "CONFENGE_WEB_INTAKE/2.0.0-draft.20260904",
+    "taxonomy": "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904",
+    "catalog": "CONFENGE_OFFER_CATALOG/2.0.0-draft.20260904",
+    "source": "CONFENGE_WEB",
+    "lane": "CONFENGE_WEB",
+    "logical_id": "nnhr-conformance-001",
+    "event_id": "nnhr-conformance-001",
+    "idempotency_key": "nnhr-conformance-001",
+    "correlation_id": "corr-conformance-001",
+    "nucleus": "property_valuation",
+    "offer_candidate": "private_project_technical_readiness_assessment",
+    "source_asset": "private_project_technical_readiness_v1",
+    "city_class": "capital",
+    "urgency": "this_week",
+    "why_now": "requested a technical readiness assessment from the public form",
+    "person": {
+      "email": "net-new.conformance@example.test",
+      "name": "Conformance Person"
+    },
+    "company": {
+      "name": "Conformance Engenharia LTDA"
+    },
+    "consent": {
+      "granted": true,
+      "source": "web_form:confenge.com/inbound",
+      "at": "2026-09-04T12:00:00Z"
+    },
+    "conflict": {
+      "status": "NONE",
+      "ref": "conflict:none"
+    },
+    "sensitive_data": false
+  }
+}

--- a/internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json
+++ b/internal/app/confenge/testdata/net_new_inbound_handraiser/conformance.json
@@ -5,7 +5,7 @@
   "rev02_observed_head": "230d73a22a321112abe09b34a0d5fe743790b857",
   "rev02_final_sha": false,
   "audience": ["REV-02", "web-cfg", "Meetcfg"],
-  "authority": "test-only adapter/fixture; never production authority. RuntimeRev02Pin stays unpinned until a final REV-02 SHA is recorded and the suite is re-run. Fixture schemas are not a runtime fallback.",
+  "authority": "test-only adapter/fixture; never production authority. This file records this repository's LOCAL drift digest over its own restatement of the schemas; it is not the Governance policy_hash. RuntimeInboundAuthorityPin carries the published Governance authority instead, and never consults this fixture. Fixture schemas are not a runtime fallback.",
   "pin_material": "CONFENGE_CORPORATE_TAXONOMY/1.0.0-draft.20260904\nnuclei=expert_evidence_assistance,property_valuation,building_engineering_documentation,occupational_safety,public_works_b2g\nCONFENGE_OFFER_CATALOG/2.0.0-draft.20260904\nCONFENGE_WEB_INTAKE/2.0.0-draft.20260904\nNET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904\nCONFENGE_HANDRAISER_STATE/1.0.0-draft.20260904\nMEETCFG_HANDRAISER_CONTEXT/1.0.0-draft.20260904\nsource=CONFENGE_WEB\nlane=CONFENGE_WEB\nasset=private_project_technical_readiness_v1\noffer=private_project_technical_readiness_assessment\ninvariants=outbound_eligible=false,auto_send=false",
   "contract_id": "NET_NEW_INBOUND_HANDRAISER",
   "version": "1.0.0-draft.20260904",


### PR DESCRIPTION
CAMPAIGN_ID=REV-03
REPOSITORY=tjsasakifln/warmbly
ACTUAL_BRANCH=integrate/revenue-20260905-warmbly-inbound
WORKTREE=/home/tjsasakifln/code/confenge/.worktrees/warmbly/rev-03-warmbly-inbound
BASE_SHA=8602ce4ae68e27080fa4431390194c09c2b76d06
INITIAL_MAIN_SHA=8602ce4ae68e27080fa4431390194c09c2b76d06
CURRENT_MAIN_SHA=8602ce4ae68e27080fa4431390194c09c2b76d06
HEAD_SHA=58b32f6c84ac30ebe26cc3f062181702af62d177

WARMBLY_REVENUE_INBOUND_CANDIDATE=WAITING_GOVERNANCE_PIN

NO_MERGE=CONFIRMED
NO_DEPLOY=CONFIRMED
NO_SMTP=CONFIRMED

Source: PR #264 HEAD `045b6b2e7f422625d14f32297a72094dc2b77ac6` (Go CI, CONFENGE product acceptance, Security Scan green). Behavior ported onto a new `origin/main` worktree. That branch/worktree was not reused.

## Exact pin

Runtime pin is **unpinned**. Fixture schemas are never production authority.

Test-only adapter (not a runtime fallback):

- `contract_id`: `NET_NEW_INBOUND_HANDRAISER`
- `version`: `1.0.0-draft.20260904`
- canonical: `NET_NEW_INBOUND_HANDRAISER/1.0.0-draft.20260904`
- `content_hash`: `92bafd8b644b1355bcf457e2aa55a7a902030234cc65139bd1c2a24ff880a30b`
- observed REV-02 HEAD (not final): `230d73a22a321112abe09b34a0d5fe743790b857` (`tjsasakifln/Governance`)
- `RuntimeRev02Pin()` stays empty until a final REV-02 SHA is recorded here and the suite is re-run. `READY` is forbidden until then.

Closed nuclei: `expert_evidence_assistance`, `property_valuation`, `building_engineering_documentation`, `occupational_safety`, `public_works_b2g`.

## Migrations

None. Persist-first receipts reuse `outreach_inbound_leads`. Net-new people/companies reuse existing `AdmitInboundOnly` (inbound-only column). One commercial action via existing `PersistHandRaise` / `ConvergeHandRaise`.

## Behavior

- Fail-closed validation of `contract_id + version + content hash`.
- Persist receipt first; then admit/queue.
- Idempotent on logical ID.
- Net-new person/company admitted inbound-only.
- Canonical ID reconciles; same display name without that ID does not merge.
- Outcomes: `ACCEPTED | REJECTED_WITH_REASON | UNKNOWN`.
- Downstream `UNKNOWN` from Admit/PersistHandRaise is retryable until `ACCEPTED` or a decision-terminal `REJECTED`/`UNKNOWN`. Replay files one commercial action without a second queue row.
- One representation, one commercial action.
- Meetcfg handoff only after `ACCEPTED`.
- `outbound_eligible=false`, `auto_send=false`.
- Absent from first-touch eligible set.
- INTEL_WATCH / Live Intelligence factual envelopes never create a CONFENGE_WEB hand-raiser here.
- HTTP 2xx is not acceptance; `outcome` plus same-`logical_id` readback is.

## Readback

`GET /confenge/inbound/handraisers/:logicalId` returns actor (`acknowledged_by`), time (`acknowledged_at`), policy version, hash, receipt, and reason for the same logical ID.

## Allowed metrics

Nucleus, state, and reason only. No email, name, payload, or conflict corpus.

## Replay proof

`TestNetNewReplay100OneReceiptOneHandraiser`: 100 replays of one logical ID.

```
REPLAY_100_LOSS=0 REPLAY_100_DUPLICATES=0
```

One receipt, one inbound-only account, one commercial action.

`TestNetNewDownstreamUnavailableThenReplay` fails the real account store and the real commercial-action store (not a persist hook). First consume is `UNKNOWN`; replay after the store recovers is `ACCEPTED` with one queue row.

## Negative SMTP / outbound proof

- `TestNetNewAcceptedInboundOnlyNoSMTP`: `ProcessFastLaneOnce` does not progress; governor/transport stay unwired; `outbound_eligible=false`; `auto_send=false`; `dispatch_attempted=false`.
- `TestNetNewFiveNucleiAcceptedInboundOnly`: all five nuclei inbound-only and first-touch ineligible.
- `TestNetNewTelemetryFailureDoesNotDropOrGrantOutbound`: telemetry panic does not grant outbound.
- Diff does not touch scheduler, kill switch, mailbox/cap/rate/window, GO/NO-GO, Live Intelligence producer, contact discovery, or provider.

PG persist/readback test exists (`TestPGNetNewInboundHandraiserPersistReadback`) and skipped here: `WARMBLY_TEST_POSTGRES_DSN/PRIMARY_DB is not set`.

`make fmt` and `make lint` PASS. Tests run twice, both PASS.
